### PR TITLE
IO: Parallel Particle ASCII Output

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,24 @@
+# Configuration ###############################################################
+#
+if(ImpactX_MPI)
+    # OpenMPI root guard: https://github.com/open-mpi/ompi/issues/4451
+    if("$ENV{USER}" STREQUAL "root")
+        # calling even --help as root will abort and warn on stderr
+        execute_process(COMMAND ${MPIEXEC_EXECUTABLE} --help
+                ERROR_VARIABLE MPIEXEC_HELP_TEXT
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+        if(${MPIEXEC_HELP_TEXT} MATCHES "^.*allow-run-as-root.*$")
+            set(MPI_ALLOW_ROOT --allow-run-as-root)
+        endif()
+    endif()
+    set(MPI_TEST_EXE
+        ${MPIEXEC_EXECUTABLE}
+        ${MPI_ALLOW_ROOT}
+        ${MPIEXEC_NUMPROC_FLAG} 2
+    )
+endif()
+
+
 # FODO Cell ###################################################################
 #
 add_test(NAME FODO.run
@@ -10,6 +31,24 @@ add_test(NAME FODO.analysis
 )
 
 set_tests_properties(FODO.analysis PROPERTIES DEPENDS "FODO.run")
+
+
+# MPI-Parallel FODO Cell ######################################################
+#
+if(ImpactX_MPI)
+    add_test(NAME FODO.MPI.run
+            COMMAND ${MPI_TEST_EXE}
+                $<TARGET_FILE:app> ${ImpactX_SOURCE_DIR}/examples/fodo/input_fodo.in
+            WORKING_DIRECTORY ${ImpactX_RUNTIME_OUTPUT_DIRECTORY}
+    )
+    add_test(NAME FODO.MPI.analysis
+            COMMAND ${ImpactX_SOURCE_DIR}/examples/fodo/analysis_fodo.py
+            WORKING_DIRECTORY ${ImpactX_RUNTIME_OUTPUT_DIRECTORY}
+    )
+
+    set_tests_properties(FODO.MPI.run PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=1")
+    set_tests_properties(FODO.MPI.analysis PROPERTIES DEPENDS "FODO.MPI.run")
+endif()
 
 
 # Chicane #####################################################################
@@ -38,6 +77,7 @@ add_test(NAME cfchannel.analysis
 )
 
 set_tests_properties(cfchannel.analysis PROPERTIES DEPENDS "cfchannel.run")
+
 
 # Kurth Distribution Test ###################################################
 #

--- a/examples/cfchannel/analysis_cfchannel.py
+++ b/examples/cfchannel/analysis_cfchannel.py
@@ -39,7 +39,7 @@ def get_moments(beam):
 
 def read_all_files(file_pattern):
     """Read in all CSV files from each MPI rank (and potentially OpenMP
-    thread. Concatinate into one Pandas dataframe.
+    thread). Concatenate into one Pandas dataframe.
 
     Returns
     -------

--- a/examples/cfchannel/analysis_cfchannel.py
+++ b/examples/cfchannel/analysis_cfchannel.py
@@ -5,6 +5,8 @@
 # License: BSD-3-Clause-LBNL
 #
 
+import glob
+
 import numpy as np
 import pandas as pd
 from scipy.stats import moment
@@ -35,9 +37,27 @@ def get_moments(beam):
         emittance_x, emittance_y, emittance_t)
 
 
+def read_all_files(file_pattern):
+    """Read in all CSV files from each MPI rank (and potentially OpenMP
+    thread. Concatinate into one Pandas dataframe.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    return pd.concat(
+        (
+            pd.read_csv(filename, delimiter=r"\s+")
+            for filename in glob.glob(file_pattern)
+        ),
+        axis=0,
+        ignore_index=True,
+    )
+
+
 # initial/final beam on rank zero
-initial = pd.read_csv("diags/initial_beam.txt.0.0", delimiter=r"\s+")
-final = pd.read_csv("diags/output_beam.txt.0.0", delimiter=r"\s+")
+initial = read_all_files("diags/initial_beam.txt.*")
+final = read_all_files("diags/output_beam.txt.*")
 
 # compare number of particles
 num_particles = 10000

--- a/examples/chicane/analysis_chicane.py
+++ b/examples/chicane/analysis_chicane.py
@@ -39,7 +39,7 @@ def get_moments(beam):
 
 def read_all_files(file_pattern):
     """Read in all CSV files from each MPI rank (and potentially OpenMP
-    thread. Concatinate into one Pandas dataframe.
+    thread). Concatenate into one Pandas dataframe.
 
     Returns
     -------

--- a/examples/chicane/analysis_chicane.py
+++ b/examples/chicane/analysis_chicane.py
@@ -5,6 +5,8 @@
 # License: BSD-3-Clause-LBNL
 #
 
+import glob
+
 import numpy as np
 import pandas as pd
 from scipy.stats import moment
@@ -35,9 +37,27 @@ def get_moments(beam):
         emittance_x, emittance_y, emittance_t)
 
 
+def read_all_files(file_pattern):
+    """Read in all CSV files from each MPI rank (and potentially OpenMP
+    thread. Concatinate into one Pandas dataframe.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    return pd.concat(
+        (
+            pd.read_csv(filename, delimiter=r"\s+")
+            for filename in glob.glob(file_pattern)
+        ),
+        axis=0,
+        ignore_index=True,
+    )
+
+
 # initial/final beam on rank zero
-initial = pd.read_csv("diags/initial_beam.txt.0.0", delimiter=r"\s+")
-final = pd.read_csv("diags/output_beam.txt.0.0", delimiter=r"\s+")
+initial = read_all_files("diags/initial_beam.txt.*")
+final = read_all_files("diags/output_beam.txt.*")
 
 # compare number of particles
 num_particles = 10000

--- a/examples/fodo/analysis_fodo.py
+++ b/examples/fodo/analysis_fodo.py
@@ -39,7 +39,7 @@ def get_moments(beam):
 
 def read_all_files(file_pattern):
     """Read in all CSV files from each MPI rank (and potentially OpenMP
-    thread. Concatinate into one Pandas dataframe.
+    thread). Concatenate into one Pandas dataframe.
 
     Returns
     -------

--- a/examples/fodo/analysis_fodo.py
+++ b/examples/fodo/analysis_fodo.py
@@ -5,6 +5,8 @@
 # License: BSD-3-Clause-LBNL
 #
 
+import glob
+
 import numpy as np
 import pandas as pd
 from scipy.stats import moment
@@ -35,9 +37,27 @@ def get_moments(beam):
         emittance_x, emittance_y, emittance_t)
 
 
+def read_all_files(file_pattern):
+    """Read in all CSV files from each MPI rank (and potentially OpenMP
+    thread. Concatinate into one Pandas dataframe.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    return pd.concat(
+        (
+            pd.read_csv(filename, delimiter=r"\s+")
+            for filename in glob.glob(file_pattern)
+        ),
+        axis=0,
+        ignore_index=True,
+    )
+
+
 # initial/final beam on rank zero
-initial = pd.read_csv("diags/initial_beam.txt.0.0", delimiter=r"\s+")
-final = pd.read_csv("diags/output_beam.txt.0.0", delimiter=r"\s+")
+initial = read_all_files("diags/initial_beam.txt.*")
+final = read_all_files("diags/output_beam.txt.*")
 
 # compare number of particles
 num_particles = 10000

--- a/examples/kurth/analysis_kurth.py
+++ b/examples/kurth/analysis_kurth.py
@@ -39,7 +39,7 @@ def get_moments(beam):
 
 def read_all_files(file_pattern):
     """Read in all CSV files from each MPI rank (and potentially OpenMP
-    thread. Concatinate into one Pandas dataframe.
+    thread). Concatenate into one Pandas dataframe.
 
     Returns
     -------

--- a/examples/kurth/analysis_kurth.py
+++ b/examples/kurth/analysis_kurth.py
@@ -5,6 +5,8 @@
 # License: BSD-3-Clause-LBNL
 #
 
+import glob
+
 import numpy as np
 import pandas as pd
 from scipy.stats import moment
@@ -35,9 +37,27 @@ def get_moments(beam):
         emittance_x, emittance_y, emittance_t)
 
 
+def read_all_files(file_pattern):
+    """Read in all CSV files from each MPI rank (and potentially OpenMP
+    thread. Concatinate into one Pandas dataframe.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    return pd.concat(
+        (
+            pd.read_csv(filename, delimiter=r"\s+")
+            for filename in glob.glob(file_pattern)
+        ),
+        axis=0,
+        ignore_index=True,
+    )
+
+
 # initial/final beam on rank zero
-initial = pd.read_csv("diags/initial_beam.txt.0.0", delimiter=r"\s+")
-final = pd.read_csv("diags/output_beam.txt.0.0", delimiter=r"\s+")
+initial = read_all_files("diags/initial_beam.txt.*")
+final = read_all_files("diags/output_beam.txt.*")
 
 # compare number of particles
 num_particles = 10000

--- a/src/particles/diagnostics/DiagnosticOutput.H
+++ b/src/particles/diagnostics/DiagnosticOutput.H
@@ -18,10 +18,14 @@ namespace impactx::diagnostics
      */
     enum class OutputType
     {
-        PrintParticles
+        PrintParticles ///< ASCII diagnostics, for small tests only
     };
 
-    /** Output diagnostics associated with the beam.
+    /** ASCII output diagnostics associated with the beam.
+     *
+     * This temporary implementation uses ASCII output.
+     * It is intended only for small tests where IO performance is not
+     * a concern. The implementation here serializes IO.
      *
      * @param pc container of the particles use for diagnostics
      * @param otype the type of output to produce

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -26,67 +26,52 @@ namespace impactx::diagnostics
         bool const local = true;
         tmp.copyParticles(pc, local);
 
-        // write file header, flush and close file
-        {
-            amrex::PrintToFile(file_name) << "x y t px py pt\n";
-        }
+        // write file header per MPI RANK
+        amrex::AllPrintToFile(file_name) << "x y t px py pt\n";
 
-        const int MyProc = amrex::ParallelDescriptor::MyProc();
+        // loop over refinement levels
+        int const nLevel = tmp.finestLevel();
+        for (int lev = 0; lev <= nLevel; ++lev) {
+            // loop over all particle boxes
+            using ParIt = typename decltype(tmp)::ParConstIterType;
+            for (ParIt pti(tmp, lev); pti.isValid(); ++pti) {
+                const int np = pti.numParticles();
 
-        for (int proc = 0; proc < amrex::ParallelDescriptor::NProcs(); proc++) {
-            // note: this is the same logic as in amrex::ParticleContainer::WriteAsciiFile
-            //   this is intended only for small tests where IO performance is not
-            //   a concern. The implementation here serializes IO, under the assumption
-            //   that MPI-sync (Barrier) is the same as parallel FS sync;
-            //   generally, it is not.
-            amrex::ParallelDescriptor::Barrier();
+                // preparing access to particle data: AoS
+                using PType = ImpactXParticleContainer::ParticleType;
+                auto const &aos = pti.GetArrayOfStructs();
+                PType const *const AMREX_RESTRICT aos_ptr = aos().dataPtr();
 
-            if (MyProc == proc) {
-                // loop over refinement levels
-                int const nLevel = tmp.finestLevel();
-                for (int lev = 0; lev <= nLevel; ++lev) {
-                    // loop over all particle boxes
-                    using ParIt = typename decltype(tmp)::ParConstIterType;
-                    for (ParIt pti(tmp, lev); pti.isValid(); ++pti) {
-                        const int np = pti.numParticles();
+                // preparing access to particle data: SoA of Reals
+                auto &soa_real = pti.GetStructOfArrays().GetRealData();
+                amrex::ParticleReal const *const AMREX_RESTRICT part_px = soa_real[RealSoA::ux].dataPtr();
+                amrex::ParticleReal const *const AMREX_RESTRICT part_py = soa_real[RealSoA::uy].dataPtr();
+                amrex::ParticleReal const *const AMREX_RESTRICT part_pt = soa_real[RealSoA::pt].dataPtr();
 
-                        // preparing access to particle data: AoS
-                        using PType = ImpactXParticleContainer::ParticleType;
-                        auto const &aos = pti.GetArrayOfStructs();
-                        PType const *const AMREX_RESTRICT aos_ptr = aos().dataPtr();
+                if (otype == OutputType::PrintParticles) {
+                    // print out particles (this hack works only on CPU and on GPUs with
+                    // unified memory access)
+                    for (int i = 0; i < np; ++i) {
 
-                        // preparing access to particle data: SoA of Reals
-                        auto &soa_real = pti.GetStructOfArrays().GetRealData();
-                        amrex::ParticleReal const *const AMREX_RESTRICT part_px = soa_real[RealSoA::ux].dataPtr();
-                        amrex::ParticleReal const *const AMREX_RESTRICT part_py = soa_real[RealSoA::uy].dataPtr();
-                        amrex::ParticleReal const *const AMREX_RESTRICT part_pt = soa_real[RealSoA::pt].dataPtr();
+                        // access AoS data such as positions and cpu/id
+                        PType const &p = aos_ptr[i];
+                        amrex::ParticleReal const x = p.pos(0);
+                        amrex::ParticleReal const y = p.pos(1);
+                        amrex::ParticleReal const t = p.pos(2);
 
-                        if (otype == OutputType::PrintParticles) {
-                            // print out particles (this hack works only on CPU and on GPUs with
-                            // unified memory access)
-                            for (int i = 0; i < np; ++i) {
+                        // access SoA Real data
+                        amrex::ParticleReal const px = part_px[i];
+                        amrex::ParticleReal const py = part_py[i];
+                        amrex::ParticleReal const pt = part_pt[i];
 
-                                // access AoS data such as positions and cpu/id
-                                PType const &p = aos_ptr[i];
-                                amrex::ParticleReal const x = p.pos(0);
-                                amrex::ParticleReal const y = p.pos(1);
-                                amrex::ParticleReal const t = p.pos(2);
-
-                                // access SoA Real data
-                                amrex::ParticleReal const px = part_px[i];
-                                amrex::ParticleReal const py = part_py[i];
-                                amrex::ParticleReal const pt = part_pt[i];
-
-                                // write particle data to file
-                                amrex::AllPrintToFile(file_name)
-                                        << x << " " << y << " " << t << " "
-                                        << px << " " << py << " " << pt << "\n";
-                            } // i=0...np
-                        } // if( otype == OutputType::PrintParticles)
-                    } // end loop over all particle boxes
-                } // env mesh-refinement level loop
-            } // current MPI rank that writes
-        } // serial MPI rank loop
+                        // write particle data to file
+                        amrex::AllPrintToFile(file_name)
+                                << x << " " << y << " " << t << " "
+                                << px << " " << py << " " << pt << "\n";
+                    } // i=0...np
+                } // if( otype == OutputType::PrintParticles)
+            } // end loop over all particle boxes
+        } // env mesh-refinement level loop
     }
 
 } // namespace impactx::diagnostics


### PR DESCRIPTION
Write one file per MPI rank (and pot. OpenMP thread).
Update post-processing logic to process this.

Needed for #103

To Do:
- [x] add a parallel test

X-ref:
- depends on #73
- https://github.com/ECP-WarpX/impactx/pull/73#issuecomment-1093075788