### PR TITLE
Cleanup: Remove std::move

### DIFF
--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -17,13 +17,12 @@
 #include <AMReX_Utility.H>
 
 #include <memory>
-#include <utility>
 
 
 namespace impactx
 {
     ImpactX::ImpactX ()
-        : AmrCore(std::move(initialization::one_box_per_rank())),
+        : AmrCore(initialization::one_box_per_rank()),
           m_particle_container(std::make_unique<ImpactXParticleContainer>(this))
     {
         // todo: if amr.n_cells is provided, overwrite/redefine AmrCore object


### PR DESCRIPTION
Superfluous, since C++17 guarantees a copy elision here.
https://en.cppreference.com/w/cpp/language/copy_elision

Follow-up to #127