### PR TITLE
Max Level: From AMRinfo

### DIFF
--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -112,7 +112,7 @@ namespace impactx
             {x_min-frac*(x_max-x_min), y_min-frac*(y_max-y_min), z_min-frac*(z_max-z_min)}, // Low bound
             {x_max+frac*(x_max-x_min), y_max+frac*(y_max-y_min), z_max+frac*(z_max-z_min)}); // High bound
         amrex::Geometry::ResetDefaultProbDomain(rb);
-        for (int lev = 0; lev <= max_level; ++lev) {
+        for (int lev = 0; lev <= this->max_level; ++lev) {
             amrex::Geometry g = Geom(lev);
             g.ProbDomain(rb);
             amrex::AmrMesh::SetGeometry(lev, g);

--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -89,7 +89,7 @@ namespace detail
         using namespace amrex::literals; // for _rt and _prt
 
         // loop over refinement levels
-        int const nLevel = 1;
+        int const nLevel = pc.maxLevel();
         for (int lev = 0; lev < nLevel; ++lev)
         {
             // get simulation geometry information


### PR DESCRIPTION
The AMRcore (AMRinfo) and particle containers store the maximum level. Remove some hard-coding to the maximum level being zero for now.

This is just cleaning, no new functionality added.