### PR TITLE
Move Diags Between Runs

### DIFF
--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -301,9 +301,9 @@ namespace impactx
                   px.push_back(ipx);
                   py.push_back(ipy);
                   pt.push_back(ipt);
-                  amrex::PrintToFile("diags/initial_beam.txt") << ix << " " << iy << " ";
-                  amrex::PrintToFile("diags/initial_beam.txt") << it << " " << ipx << " ";
-                  amrex::PrintToFile("diags/initial_beam.txt") << ipy << " " << ipt << "\n";
+                  amrex::PrintToFile("diags/initial_beam.txt")
+                      << ix << " " << iy << " " << it << " "
+                      << ipx << " " << ipy << " " << ipt << "\n";
               }
           }
 

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -15,6 +15,7 @@
 #include <AMReX_REAL.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_Print.H>
+#include <AMReX_Utility.H>
 
 #include <string>
 #include <vector>
@@ -42,6 +43,9 @@ namespace impactx
     {
         AmrCore::InitFromScratch(0.0);
         amrex::Print() << "boxArray(0) " << boxArray(0) << std::endl;
+
+        // move old diagnostics out of the way
+        amrex::UtilCreateCleanDirectory("diags", true);
 
         this->initDist();
         amrex::Print() << "# of particles: " << m_particle_container->TotalNumberOfParticles() << std::endl;
@@ -286,7 +290,7 @@ namespace impactx
               pt.reserve(npart);
 
               // write file header
-              amrex::PrintToFile("initial_beam.txt") << "#x y t px py pt\n";
+              amrex::PrintToFile("diags/initial_beam.txt") << "#x y t px py pt\n";
 
               for(amrex::Long i = 0; i < npart; ++i) {
 
@@ -297,9 +301,9 @@ namespace impactx
                   px.push_back(ipx);
                   py.push_back(ipy);
                   pt.push_back(ipt);
-                  amrex::PrintToFile("initial_beam.txt") << ix << " " << iy << " ";
-                  amrex::PrintToFile("initial_beam.txt") << it << " " << ipx << " ";
-                  amrex::PrintToFile("initial_beam.txt") << ipy << " " << ipt << "\n";
+                  amrex::PrintToFile("diags/initial_beam.txt") << ix << " " << iy << " ";
+                  amrex::PrintToFile("diags/initial_beam.txt") << it << " " << ipx << " ";
+                  amrex::PrintToFile("diags/initial_beam.txt") << ipy << " " << ipt << "\n";
               }
           }
 

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -25,7 +25,7 @@ namespace impactx::diagnostics
         tmp.copyParticles(pc, local);
 
         // write file header
-        amrex::PrintToFile("output_beam.txt") << "#x y t px py pt\n";
+        amrex::PrintToFile("diags/output_beam.txt") << "#x y t px py pt\n";
 
         // loop over refinement levels
         int const nLevel = tmp.maxLevel() + 1;
@@ -64,9 +64,9 @@ namespace impactx::diagnostics
                         amrex::ParticleReal const pt = part_pt[i];
 
                         // write particle data to file
-                        amrex::PrintToFile("output_beam.txt") << x << " " << y << " ";
-                        amrex::PrintToFile("output_beam.txt") << t << " " << px << " ";
-                        amrex::PrintToFile("output_beam.txt") << py << " " << pt << "\n";
+                        amrex::PrintToFile("diags/output_beam.txt") << x << " " << y << " ";
+                        amrex::PrintToFile("diags/output_beam.txt") << t << " " << px << " ";
+                        amrex::PrintToFile("diags/output_beam.txt") << py << " " << pt << "\n";
                     } // i=0...np
                 } // if( otype == OutputType::PrintParticles)
             } // end loop over all particle boxes

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -64,9 +64,9 @@ namespace impactx::diagnostics
                         amrex::ParticleReal const pt = part_pt[i];
 
                         // write particle data to file
-                        amrex::PrintToFile("diags/output_beam.txt") << x << " " << y << " ";
-                        amrex::PrintToFile("diags/output_beam.txt") << t << " " << px << " ";
-                        amrex::PrintToFile("diags/output_beam.txt") << py << " " << pt << "\n";
+                        amrex::PrintToFile("diags/output_beam.txt")
+                            << x << " " << y << " "<< t << " "
+                            << px << " " << py << " " << pt << "\n";
                     } // i=0...np
                 } // if( otype == OutputType::PrintParticles)
             } // end loop over all particle boxes


### PR DESCRIPTION
Create diagnostics in `diags/`.
Move when starting a new run to a backup name.

This avoids that we simply append to a previous run, which would be confusing during debugging and benchmarking.

Follow-up to #62