### PR TITLE
Added a thin multipole element

### DIFF
--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -13,6 +13,7 @@ This section allows you to **download input files** that correspond to different
    examples/cfchannel/README.rst
    examples/kurth/README.rst
    examples/fodo_rf/README.rst
+   examples/multipole/README.rst
 
 
 Test Cases / Benchmarks

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -228,6 +228,17 @@ Lattice Elements
             * ``<element_name>.k`` (``float``, in 1/meters) the RF wavenumber
                     = 2*pi/(RF wavelength in m)
 
+        * ``multipole`` for a thin multipole element. This requires these additional parameters:
+
+            * ``<element_name>.multipole`` (``integer``, dimensionless) order of multipole
+                    (m = 1) dipole, (m = 2) quadrupole, (m = 3) sextupole, etc.
+
+            * ``<element_name>.k_normal`` (``float``, in 1/meters^m) integrated normal multipole coefficient (MAD-X convention)
+                   = 1/(magnetic rigidity in T-m) * (derivative of order m-1 of By with respect to x)
+
+            * ``<element_name>.k_skew`` (``float``, in 1/meters^m) integrated skew multipole strength (MAD-X convention)
+
+
 .. _running-cpp-parameters-parallelization:
 
 Distribution across MPI ranks and parallelization

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -161,3 +161,16 @@ add_test(NAME semigaussian.analysis
 )
 
 set_tests_properties(semigaussian.analysis PROPERTIES DEPENDS "semigaussian.run")
+
+# Chain of Multipoles Test ############################################################
+#
+add_test(NAME multipole.run
+         COMMAND $<TARGET_FILE:app> ${ImpactX_SOURCE_DIR}/examples/multipole/input_multipole.in
+         WORKING_DIRECTORY ${ImpactX_RUNTIME_OUTPUT_DIRECTORY}
+)
+add_test(NAME multipole.analysis
+         COMMAND ${ImpactX_SOURCE_DIR}/examples/multipole/analysis_multipole.py
+         WORKING_DIRECTORY ${ImpactX_RUNTIME_OUTPUT_DIRECTORY}
+)
+
+set_tests_properties(multipole.analysis PROPERTIES DEPENDS "multipole.run")

--- a/examples/multipole/README.rst
+++ b/examples/multipole/README.rst
@@ -1,15 +1,13 @@
 .. _examples-multipole:
 
 Chain of thin multipoles
-=========
+========================
 
-A series of thin multipoles (quad, sext, oct) with both normal and skew
-coefficients.
+A series of thin multipoles (quad, sext, oct) with both normal and skew coefficients.
 
 We use a 2 GeV proton beam.
 
-The second moments of x, y, and t should be unchanged, but there is large
-emittance growth in the x and y phase planes.
+The second moments of x, y, and t should be unchanged, but there is large emittance growth in the x and y phase planes.
 
 In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 

--- a/examples/multipole/README.rst
+++ b/examples/multipole/README.rst
@@ -1,0 +1,20 @@
+.. _examples-multipole:
+
+Chain of thin multipoles
+=========
+
+A series of thin multipoles (quad, sext, oct) with both normal and skew
+coefficients.
+
+We use a 2 GeV proton beam.
+
+The second moments of x, y, and t should be unchanged, but there is large
+emittance growth in the x and y phase planes.
+
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+
+
+
+.. literalinclude:: input_multipole.in
+   :language: ini
+   :caption: You can copy this file from ``examples/multipole/input_multipole.in``.

--- a/examples/multipole/analysis_multipole.py
+++ b/examples/multipole/analysis_multipole.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+import glob
+
+import numpy as np
+import pandas as pd
+from scipy.stats import moment
+
+
+def get_moments(beam):
+    """Calculate standard deviations of beam position & momenta
+    and emittance values
+
+    Returns
+    -------
+    sigx, sigy, sigt, emittance_x, emittance_y, emittance_t
+    """
+    sigx = moment(beam["x"], moment=2)**0.5  # variance -> std dev.
+    sigpx = moment(beam["px"], moment=2)**0.5
+    sigy = moment(beam["y"], moment=2)**0.5
+    sigpy = moment(beam["py"], moment=2)**0.5
+    sigt = moment(beam["t"], moment=2)**0.5
+    sigpt = moment(beam["pt"], moment=2)**0.5
+
+    epstrms = beam.cov(ddof=0)
+    emittance_x = (sigx**2 * sigpx**2 - epstrms["x"]["px"]**2)**0.5
+    emittance_y = (sigy**2 * sigpy**2 - epstrms["y"]["py"]**2)**0.5
+    emittance_t = (sigt**2 * sigpt**2 - epstrms["t"]["pt"]**2)**0.5
+
+    return (
+        sigx, sigy, sigt,
+        emittance_x, emittance_y, emittance_t)
+
+
+def read_all_files(file_pattern):
+    """Read in all CSV files from each MPI rank (and potentially OpenMP
+    thread). Concatenate into one Pandas dataframe.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    return pd.concat(
+        (
+            pd.read_csv(filename, delimiter=r"\s+")
+            for filename in glob.glob(file_pattern)
+        ),
+        axis=0,
+        ignore_index=True,
+    )
+
+
+# initial/final beam on rank zero
+initial = read_all_files("diags/initial_beam.txt.*")
+final = read_all_files("diags/output_beam.txt.*")
+
+# compare number of particles
+num_particles = 10000
+assert num_particles == len(initial)
+assert num_particles == len(final)
+
+print("Initial Beam:")
+sigx, sigy, sigt, \
+    emittance_x, emittance_y, emittance_t = get_moments(initial)
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
+print(f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}")
+
+atol = 1.0  # a big number
+rtol = num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigx, sigy, sigt,
+     emittance_x, emittance_y, emittance_t],
+    [4.017554e-03, 4.017044e-03, 9.977588e-04,
+     1.197572e-06, 1.210501e-06, 2.001382e-06],
+    rtol=rtol,
+    atol=atol
+)
+
+
+print("")
+print("Final Beam:")
+sigx, sigy, sigt, \
+    emittance_x, emittance_y, emittance_t = get_moments(final)
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
+print(f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}")
+
+atol = 1.0  # a big number
+rtol = num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigx, sigy, sigt,
+     emittance_x, emittance_y, emittance_t],
+    [4.017554e-03, 4.017044e-03, 9.977588e-04,
+     6.532644e-06, 6.630912e-06, 2.001382e-06],
+    rtol=rtol,
+    atol=atol
+)

--- a/examples/multipole/input_multipole.in
+++ b/examples/multipole/input_multipole.in
@@ -1,0 +1,45 @@
+###############################################################################
+# Particle Beam(s)
+###############################################################################
+beam.npart = 10000
+beam.units = static
+beam.energy = 2.0e3
+beam.charge = 0.0
+beam.particle = electron
+beam.distribution = waterbag
+beam.sigmaX = 4.0e-3
+beam.sigmaY = 4.0e-3
+beam.sigmaT = 1.0e-3
+beam.sigmaPx = 3.0e-4
+beam.sigmaPy = 3.0e-4
+beam.sigmaPt = 2.0e-3
+beam.muxpx = 0.0
+beam.muypy = 0.0
+beam.mutpt = 0.0
+
+
+###############################################################################
+# Beamline: lattice elements and segments
+###############################################################################
+
+lattice.elements = thin_quadrupole thin_sextupole thin_octupole
+
+thin_quadrupole.type = multipole
+thin_quadrupole.multipole = 2      //Thin quadrupole
+thin_quadrupole.k_normal = 3.0
+thin_quadrupole.k_skew = 0.0
+
+thin_sextupole.type = multipole
+thin_sextupole.multipole = 3      //Thin sextupole
+thin_sextupole.k_normal = 100.0
+thin_sextupole.k_skew = -50.0
+
+thin_octupole.type = multipole
+thin_octupole.multipole = 4     //Thin octupole
+thin_octupole.k_normal = 65.0
+thin_octupole.k_skew = 6.0
+
+###############################################################################
+# Algorithms
+###############################################################################
+algo.particle_shape = 2

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -68,6 +68,13 @@ namespace impactx
                 pp_element.get("V", V);
                 pp_element.get("k", k);
                 m_lattice.emplace_back( ShortRF(V, k) );
+            } else if (element_type == "multipole") {
+                int m;
+                amrex::Real k_normal, k_skew;
+                pp_element.get("multipole", m);
+                pp_element.get("k_normal", k_normal);
+                pp_element.get("k_skew", k_skew);
+                m_lattice.emplace_back( Multipole(m, k_normal, k_skew) );
             } else {
                 amrex::Abort("Unknown type for lattice element " + element_name + ": " + element_type);
             }

--- a/src/particles/elements/All.H
+++ b/src/particles/elements/All.H
@@ -13,6 +13,7 @@
 #include "DipEdge.H"
 #include "ConstF.H"
 #include "ShortRF.H"
+#include "Multipole.H"
 
 #include <variant>
 
@@ -20,7 +21,7 @@
 namespace impactx
 {
     using KnownElements = std::variant<Drift, Sbend, Quad, DipEdge, ConstF,
-                                       ShortRF>;
+                                       ShortRF, Multipole>;
 
 } // namespace impactx
 

--- a/src/particles/elements/Multipole.H
+++ b/src/particles/elements/Multipole.H
@@ -42,7 +42,7 @@ namespace impactx
          * @param px particle momentum in x
          * @param py particle momentum in y
          * @param pt particle momentum in t
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -50,7 +50,7 @@ namespace impactx
                 amrex::ParticleReal & AMREX_RESTRICT px,
                 amrex::ParticleReal & AMREX_RESTRICT py,
                 amrex::ParticleReal & AMREX_RESTRICT pt,
-                RefPart const refpart) const {
+                [[maybe_unused]] RefPart const refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 

--- a/src/particles/elements/Multipole.H
+++ b/src/particles/elements/Multipole.H
@@ -23,13 +23,14 @@ namespace impactx
 
         /** A general thin multipole element
          *
-         * @param m multipole index (m=1 dipole, m=2 quadrupole, m=3 sextupole etc.)
+         * @param multipole index m (m=1 dipole, m=2 quadrupole, m=3 sextupole etc.)
          * @param K_normal Integrated normal multipole coefficient (1/meter^m)
          * @param K_skew Integrated skew multipole coefficient (1/meter^m)
          *
          */
-        Multipole( int const multipole, amrex::ParticleReal const
-                   K_normal, amrex::ParticleReal const K_skew )
+        Multipole( int const multipole,
+                   amrex::ParticleReal const K_normal,
+                   amrex::ParticleReal const K_skew )
         : m_multipole(multipole), m_Kn(K_normal), m_Ks(K_skew)
         {
         }

--- a/src/particles/elements/Multipole.H
+++ b/src/particles/elements/Multipole.H
@@ -1,0 +1,113 @@
+/* Copyright 2022 Chad Mitchell, Axel Huebl
+ *
+ * This file is part of ImpactX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_MULTIPOLE_H
+#define IMPACTX_MULTIPOLE_H
+
+#include "particles/ImpactXParticleContainer.H"
+
+#include <AMReX_Extension.H>
+#include <AMReX_REAL.H>
+#include <AMReX_GpuComplex.H>
+
+#include <cmath>
+
+namespace impactx
+{
+    struct Multipole
+    {
+        using PType = ImpactXParticleContainer::ParticleType;
+
+        /** A general thin multipole element
+         *
+         * @param m multipole index (m=1 dipole, m=2 quadrupole, m=3 sextupole etc.)
+         * @param K_normal Integrated normal multipole coefficient (1/meter^m)
+         * @param K_skew Integrated skew multipole coefficient (1/meter^m)
+         *
+         */
+        Multipole( int const multipole, amrex::ParticleReal const
+                   K_normal, amrex::ParticleReal const K_skew )
+        : m_multipole(multipole), m_Kn(K_normal), m_Ks(K_skew)
+        {
+        }
+
+        /** This is a multipole functor, so that a variable of this type can be used like a
+         *  multipole function.
+         *
+         * @param p Particle AoS data for positions and cpu/id
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param refpart reference particle
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void operator() (
+                PType& AMREX_RESTRICT p,
+                amrex::ParticleReal & AMREX_RESTRICT px,
+                amrex::ParticleReal & AMREX_RESTRICT py,
+                amrex::ParticleReal & AMREX_RESTRICT pt,
+                RefPart const refpart) const {
+
+            using namespace amrex::literals; // for _rt and _prt
+
+            // access AoS data such as positions and cpu/id
+            amrex::ParticleReal const x = p.pos(0);
+            amrex::ParticleReal const y = p.pos(1);
+            amrex::ParticleReal const t = p.pos(2);
+
+            // access reference particle values to find (beta*gamma)^2
+            //amrex::ParticleReal const pt_ref = refpart.pt;
+            //amrex::ParticleReal const betgam2 = pow(pt_ref, 2) - 1.0_prt;
+
+            // intialize output values of momenta
+            amrex::ParticleReal pxout = px;
+            amrex::ParticleReal pyout = py;
+            amrex::ParticleReal ptout = pt;
+
+            // assign complex position and complex multipole strength
+            amrex::GpuComplex zeta(x,y);
+            amrex::GpuComplex alpha(m_Kn,m_Ks);
+
+            // compute factorial of multipole index
+            int m = m_multipole - 1;
+            int mfactorial = 1;
+            for( int n = 1; n < m + 1; n = n + 1 ) {
+               mfactorial *= n;
+            }
+
+            // compute complex momentum kick
+            amrex::GpuComplex kick = amrex::pow(zeta,m);
+            kick *= alpha;
+            amrex::ParticleReal dpx = -1.0_prt*kick.m_real/mfactorial;
+            amrex::ParticleReal dpy = kick.m_imag/mfactorial;
+
+            // advance position and momentum
+            p.pos(0) = x;
+            pxout = px + dpx;
+
+            p.pos(1) = y;
+            pyout = py + dpy;
+
+            p.pos(2) = t;
+            ptout = pt;
+
+            // assign updated momenta
+            px = pxout;
+            py = pyout;
+            pt = ptout;
+
+        }
+
+    private:
+        int m_multipole; //! multipole index
+        amrex::ParticleReal m_Kn; //! integrated normal multipole coefficient
+        amrex::ParticleReal m_Ks; //! integrated skew multipole coefficient
+
+    };
+
+} // namespace impactx
+
+#endif // IMPACTX_MULTIPOLE_H


### PR DESCRIPTION
This includes addition of a new element type "multipole", which accepts as input an arbitrary multipole index, together with a normal and skew integrated strength, and produces the kick associated with a thin multipole element.

An example is included, which checks the propagation of the beam moments.  

Possible future changes:
1) Allow the possibility to input an arbitrary number of multipole coefficients, and take the superposition of these
1a) for the special case of a thin multipoles, we can also stack them in a line, e.g., via Python inputs #93 & Mad-X #104 
2) Modify the example to compute the Hamiltonian and check its preservation under the multipole kick
