### PR TITLE
Limit the scope of profiler

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,8 +27,9 @@ int main(int argc, char* argv[])
         impactx::overwrite_amrex_parser_defaults
     );
 
-    BL_PROFILE_VAR("main()", pmain);
     {
+        BL_PROFILE_VAR("main()", pmain);
+
         amrex::AmrInfo amr_info;
         const int nprocs = amrex::ParallelDescriptor::NProcs();
         const amrex::IntVect high_end = amr_info.blocking_factor[0]
@@ -42,8 +43,9 @@ int main(int argc, char* argv[])
         impactX->initData();
         impactX->initElements();
         impactX->evolve( /* num_steps = */ 10);
+
+        BL_PROFILE_VAR_STOP(pmain);
     }
-    BL_PROFILE_VAR_STOP(pmain);
 
     amrex::Finalize();
 #if defined(AMREX_USE_MPI)


### PR DESCRIPTION
In main.cpp, the destructor of the profiler was called after
amrex::Finalize.  This might cause an error in the future in SYCL if there
is a device synchronization call in the dtor, because the SYCL queues in
amrex have been deleted.  In this commit, we limit the scope of the profiler
so that its destructor is called before the queues are deleted.  Note that
it is never an issue for CUDA/HIP, because the device synchronization calls
in those backends do not need any amrex objects.  Furthermore, this is not
an issue currently for SYCL either.  But in the future, we might adopt the
WarpX approach of wrapping AMReX profilers and calling device
synchronization in the destructor.