### PR TITLE
Docs: Fix Parameters (Close Verbatim)

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -141,7 +141,7 @@ Lattice Elements
 Distribution across MPI ranks and parallelization
 -------------------------------------------------
 
-* ``amr.max_grid_size`` (``integer``) optional (default ``128`)
+* ``amr.max_grid_size`` (``integer``) optional (default ``128``)
     Maximum allowable size of each **subdomain**
     (expressed in number of grid points, in each direction).
     Each subdomain has its own ghost cells, and can be handled by a


### PR DESCRIPTION
Fix a little formatting issues in a missing close of a verbatim block.