### PR TITLE
Rename ImpactX:: Public Methods

### DIFF
--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -43,14 +43,26 @@ namespace impactx
         void operator= (ImpactX const&) = delete;
         void operator= (ImpactX &&) = delete;
 
-        /** Initialize particle containers and MultiFabs (fields) */
-        void initData ();
+        /** Initialize AMReX blocks/grids
+         *
+         * This must come first, before particle beams and lattice elements are
+         * initialized.
+         */
+        void initGrids ();
 
-        /** Initialize the list of lattice elements */
-        void initElements ();
+        /** Initialize the particle beam distribution
+         *
+         * This clears and initialized the particle beam from input file and
+         * command-line options, as parsed by amrex::ParmParse.
+         */
+        void initBeamDistributionFromInputs ();
 
-        /** Initialize the beam distribution parameters */
-        void initDist ();
+        /** Initialize the list of lattice elements
+         *
+         * This clears and initialized the accelerator lattice elements from
+         * input file and command-line options, as parsed by amrex::ParmParse.
+         */
+        void initLatticeElementsFromInputs ();
 
         /** Run the main simulation loop for a number of steps
          *

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -23,16 +23,13 @@ namespace impactx
     {
     }
 
-    void ImpactX::initData ()
+    void ImpactX::initGrids ()
     {
         AmrCore::InitFromScratch(0.0);
         amrex::Print() << "boxArray(0) " << boxArray(0) << std::endl;
 
         // move old diagnostics out of the way
         amrex::UtilCreateCleanDirectory("diags", true);
-
-        this->initDist();
-        amrex::Print() << "# of particles: " << m_particle_container->TotalNumberOfParticles() << std::endl;
     }
 
     void ImpactX::evolve (int num_steps)

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -82,7 +82,7 @@ namespace
 
 namespace impactx
 {
-    void ImpactX::initDist ()
+    void ImpactX::initBeamDistributionFromInputs ()
     {
         using namespace amrex::literals;
 
@@ -279,5 +279,6 @@ namespace impactx
         }
 
         amrex::Print() << "Initialized beam distribution parameters" << std::endl;
+        amrex::Print() << "# of particles: " << m_particle_container->TotalNumberOfParticles() << std::endl;
     }
 } // namespace impactx

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -18,7 +18,7 @@
 
 namespace impactx
 {
-    void ImpactX::initElements ()
+    void ImpactX::initLatticeElementsFromInputs ()
     {
         // make sure the element sequence is empty
         m_lattice.clear();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,8 +41,9 @@ int main(int argc, char* argv[])
         amrex::Geometry geom(domain, rb, amrex::CoordSys::cartesian, is_periodic);
         auto impactX = std::make_unique<impactx::ImpactX>(geom, amr_info);
 
-        impactX->initData();
-        impactX->initElements();
+        impactX->initGrids();
+        impactX->initBeamDistributionFromInputs();
+        impactX->initLatticeElementsFromInputs();
         impactX->evolve( /* num_steps = */ 1);
 
         BL_PROFILE_VAR_STOP(pmain);


### PR DESCRIPTION
Rename some common methods to be more descriptive, avoiding abbreviations and readying them to be replaced by non-inputs-file control from Python.