### PR TITLE
Fix MR Level Loops: `finestLevel()`

### DIFF
--- a/src/particles/ChargeDeposition.cpp
+++ b/src/particles/ChargeDeposition.cpp
@@ -24,7 +24,7 @@ namespace impactx
         amrex::Vector<amrex::IntVect> const & ref_ratio)
     {
         // loop over refinement levels
-        int const nLevel = this->maxLevel();
+        int const nLevel = this->finestLevel();
         for (int lev = 0; lev <= nLevel; ++lev) {
             amrex::MultiFab & rho_at_level = rho.at(lev);
             // reset the values in rho to zero

--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -95,8 +95,8 @@ namespace detail
         using namespace amrex::literals; // for _rt and _prt
 
         // loop over refinement levels
-        int const nLevel = pc.maxLevel() + 1;
-        for (int lev = 0; lev < nLevel; ++lev)
+        int const nLevel = pc.finestLevel();
+        for (int lev = 0; lev <= nLevel; ++lev)
         {
             // get simulation geometry information
             //const amrex::Geometry& gm = this->Geom(lev);

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -28,8 +28,8 @@ namespace impactx::diagnostics
         amrex::PrintToFile("diags/output_beam.txt") << "x y t px py pt\n";
 
         // loop over refinement levels
-        int const nLevel = tmp.maxLevel() + 1;
-        for (int lev = 0; lev < nLevel; ++lev)
+        int const nLevel = tmp.finestLevel();
+        for (int lev = 0; lev <= nLevel; ++lev)
         {
             // loop over all particle boxes
             using ParIt = typename decltype(tmp)::ParConstIterType;

--- a/src/particles/transformation/CoordinateTransformation.cpp
+++ b/src/particles/transformation/CoordinateTransformation.cpp
@@ -27,8 +27,8 @@ namespace transformation {
         amrex::ParticleReal const pd = ref_part.pt;  // Design value of pt/mc2 = -gamma
 
         // loop over refinement levels
-        int const nLevel = pc.maxLevel();
-        for (int lev = 0; lev < nLevel; ++lev) {
+        int const nLevel = pc.finestLevel();
+        for (int lev = 0; lev <= nLevel; ++lev) {
             // loop over all particle boxes
             using ParIt = ImpactXParticleContainer::iterator;
             for (ParIt pti(pc, lev); pti.isValid(); ++pti) {


### PR DESCRIPTION
Only iterate up to `finestLevel` of the simulation.

- `maxLevel`: the maximum allowed refinement level in a simulation
- `finestLevel`: the currently used, finest refinement level (can change over steps between `0` and `maxLevel` with AMR)