### PR TITLE
Added diagnostic to print IOTA invariants H and I for all particles.

### DIFF
--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -110,8 +110,8 @@ namespace impactx
 
         // print the two invariants H and I
         diagnostics::DiagnosticOutput(*m_particle_container,
-                                      diagnostics::OutputType::PrintInvariants,
-                                      "diags/output_invariants.txt");
+                                      diagnostics::OutputType::PrintNonlinearLensInvariants,
+                                      "diags/output_nonlinear_lens_invariants.txt");
 
     }
 } // namespace impactx

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -108,5 +108,10 @@ namespace impactx
                                       diagnostics::OutputType::PrintParticles,
                                       "diags/output_beam.txt");
 
+        // print the two invariants H and I
+        diagnostics::DiagnosticOutput(*m_particle_container,
+                                      diagnostics::OutputType::PrintInvariants,
+                                      "diags/output_invariants.txt");
+
     }
 } // namespace impactx

--- a/src/particles/diagnostics/DiagnosticOutput.H
+++ b/src/particles/diagnostics/DiagnosticOutput.H
@@ -19,7 +19,7 @@ namespace impactx::diagnostics
     enum class OutputType
     {
         PrintParticles, ///< ASCII diagnostics, for small tests only
-        PrintInvariants ///< Also as above
+        PrintNonlinearLensInvariants ///< ASCII diagnostics for the IOTA nonlinear lens, for small tests only
     };
 
     /** ASCII output diagnostics associated with the beam.

--- a/src/particles/diagnostics/DiagnosticOutput.H
+++ b/src/particles/diagnostics/DiagnosticOutput.H
@@ -18,7 +18,8 @@ namespace impactx::diagnostics
      */
     enum class OutputType
     {
-        PrintParticles ///< ASCII diagnostics, for small tests only
+        PrintParticles, ///< ASCII diagnostics, for small tests only
+        PrintInvariants ///< Also as above
     };
 
     /** ASCII output diagnostics associated with the beam.

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -5,6 +5,7 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "DiagnosticOutput.H"
+#include "Invariants.H"
 
 #include <ablastr/particles/IndexHandling.H>
 
@@ -74,6 +75,35 @@ namespace impactx::diagnostics
                                 << px << " " << py << " " << pt << "\n";
                     } // i=0...np
                 } // if( otype == OutputType::PrintParticles)
+                if (otype == OutputType::PrintInvariants) {
+
+                    amrex::ParticleReal const alpha = 0.0;
+                    amrex::ParticleReal const beta = 1.0;
+                    amrex::ParticleReal const tn = 0.4;
+                    amrex::ParticleReal const cn = 0.01;
+                    Invariants Invariants(alpha,beta,tn,cn);
+
+                    // print out particles (this hack works only on CPU and on GPUs with
+                    // unified memory access)
+                    for (int i = 0; i < np; ++i) {
+
+                        // access AoS data such as positions and cpu/id
+                        PType const &p = aos_ptr[i];
+                        amrex::ParticleReal const x = p.pos(0);
+                        amrex::ParticleReal const y = p.pos(1);
+
+                        // access SoA Real data
+                        amrex::ParticleReal const px = part_px[i];
+                        amrex::ParticleReal const py = part_py[i];
+
+                        // write particle invariant data to file
+                        invariants_out HI_out;
+                        HI_out = Invariants(x, y, px, py);
+                        amrex::AllPrintToFile(file_name)
+                                << HI_out.H << " " << HI_out.I << "\n";
+
+                    } // i=0...np
+                } // if( otype == OutputType::PrintInvariants)
             } // end loop over all particle boxes
         } // env mesh-refinement level loop
     }

--- a/src/particles/diagnostics/Invariants.H
+++ b/src/particles/diagnostics/Invariants.H
@@ -1,0 +1,127 @@
+/* Copyright 2022 Chad Mitchell, Axel Huebl
+ *
+ * This file is part of ImpactX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_INVARIANTS_H
+#define IMPACTX_INVARIANTS_H
+
+#include "particles/ImpactXParticleContainer.H"
+
+#include <AMReX_Extension.H>
+#include <AMReX_REAL.H>
+#include <AMReX_GpuComplex.H>
+
+#include <cmath>
+
+namespace impactx
+{
+    struct invariants_out {
+        amrex::ParticleReal H;
+        amrex::ParticleReal I;
+    };
+
+    struct Invariants
+    {
+        using PType = ImpactXParticleContainer::ParticleType;
+
+        /** Compute invariants within the nonlinear magnetic insert element
+         *
+         *  Invariants associated with a single short segment of the
+         *  nonlinear magnetic insert described by V. Danilov and
+         *  S. Nagaitsev, PRSTAB 13, 084002 (2010), Sect. V.A.
+         *
+         * @param alpha - Twiss alpha for the bare lattice
+         * @param beta - Twiss beta for the bare lattice (m)
+         * @param tn - dimensionless strength of the nonlinear insert
+         * @param cn - scale parameter of the nonlinear insert (m^[1/2])
+         *
+         */
+        Invariants( amrex::ParticleReal const alpha,
+                   amrex::ParticleReal const beta,
+                   amrex::ParticleReal const tn,
+                   amrex::ParticleReal const cn )
+        : m_alpha(alpha), m_beta(beta), m_tn(tn), m_cn(cn)
+        {
+        }
+
+        /** This is a nonlinear invariant functor, so that a variable of this type
+         *  can be used like a nonlinear invariant function.
+         *
+         * @param x particle position in x
+         * @param y particle position in y
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         */
+
+
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        invariants_out operator() (
+                amrex::ParticleReal const x,
+                amrex::ParticleReal const y,
+                amrex::ParticleReal const px,
+                amrex::ParticleReal const py ) {
+
+            using namespace amrex::literals; // for _rt and _prt
+
+            // a complex type with two amrex::ParticleReal
+            using Complex = amrex::GpuComplex<amrex::ParticleReal>;
+
+            // convert transverse phase space coordinates to normalized units
+            amrex::ParticleReal xn = x/(m_cn*sqrt(m_beta));
+            amrex::ParticleReal yn = y/(m_cn*sqrt(m_beta));
+            amrex::ParticleReal pxn = px*sqrt(m_beta)/m_cn + m_alpha*x;
+            amrex::ParticleReal pyn = py*sqrt(m_beta)/m_cn + m_alpha*y;
+
+            // assign complex position zeta = x + iy
+            Complex zeta(xn, yn);
+            Complex zetaconj(xn, -yn);
+            Complex re1(1.0_prt, 0.0_prt);
+            Complex im1(0.0_prt, 1.0_prt);
+
+            // compute croot = sqrt(1-zeta**2)
+            Complex croot = amrex::pow(zeta, 2);
+            croot = re1 - croot;
+            croot = amrex::sqrt(croot);
+
+            // compute carcsin = arcsin(zeta)
+            Complex carcsin = im1*zeta + croot;
+            carcsin = -im1*amrex::log(carcsin);
+
+            // compute complex potential appearing in H invariant
+            Complex Hpotential = zeta/croot;
+            Hpotential = Hpotential*carcsin;
+
+            // compute complex potential appearing in I invariant
+            Complex Ipotential = (zeta+zetaconj)/croot;
+            Ipotential = Ipotential*carcsin;
+
+            // evaluate real parts
+            amrex::ParticleReal Hinv = Hpotential.m_real;
+            amrex::ParticleReal Iinv = Ipotential.m_real;
+
+            // compute invariants H and I
+            amrex::ParticleReal Jz = xn*pyn - yn*pxn;
+            Hinv = (pow(xn,2) + pow(yn,2) + pow(pxn,2) + pow(pyn,2))/2
+                 + m_tn*Hinv;
+            Iinv = pow(Jz,2) + pow(pxn,2) + pow(xn,2) + m_tn*Iinv;
+
+            invariants_out HI_out;
+            HI_out.H = Hinv;
+            HI_out.I = Iinv;
+            return HI_out;
+
+        }
+
+    private:
+        amrex::ParticleReal m_alpha; //! Twiss alpha
+        amrex::ParticleReal m_beta; //! Twiss beta (m)
+        amrex::ParticleReal m_tn; //! dimensionless strength of the nonlinear insert
+        amrex::ParticleReal m_cn; //! scale parameter of the nonlinear insert (m^[1/2])
+
+    };
+
+} // namespace impactx
+
+#endif // IMPACTX_INVARIANTS_H

--- a/src/particles/diagnostics/NonlinearLensInvariants.H
+++ b/src/particles/diagnostics/NonlinearLensInvariants.H
@@ -27,13 +27,14 @@ namespace impactx::diagnostics
     {
         using PType = ImpactXParticleContainer::ParticleType;
 
-        /** Independent coordinates
+        /** Two independent phase space functions in involution
          *
-         * Independent coordinates that are tracked as invariants of motion.
+         * Independent functions that are tracked as invariants of motion
+         * in the IOTA nonlinear magnetic insert.
          */
         struct Data {
-            amrex::ParticleReal H; ///< first generalized coordinate
-            amrex::ParticleReal I; ///< second generalized coordinate
+            amrex::ParticleReal H; ///< first phase space function (Hamiltonian) 
+            amrex::ParticleReal I; ///< second phase space function ("second invariant")
         };
 
         /** Initialize the parameters for the invariants based on the beam

--- a/src/particles/diagnostics/NonlinearLensInvariants.H
+++ b/src/particles/diagnostics/NonlinearLensInvariants.H
@@ -15,22 +15,29 @@
 
 #include <cmath>
 
-namespace impactx
+namespace impactx::diagnostics
 {
-    struct invariants_out {
-        amrex::ParticleReal H;
-        amrex::ParticleReal I;
-    };
-
-    struct Invariants
+    /** Compute invariants within the nonlinear magnetic insert element
+     *
+     *  Invariants associated with a single short segment of the
+     *  nonlinear magnetic insert described by V. Danilov and
+     *  S. Nagaitsev, PRSTAB 13, 084002 (2010), Sect. V.A.
+     */
+    struct NonlinearLensInvariants
     {
         using PType = ImpactXParticleContainer::ParticleType;
 
-        /** Compute invariants within the nonlinear magnetic insert element
+        /** Independent coordinates
          *
-         *  Invariants associated with a single short segment of the
-         *  nonlinear magnetic insert described by V. Danilov and
-         *  S. Nagaitsev, PRSTAB 13, 084002 (2010), Sect. V.A.
+         * Independent coordinates that are tracked as invariants of motion.
+         */
+        struct Data {
+            amrex::ParticleReal H; ///< first generalized coordinate
+            amrex::ParticleReal I; ///< second generalized coordinate
+        };
+
+        /** Initialize the parameters for the invariants based on the beam
+         *  distribution and parameters of the nonlinear insert element
          *
          * @param alpha - Twiss alpha for the bare lattice
          * @param beta - Twiss beta for the bare lattice (m)
@@ -38,10 +45,11 @@ namespace impactx
          * @param cn - scale parameter of the nonlinear insert (m^[1/2])
          *
          */
-        Invariants( amrex::ParticleReal const alpha,
-                   amrex::ParticleReal const beta,
-                   amrex::ParticleReal const tn,
-                   amrex::ParticleReal const cn )
+        NonlinearLensInvariants(
+            amrex::ParticleReal const alpha,
+            amrex::ParticleReal const beta,
+            amrex::ParticleReal const tn,
+            amrex::ParticleReal const cn )
         : m_alpha(alpha), m_beta(beta), m_tn(tn), m_cn(cn)
         {
         }
@@ -54,14 +62,13 @@ namespace impactx
          * @param px particle momentum in x
          * @param py particle momentum in y
          */
-
-
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        invariants_out operator() (
+        Data operator() (
                 amrex::ParticleReal const x,
                 amrex::ParticleReal const y,
                 amrex::ParticleReal const px,
-                amrex::ParticleReal const py ) {
+                amrex::ParticleReal const py ) const
+        {
 
             using namespace amrex::literals; // for _rt and _prt
 
@@ -107,10 +114,7 @@ namespace impactx
                  + m_tn*Hinv;
             Iinv = pow(Jz,2) + pow(pxn,2) + pow(xn,2) + m_tn*Iinv;
 
-            invariants_out HI_out;
-            HI_out.H = Hinv;
-            HI_out.I = Iinv;
-            return HI_out;
+            return {Hinv, Iinv};
 
         }
 

--- a/src/particles/diagnostics/NonlinearLensInvariants.H
+++ b/src/particles/diagnostics/NonlinearLensInvariants.H
@@ -33,7 +33,7 @@ namespace impactx::diagnostics
          * in the IOTA nonlinear magnetic insert.
          */
         struct Data {
-            amrex::ParticleReal H; ///< first phase space function (Hamiltonian) 
+            amrex::ParticleReal H; ///< first phase space function (Hamiltonian)
             amrex::ParticleReal I; ///< second phase space function ("second invariant")
         };
 


### PR DESCRIPTION
Computes IOTA invariants of motion for all particles and prints to file.

1) Is the call from "DiagnosticOutput.cpp" the best place to put this?  

2) Input values of alpha, beta, t, and c are hard-coded, and this needs to be updated.

3) A follow-up request will update the IOTA thin lens element test problem to use this new diagnostic.