### PR TITLE
Added a thin nonlinear element based IOTA magnet

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -238,6 +238,14 @@ Lattice Elements
 
             * ``<element_name>.k_skew`` (``float``, in 1/meters^m) integrated skew multipole strength (MAD-X convention)
 
+        * ``nonlinear_lens`` for a thin IOTA nonlinear lens element. This requires these additional parameters:
+
+            * ``<element_name>.knll`` (``float``, in meters) integrated strength of the lens segment (MAD-X convention)
+                   = dimensionless lens strength * c parameter**2 * length / Twiss beta
+
+            * ``<element_name>.cnll`` (``float``, in meters) distance of the singularities from the origin (MAD-X convention)
+                   = c parameter * sqrt(Twiss beta)
+
 
 .. _running-cpp-parameters-parallelization:
 

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -75,6 +75,11 @@ namespace impactx
                 pp_element.get("k_normal", k_normal);
                 pp_element.get("k_skew", k_skew);
                 m_lattice.emplace_back( Multipole(m, k_normal, k_skew) );
+            } else if (element_type == "nonlinear_lens") {
+                amrex::Real knll, cnll;
+                pp_element.get("knll", knll);
+                pp_element.get("cnll", cnll);
+                m_lattice.emplace_back( NonlinearLens(knll, cnll) );
             } else {
                 amrex::Abort("Unknown type for lattice element " + element_name + ": " + element_type);
             }

--- a/src/particles/elements/All.H
+++ b/src/particles/elements/All.H
@@ -14,6 +14,7 @@
 #include "ConstF.H"
 #include "ShortRF.H"
 #include "Multipole.H"
+#include "NonlinearLens.H"
 
 #include <variant>
 
@@ -21,7 +22,7 @@
 namespace impactx
 {
     using KnownElements = std::variant<Drift, Sbend, Quad, DipEdge, ConstF,
-                                       ShortRF, Multipole>;
+                                       ShortRF, Multipole, NonlinearLens>;
 
 } // namespace impactx
 

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -73,9 +73,9 @@ namespace impactx
             amrex::ParticleReal ptout = pt;
 
             // assign complex position zeta = x + iy
-            amrex::GpuComplex zeta(x,y);
-            amrex::GpuComplex re1(1.0,0.0);
-            amrex::GpuComplex im1(0.0,1.0);
+            Complex zeta(x, y);
+            Complex re1(1.0_prt, 0.0_prt);
+            Complex im1(0.0_prt, 1.0_prt);
 
             // compute croot = sqrt(1-zeta**2)
             amrex::GpuComplex croot = amrex::pow(zeta,2);

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -21,7 +21,9 @@ namespace impactx
     {
         using PType = ImpactXParticleContainer::ParticleType;
 
-        /** A thin lens associated with a single short segment of the
+        /** Single short segment of the nonlinear magnetic insert element
+         *
+         *  A thin lens associated with a single short segment of the
          *  nonlinear magnetic insert described by V. Danilov and
          *  S. Nagaitsev, PRSTAB 13, 084002 (2010), Sect. V.A.  This
          *  element appears in MAD-X as type NLLENS.
@@ -36,8 +38,8 @@ namespace impactx
         {
         }
 
-        /** This is a nonlinear lens functor, so that a variable of this type can be used like a
-         *  nonlinear lens function.
+        /** This is a nonlinear lens functor, so that a variable of this type
+         *  can be used like a nonlinear lens function.
          *
          * @param p Particle AoS data for positions and cpu/id
          * @param px particle momentum in x

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -55,6 +55,9 @@ namespace impactx
 
             using namespace amrex::literals; // for _rt and _prt
 
+            // a complex type with two amrex::ParticleReal
+            using Complex = amrex::GpuComplex<amrex::ParticleReal>;
+
             // access AoS data such as positions and cpu/id
             amrex::ParticleReal const x = p.pos(0);
             amrex::ParticleReal const y = p.pos(1);

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -1,0 +1,120 @@
+/* Copyright 2022 Chad Mitchell, Axel Huebl
+ *
+ * This file is part of ImpactX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_NONLINEARLENS_H
+#define IMPACTX_NONLINEARLENS_H
+
+#include "particles/ImpactXParticleContainer.H"
+
+#include <AMReX_Extension.H>
+#include <AMReX_REAL.H>
+#include <AMReX_GpuComplex.H>
+
+#include <cmath>
+
+namespace impactx
+{
+    struct NonlinearLens
+    {
+        using PType = ImpactXParticleContainer::ParticleType;
+
+        /** A thin lens associated with a single short segment of the
+         *  nonlinear magnetic insert described by V. Danilov and
+         *  S. Nagaitsev, PRSTAB 13, 084002 (2010), Sect. V.A.  This
+         *  element appears in MAD-X as type NLLENS.
+         *
+         * @param knll - integrated strength of the nonlinear lens (m)
+         * @param cnll - distance of singularities from the origin (m)
+         *
+         */
+        NonlinearLens( amrex::ParticleReal const knll,
+                   amrex::ParticleReal const cnll )
+        : m_knll(knll), m_cnll(cnll)
+        {
+        }
+
+        /** This is a nonlinear lens functor, so that a variable of this type can be used like a
+         *  nonlinear lens function.
+         *
+         * @param p Particle AoS data for positions and cpu/id
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param refpart reference particle (unused)
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void operator() (
+                PType& AMREX_RESTRICT p,
+                amrex::ParticleReal & AMREX_RESTRICT px,
+                amrex::ParticleReal & AMREX_RESTRICT py,
+                amrex::ParticleReal & AMREX_RESTRICT pt,
+                [[maybe_unused]] RefPart const refpart) const {
+
+            using namespace amrex::literals; // for _rt and _prt
+
+            // access AoS data such as positions and cpu/id
+            amrex::ParticleReal const x = p.pos(0);
+            amrex::ParticleReal const y = p.pos(1);
+            amrex::ParticleReal const t = p.pos(2);
+
+            // access reference particle values to find (beta*gamma)^2
+            //amrex::ParticleReal const pt_ref = refpart.pt;
+            //amrex::ParticleReal const betgam2 = pow(pt_ref, 2) - 1.0_prt;
+
+            // intialize output values of momenta
+            amrex::ParticleReal pxout = px;
+            amrex::ParticleReal pyout = py;
+            amrex::ParticleReal ptout = pt;
+
+            // assign complex position zeta = x + iy
+            amrex::GpuComplex zeta(x,y);
+            amrex::GpuComplex re1(1.0,0.0);
+            amrex::GpuComplex im1(0.0,1.0);
+
+            // compute croot = sqrt(1-zeta**2)
+            amrex::GpuComplex croot = amrex::pow(zeta,2);
+            croot = re1 - croot;
+            croot = amrex::sqrt(croot);
+
+            // compute carcsin = arcsin(zeta)
+            amrex::GpuComplex carcsin = im1*zeta + croot;
+            carcsin = -im1*amrex::log(carcsin);
+
+            // compute complex function F'(zeta)            
+            amrex::GpuComplex dF = zeta/amrex::pow(croot,2);
+            dF = dF + carcsin/amrex::pow(croot,3);
+
+            // compute momentum kick
+            amrex::ParticleReal kick = -m_knll/m_cnll;
+            amrex::ParticleReal dpx = kick*dF.m_real;
+            amrex::ParticleReal dpy = -kick*dF.m_imag;
+
+            // advance position and momentum
+            p.pos(0) = x;
+            pxout = px + dpx;
+
+            p.pos(1) = y;
+            pyout = py + dpy;
+
+            p.pos(2) = t;
+            ptout = pt;
+
+            // assign updated momenta
+            px = pxout;
+            py = pyout;
+            pt = ptout;
+
+        }
+
+    private:
+        amrex::ParticleReal m_knll; //! integrated strength of the nonlinear lens (m)
+        amrex::ParticleReal m_cnll; //! distance of singularities from the origin (m)
+
+    };
+
+} // namespace impactx
+
+#endif // IMPACTX_NONLINEARLENS_H

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -83,11 +83,11 @@ namespace impactx
             croot = amrex::sqrt(croot);
 
             // compute carcsin = arcsin(zeta)
-            amrex::GpuComplex carcsin = im1*zeta + croot;
+            Complex carcsin = im1*zeta + croot;
             carcsin = -im1*amrex::log(carcsin);
 
             // compute complex function F'(zeta)
-            amrex::GpuComplex dF = zeta/amrex::pow(croot,2);
+            Complex dF = zeta/amrex::pow(croot, 2);
             dF = dF + carcsin/amrex::pow(croot,3);
 
             // compute momentum kick

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -78,7 +78,7 @@ namespace impactx
             Complex im1(0.0_prt, 1.0_prt);
 
             // compute croot = sqrt(1-zeta**2)
-            amrex::GpuComplex croot = amrex::pow(zeta,2);
+            Complex croot = amrex::pow(zeta, 2);
             croot = re1 - croot;
             croot = amrex::sqrt(croot);
 

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -83,7 +83,7 @@ namespace impactx
             amrex::GpuComplex carcsin = im1*zeta + croot;
             carcsin = -im1*amrex::log(carcsin);
 
-            // compute complex function F'(zeta)            
+            // compute complex function F'(zeta)
             amrex::GpuComplex dF = zeta/amrex::pow(croot,2);
             dF = dF + carcsin/amrex::pow(croot,3);
 


### PR DESCRIPTION
Added a thin element associated with the kick across a thin segment of the IOTA nonlinear magnetic element.

Inputs correspond to those used in MAD-X.  Implementation is based on the complex formalism documented in the Google drive ABLASTR/ImpactX/Literature subfolder.

An example will appear in a follow-up PR once reduced diagnostics to output the invariants of motion are implemented.