### PR TITLE
Turn-off Poisson solver if there is only 1 macroparticle (or less)

### DIFF
--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -139,8 +139,9 @@ namespace impactx
             // Note: The following operation assume that
             // the particles are in x, y, z coordinates.
             // Resize the mesh, based on `m_particle_container` extent
-            //   TODO: this is broken (fails in Debug mode)
-            //ResizeMesh();
+            if (m_particle_container.TotalNumberOfParticles(false,false) > 0) {
+                ResizeMesh();
+            }
 
             // Redistribute particles in the new mesh in x, y, z
             //m_particle_container->Redistribute();  // extra overload/arguments?

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -136,21 +136,24 @@ namespace impactx
                                                      transformation::Direction::T2Z,
                                                      pzd);
 
-            // Note: The following operation assume that
-            // the particles are in x, y, z coordinates.
-            // Resize the mesh, based on `m_particle_container` extent
-            if (m_particle_container->TotalNumberOfParticles(false,false) > 0) {
+            // Space-charge calculation: turn off if there is only 1 particle
+            if (m_particle_container->TotalNumberOfParticles(false,false) > 1) {
+
+                // Note: The following operation assume that
+                // the particles are in x, y, z coordinates.
+
+                // Resize the mesh, based on `m_particle_container` extent
                 ResizeMesh();
+
+                // Redistribute particles in the new mesh in x, y, z
+                //m_particle_container->Redistribute();  // extra overload/arguments?
+
+                // charge deposition on level 0
+                //m_particle_container->DepositCharge(*m_rho.at(0));
+
+                // poisson solve in x,y,z
+                //   TODO
             }
-
-            // Redistribute particles in the new mesh in x, y, z
-            //m_particle_container->Redistribute();  // extra overload/arguments?
-
-            // charge deposition on level 0
-            //m_particle_container->DepositCharge(*m_rho.at(0));
-
-            // poisson solve in x,y,z
-            //   TODO
 
             // transform from x,y,z to x',y',t
             //    TODO: replace hard-coded values with options/parameters

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -139,7 +139,7 @@ namespace impactx
             // Note: The following operation assume that
             // the particles are in x, y, z coordinates.
             // Resize the mesh, based on `m_particle_container` extent
-            if (m_particle_container.TotalNumberOfParticles(false,false) > 0) {
+            if (m_particle_container->TotalNumberOfParticles(false,false) > 0) {
                 ResizeMesh();
             }
 


### PR DESCRIPTION
~~We should not resize the mesh when no particle is present.~~

This PR disables the Poisson solver when only one particle is present.

Fix #44