### PR TITLE
Cleanup: Start Members with `m_...`

### DIFF
--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -85,10 +85,10 @@ namespace impactx
         void ClearLevel (int lev) override;
 
         /** these are the physical/beam particles of the simulation */
-        std::unique_ptr<ImpactXParticleContainer> mypc;
+        std::unique_ptr<ImpactXParticleContainer> m_particle_container;
 
         /** these are elements defining the lattice */
-        std::list<KnownElements> myelements;
+        std::list<KnownElements> m_lattice;
     };
 
 } // namespace impactx

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -27,7 +27,7 @@ namespace impactx
 
     ImpactX::ImpactX (amrex::Geometry const& simulation_geometry, amrex::AmrInfo const& amr_info)
         : AmrCore(simulation_geometry, amr_info),
-          mypc(std::make_unique<ImpactXParticleContainer>(this))
+          m_particle_container(std::make_unique<ImpactXParticleContainer>(this))
     {
     }
 
@@ -36,8 +36,8 @@ namespace impactx
         AmrCore::InitFromScratch(0.0);
         amrex::Print() << "boxArray(0) " << boxArray(0) << std::endl;;
 
-        mypc->AddNParticles(0, {0.0}, {0.2}, {0.4});
-        amrex::Print() << "# of particles: " << mypc->TotalNumberOfParticles() << std::endl;
+        m_particle_container->AddNParticles(0, {0.0}, {0.2}, {0.4});
+        amrex::Print() << "# of particles: " << m_particle_container->TotalNumberOfParticles() << std::endl;
     }
 
     /** Tag cells for refinement.  TagBoxArray tags is built on level lev grids.
@@ -107,7 +107,7 @@ namespace impactx
             amrex::Print() << " ++++ Starting step=" << step << "\n";
 
             // push all particles
-            Push(*mypc, myelements);
+            Push(*m_particle_container, m_lattice);
 
             // do more stuff in the step
             //...
@@ -120,16 +120,16 @@ namespace impactx
     void ImpactX::initElements ()
     {
         // make sure the element sequence is empty
-        myelements.clear();
+        m_lattice.clear();
 
         // add elements
         //   FODO cell
-        myelements.emplace_back(Quad(1.0, 4.0));
-        myelements.emplace_back(Drift(0.5));
-        myelements.emplace_back(Quad(1.0, 4.0));
-        myelements.emplace_back(Drift(0.5));
+        m_lattice.emplace_back(Quad(1.0, 4.0));
+        m_lattice.emplace_back(Drift(0.5));
+        m_lattice.emplace_back(Quad(1.0, 4.0));
+        m_lattice.emplace_back(Drift(0.5));
         //   a bending magnet
-        myelements.emplace_back(Sbend(0.5, 2.0));
+        m_lattice.emplace_back(Sbend(0.5, 2.0));
 
         amrex::Print() << "Initialized element list" << std::endl;
     }

--- a/src/particles/Push.H
+++ b/src/particles/Push.H
@@ -18,10 +18,10 @@ namespace impactx
     /** Push particles
      *
      * @param pc container of the particles to push
-     * @param beamline_elements elements to push the particles through
+     * @param lattice elements to push the particles through
      */
     void Push (ImpactXParticleContainer & pc,
-               std::list<KnownElements> const & beamline_elements);
+               std::list<KnownElements> const & lattice);
 
 } // namespace impactx
 

--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -18,7 +18,7 @@ namespace detail
      *
      * Note: we usually would just write a C++ lambda below in ParallelFor. But, due to restrictions
      * in NVCC as of 11.0.2, we cannot write a lambda in a lambda as we also std::visit the element
-     * types of our beamline_element list.
+     * types of our lattice elements list.
      *    error #3206-D: An extended __device__ lambda cannot be defined inside a generic lambda expression("operator()").
      * Thus, we fall back to writing a C++ functor here, instead of nesting two lambdas.
      *
@@ -77,7 +77,7 @@ namespace detail
 } // namespace detail
 
     void Push (ImpactXParticleContainer & pc,
-               std::list<KnownElements> const & beamline_elements)
+               std::list<KnownElements> const & lattice)
     {
         using namespace amrex::literals; // for _rt and _prt
 
@@ -110,7 +110,7 @@ namespace detail
                 // ...
 
                 // loop over all beamline elements
-                for (auto & element_variant : beamline_elements) {
+                for (auto & element_variant : lattice) {
                     // here we just access the element by its respective type
                     std::visit([=](auto&& element) {
                         detail::PushSingleParticle<decltype(element)> const pushSingleParticle(


### PR DESCRIPTION
Start member variables with `m_...` and avoid unnecessary plurals.