### PR TITLE
Added declaration and initialization of a list of beamline elements.

### DIFF
--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -7,15 +7,14 @@
 #ifndef IMPACT_X_H
 #define IMPACT_X_H
 
-#include "particles/ImpactXParticleContainer.H"
-
 #include "particles/elements/Drift.H"
+#include "particles/ImpactXParticleContainer.H"
 
 #include <AMReX_AmrCore.H>
 
+#include <list>
 #include <memory>
 
-#include <list>
 
 namespace impactx
 {

--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -9,9 +9,13 @@
 
 #include "particles/ImpactXParticleContainer.H"
 
+#include "particles/elements/Drift.H"
+
 #include <AMReX_AmrCore.H>
 
 #include <memory>
+
+#include <list>
 
 namespace impactx
 {
@@ -49,6 +53,9 @@ namespace impactx
         /** Initialize particle containers and MultiFabs (fields) */
         void initData ();
 
+        /** Initialize the list of lattice elements */
+        void initElements ();
+
         /** Run the main simulation loop for a number of steps
          *
          * @param num_steps number of steps to evolve
@@ -80,6 +87,9 @@ namespace impactx
 
         /** these are the physical/beam particles of the simulation */
         std::unique_ptr<ImpactXParticleContainer> mypc;
+
+        /** these are elements defining the lattice */
+        std::list<Drift> myelements;
     };
 
 } // namespace impactx

--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -7,7 +7,7 @@
 #ifndef IMPACT_X_H
 #define IMPACT_X_H
 
-#include "particles/elements/Drift.H"
+#include "particles/elements/All.H"
 #include "particles/ImpactXParticleContainer.H"
 
 #include <AMReX_AmrCore.H>
@@ -88,7 +88,7 @@ namespace impactx
         std::unique_ptr<ImpactXParticleContainer> mypc;
 
         /** these are elements defining the lattice */
-        std::list<Drift> myelements;
+        std::list<KnownElements> myelements;
     };
 
 } // namespace impactx

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -117,4 +117,18 @@ namespace impactx
         } // end step loop
     }
 
+    void ImpactX::initElements ()
+    {
+        // initialize element sequence
+        myelements = { };
+        
+        // add elements
+        Drift drift1(1.0);
+        Drift drift2(0.5);
+        myelements.push_back(drift1);
+        myelements.push_back(drift2);
+        
+        amrex::Print() << "Initialized element list" << std::endl;
+    }
+
 } // namespace impactx

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -107,7 +107,7 @@ namespace impactx
             amrex::Print() << " ++++ Starting step=" << step << "\n";
 
             // push all particles
-            Push(*mypc);
+            Push(*mypc, myelements);
 
             // do more stuff in the step
             //...

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -121,13 +121,13 @@ namespace impactx
     {
         // initialize element sequence
         myelements = { };
-        
+
         // add elements
         Drift drift1(1.0);
         Drift drift2(0.5);
         myelements.push_back(drift1);
         myelements.push_back(drift2);
-        
+
         amrex::Print() << "Initialized element list" << std::endl;
     }
 

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -119,14 +119,12 @@ namespace impactx
 
     void ImpactX::initElements ()
     {
-        // initialize element sequence
-        myelements = { };
+        // make sure the element sequence is empty
+        myelements.clear();
 
         // add elements
-        Drift drift1(1.0);
-        Drift drift2(0.5);
-        myelements.push_back(drift1);
-        myelements.push_back(drift2);
+        myelements.emplace_back(Drift(1.0));
+        myelements.emplace_back(Drift(0.5));
 
         amrex::Print() << "Initialized element list" << std::endl;
     }

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -123,8 +123,13 @@ namespace impactx
         myelements.clear();
 
         // add elements
-        myelements.emplace_back(Drift(1.0));
+        //   FODO cell
+        myelements.emplace_back(Quad(1.0, 4.0));
         myelements.emplace_back(Drift(0.5));
+        myelements.emplace_back(Quad(1.0, 4.0));
+        myelements.emplace_back(Drift(0.5));
+        //   a bending magnet
+        myelements.emplace_back(Sbend(0.5, 2.0));
 
         amrex::Print() << "Initialized element list" << std::endl;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@ int main(int argc, char* argv[])
         auto impactX = std::make_unique<impactx::ImpactX>(geom, amr_info);
 
         impactX->initData();
+        impactX->initElements();
         impactX->evolve( /* num_steps = */ 10);
     }
     BL_PROFILE_VAR_STOP(pmain);

--- a/src/particles/Push.H
+++ b/src/particles/Push.H
@@ -7,7 +7,10 @@
 #ifndef IMPACTX_PUSH_H
 #define IMPACTX_PUSH_H
 
+#include "elements/All.H"
 #include "particles/ImpactXParticleContainer.H"
+
+#include <list>
 
 
 namespace impactx
@@ -15,8 +18,10 @@ namespace impactx
     /** Push particles
      *
      * @param pc container of the particles to push
+     * @param beamline_elements elements to push the particles through
      */
-    void Push (ImpactXParticleContainer & pc);
+    void Push (ImpactXParticleContainer & pc,
+               std::list<KnownElements> const & beamline_elements);
 
 } // namespace impactx
 

--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -12,6 +12,70 @@
 
 namespace impactx
 {
+namespace detail
+{
+    /** Push a single particle through an element
+     *
+     * Note: we usually would just write a C++ lambda below in ParallelFor. But, due to restrictions
+     * in NVCC as of 11.0.2, we cannot write a lambda in a lambda as we also std::visit the element
+     * types of our beamline_element list.
+     *    error #3206-D: An extended __device__ lambda cannot be defined inside a generic lambda expression("operator()").
+     * Thus, we fall back to writing a C++ functor here, instead of nesting two lambdas.
+     *
+     * @tparam T_Element This can be a \see Drift, \see Quad, \see Sbend, etc.
+     */
+    template <typename T_Element>
+    struct PushSingleParticle
+    {
+        using PType = ImpactXParticleContainer::ParticleType;
+
+        /** Constructor taking in pointers to particle data
+         *
+         * @param element the beamline element to push through
+         * @param aos_ptr the array-of-struct with position and ids
+         * @param part_px the array to the particle momentum (x)
+         * @param part_py the array to the particle momentum (y)
+         * @param part_pt the array to the particle momentum (t)
+         */
+        PushSingleParticle (T_Element element,
+                            PType* aos_ptr,
+                            amrex::ParticleReal* part_px,
+                            amrex::ParticleReal* part_py,
+                            amrex::ParticleReal* part_pt)
+            : m_element(element), m_aos_ptr(aos_ptr),
+              m_part_px(part_px), m_part_py(part_py), m_part_pt(part_pt)
+        {
+        }
+
+        PushSingleParticle () = delete;
+        PushSingleParticle (PushSingleParticle const &) = default;
+        PushSingleParticle (PushSingleParticle &&) = default;
+        ~PushSingleParticle () = default;
+
+        AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+        void
+        operator() (long i) const
+        {
+            // access AoS data such as positions and cpu/id
+            PType& p = m_aos_ptr[i];
+
+            // access SoA Real data
+            amrex::ParticleReal & px = m_part_px[i];
+            amrex::ParticleReal & py = m_part_py[i];
+            amrex::ParticleReal & pt = m_part_pt[i];
+
+            m_element(p, px, py, pt);
+        }
+
+    private:
+        T_Element const m_element;
+        PType* const AMREX_RESTRICT m_aos_ptr;
+        amrex::ParticleReal* const AMREX_RESTRICT m_part_px;
+        amrex::ParticleReal* const AMREX_RESTRICT m_part_py;
+        amrex::ParticleReal* const AMREX_RESTRICT m_part_pt;
+    };
+} // namespace detail
+
     void Push (ImpactXParticleContainer & pc,
                std::list<KnownElements> const & beamline_elements)
     {
@@ -49,19 +113,11 @@ namespace impactx
                 for (auto & element_variant : beamline_elements) {
                     // here we just access the element by its respective type
                     std::visit([=](auto&& element) {
+                        detail::PushSingleParticle<decltype(element)> const pushSingleParticle(
+                            element, aos_ptr, part_px, part_py, part_pt);
+
                         // loop over particles in the box
-                        amrex::ParallelFor( np, [=] AMREX_GPU_DEVICE (long i)
-                        {
-                            // access AoS data such as positions and cpu/id
-                            PType& p = aos_ptr[i];
-
-                            // access SoA Real data
-                            amrex::ParticleReal & px = part_px[i];
-                            amrex::ParticleReal & py = part_py[i];
-                            amrex::ParticleReal & pt = part_pt[i];
-
-                            element(p, px, py, pt);
-                        });
+                        amrex::ParallelFor(np, pushSingleParticle);
                     }, element_variant);
                 }; // end loop over all beamline elements
 

--- a/src/particles/elements/All.H
+++ b/src/particles/elements/All.H
@@ -1,0 +1,23 @@
+/* Copyright 2021 Axel Huebl
+ *
+ * This file is part of ImpactX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_ELEMENTS_ALL_H
+#define IMPACTX_ELEMENTS_ALL_H
+
+#include "Drift.H"
+#include "Sbend.H"
+#include "Quad.H"
+
+#include <variant>
+
+
+namespace impactx
+{
+    using KnownElements = std::variant<Drift, Sbend, Quad>;
+
+} // namespace impactx
+
+#endif // IMPACTX_ELEMENTS_ALL_H


### PR DESCRIPTION
This is a first attempt at initializing a list of beamline elements defining the lattice.  For now, the list includes only drift elements.  The main work is done in the function initElements() in ImpactX.cpp.  

Request sanity check that this makes some sense before proceeding further.