### PR TITLE
Doc: Pre-Defined Particle AoS Reals

### DIFF
--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -30,9 +30,9 @@ namespace impactx
     {
         enum
         {
-            x,  ///< position in x, meters  OR  ...
-            y,  ///< position in y, meters  OR  ...
-            z,  ///< position in z, meters  OR  phase "t" in arrival time * 2pi * reference frequency, radians
+            x,  ///< position in x [m] (at fixed t OR fixed z)
+            y,  ///< position in y [m] (at fixed t OR fixed z)
+            z,  ///< position in z [m] (at fixed t) OR time-of-flight ct [m] (at fixed z)
         };
     };
 

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -19,6 +19,23 @@
 
 namespace impactx
 {
+    /** AMReX pre-defined Real attributes
+     *
+     * These are the AMReX pre-defined struct indexes for the Real attributes
+     * stored in an AoS in ImpactXParticleContainer. We document this here,
+     * because we change the meaning of these "positions" depending on the
+     * coordinate system we are currently in.
+     */
+    struct RealAoS
+    {
+        enum
+        {
+            x,  ///< position in x, meters  OR  ...
+            y,  ///< position in y, meters  OR  ...
+            z,  ///< position in z, meters  OR  phase "t" in arrival time * 2pi * reference frequency, radians
+        };
+    };
+
     /** This struct indexes the additional Real attributes
      *  stored in an SoA in ImpactXParticleContainer
      */


### PR DESCRIPTION
Add documentation on how we interpret the pre-defined AMReX "position" attributes in the Array-of-Struct (AoS) `Real` attributes of a particle.