### PR TITLE
Docs: Clang 7+

### DIFF
--- a/docs/source/install/dependencies.rst
+++ b/docs/source/install/dependencies.rst
@@ -6,7 +6,7 @@ Dependencies
 ImpactX depends on the following popular third party software.
 Please see installation instructions below.
 
-- a mature `C++17 <https://en.wikipedia.org/wiki/C%2B%2B17>`__ compiler, e.g., GCC 7, Clang 6, NVCC 11.0, MSVC 19.15 or newer
+- a mature `C++17 <https://en.wikipedia.org/wiki/C%2B%2B17>`__ compiler, e.g., GCC 7, Clang 7, NVCC 11.0, MSVC 19.15 or newer
 - `CMake 3.15.0+ <https://cmake.org>`__
 - `Git 2.18+ <https://git-scm.com>`__
 - `AMReX <https://amrex-codes.github.io>`__: we automatically download and compile a copy


### PR DESCRIPTION
Seen in https://github.com/openPMD/openPMD-api/pull/1164 for `<variant>`, clang 6 is not to be recommended for C++17 compilation unless by expert users that know how to change the stdlib.

Thus, let's only recommend Clang 7+.

Ubuntu 18.04 (bionic/oldstable) ships clang 6 by default, but Ubuntu 20.04 (focal/stable) is already at clang 10.