### PR TITLE
Docs: Link Constant Focusing Channel

### DIFF
--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -10,6 +10,7 @@ This section allows you to **download input files** that correspond to different
 
    examples/fodo/README.rst
    examples/chicane/README.rst
+   examples/cfchannel/README.rst
 
 
 Test Cases / Benchmarks


### PR DESCRIPTION
Link the `cfchannel` example in the manual.
Follow-up to #85.