### PR TITLE
CI: HIP with https

### DIFF
--- a/.github/workflows/dependencies/hip.sh
+++ b/.github/workflows/dependencies/hip.sh
@@ -8,9 +8,9 @@
 set -eu -o pipefail
 
 # Ref.: https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html#ubuntu
-wget -q -O - http://repo.radeon.com/rocm/rocm.gpg.key \
+wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key \
   | sudo apt-key add -
-echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ ubuntu main' \
+echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' \
   | sudo tee /etc/apt/sources.list.d/rocm.list
 
 echo 'export PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin:$PATH' \


### PR DESCRIPTION
Small update in HIP docs: now supports HTTPS:
https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html#ubuntu

X-ref: https://github.com/AMReX-Codes/amrex/pull/2771