### PR TITLE
Ignore *~ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ cmake-build-*/
 # File-based project format:
 *.iws
 
+# temporary files from some editors
+*~
+
 ######
 # OS #
 ######


### PR DESCRIPTION
Some editors create `...~` files while editing them, as a backup.
Let's ignore those files in git.