### PR TITLE
Min/Max/Std Position: from ABLASTR

### DIFF
--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -102,7 +102,7 @@ set(ImpactX_ablastr_src ""
 set(ImpactX_ablastr_repo "https://github.com/ECP-WarpX/WarpX.git"
     CACHE STRING
     "Repository URI to pull and build ABLASTR from if(ImpactX_ablastr_internal)")
-set(ImpactX_ablastr_branch "7cd660b5061dd76240d8377fed3d2466aeaa346d"
+set(ImpactX_ablastr_branch "2a24ba13c214b3e4345529deecf627d6d113004e"
     CACHE STRING
     "Repository branch for ImpactX_ablastr_repo if(ImpactX_ablastr_internal)")
 

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -86,14 +86,24 @@ namespace impactx
                        amrex::Vector<amrex::ParticleReal> const & z);
 
         /** Compute the min and max of the particle position in each dimension
-        *
-        * @returns x_min, x_max, y_min, y_max, z_min, z_max
-        */
+         *
+         * @returns x_min, x_max, y_min, y_max, z_min, z_max
+         */
         std::tuple<
             amrex::ParticleReal, amrex::ParticleReal,
             amrex::ParticleReal, amrex::ParticleReal,
             amrex::ParticleReal, amrex::ParticleReal>
         MinAndMaxPositions ();
+
+        /** Compute the mean and std of the particle position in each dimension
+         *
+         * @returns x_mean, x_std, y_mean, y_std, z_mean, z_std
+         */
+        std::tuple<
+                amrex::ParticleReal, amrex::ParticleReal,
+                amrex::ParticleReal, amrex::ParticleReal,
+                amrex::ParticleReal, amrex::ParticleReal>
+        MeanAndStdPositions ();
 
     }; // ImpactXParticleContainer
 

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -1,10 +1,12 @@
-/* Copyright 2021 Axel Huebl
+/* Copyright 2021 Axel Huebl, Remi Lehe
  *
  * This file is part of ImpactX.
  *
  * License: BSD-3-Clause-LBNL
  */
 #include "ImpactXParticleContainer.H"
+
+#include <ablastr/particles/ParticleMoments.H>
 
 #include <AMReX_AmrCore.H>
 #include <AMReX_AmrParGDB.H>
@@ -89,36 +91,17 @@ namespace impactx
             amrex::ParticleReal, amrex::ParticleReal>
     ImpactXParticleContainer::MinAndMaxPositions ()
     {
-        using PType = ImpactXParticleContainer::SuperParticleType;
-
-        // Get min and max for the local rank
-        amrex::ReduceOps<amrex::ReduceOpMin, amrex::ReduceOpMin, amrex::ReduceOpMin, amrex::ReduceOpMax, amrex::ReduceOpMax, amrex::ReduceOpMax> reduce_ops;
-        auto r = amrex::ParticleReduce<amrex::ReduceData<amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal>>(
-            *this,
-            [=] AMREX_GPU_DEVICE(const PType& p) noexcept -> amrex::GpuTuple<amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal>
-            {
-                amrex::ParticleReal x = p.pos(0);
-                amrex::ParticleReal y = p.pos(1);
-                amrex::ParticleReal z = p.pos(2);
-                return {x, y, z, x, y, z};
-            },
-            reduce_ops);
-
-        // Get min and max across all ranks
-        std::vector<amrex::ParticleReal> xyz_min = {
-            amrex::get<0>(r),
-            amrex::get<1>(r),
-            amrex::get<2>(r)
-        };
-        amrex::ParallelDescriptor::ReduceRealMin(xyz_min.data(), xyz_min.size());
-        std::vector<amrex::ParticleReal> xyz_max = {
-            amrex::get<3>(r),
-            amrex::get<4>(r),
-            amrex::get<5>(r)
-        };
-        amrex::ParallelDescriptor::ReduceRealMax(xyz_max.data(), xyz_max.size());
-
-        return {xyz_min[0], xyz_min[1], xyz_min[2], xyz_max[0], xyz_max[1], xyz_max[2]};
+        return ablastr::particles::MinAndMaxPositions(*this);
     }
 
+    std::tuple<
+            amrex::ParticleReal, amrex::ParticleReal,
+            amrex::ParticleReal, amrex::ParticleReal,
+            amrex::ParticleReal, amrex::ParticleReal>
+    ImpactXParticleContainer::MeanAndStdPositions ()
+    {
+        return ablastr::particles::MeanAndStdPositions<
+            ImpactXParticleContainer, RealSoA::w
+        >(*this);
+    }
 } // namespace impactx


### PR DESCRIPTION
Move general min/max/std functions for particle containers into the ABLASTR library. Re-use from there.

Replaces #32

- [x] merge https://github.com/ECP-WarpX/WarpX/pull/2675
- [x] update commit in `cmake/dependencies/ABLASTR.cmake`