### PR TITLE
Fix order in which min/max is extracted from ABLASTR function

### DIFF
--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -104,7 +104,7 @@ namespace impactx
 
     void ImpactX::ResizeMesh () {
         // Extract the min and max of the particle positions
-        auto const [x_min, x_max, y_min, y_max, z_min, z_max] = m_particle_container->MinAndMaxPositions();
+        auto const [x_min, y_min, z_min, x_max, y_max, z_max] = m_particle_container->MinAndMaxPositions();
         // Resize the domain size
         // The box is expanded slightly beyond the min and max of particles.
         // This controlled by the variable `frac` below.


### PR DESCRIPTION
The order in which the values are extracted need to match this line:
https://github.com/ECP-WarpX/WarpX/blob/development/Source/ablastr/particles/ParticleMoments.H#L74

Seen in #47