### PR TITLE
Moved reference particle access inside "CoordinateTransformation".

### DIFF
--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -160,11 +160,8 @@ namespace impactx
             amrex::Print() << " ++++ Starting step=" << step << "\n";
 
             // transform from x',y',t to x,y,z
-            //    TODO: replace hard-coded values with options/parameters
-            amrex::ParticleReal const pzd = 5.0;  // Design value of pz/mc = beta*gamma
             transformation::CoordinateTransformation(*m_particle_container,
-                                                     transformation::Direction::T2Z,
-                                                     pzd);
+                                                     transformation::Direction::T2Z);
 
             // Space-charge calculation: turn off if there is only 1 particle
             if (m_particle_container->TotalNumberOfParticles(false,false) > 1) {
@@ -190,11 +187,8 @@ namespace impactx
             }
 
             // transform from x,y,z to x',y',t
-            //    TODO: replace hard-coded values with options/parameters
-            amrex::ParticleReal const ptd = 5.0;  // Design value of pt/mc2 = -gamma.
             transformation::CoordinateTransformation(*m_particle_container,
-                                                     transformation::Direction::Z2T,
-                                                     ptd);
+                                                     transformation::Direction::Z2T);
 
             // for later: original Impact implementation as an option
             // Redistribute particles in x',y',t

--- a/src/particles/transformation/CoordinateTransformation.H
+++ b/src/particles/transformation/CoordinateTransformation.H
@@ -26,12 +26,9 @@ namespace transformation
      *
      * @param pc container of the particles to push
      * @param direction the direction (Z to T or vice versa)
-     * @param pd design value of pz/mc = beta*gamma (for T2Z) or design value
-     *           of pt/mc2 = -gamma (Z2T)
      */
     void CoordinateTransformation(ImpactXParticleContainer &pc,
-                                  Direction const & direction,
-                                  amrex::ParticleReal const pd);
+                                  Direction const & direction);
 
 } // namespace transformation
 } // namespace impactx

--- a/src/particles/transformation/CoordinateTransformation.cpp
+++ b/src/particles/transformation/CoordinateTransformation.cpp
@@ -12,6 +12,8 @@
 #include <AMReX_Extension.H>  // for AMREX_RESTRICT
 #include <AMReX_REAL.H>       // for ParticleReal
 
+#include <cmath>
+
 
 namespace impactx
 {
@@ -21,10 +23,8 @@ namespace transformation {
         using namespace amrex::literals; // for _rt and _prt
 
         // preparing to access reference particle data: RefPart
-        RefPart ref_part;
-        ref_part = pc.GetRefParticle();
+        RefPart ref_part = pc.GetRefParticle();
         amrex::ParticleReal const pd = ref_part.pt;  // Design value of pt/mc2 = -gamma
-        amrex::Print() << "Ref pt = " << pd;
 
         // loop over refinement levels
         int const nLevel = pc.maxLevel();
@@ -45,9 +45,10 @@ namespace transformation {
                 amrex::ParticleReal *const AMREX_RESTRICT part_py = soa_real[RealSoA::uy].dataPtr();
                 amrex::ParticleReal *const AMREX_RESTRICT part_pt = soa_real[RealSoA::pt].dataPtr();
 
-
                 if( direction == Direction::T2Z) {
-                    amrex::ParticleReal const pzd = sqrt(pow(pd,2)-1.0);  // Design value of pz/mc = beta*gamma
+                    // Design value of pz/mc = beta*gamma
+                    amrex::ParticleReal const pzd = sqrt(pow(pd, 2) - 1.0);
+
                     T2Z t2z(pzd);
                     amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE(long i) {
                         // access AoS data such as positions and cpu/id
@@ -57,7 +58,6 @@ namespace transformation {
                         amrex::ParticleReal &px = part_px[i];
                         amrex::ParticleReal &py = part_py[i];
                         amrex::ParticleReal &pt = part_pt[i];
-
 
                         t2z(p, px, py, pt);
                     });

--- a/src/particles/transformation/CoordinateTransformation.cpp
+++ b/src/particles/transformation/CoordinateTransformation.cpp
@@ -23,7 +23,7 @@ namespace transformation {
         // preparing to access reference particle data: RefPart
         RefPart ref_part;
         ref_part = pc.GetRefParticle();
-        amrex::ParticleReal const pd = ref_part.pt;  // Design value of pt/mc2 = -gamma  
+        amrex::ParticleReal const pd = ref_part.pt;  // Design value of pt/mc2 = -gamma
         amrex::Print() << "Ref pt = " << pd;
 
         // loop over refinement levels


### PR DESCRIPTION
This removes hard-coded values for ptd, pzd that were previously used.