### PR TITLE
Doxygen: include `static` functions

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -454,7 +454,7 @@ EXTRACT_PACKAGE        = NO
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO,


### PR DESCRIPTION
We use this for ODR-friendly specifications of public functions.

https://stackoverflow.com/a/22103109

Same as https://github.com/ECP-WarpX/WarpX/pull/2701