### PR TITLE
Added parsing of basic beam parameters from input file.

### DIFF
--- a/examples/input_fodo.in
+++ b/examples/input_fodo.in
@@ -1,3 +1,10 @@
+beam.npart = 10000
+beam.units = static
+beam.energy = 2.0e3
+beam.charge = 100.0e-12
+beam.particle = electron
+beam.distribution = gauss6d
+
 lattice.elements = quad1 drift1 quad2 drift2 sbend1
 
 quad1.type = quad

--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -55,6 +55,9 @@ namespace impactx
         /** Initialize the list of lattice elements */
         void initElements ();
 
+        /** Initialize the beam distribution parameters */
+        void initDist ();
+
         /** Run the main simulation loop for a number of steps
          *
          * @param num_steps number of steps to evolve

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -191,23 +191,23 @@ namespace impactx
         // Parse the beam distribution parameters
         amrex::ParmParse pp_dist("beam");
 
-        amrex::Real energy = 0.0;   //Beam kinetic energy (MeV)
+        amrex::Real energy = 0.0;  // Beam kinetic energy (MeV)
         pp_dist.get("energy", energy);
 
-        amrex::Real bunch_charge = 0.0;   //Bunch charge (C)
+        amrex::Real bunch_charge = 0.0;  // Bunch charge (C)
         pp_dist.get("charge", bunch_charge);
 
-        std:: string particle_type;  //Particle type
-        pp_dist.get("particle",particle_type);
+        std::string particle_type;  // Particle type
+        pp_dist.get("particle", particle_type);
 
-        int npart = 1;  //Number of simulation particles
+        int npart = 1;  // Number of simulation particles
         pp_dist.get("npart", npart);
 
-        std:: string unit_type;  //System of units
+        std::string unit_type;  // System of units
         pp_dist.get("units", unit_type);
 
-        std:: string distribution_type;  //Beam distribution type
-        pp_dist.get("distribution",distribution_type);
+        std::string distribution_type;  // Beam distribution type
+        pp_dist.get("distribution", distribution_type);
 
         amrex::Print() << "Beam kinetic energy (MeV): " << energy << std::endl;
         amrex::Print() << "Bunch charge (C): " << bunch_charge << std::endl;
@@ -220,7 +220,7 @@ namespace impactx
         } else if (unit_type == "dynamic") {
             amrex::Print() << "Dynamic units" << std::endl;
         } else {
-                amrex::Abort("Unknown units (static/dynamic): " + unit_type);
+            amrex::Abort("Unknown units (static/dynamic): " + unit_type);
         }
 
         amrex::Print() << "Initialized beam distribution parameters" << std::endl;

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -208,7 +208,7 @@ namespace impactx
 
         std:: string distribution_type;  //Beam distribution type
         pp_dist.get("distribution",distribution_type);
- 
+
         amrex::Print() << "Beam kinetic energy (MeV): " << energy << std::endl;
         amrex::Print() << "Bunch charge (C): " << bunch_charge << std::endl;
         amrex::Print() << "Particle type: " << particle_type << std::endl;
@@ -224,7 +224,7 @@ namespace impactx
         }
 
         amrex::Print() << "Initialized beam distribution parameters" << std::endl;
-    } 
+    }
 
 
 } // namespace impactx

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -185,4 +185,46 @@ namespace impactx
         amrex::Print() << "Initialized element list" << std::endl;
     }
 
+    void ImpactX::initDist ()
+    {
+
+        // Parse the beam distribution parameters
+        amrex::ParmParse pp_dist("beam");
+
+        amrex::Real energy = 0.0;   //Beam kinetic energy (MeV)
+        pp_dist.get("energy", energy);
+
+        amrex::Real bunch_charge = 0.0;   //Bunch charge (C)
+        pp_dist.get("charge", bunch_charge);
+
+        std:: string particle_type;  //Particle type
+        pp_dist.get("particle",particle_type);
+
+        int npart = 1;  //Number of simulation particles
+        pp_dist.get("npart", npart);
+
+        std:: string unit_type;  //System of units
+        pp_dist.get("units", unit_type);
+
+        std:: string distribution_type;  //Beam distribution type
+        pp_dist.get("distribution",distribution_type);
+ 
+        amrex::Print() << "Beam kinetic energy (MeV): " << energy << std::endl;
+        amrex::Print() << "Bunch charge (C): " << bunch_charge << std::endl;
+        amrex::Print() << "Particle type: " << particle_type << std::endl;
+        amrex::Print() << "Number of particles: " << npart << std::endl;
+        amrex::Print() << "Beam distribution type: " << distribution_type << std::endl;
+
+        if (unit_type == "static") {
+            amrex::Print() << "Static units" << std::endl;
+        } else if (unit_type == "dynamic") {
+            amrex::Print() << "Dynamic units" << std::endl;
+        } else {
+                amrex::Abort("Unknown units (static/dynamic): " + unit_type);
+        }
+
+        amrex::Print() << "Initialized beam distribution parameters" << std::endl;
+    } 
+
+
 } // namespace impactx


### PR DESCRIPTION
The branch "add_normalization" is a misnomer--all I did was add some necessary inputs, with the system of units as one of them.

Includes:  beam energy, bunch charge, number of particles, systems of units (static/dynamic), and distribution type.  These parameters currently exist only in "initDist", and will next need to be passed elsewhere.


## `amrex::ParmParse`

Documentation: https://amrex-codes.github.io/amrex/docs_html/Basics.html#parmparse
Location in AMReX: https://github.com/AMReX-Codes/amrex/blob/development/Src/Base/AMReX_ParmParse.H