### PR TITLE
Changes to allow benchmark of matched zero-current FODO lattice.

### DIFF
--- a/examples/input_fodo.in
+++ b/examples/input_fodo.in
@@ -1,46 +1,45 @@
 ###############################################################################
 # Particle Beam(s)
 ###############################################################################
-beam.npart = 10000
+beam.npart = 100000
 beam.units = static
 beam.energy = 2.0e3
-beam.charge = 100.0e-12
+beam.charge = 0.0
 beam.particle = electron
 beam.distribution = waterbag
-beam.sigmaX = 1.0e-6
-beam.sigmaY = 1.0e-6
-beam.sigmaT = 1.0e-6
-beam.sigmaPx = 0.0
-beam.sigmaPy = 0.0
-beam.sigmaPt = 0.0
-beam.muxpx = 0.0
-beam.muypy = 0.0
+beam.sigmaX = 3.9984884770e-5
+beam.sigmaY = 3.9984884770e-5
+beam.sigmaT = 1.0e-3
+beam.sigmaPx = 2.6623538760e-5
+beam.sigmaPy = 2.6623538760e-5
+beam.sigmaPt = 2.0e-3
+beam.muxpx = -0.846574929020762
+beam.muypy = 0.846574929020762
 beam.mutpt = 0.0
 
 
 ###############################################################################
 # Beamline: lattice elements and segments
 ###############################################################################
-lattice.elements = quad1 drift1 quad2 drift2 sbend1
+
+lattice.elements = drift1 quad1 drift2 quad2 drift3
+
+drift1.type = drift
+drift1.ds = 0.25
 
 quad1.type = quad
 quad1.ds = 1.0
-quad1.k = 4.0
-
-drift1.type = drift
-drift1.ds = 0.5
-
-quad2.type = quad
-quad2.ds = 1.0
-quad2.k = 4.0
+quad1.k = 1.0
 
 drift2.type = drift
 drift2.ds = 0.5
 
-sbend1.type = sbend
-sbend1.ds = 0.5
-sbend1.rc = 2.0
+quad2.type = quad
+quad2.ds = 1.0
+quad2.k = -1.0
 
+drift3.type = drift
+drift3.ds = 0.25
 
 ###############################################################################
 # Algorithms

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char* argv[])
 
         impactX->initData();
         impactX->initElements();
-        impactX->evolve( /* num_steps = */ 10);
+        impactX->evolve( /* num_steps = */ 1);
 
         BL_PROFILE_VAR_STOP(pmain);
     }

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -24,7 +24,10 @@ namespace impactx
         /** A Quadrupole magnet
          *
          * @param ds Segment length in m.
-         * @param k  quadrupole strength in 1/m
+         * @param k  Quadrupole strength in m^(-2) (MADX convention)
+         *           = (gradient in T/m) / (rigidity in T-m)
+         *           k > 0 horizontal focusing
+         *           k < 0 horizontal defocusing
          */
         Quad( amrex::ParticleReal const ds, amrex::ParticleReal const k )
         : m_ds(ds), m_k(k)
@@ -58,6 +61,7 @@ namespace impactx
             amrex::ParticleReal const pt_ref = refpart.pt;
             amrex::ParticleReal const betgam2 = pow(pt_ref, 2) - 1.0_prt;
 
+            // compute phase advance per unit length in s (in rad/m)
             amrex::ParticleReal const omega = sqrt(abs(m_k));
 
             if(m_k > 0.0) {     

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -58,17 +58,29 @@ namespace impactx
             amrex::ParticleReal const pt_ref = refpart.pt;
             amrex::ParticleReal const betgam2 = pow(pt_ref, 2) - 1.0_prt;
 
-            // advance position and momentum (drift)
-            p.pos(0) = cos(m_k*m_ds)*x + sin(m_k*m_ds)/m_k*px;
-            // px = px;
-            px = -m_k*sin(m_k*m_ds)*x + cos(m_k*m_ds)*px;
+            amrex::ParticleReal const omega = sqrt(abs(m_k));
 
-            p.pos(1) = cosh(m_k*m_ds)*y + sinh(m_k*m_ds)/m_k*py;
-            py = m_k*sinh(m_k*m_ds)*y + cosh(m_k*m_ds)*py;
+            if(m_k > 0.0) {     
+               // advance position and momentum (focusing quad)
+               p.pos(0) = cos(omega*m_ds)*x + sin(omega*m_ds)/omega*px;
+               px = -omega*sin(omega*m_ds)*x + cos(omega*m_ds)*px;
 
-            p.pos(2) = t + (m_ds/betgam2)*pt;
-            // pt = pt;
+               p.pos(1) = cosh(omega*m_ds)*y + sinh(omega*m_ds)/omega*py;
+               py = omega*sinh(omega*m_ds)*y + cosh(omega*m_ds)*py;
 
+               p.pos(2) = t + (m_ds/betgam2)*pt;
+               // pt = pt;
+            } else {
+               // advance position and momentum (defocusing quad)
+               p.pos(0) = cosh(omega*m_ds)*x + sinh(omega*m_ds)/omega*px;
+               px = omega*sinh(omega*m_ds)*x + cosh(omega*m_ds)*px;
+
+               p.pos(1) = cos(omega*m_ds)*y + sin(omega*m_ds)/omega*py;
+               py = -omega*sin(omega*m_ds)*y + cos(omega*m_ds)*py;
+
+               p.pos(2) = t + (m_ds/betgam2)*pt;
+               // pt = pt;
+            }
         }
 
     private:

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -60,7 +60,7 @@ namespace impactx
 
             amrex::ParticleReal const omega = sqrt(abs(m_k));
 
-            if(m_k > 0.0) {     
+            if(m_k > 0.0) {
                // advance position and momentum (focusing quad)
                p.pos(0) = cos(omega*m_ds)*x + sin(omega*m_ds)/omega*px;
                px = -omega*sin(omega*m_ds)*x + cos(omega*m_ds)*px;


### PR DESCRIPTION
1) Modified call to "evolve" to use 1 step only.
(Currently setting this to > 1 leads to iteration of the map.)

2) Modified "Quad" element to correctly handle the defocusing case,
and changed the definition of the input parameter.

3) Modified "input_fodo.in" as follows:
   a) set beam current/charge to zero
   b) change quad settings to ensure stability
   c) change beam parameters to produce a matched beam
   d) change number of particles to 100K to give good moments

The second moments of the input and output beam should be equal.