### PR TITLE
Resize grid based on beam extent

### DIFF
--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -84,6 +84,9 @@ namespace impactx
         //! Delete level data
         void ClearLevel (int lev) override;
 
+        // Resize the mesh, based on the extent of the bunch of particle
+        void ResizeMesh ();
+
         /** these are the physical/beam particles of the simulation */
         std::unique_ptr<ImpactXParticleContainer> m_particle_container;
 

--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -84,7 +84,7 @@ namespace impactx
         //! Delete level data
         void ClearLevel (int lev) override;
 
-        // Resize the mesh, based on the extent of the bunch of particle
+        //! Resize the mesh, based on the extent of the bunch of particle
         void ResizeMesh ();
 
         /** these are the physical/beam particles of the simulation */

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -101,12 +101,15 @@ namespace impactx
     */
     void ImpactX::ResizeMesh () {
         // Extract the mean and RMS size of the particle positions
-        amrex::ParticleReal x_mean, x_std, y_mean, y_std, z_mean, z_std;
-        mypc->MeanAndStdPositions(x_mean, x_std, y_mean, y_std, z_mean, z_std);
+        amrex::ParticleReal x_min, x_max, y_min, y_max, z_min, z_max;
+        mypc->MinAndMaxPositions(x_min, x_max, y_min, y_max, z_min, z_max);
         // Resize the domain size
+        // The box is expanded slightly beyond the min and max of particles.
+        // This controlled by the variable `frac` below.
+        const amrex::Real frac=0.1;
         amrex::RealBox rb(
-            {x_mean-3*x_std, y_mean-3*y_std, z_mean-3*z_std}, // Low bound
-            {x_mean+3*x_std, y_mean+3*y_std, z_mean+3*z_std}); // High bound
+            {x_min-frac*(x_max-x_min), y_min-frac*(y_max-y_min), z_min-frac*(z_max-z_min)}, // Low bound
+            {x_max+frac*(x_max-x_min), y_max+frac*(y_max-y_min), z_max+frac*(z_max-z_min)}); // High bound
         amrex::Geometry::ResetDefaultProbDomain(rb);
         for (int lev = 0; lev <= max_level; ++lev) {
             amrex::Geometry g = Geom(lev);

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -102,7 +102,7 @@ namespace impactx
     void ImpactX::ResizeMesh () {
         // Extract the mean and RMS size of the particle positions
         amrex::ParticleReal x_min, x_max, y_min, y_max, z_min, z_max;
-        mypc->MinAndMaxPositions(x_min, x_max, y_min, y_max, z_min, z_max);
+        m_particle_container->MinAndMaxPositions(x_min, x_max, y_min, y_max, z_min, z_max);
         // Resize the domain size
         // The box is expanded slightly beyond the min and max of particles.
         // This controlled by the variable `frac` below.
@@ -129,10 +129,10 @@ namespace impactx
 
             // Note: The following operation assume that
             // the particles are in x, y, z coordinates.
-            // Resize the mesh, based on `mypc` extent
+            // Resize the mesh, based on `m_particle_container` extent
             ResizeMesh();
             // Redistribute particles in the new mesh
-            mypc->Redistribute();
+            m_particle_container->Redistribute();
 
             // push all particles
             Push(*m_particle_container, m_lattice);

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -97,12 +97,9 @@ namespace impactx
         amrex::ignore_unused(lev);
     }
 
-    /** Resize the mesh, based on the extent of the bunch of particle
-    */
     void ImpactX::ResizeMesh () {
         // Extract the min and max of the particle positions
-        amrex::ParticleReal x_min, x_max, y_min, y_max, z_min, z_max;
-        m_particle_container->MinAndMaxPositions(x_min, x_max, y_min, y_max, z_min, z_max);
+        auto const [x_min, x_max, y_min, y_max, z_min, z_max] = m_particle_container->MinAndMaxPositions();
         // Resize the domain size
         // The box is expanded slightly beyond the min and max of particles.
         // This controlled by the variable `frac` below.

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -99,9 +99,16 @@ namespace impactx
 
     /** Resize the mesh, based on the extent of the bunch of particle
     */
-    //void ImpactX::ResizeMesh () {
-        // Get the particles' mean and RMS in each direction
-    //}
+    void ImpactX::ResizeMesh () {
+        // Extract the mean and RMS size of the particle positions
+        amrex::ParticleReal x_mean, x_std, y_mean, y_std, z_mean, z_std;
+        mypc->MeanAndStdPositions(x_mean, x_std, y_mean, y_std, z_mean, z_std);
+        // Resize the domain size
+        amrex::RealBox rb(
+            {x_mean-3*x_std, y_mean-3*y_std, z_mean-3*z_std}, // Low bound
+            {x_mean+3*x_std, y_mean+3*y_std, z_mean+3*z_std}); // High bound
+        amrex::Geometry::ResetDefaultProbDomain(rb);
+    }
 
     void ImpactX::evolve (int num_steps)
     {

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -100,7 +100,7 @@ namespace impactx
     /** Resize the mesh, based on the extent of the bunch of particle
     */
     void ImpactX::ResizeMesh () {
-        // Extract the mean and RMS size of the particle positions
+        // Extract the min and max of the particle positions
         amrex::ParticleReal x_min, x_max, y_min, y_max, z_min, z_max;
         m_particle_container->MinAndMaxPositions(x_min, x_max, y_min, y_max, z_min, z_max);
         // Resize the domain size

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -108,6 +108,11 @@ namespace impactx
             {x_mean-3*x_std, y_mean-3*y_std, z_mean-3*z_std}, // Low bound
             {x_mean+3*x_std, y_mean+3*y_std, z_mean+3*z_std}); // High bound
         amrex::Geometry::ResetDefaultProbDomain(rb);
+        for (int lev = 0; lev <= max_level; ++lev) {
+            amrex::Geometry g = Geom(lev);
+            g.ProbDomain(rb);
+            amrex::AmrMesh::SetGeometry(lev, g);
+        }
     }
 
     void ImpactX::evolve (int num_steps)

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -127,7 +127,7 @@ namespace impactx
             // Note: The following operation assume that
             // the particles are in x, y, z coordinates.
             // Resize the mesh, based on `mypc` extent
-            // ResizeMesh();
+            ResizeMesh();
             // Redistribute particles in the new mesh
             mypc->Redistribute();
 

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -97,6 +97,12 @@ namespace impactx
         amrex::ignore_unused(lev);
     }
 
+    /** Resize the mesh, based on the extent of the bunch of particle
+    */
+    //void ImpactX::ResizeMesh () {
+        // Get the particles' mean and RMS in each direction
+    //}
+
     void ImpactX::evolve (int num_steps)
     {
         BL_PROFILE("ImpactX::evolve");
@@ -105,6 +111,13 @@ namespace impactx
         {
             BL_PROFILE("ImpactX::evolve::step");
             amrex::Print() << " ++++ Starting step=" << step << "\n";
+
+            // Note: The following operation assume that
+            // the particles are in x, y, z coordinates.
+            // Resize the mesh, based on `mypc` extent
+            // ResizeMesh();
+            // Redistribute particles in the new mesh
+            mypc->Redistribute();
 
             // push all particles
             Push(*m_particle_container, m_lattice);

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -83,13 +83,13 @@ namespace impactx
                        amrex::Vector<amrex::ParticleReal> const & y,
                        amrex::Vector<amrex::ParticleReal> const & z);
 
-        /** Compute the mean and RMS of the particle position in each dimension
+        /** Compute the min and max of the particle position in each dimension
         */
         void
-        MeanAndStdPositions (
-           amrex::ParticleReal& x_mean, amrex::ParticleReal& x_std,
-           amrex::ParticleReal& y_mean, amrex::ParticleReal& y_std,
-           amrex::ParticleReal& z_mean, amrex::ParticleReal& z_std );
+        MinAndMaxPositions (
+           amrex::ParticleReal& x_min, amrex::ParticleReal& x_max,
+           amrex::ParticleReal& y_min, amrex::ParticleReal& y_max,
+           amrex::ParticleReal& z_min, amrex::ParticleReal& z_max );
 
     }; // ImpactXParticleContainer
 

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -84,12 +84,14 @@ namespace impactx
                        amrex::Vector<amrex::ParticleReal> const & z);
 
         /** Compute the min and max of the particle position in each dimension
+        *
+        * @returns x_min, x_max, y_min, y_max, z_min, z_max
         */
-        void
-        MinAndMaxPositions (
-           amrex::ParticleReal& x_min, amrex::ParticleReal& x_max,
-           amrex::ParticleReal& y_min, amrex::ParticleReal& y_max,
-           amrex::ParticleReal& z_min, amrex::ParticleReal& z_max );
+        std::tuple<
+            amrex::ParticleReal, amrex::ParticleReal,
+            amrex::ParticleReal, amrex::ParticleReal,
+            amrex::ParticleReal, amrex::ParticleReal>
+        MinAndMaxPositions ();
 
     }; // ImpactXParticleContainer
 

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -86,7 +86,7 @@ namespace impactx
         /** Compute the mean and RMS of the particle position in each dimension
         */
         void
-        ImpactXParticleContainer::MeanAndStdPositions(
+        MeanAndStdPositions (
            amrex::ParticleReal& x_mean, amrex::ParticleReal& x_std,
            amrex::ParticleReal& y_mean, amrex::ParticleReal& y_std,
            amrex::ParticleReal& z_mean, amrex::ParticleReal& z_std );

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -83,6 +83,14 @@ namespace impactx
                        amrex::Vector<amrex::ParticleReal> const & y,
                        amrex::Vector<amrex::ParticleReal> const & z);
 
+        /** Compute the mean and RMS of the particle position in each dimension
+        */
+        void
+        ImpactXParticleContainer::MeanAndStdPositions(
+           amrex::ParticleReal& x_mean, amrex::ParticleReal& x_std,
+           amrex::ParticleReal& y_mean, amrex::ParticleReal& y_std,
+           amrex::ParticleReal& z_mean, amrex::ParticleReal& z_std );
+
     }; // ImpactXParticleContainer
 
 } // namespace impactx

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -14,6 +14,8 @@
 
 #include <AMReX_Vector.H>
 
+#include <tuple>
+
 
 namespace impactx
 {

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -8,7 +8,7 @@
 
 #include <AMReX_AmrCore.H>
 #include <AMReX_AmrParGDB.H>
-#include <AMReX_amrex::ParallelDescriptor.H>
+#include <AMReX_ParallelDescriptor.H>
 #include <AMReX_ParticleTile.H>
 
 
@@ -53,7 +53,7 @@ namespace impactx
         {
             ParticleType p;
             p.id() = ParticleType::NextID();
-            p.cpu() = amrex::amrex::ParallelDescriptor::MyProc();
+            p.cpu() = amrex::ParallelDescriptor::MyProc();
             p.pos(0) = x[i];
             p.pos(1) = y[i];
             p.pos(2) = z[i];
@@ -121,7 +121,7 @@ namespace impactx
         amrex::ParallelDescriptor::ReduceRealSum(sum_y2);
         amrex::ParallelDescriptor::ReduceRealSum(sum_z);
         amrex::ParallelDescriptor::ReduceRealSum(sum_z2);
-        amrex::ParallelDescriptor::ReduceLongSum(sum_w);
+        amrex::ParallelDescriptor::ReduceRealSum(sum_w);
 
         x_mean = sum_x/sum_w;
         x_std = sum_x2/sum_w - x_mean*x_mean;

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -8,7 +8,7 @@
 
 #include <AMReX_AmrCore.H>
 #include <AMReX_AmrParGDB.H>
-#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_amrex::ParallelDescriptor.H>
 #include <AMReX_ParticleTile.H>
 
 
@@ -53,7 +53,7 @@ namespace impactx
         {
             ParticleType p;
             p.id() = ParticleType::NextID();
-            p.cpu() = amrex::ParallelDescriptor::MyProc();
+            p.cpu() = amrex::amrex::ParallelDescriptor::MyProc();
             p.pos(0) = x[i];
             p.pos(1) = y[i];
             p.pos(2) = z[i];
@@ -84,19 +84,19 @@ namespace impactx
     }
 
     void
-    ImpactXParticleContainer::MeanAndStdPositions(
+    ImpactXParticleContainer::MeanAndStdPositions (
         amrex::ParticleReal& x_mean, amrex::ParticleReal& x_std,
         amrex::ParticleReal& y_mean, amrex::ParticleReal& y_std,
         amrex::ParticleReal& z_mean, amrex::ParticleReal& z_std )
     {
-        amrex::ParticleReal sum_w, sum_x, sum_x2, sum_y, sum_y2, sum_z, sum_z2;
+        amrex::ParticleReal sum_x, sum_x2, sum_y, sum_y2, sum_z, sum_z2, sum_w;
 
         using PType = ImpactXParticleContainer::SuperParticleType;
 
-        amrex::ReduceOps<ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum> reduce_ops;
-        auto r = amrex::ParticleReduce<amrex::ReduceData<ParticleReal, ParticleReal, ParticleReal, ParticleReal, ParticleReal, ParticleReal, ParticleReal>>(
+        amrex::ReduceOps<amrex::ReduceOpSum, amrex::ReduceOpSum, amrex::ReduceOpSum, amrex::ReduceOpSum, amrex::ReduceOpSum, amrex::ReduceOpSum, amrex::ReduceOpSum> reduce_ops;
+        auto r = amrex::ParticleReduce<amrex::ReduceData<amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal>>(
             *this,
-            [=] AMREX_GPU_DEVICE(const PType& p) noexcept -> amrex::GpuTuple<ParticleReal, ParticleReal, ParticleReal, ParticleReal, ParticleReal, ParticleReal, ParticleReal>
+            [=] AMREX_GPU_DEVICE(const PType& p) noexcept -> amrex::GpuTuple<amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal>
             {
                 amrex::ParticleReal x = p.pos(0);
                 amrex::ParticleReal y = p.pos(1);
@@ -115,13 +115,13 @@ namespace impactx
         sum_z2 = amrex::get<5>(r);
         sum_w = amrex::get<6>(r);
 
-        ParallelDescriptor::ReduceRealSum(sum_x);
-        ParallelDescriptor::ReduceRealSum(sum_x2);
-        ParallelDescriptor::ReduceRealSum(sum_y);
-        ParallelDescriptor::ReduceRealSum(sum_y2);
-        ParallelDescriptor::ReduceRealSum(sum_z);
-        ParallelDescriptor::ReduceRealSum(sum_z2);
-        ParallelDescriptor::ReduceLongSum(sum_w);
+        amrex::ParallelDescriptor::ReduceRealSum(sum_x);
+        amrex::ParallelDescriptor::ReduceRealSum(sum_x2);
+        amrex::ParallelDescriptor::ReduceRealSum(sum_y);
+        amrex::ParallelDescriptor::ReduceRealSum(sum_y2);
+        amrex::ParallelDescriptor::ReduceRealSum(sum_z);
+        amrex::ParallelDescriptor::ReduceRealSum(sum_z2);
+        amrex::ParallelDescriptor::ReduceLongSum(sum_w);
 
         x_mean = sum_x/sum_w;
         x_std = sum_x2/sum_w - x_mean*x_mean;

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -83,11 +83,11 @@ namespace impactx
 
     }
 
-    void
-    ImpactXParticleContainer::MinAndMaxPositions (
-        amrex::ParticleReal& x_min, amrex::ParticleReal& x_max,
-        amrex::ParticleReal& y_min, amrex::ParticleReal& y_max,
-        amrex::ParticleReal& z_min, amrex::ParticleReal& z_max )
+    std::tuple<
+            amrex::ParticleReal, amrex::ParticleReal,
+            amrex::ParticleReal, amrex::ParticleReal,
+            amrex::ParticleReal, amrex::ParticleReal>
+    ImpactXParticleContainer::MinAndMaxPositions ()
     {
         using PType = ImpactXParticleContainer::SuperParticleType;
 
@@ -116,6 +116,7 @@ namespace impactx
         amrex::ParallelDescriptor::ReduceRealMax(x_max);
         amrex::ParallelDescriptor::ReduceRealMax(y_max);
         amrex::ParallelDescriptor::ReduceRealMax(z_max);
+        return {x_min, x_max, y_min, y_max, z_min, z_max};
     }
 
 } // namespace impactx


### PR DESCRIPTION
This resizes the box by the min and max of the particle container (+ an additional 10%) and then redistributes the particles, in preparation for the space charge calculation.