### PR TITLE
CI: ccache

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -25,7 +25,18 @@ jobs:
       run: |
         .github/workflows/dependencies/nvcc11.sh
 
-    - name: build WarpX
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.cache/ccache
+        key: ccache-cuda-nvcc-${{ hashFiles('.github/workflows/cuda.yml') }}-${{ hashFiles('cmake/dependencies/ABLASTR.cmake') }}
+        restore-keys: |
+          ccache-cuda-nvcc-${{ hashFiles('.github/workflows/cuda.yml') }}-
+          ccache-cuda-nvcc-
+
+    - name: build ImpactX
       run: |
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
         export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}

--- a/.github/workflows/dependencies/gcc.sh
+++ b/.github/workflows/dependencies/gcc.sh
@@ -11,6 +11,7 @@ sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \
     ca-certificates     \
+    ccache              \
     cmake               \
     gnupg               \
     libopenmpi-dev      \

--- a/.github/workflows/dependencies/hip.sh
+++ b/.github/workflows/dependencies/hip.sh
@@ -26,8 +26,10 @@ sudo apt-get update
 sudo apt-get install -y --no-install-recommends \
     build-essential \
     gfortran        \
+    libhiredis-dev  \
     libnuma-dev     \
     libopenmpi-dev  \
+    libzstd-dev     \
     ninja-build     \
     openmpi-bin     \
     rocm-dev        \
@@ -47,3 +49,13 @@ which clang++
 sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY
 sudo chmod a+x /usr/local/bin/cmake-easyinstall
 export CEI_SUDO="sudo"
+export CEI_TMP="/tmp/cei"
+
+# ccache 4.2+
+#
+CXXFLAGS="" cmake-easyinstall --prefix=/usr/local \
+    git+https://github.com/ccache/ccache.git@v4.6 \
+    -DCMAKE_BUILD_TYPE=Release        \
+    -DENABLE_DOCUMENTATION=OFF        \
+    -DENABLE_TESTING=OFF              \
+    -DWARNINGS_AS_ERRORS=OFF

--- a/.github/workflows/dependencies/nvcc11.sh
+++ b/.github/workflows/dependencies/nvcc11.sh
@@ -13,7 +13,9 @@ sudo apt-get install -y \
     ca-certificates     \
     cmake               \
     gnupg               \
+    libhiredis-dev      \
     libopenmpi-dev      \
+    libzstd-dev         \
     ninja-build         \
     openmpi-bin         \
     pkg-config          \
@@ -40,3 +42,14 @@ sudo ln -s cuda-11.0 /usr/local/cuda
 #
 sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY
 sudo chmod a+x /usr/local/bin/cmake-easyinstall
+export CEI_SUDO="sudo"
+export CEI_TMP="/tmp/cei"
+
+# ccache 4.2+
+#
+CXXFLAGS="" cmake-easyinstall --prefix=/usr/local \
+    git+https://github.com/ccache/ccache.git@v4.6 \
+    -DCMAKE_BUILD_TYPE=Release        \
+    -DENABLE_DOCUMENTATION=OFF        \
+    -DENABLE_TESTING=OFF              \
+    -DWARNINGS_AS_ERRORS=OFF

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -16,9 +16,22 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
+
     - name: install dependencies
       shell: bash
       run: .github/workflows/dependencies/hip.sh
+
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.cache/ccache
+        key: ccache-hip-clang-${{ hashFiles('.github/workflows/hip.yml') }}-${{ hashFiles('cmake/dependencies/ABLASTR.cmake') }}
+        restore-keys: |
+          ccache-hip-clang-${{ hashFiles('.github/workflows/hip.yml') }}-
+          ccache-hip-clang-
+
     - name: build ImpactX
       shell: bash
       run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,12 +13,26 @@ jobs:
     if: github.event.pull_request.draft == false
     env:
       CMAKE_GENERATOR: Ninja
-    #  CXXFLAGS: "-Werror"
+      CXXFLAGS: "-Werror"
+      OMP_NUM_THREADS: 2
     steps:
     - uses: actions/checkout@v2
+
     - name: install dependencies
       run: |
         .github/workflows/dependencies/gcc.sh
+
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: ~/.ccache
+        key: ccache-openmp-gcc-${{ hashFiles('.github/workflows/ubuntu.yml') }}-${{ hashFiles('cmake/dependencies/ABLASTR.cmake') }}
+        restore-keys: |
+          ccache-openmp-gcc-${{ hashFiles('.github/workflows/ubuntu.yml') }}-
+          ccache-openmp-gcc-
+
     - name: build ImpactX
       run: |
         cmake -S . -B build            \
@@ -28,8 +42,6 @@ jobs:
 
     - name: run ImpactX
       run: |
-        export OMP_NUM_THREADS=2
-
         build/bin/impactx examples/input_fodo.in algo.particle_shape = 1 || \
         { cat Backtrace.0.0; exit 1; }
         build/bin/impactx examples/input_fodo.in algo.particle_shape = 2 || \


### PR DESCRIPTION
Speed up CI builds by caching individual object files with `ccache` between runs.