### PR TITLE
Modified Push and PushSingleParticle functions to access reference

### DIFF
--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -305,6 +305,8 @@ namespace impactx
             massE = 0.510998950;
         } else if (particle_type == "proton") {
             massE = 938.27208816;
+        } else {
+            massE = 0.510998950;  // default to electron
         }
         RefPart refPart;
         refPart.x = 0.0;

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -104,9 +104,9 @@ namespace impactx
                        amrex::Vector<amrex::ParticleReal> const & py,
                        amrex::Vector<amrex::ParticleReal> const & pz);
 
-        /** Set initial reference particle attributes
+        /** Set reference particle attributes
          *
-         * @param refpart initial reference particle
+         * @param refpart reference particle
          */
         void
         SetRefParticle (RefPart const refpart);

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -107,6 +107,8 @@ namespace impactx
         void
         SetRefParticle (RefPart const refpart);
 
+        RefPart
+        CallRefParticle ();
 
         /** Compute the min and max of the particle position in each dimension
          *

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -108,7 +108,7 @@ namespace impactx
         SetRefParticle (RefPart const refpart);
 
         RefPart
-        CallRefParticle ();
+        GetRefParticle () const;
 
         /** Compute the min and max of the particle position in each dimension
          *

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -104,9 +104,17 @@ namespace impactx
                        amrex::Vector<amrex::ParticleReal> const & py,
                        amrex::Vector<amrex::ParticleReal> const & pz);
 
+        /** Set initial reference particle attributes
+         *
+         * @param refpart initial reference particle
+         */
         void
         SetRefParticle (RefPart const refpart);
 
+        /** Get reference particle attributes
+         *
+         * @returns refpart
+         */
         RefPart
         GetRefParticle () const;
 

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -99,6 +99,12 @@ namespace impactx
         m_refpart = refpart;
     }
 
+    RefPart
+    ImpactXParticleContainer::CallRefParticle ()
+    {
+        return m_refpart;
+    }
+
     std::tuple<
             amrex::ParticleReal, amrex::ParticleReal,
             amrex::ParticleReal, amrex::ParticleReal,

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -100,7 +100,7 @@ namespace impactx
     }
 
     RefPart
-    ImpactXParticleContainer::GetRefParticle ()
+    ImpactXParticleContainer::GetRefParticle () const
     {
         return m_refpart;
     }

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -100,7 +100,7 @@ namespace impactx
     }
 
     RefPart
-    ImpactXParticleContainer::CallRefParticle ()
+    ImpactXParticleContainer::GetRefParticle ()
     {
         return m_refpart;
     }

--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -73,7 +73,7 @@ namespace detail
             amrex::ParticleReal & py = m_part_py[i];
             amrex::ParticleReal & pt = m_part_pt[i];
 
-            //amrex::Print() << "Reference particle pt: " << m_ref_part.pt << std::endl;            
+            //amrex::Print() << "Reference particle pt: " << m_ref_part.pt << std::endl;
 
             // push through element;
             m_element(p, px, py, pt);
@@ -122,11 +122,11 @@ namespace detail
                 amrex::ParticleReal* const AMREX_RESTRICT part_py = soa_real[RealSoA::uy].dataPtr();
                 amrex::ParticleReal* const AMREX_RESTRICT part_pt = soa_real[RealSoA::pt].dataPtr();
                 // ...
-                
+
                 // preparing to access reference particle data: RefPart
                 RefPart ref_part;
                 ref_part = pc.CallRefParticle();
-                
+
                 // loop over all beamline elements
                 for (auto & element_variant : lattice) {
                     // here we just access the element by its respective type

--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -76,7 +76,7 @@ namespace detail
             //amrex::Print() << "Reference particle pt: " << m_ref_part.pt << std::endl;            
 
             // push through element;
-            m_element(p, px, py, pt);
+            m_element(p, px, py, pt, m_ref_part);
 
         }
 

--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -125,7 +125,7 @@ namespace detail
 
                 // preparing to access reference particle data: RefPart
                 RefPart ref_part;
-                ref_part = pc.CallRefParticle();
+                ref_part = pc.GetRefParticle();
 
                 // loop over all beamline elements
                 for (auto & element_variant : lattice) {

--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -39,6 +39,7 @@ namespace detail
          * @param part_px the array to the particle momentum (x)
          * @param part_py the array to the particle momentum (y)
          * @param part_pt the array to the particle momentum (t)
+         * @param ref_part the struct containing the reference particle
          */
         PushSingleParticle (T_Element element,
                             PType* aos_ptr,

--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -74,9 +74,7 @@ namespace detail
             amrex::ParticleReal & py = m_part_py[i];
             amrex::ParticleReal & pt = m_part_pt[i];
 
-            //amrex::Print() << "Reference particle pt: " << m_ref_part.pt << std::endl;
-
-            // push through element;
+            // push through element
             m_element(p, px, py, pt, m_ref_part);
 
         }

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -35,6 +35,7 @@ namespace impactx
          * @param px particle momentum in x
          * @param py particle momentum in y
          * @param pt particle momentum in t
+         * @param refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -19,7 +19,6 @@ namespace impactx
     struct Drift
     {
         using PType = ImpactXParticleContainer::ParticleType;
-//        using RType = ImpactXParticleContainer::RefPart;
 
         /** A drift
          *

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -51,7 +51,7 @@ namespace impactx
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = pow(pt_ref, 2)-1.0;
+            amrex::ParticleReal const betgam2 = pow(pt_ref, 2) - 1.0_prt;
 
             // advance position and momentum (drift)
             p.pos(0) = x + m_ds * px;

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -19,6 +19,7 @@ namespace impactx
     struct Drift
     {
         using PType = ImpactXParticleContainer::ParticleType;
+//        using RType = ImpactXParticleContainer::RefPart;
 
         /** A drift
          *
@@ -41,16 +42,17 @@ namespace impactx
                 PType& p,
                 amrex::ParticleReal & px,
                 amrex::ParticleReal & py,
-                amrex::ParticleReal & pt) const {
+                amrex::ParticleReal & pt,
+                RefPart const refpart) const {
 
             // access AoS data such as positions and cpu/id
             amrex::ParticleReal const x = p.pos(0);
             amrex::ParticleReal const y = p.pos(1);
             amrex::ParticleReal const t = p.pos(2);
 
-            // intermediate values (universal for all elements - needs tracking for RF elements)
-            amrex::ParticleReal const betgam = 2.0; // todo: make this an input parameter (reference energy -> reference betagam)
-            amrex::ParticleReal const betgam2 = pow(betgam, 2);
+            // access reference particle values to find beta*gamma^2
+            amrex::ParticleReal const pt_ref = refpart.pt;
+            amrex::ParticleReal const betgam2 = pow(pt_ref, 2)-1.0;            
 
             // advance position and momentum (drift)
             p.pos(0) = x + m_ds * px;

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -44,6 +44,8 @@ namespace impactx
                 amrex::ParticleReal & pt,
                 RefPart const refpart) const {
 
+            using namespace amrex::literals; // for _rt and _prt
+
             // access AoS data such as positions and cpu/id
             amrex::ParticleReal const x = p.pos(0);
             amrex::ParticleReal const y = p.pos(1);

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -51,7 +51,7 @@ namespace impactx
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = pow(pt_ref, 2)-1.0;            
+            amrex::ParticleReal const betgam2 = pow(pt_ref, 2)-1.0;
 
             // advance position and momentum (drift)
             p.pos(0) = x + m_ds * px;

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -45,6 +45,8 @@ namespace impactx
                 amrex::ParticleReal & pt,
                 RefPart const refpart) const {
 
+            using namespace amrex::literals; // for _rt and _prt
+
             // access AoS data such as positions and cpu/id
             amrex::ParticleReal const x = p.pos(0);
             amrex::ParticleReal const y = p.pos(1);

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -36,6 +36,7 @@ namespace impactx
          * @param px particle momentum in x
          * @param py particle momentum in y
          * @param pt particle momentum in t
+         * @param refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -42,16 +42,17 @@ namespace impactx
                 PType& p,
                 amrex::ParticleReal & px,
                 amrex::ParticleReal & py,
-                amrex::ParticleReal & pt) const {
+                amrex::ParticleReal & pt,
+                RefPart const refpart) const {
 
             // access AoS data such as positions and cpu/id
             amrex::ParticleReal const x = p.pos(0);
             amrex::ParticleReal const y = p.pos(1);
             amrex::ParticleReal const t = p.pos(2);
 
-            // intermediate values (universal for all elements - needs tracking for RF elements)
-            amrex::ParticleReal const betgam = 2.0; // todo: make this an input parameter (reference energy -> reference betagam)
-            amrex::ParticleReal const betgam2 = pow(betgam, 2);
+            // access reference particle values to find beta*gamma^2
+            amrex::ParticleReal const pt_ref = refpart.pt;
+            amrex::ParticleReal const betgam2 = pow(pt_ref, 2)-1.0;
 
             // advance position and momentum (drift)
             p.pos(0) = cos(m_k*m_ds)*x + sin(m_k*m_ds)/m_k*px;

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -52,7 +52,7 @@ namespace impactx
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = pow(pt_ref, 2)-1.0;
+            amrex::ParticleReal const betgam2 = pow(pt_ref, 2) - 1.0_prt;
 
             // advance position and momentum (drift)
             p.pos(0) = cos(m_k*m_ds)*x + sin(m_k*m_ds)/m_k*px;

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -53,7 +53,7 @@ namespace impactx
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
             amrex::ParticleReal const betgam2 = pow(pt_ref, 2) - 1.0_prt;
-            amrex::ParticleReal const bet = sqrt(betgam2/(1.0+betgam2));
+            amrex::ParticleReal const bet = sqrt(betgam2/(1.0_prt + betgam2));
             amrex::ParticleReal const theta = m_ds/m_rc;
 
             // advance position and momentum (sector bend)

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -45,6 +45,8 @@ namespace impactx
                 amrex::ParticleReal & pt,
                 RefPart const refpart) const {
 
+            using namespace amrex::literals; // for _rt and _prt
+
             // access AoS data such as positions and cpu/id
             amrex::ParticleReal const x = p.pos(0);
             amrex::ParticleReal const y = p.pos(1);
@@ -57,13 +59,14 @@ namespace impactx
             amrex::ParticleReal const theta = m_ds/m_rc;
 
             // advance position and momentum (sector bend)
-            p.pos(0) = cos(theta)*x + m_rc*sin(theta)*px - (m_rc/bet)*(1.0-cos(theta))*pt;
+            p.pos(0) = cos(theta)*x + m_rc*sin(theta)*px 
+                     - (m_rc/bet)*(1.0_prt - cos(theta))*pt;
             px = -sin(theta)/m_rc*x + cos(theta)*px - sin(theta)/bet*pt;
 
             p.pos(1) = y + m_rc*theta*py;
             // py = py;
 
-            p.pos(2) = sin(theta)/bet*x + m_rc/bet*(1.0-cos(theta))*px + t
+            p.pos(2) = sin(theta)/bet*x + m_rc/bet*(1.0_prt - cos(theta))*px + t
                      + m_rc*(-theta+sin(theta)/(bet*bet))*pt;
             // pt = pt;
         }

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -25,7 +25,7 @@ namespace impactx
          * @param ds Segment length in m.
          * @param rc Radius of curvature in m.
          */
-        Sbend( amrex::ParticleReal const ds, amrex::ParticleReal const rc )
+        Sbend( amrex::ParticleReal const ds, amrex::ParticleReal const rc)
         : m_ds(ds), m_rc(rc)
         {
         }

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -52,7 +52,7 @@ namespace impactx
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = pow(pt_ref, 2)-1.0;
+            amrex::ParticleReal const betgam2 = pow(pt_ref, 2) - 1.0_prt;
             amrex::ParticleReal const bet = sqrt(betgam2/(1.0+betgam2));
             amrex::ParticleReal const theta = m_ds/m_rc;
 

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -36,6 +36,7 @@ namespace impactx
          * @param px particle momentum in x
          * @param py particle momentum in y
          * @param pt particle momentum in t
+         * @param refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -42,16 +42,17 @@ namespace impactx
                 PType& p,
                 amrex::ParticleReal & px,
                 amrex::ParticleReal & py,
-                amrex::ParticleReal & pt) const {
+                amrex::ParticleReal & pt,
+                RefPart const refpart) const {
 
             // access AoS data such as positions and cpu/id
             amrex::ParticleReal const x = p.pos(0);
             amrex::ParticleReal const y = p.pos(1);
             amrex::ParticleReal const t = p.pos(2);
 
-            // intermediate values (universal for all elements - needs tracking for RF elements)
-            amrex::ParticleReal const betgam = 2.0; // todo: make this an input parameter (reference energy -> reference betagam)
-            amrex::ParticleReal const betgam2 = pow(betgam, 2);
+            // access reference particle values to find beta*gamma^2
+            amrex::ParticleReal const pt_ref = refpart.pt;
+            amrex::ParticleReal const betgam2 = pow(pt_ref, 2)-1.0;
             amrex::ParticleReal const bet = sqrt(betgam2/(1.0+betgam2));
             amrex::ParticleReal const theta = m_ds/m_rc;
 

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -59,7 +59,7 @@ namespace impactx
             amrex::ParticleReal const theta = m_ds/m_rc;
 
             // advance position and momentum (sector bend)
-            p.pos(0) = cos(theta)*x + m_rc*sin(theta)*px 
+            p.pos(0) = cos(theta)*x + m_rc*sin(theta)*px
                      - (m_rc/bet)*(1.0_prt - cos(theta))*pt;
             px = -sin(theta)/m_rc*x + cos(theta)*px - sin(theta)/bet*pt;
 


### PR DESCRIPTION
Modified the Push and PushSingleParticle functions to access the reference particle data.  

Next: reference particle will be added as an argument to each element "Drift.H", etc.