### PR TITLE
Made changes needed to include a chicane benchmark.

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -124,6 +124,18 @@ Lattice Elements
 
             * ``<element_name>.rc`` (``float``, in meters) the bend radius
 
+        * ``dipedge`` for dipole edge focusing. This requires these additional parameters:
+
+            * ``<element_name>.psi`` (``float``, in radians) the pole face
+              rotation angle
+
+            * ``<element_name>.rc`` (``float``, in meters) the bend radius
+
+            * ``<element_name>.g`` (``float``, in meters) the gap size
+
+            * ``<element_name>.K2`` (``float``, dimensionless) normalized
+              field integral for fringe field
+
 .. _running-cpp-parameters-parallelization:
 
 Distribution across MPI ranks and parallelization

--- a/examples/input_chicane.in
+++ b/examples/input_chicane.in
@@ -1,0 +1,64 @@
+###############################################################################
+# Particle Beam(s)
+###############################################################################
+beam.npart = 10000
+beam.units = static
+beam.energy = 5.0e3
+beam.charge = 0.0
+beam.particle = electron
+beam.distribution = waterbag
+beam.sigmaX = 2.2951017632e-5
+beam.sigmaY = 1.3084093142e-5
+#beam.sigmaT = 5.5555553e-8
+beam.sigmaT = 6.00800897618671048624845e-8
+beam.sigmaPx = 1.598353425e-6
+beam.sigmaPy = 2.803697378e-6
+#beam.sigmaPt = 2.000000000e-6
+beam.sigmaPt = 2.1628993476497387730437553e-6
+beam.muxpx = 0.933345606203060
+beam.muypy = 0.933345606203060
+#beam.mutpt = 0.999999961419755
+beam.mutpt = 0.999999954815784
+
+
+###############################################################################
+# Beamline: lattice elements and segments
+###############################################################################
+
+lattice.elements = sbend1 dipedge1 drift1 dipedge2 sbend2 drift2 sbend2
+                   dipedge2 drift1 dipedge1 sbend1 drift3
+
+sbend1.type = sbend
+sbend1.ds = 0.50037       #projected length 0.5 m, angle 2.77 deg
+sbend1.rc = -10.35
+
+drift1.type = drift
+drift1.ds = 5.0058489435  #projected length 5 m
+
+sbend2.type = sbend
+sbend2.ds = 0.50037       #projected length 0.5 m, angle 2.77 deg
+sbend2.rc = 10.35
+
+drift2.type = drift
+drift2.ds = 1.0
+
+drift3.type = drift
+drift3.ds = 2.0
+
+dipedge1.type = dipedge   #dipole edge focusing
+dipedge1.psi = -0.048345620280243 
+dipedge1.rc = -10.35
+dipedge1.g = 0.0
+dipedge1.K2 = 0.0
+
+dipedge2.type = dipedge
+dipedge2.psi = 0.048345620280243 
+dipedge2.rc = 10.35
+dipedge2.g = 0.0
+dipedge2.K2 = 0.0
+
+
+###############################################################################
+# Algorithms
+###############################################################################
+algo.particle_shape = 2

--- a/examples/input_chicane.in
+++ b/examples/input_chicane.in
@@ -29,14 +29,14 @@ lattice.elements = sbend1 dipedge1 drift1 dipedge2 sbend2 drift2 sbend2
                    dipedge2 drift1 dipedge1 sbend1 drift3
 
 sbend1.type = sbend
-sbend1.ds = 0.50037       #projected length 0.5 m, angle 2.77 deg
+sbend1.ds = 0.50037       # projected length 0.5 m, angle 2.77 deg
 sbend1.rc = -10.35
 
 drift1.type = drift
-drift1.ds = 5.0058489435  #projected length 5 m
+drift1.ds = 5.0058489435  # projected length 5 m
 
 sbend2.type = sbend
-sbend2.ds = 0.50037       #projected length 0.5 m, angle 2.77 deg
+sbend2.ds = 0.50037       # projected length 0.5 m, angle 2.77 deg
 sbend2.rc = 10.35
 
 drift2.type = drift
@@ -45,7 +45,7 @@ drift2.ds = 1.0
 drift3.type = drift
 drift3.ds = 2.0
 
-dipedge1.type = dipedge   #dipole edge focusing
+dipedge1.type = dipedge   # dipole edge focusing
 dipedge1.psi = -0.048345620280243
 dipedge1.rc = -10.35
 dipedge1.g = 0.0

--- a/examples/input_chicane.in
+++ b/examples/input_chicane.in
@@ -46,13 +46,13 @@ drift3.type = drift
 drift3.ds = 2.0
 
 dipedge1.type = dipedge   #dipole edge focusing
-dipedge1.psi = -0.048345620280243 
+dipedge1.psi = -0.048345620280243
 dipedge1.rc = -10.35
 dipedge1.g = 0.0
 dipedge1.K2 = 0.0
 
 dipedge2.type = dipedge
-dipedge2.psi = 0.048345620280243 
+dipedge2.psi = 0.048345620280243
 dipedge2.rc = 10.35
 dipedge2.g = 0.0
 dipedge2.K2 = 0.0

--- a/examples/input_chicane.in
+++ b/examples/input_chicane.in
@@ -9,16 +9,13 @@ beam.particle = electron
 beam.distribution = waterbag
 beam.sigmaX = 2.2951017632e-5
 beam.sigmaY = 1.3084093142e-5
-#beam.sigmaT = 5.5555553e-8
-beam.sigmaT = 6.00800897618671048624845e-8
+beam.sigmaT = 5.5555553e-8
 beam.sigmaPx = 1.598353425e-6
 beam.sigmaPy = 2.803697378e-6
-#beam.sigmaPt = 2.000000000e-6
-beam.sigmaPt = 2.1628993476497387730437553e-6
+beam.sigmaPt = 2.000000000e-6
 beam.muxpx = 0.933345606203060
 beam.muypy = 0.933345606203060
-#beam.mutpt = 0.999999961419755
-beam.mutpt = 0.999999954815784
+beam.mutpt = 0.999999961419755
 
 
 ###############################################################################

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -245,6 +245,13 @@ namespace impactx
                 pp_element.get("ds", ds);
                 pp_element.get("rc", rc);
                 m_lattice.emplace_back( Sbend(ds, rc) );
+            } else if (element_type == "dipedge") {
+                amrex::Real psi, rc, g, K2;
+                pp_element.get("psi", psi);
+                pp_element.get("rc", rc);
+                pp_element.get("g", g);
+                pp_element.get("K2", K2);
+                m_lattice.emplace_back( DipEdge(psi, rc, g, K2) );
             } else {
                 amrex::Abort("Unknown type for lattice element " + element_name + ": " + element_type);
             }

--- a/src/particles/elements/All.H
+++ b/src/particles/elements/All.H
@@ -10,13 +10,14 @@
 #include "Drift.H"
 #include "Sbend.H"
 #include "Quad.H"
+#include "DipEdge.H"
 
 #include <variant>
 
 
 namespace impactx
 {
-    using KnownElements = std::variant<Drift, Sbend, Quad>;
+    using KnownElements = std::variant<Drift, Sbend, Quad, DipEdge>;
 
 } // namespace impactx
 

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -66,8 +66,8 @@ namespace impactx
 
             // first-order effect of nonzero gap
             vf = (1.0_prt + pow(sin(m_psi),2))/(pow(cos(m_psi),3));
-            vf = vf * m_g * m_K2/(pow(m_rc,2));
-            R43 = R43 + vf;
+            vf *= m_g * m_K2/(pow(m_rc,2));
+            R43 += vf;
 
             // apply edge focusing
             px = px + R21*x;

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -40,7 +40,7 @@ namespace impactx
          * @param p Particle AoS data for positions and cpu/id
          * @param px particle momentum in x
          * @param py particle momentum in y
-         * @param pt particle momentum in t
+         * @param pt particle momentum in t (unchanged)
          * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -29,7 +29,7 @@ namespace impactx
          * @param K2 Fringe field integral (unitless).
          */
         DipEdge( amrex::ParticleReal const psi, amrex::ParticleReal const rc, amrex::ParticleReal const
-		g, amrex::ParticleReal const K2)
+        g, amrex::ParticleReal const K2)
         : m_psi(psi), m_rc(rc), m_g(g), m_K2(K2)
         {
         }

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -1,0 +1,88 @@
+/* Copyright 2021 Chad Mitchell, Axel Huebl
+ *
+ * This file is part of ImpactX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_DIPEDGE_H
+#define IMPACTX_DIPEDGE_H
+
+#include "particles/ImpactXParticleContainer.H"
+
+#include <AMReX_Extension.H>
+#include <AMReX_REAL.H>
+
+#include <cmath>
+
+
+namespace impactx
+{
+    struct DipEdge
+    {
+        using PType = ImpactXParticleContainer::ParticleType;
+
+        /** Edge focusing associated with bend entry or exit
+         *
+         * @param psi Pole face angle in rad.
+         * @param rc Radius of curvature in m.
+         * @param g Gap parameter in m.
+         * @param K2 Fringe field integral (unitless).
+         */
+        DipEdge( amrex::ParticleReal const psi, amrex::ParticleReal const rc, amrex::ParticleReal const
+		g, amrex::ParticleReal const K2)
+        : m_psi(psi), m_rc(rc), m_g(g), m_K2(K2)
+        {
+        }
+
+        /** This is a dipedge functor, so that a variable of this type can be used like a
+         *  dipedge function.
+         *
+         * @param p Particle AoS data for positions and cpu/id
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param refpart reference particle
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void operator() (
+                PType& AMREX_RESTRICT p,
+                amrex::ParticleReal & AMREX_RESTRICT px,
+                amrex::ParticleReal & AMREX_RESTRICT py,
+                amrex::ParticleReal & AMREX_RESTRICT pt,
+                RefPart const refpart) const {
+
+            using namespace amrex::literals; // for _rt and _prt
+
+            // access AoS data such as positions and cpu/id
+            amrex::ParticleReal const x = p.pos(0);
+            amrex::ParticleReal const y = p.pos(1);
+            amrex::ParticleReal const t = p.pos(2);
+
+            // access reference particle values if needed
+
+            // edge focusing matrix elements (zero gap)
+            amrex::ParticleReal R21 = tan(m_psi)/m_rc;
+            amrex::ParticleReal R43 = -tan(m_psi)/m_rc;
+            amrex::ParticleReal vf = 0;
+
+            // first-order effect of nonzero gap
+            vf = (1.0_prt + pow(sin(m_psi),2))/(pow(cos(m_psi),3));
+            vf = vf * m_g * m_K2/(pow(m_rc,2));
+            R43 = R43 + vf;
+
+            // apply edge focusing
+            px = px + R21*x;
+            py = py + R43*y;
+
+        }
+
+    private:
+        amrex::ParticleReal m_psi; //! pole face angle in rad
+        amrex::ParticleReal m_rc; //! bend radius in m
+        amrex::ParticleReal m_g; //! gap parameter in m
+        amrex::ParticleReal m_K2; //! fringe field integral
+    };
+
+} // namespace impactx
+
+#endif // IMPACTX_DIPEDGE_H

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -23,6 +23,13 @@ namespace impactx
 
         /** Edge focusing associated with bend entry or exit
          *
+         * This model assumes a first-order effect of nonzero gap.
+         * Here we use the linear fringe field map, given to first order in g/rc (gap / radius of curvature).
+         *
+         * References:
+         *   K. L. Brown, SLAC Report No. 75 (1982).
+         *   K. Hwang and S. Y. Lee, PRAB 18, 122401 (2015).
+         *
          * @param psi Pole face angle in rad.
          * @param rc Radius of curvature in m.
          * @param g Gap parameter in m.
@@ -60,8 +67,8 @@ namespace impactx
             // access reference particle values if needed
 
             // edge focusing matrix elements (zero gap)
-            amrex::ParticleReal R21 = tan(m_psi)/m_rc;
-            amrex::ParticleReal R43 = -tan(m_psi)/m_rc;
+            amrex::ParticleReal const R21 = tan(m_psi)/m_rc;
+            amrex::ParticleReal R43 = -R21;
             amrex::ParticleReal vf = 0;
 
             // first-order effect of nonzero gap

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -48,7 +48,7 @@ namespace impactx
                 PType& AMREX_RESTRICT p,
                 amrex::ParticleReal & AMREX_RESTRICT px,
                 amrex::ParticleReal & AMREX_RESTRICT py,
-                amrex::ParticleReal & AMREX_RESTRICT pt,
+                [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT pt,
                 [[maybe_unused]] RefPart const refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -1,4 +1,4 @@
-/* Copyright 2021 Chad Mitchell, Axel Huebl
+/* Copyright 2021-2022 Chad Mitchell, Axel Huebl
  *
  * This file is part of ImpactX.
  *
@@ -41,7 +41,7 @@ namespace impactx
          * @param px particle momentum in x
          * @param py particle momentum in y
          * @param pt particle momentum in t
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -49,14 +49,13 @@ namespace impactx
                 amrex::ParticleReal & AMREX_RESTRICT px,
                 amrex::ParticleReal & AMREX_RESTRICT py,
                 amrex::ParticleReal & AMREX_RESTRICT pt,
-                RefPart const refpart) const {
+                [[maybe_unused]] RefPart const refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 
             // access AoS data such as positions and cpu/id
             amrex::ParticleReal const x = p.pos(0);
             amrex::ParticleReal const y = p.pos(1);
-            amrex::ParticleReal const t = p.pos(2);
 
             // access reference particle values if needed
 
@@ -73,7 +72,6 @@ namespace impactx
             // apply edge focusing
             px = px + R21*x;
             py = py + R43*y;
-
         }
 
     private:

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -53,17 +53,27 @@ namespace impactx
             amrex::ParticleReal const y = p.pos(1);
             amrex::ParticleReal const t = p.pos(2);
 
+            // intialize output values of momenta
+            amrex::ParticleReal pxout = px;
+            amrex::ParticleReal pyout = py;
+            amrex::ParticleReal ptout = pt;
+
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
             amrex::ParticleReal const betgam2 = pow(pt_ref, 2) - 1.0_prt;
 
             // advance position and momentum (drift)
             p.pos(0) = x + m_ds * px;
-            // px = px;
+            // pxout = px;
             p.pos(1) = y + m_ds * py;
-            // py = py;
+            // pyout = py;
             p.pos(2) = t + (m_ds/betgam2) * pt;
-            // pt = pt;
+            // ptout = pt;
+
+            // assign updated momenta
+            px = pxout;
+            py = pyout;
+            pt = ptout;
         }
 
     private:

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -64,27 +64,38 @@ namespace impactx
             // compute phase advance per unit length in s (in rad/m)
             amrex::ParticleReal const omega = sqrt(abs(m_k));
 
+            // intialize output values of momenta
+            amrex::ParticleReal pxout = px;
+            amrex::ParticleReal pyout = py;
+            amrex::ParticleReal ptout = pt;
+
             if(m_k > 0.0) {
                // advance position and momentum (focusing quad)
                p.pos(0) = cos(omega*m_ds)*x + sin(omega*m_ds)/omega*px;
-               px = -omega*sin(omega*m_ds)*x + cos(omega*m_ds)*px;
+               pxout = -omega*sin(omega*m_ds)*x + cos(omega*m_ds)*px;
 
                p.pos(1) = cosh(omega*m_ds)*y + sinh(omega*m_ds)/omega*py;
-               py = omega*sinh(omega*m_ds)*y + cosh(omega*m_ds)*py;
+               pyout = omega*sinh(omega*m_ds)*y + cosh(omega*m_ds)*py;
 
                p.pos(2) = t + (m_ds/betgam2)*pt;
-               // pt = pt;
+               // ptout = pt;
             } else {
                // advance position and momentum (defocusing quad)
                p.pos(0) = cosh(omega*m_ds)*x + sinh(omega*m_ds)/omega*px;
-               px = omega*sinh(omega*m_ds)*x + cosh(omega*m_ds)*px;
+               pxout = omega*sinh(omega*m_ds)*x + cosh(omega*m_ds)*px;
 
                p.pos(1) = cos(omega*m_ds)*y + sin(omega*m_ds)/omega*py;
-               py = -omega*sin(omega*m_ds)*y + cos(omega*m_ds)*py;
+               pyout = -omega*sin(omega*m_ds)*y + cos(omega*m_ds)*py;
 
                p.pos(2) = t + (m_ds/betgam2)*pt;
-               // pt = pt;
+               // ptout = pt;
             }
+
+            // assign updated momenta
+            px = pxout;
+            py = pyout;
+            pt = ptout;
+
         }
 
     private:

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -54,6 +54,11 @@ namespace impactx
             amrex::ParticleReal const y = p.pos(1);
             amrex::ParticleReal const t = p.pos(2);
 
+            // initialize output values of momenta
+            amrex::ParticleReal pxout = px;
+            amrex::ParticleReal pyout = py;
+            amrex::ParticleReal ptout = pt;
+
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
             amrex::ParticleReal const betgam2 = pow(pt_ref, 2) - 1.0_prt;
@@ -61,16 +66,26 @@ namespace impactx
             amrex::ParticleReal const theta = m_ds/m_rc;
 
             // advance position and momentum (sector bend)
+
             p.pos(0) = cos(theta)*x + m_rc*sin(theta)*px
                      - (m_rc/bet)*(1.0_prt - cos(theta))*pt;
-            px = -sin(theta)/m_rc*x + cos(theta)*px - sin(theta)/bet*pt;
+
+            pxout = -sin(theta)/m_rc*x + cos(theta)*px - sin(theta)/bet*pt;
 
             p.pos(1) = y + m_rc*theta*py;
-            // py = py;
+
+            // pyout = py;
 
             p.pos(2) = sin(theta)/bet*x + m_rc/bet*(1.0_prt - cos(theta))*px + t
                      + m_rc*(-theta+sin(theta)/(bet*bet))*pt;
-            // pt = pt;
+
+            // ptout = pt;
+
+            // assign updated momenta
+            px = pxout;
+            py = pyout;
+            pt = ptout;
+
         }
 
     private:


### PR DESCRIPTION
1) Added a new "dipedge" element to correcty include dipole
   edge focusing

2) Corrected treatment of momenta in elements (affects only the dipole case)

3) Added a new input file "input_chicane.in" for compression of
   a beam in the Berlin-Zeuthen benchmark chicane.