### PR TITLE
Doxygen: `PushSingleParticle::operator()`

### DIFF
--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -55,6 +55,10 @@ namespace detail
         PushSingleParticle (PushSingleParticle &&) = default;
         ~PushSingleParticle () = default;
 
+        /** Push a single particle through an element
+         *
+         * @param i particle index in the current box
+         */
         AMREX_GPU_DEVICE AMREX_FORCE_INLINE
         void
         operator() (long i) const


### PR DESCRIPTION
Add the missing Doxygen API string to `PushSingleParticle::operator()`.

Follow-up to #21 