### PR TITLE
Fix: Elements `operator()` is `const`

### DIFF
--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -41,7 +41,7 @@ namespace impactx
                 PType& p,
                 amrex::ParticleReal & px,
                 amrex::ParticleReal & py,
-                amrex::ParticleReal & pt) {
+                amrex::ParticleReal & pt) const {
 
             // access AoS data such as positions and cpu/id
             amrex::ParticleReal const x = p.pos(0);

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -42,7 +42,7 @@ namespace impactx
                 PType& p,
                 amrex::ParticleReal & px,
                 amrex::ParticleReal & py,
-                amrex::ParticleReal & pt) {
+                amrex::ParticleReal & pt) const {
 
             // access AoS data such as positions and cpu/id
             amrex::ParticleReal const x = p.pos(0);

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -42,7 +42,7 @@ namespace impactx
                 PType& p,
                 amrex::ParticleReal & px,
                 amrex::ParticleReal & py,
-                amrex::ParticleReal & pt) {
+                amrex::ParticleReal & pt) const {
 
             // access AoS data such as positions and cpu/id
             amrex::ParticleReal const x = p.pos(0);


### PR DESCRIPTION
We promise to only read, but not modify the data members of an element (e.g., its map) as we push particles through it.