### PR TITLE
Elements: Restrict Pointers & References

### DIFF
--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -42,10 +42,10 @@ namespace detail
          * @param ref_part the struct containing the reference particle
          */
         PushSingleParticle (T_Element element,
-                            PType* aos_ptr,
-                            amrex::ParticleReal* part_px,
-                            amrex::ParticleReal* part_py,
-                            amrex::ParticleReal* part_pt,
+                            PType* AMREX_RESTRICT aos_ptr,
+                            amrex::ParticleReal* AMREX_RESTRICT part_px,
+                            amrex::ParticleReal* AMREX_RESTRICT part_py,
+                            amrex::ParticleReal* AMREX_RESTRICT part_pt,
                             RefPart ref_part)
             : m_element(element), m_aos_ptr(aos_ptr),
               m_part_px(part_px), m_part_py(part_py), m_part_pt(part_pt),
@@ -67,12 +67,12 @@ namespace detail
         operator() (long i) const
         {
             // access AoS data such as positions and cpu/id
-            PType& p = m_aos_ptr[i];
+            PType& AMREX_RESTRICT p = m_aos_ptr[i];
 
             // access SoA Real data
-            amrex::ParticleReal & px = m_part_px[i];
-            amrex::ParticleReal & py = m_part_py[i];
-            amrex::ParticleReal & pt = m_part_pt[i];
+            amrex::ParticleReal & AMREX_RESTRICT px = m_part_px[i];
+            amrex::ParticleReal & AMREX_RESTRICT py = m_part_py[i];
+            amrex::ParticleReal & AMREX_RESTRICT pt = m_part_pt[i];
 
             // push through element
             m_element(p, px, py, pt, m_ref_part);

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -9,6 +9,7 @@
 
 #include "particles/ImpactXParticleContainer.H"
 
+#include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
@@ -39,10 +40,10 @@ namespace impactx
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                PType& p,
-                amrex::ParticleReal & px,
-                amrex::ParticleReal & py,
-                amrex::ParticleReal & pt,
+                PType& AMREX_RESTRICT p,
+                amrex::ParticleReal & AMREX_RESTRICT px,
+                amrex::ParticleReal & AMREX_RESTRICT py,
+                amrex::ParticleReal & AMREX_RESTRICT pt,
                 RefPart const refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -9,6 +9,7 @@
 
 #include "particles/ImpactXParticleContainer.H"
 
+#include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
@@ -40,10 +41,10 @@ namespace impactx
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                PType& p,
-                amrex::ParticleReal & px,
-                amrex::ParticleReal & py,
-                amrex::ParticleReal & pt,
+                PType& AMREX_RESTRICT p,
+                amrex::ParticleReal & AMREX_RESTRICT px,
+                amrex::ParticleReal & AMREX_RESTRICT py,
+                amrex::ParticleReal & AMREX_RESTRICT pt,
                 RefPart const refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -9,6 +9,7 @@
 
 #include "particles/ImpactXParticleContainer.H"
 
+#include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
@@ -40,10 +41,10 @@ namespace impactx
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                PType& p,
-                amrex::ParticleReal & px,
-                amrex::ParticleReal & py,
-                amrex::ParticleReal & pt,
+                PType& AMREX_RESTRICT p,
+                amrex::ParticleReal & AMREX_RESTRICT px,
+                amrex::ParticleReal & AMREX_RESTRICT py,
+                amrex::ParticleReal & AMREX_RESTRICT pt,
                 RefPart const refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt


### PR DESCRIPTION
Explicitly declare that AoS and SoA arguments do not alias each other when passed into beamline elements. This allows the compiler to optimize more, as we guarantee that these are unique memory addresses.

- [x] rebase after #56 was merged

Minimal example:
- https://godbolt.org/z/vofejGsK8