### PR TITLE
CMAKE_INSTALL_LIBDIR: Absolute (or auto-prefixed)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ if(ImpactX_LIB)
     endif()
     install(CODE "file(CREATE_LINK
         $<TARGET_FILE_NAME:shared>
-        ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libImpactX.${mod_ext}
+        ${CMAKE_INSTALL_LIBDIR}/libImpactX.${mod_ext}
         COPY_ON_ERROR SYMBOLIC)")
 endif()
 


### PR DESCRIPTION
`CMAKE_INSTALL_LIBDIR` is either absolute or gets automatically prefixed with `CMAKE_INSTALL_PREFIX`.

X-Ref.:
- https://github.com/ECP-WarpX/WarpX/pull/2583
- https://cmake.org/pipermail/cmake/2012-February/049206.html