### PR TITLE
.gitignore: ignore all build_* directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 build/
-build_cori/
+build_*/
 Backtrace.*
 *.vth
 *.sw[opqrs]

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build_cori/
 Backtrace.*
 *.vth
 *.sw[opqrs]


### PR DESCRIPTION
Added `build_*/` to the file `.gitignore`.
That change makes sure that our build directories on Cori, e.g., `build_cori/`, and Perlmutter, e.g., `build_perlmutter/`, are not tracked by `git`.