### PR TITLE
Particle Init: 1->8

### DIFF
--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -41,7 +41,14 @@ namespace impactx
         AmrCore::InitFromScratch(0.0);
         amrex::Print() << "boxArray(0) " << boxArray(0) << std::endl;;
 
-        m_particle_container->AddNParticles(0, {0.0}, {0.2}, {0.4});
+        m_particle_container->AddNParticles(0, { 0.2}, { 0.2}, { 0.0});
+        m_particle_container->AddNParticles(0, {-0.2}, { 0.2}, { 0.0});
+        m_particle_container->AddNParticles(0, { 0.2}, {-0.2}, { 0.0});
+        m_particle_container->AddNParticles(0, {-0.2}, {-0.2}, { 0.0});
+        m_particle_container->AddNParticles(0, { 0.2}, { 0.2}, { 0.4});
+        m_particle_container->AddNParticles(0, {-0.2}, { 0.2}, { 0.4});
+        m_particle_container->AddNParticles(0, { 0.2}, {-0.2}, { 0.4});
+        m_particle_container->AddNParticles(0, {-0.2}, {-0.2}, { 0.4});
         amrex::Print() << "# of particles: " << m_particle_container->TotalNumberOfParticles() << std::endl;
     }
 


### PR DESCRIPTION
Add 8 instead of 1 particle with distinct positions.
This allows us to spawn a 3D grid.

Work-around for #44 so we can continue with #30