### PR TITLE
Fix: Installed Symlink LIB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,9 +252,14 @@ if(ImpactX_LIB)
     else()
         set(mod_ext "so")
     endif()
+    if(IS_ABSOLUTE CMAKE_INSTALL_LIBDIR)
+        set(ABS_INSTALL_LIB_DIR ${CMAKE_INSTALL_LIBDIR})
+    else()
+        set(ABS_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+    endif()
     install(CODE "file(CREATE_LINK
         $<TARGET_FILE_NAME:shared>
-        ${CMAKE_INSTALL_LIBDIR}/libImpactX.${mod_ext}
+        ${ABS_INSTALL_LIB_DIR}/libImpactX.${mod_ext}
         COPY_ON_ERROR SYMBOLIC)")
 endif()
 


### PR DESCRIPTION
The latest patch (#20) to these routines broke our library alias in installs.

By default, this variable is relative and needs the prefix appended.
In some cases, e.g., if externally set, it can already be absolute. In that case, we skip adding the prefix.