### PR TITLE
Update: ABLASTR; Diagnostics: Globally Unique ID

### DIFF
--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -118,7 +118,7 @@ set(ImpactX_ablastr_src ""
 set(ImpactX_ablastr_repo "https://github.com/ECP-WarpX/WarpX.git"
     CACHE STRING
     "Repository URI to pull and build ABLASTR from if(ImpactX_ablastr_internal)")
-set(ImpactX_ablastr_branch "4922e3397735608f060bf26008f1f4426ca1f855"
+set(ImpactX_ablastr_branch "3c2d0ee2815ab1df21b9f78d899fe7b1a9651758"
     CACHE STRING
     "Repository branch for ImpactX_ablastr_repo if(ImpactX_ablastr_internal)")
 

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -6,6 +6,8 @@
  */
 #include "DiagnosticOutput.H"
 
+#include <ablastr/particles/IndexHandling.H>
+
 #include <AMReX_Extension.H>  // for AMREX_RESTRICT
 #include <AMReX_ParallelDescriptor.H>  // for ParallelDescriptor
 #include <AMReX_REAL.H>       // for ParticleReal
@@ -27,7 +29,7 @@ namespace impactx::diagnostics
         tmp.copyParticles(pc, local);
 
         // write file header per MPI RANK
-        amrex::AllPrintToFile(file_name) << "x y t px py pt\n";
+        amrex::AllPrintToFile(file_name) << "id x y t px py pt\n";
 
         // loop over refinement levels
         int const nLevel = tmp.finestLevel();
@@ -58,6 +60,7 @@ namespace impactx::diagnostics
                         amrex::ParticleReal const x = p.pos(0);
                         amrex::ParticleReal const y = p.pos(1);
                         amrex::ParticleReal const t = p.pos(2);
+                        uint64_t const global_id = ablastr::particles::localIDtoGlobal(p.id(), p.cpu());
 
                         // access SoA Real data
                         amrex::ParticleReal const px = part_px[i];
@@ -66,6 +69,7 @@ namespace impactx::diagnostics
 
                         // write particle data to file
                         amrex::AllPrintToFile(file_name)
+                                << global_id << " "
                                 << x << " " << y << " " << t << " "
                                 << px << " " << py << " " << pt << "\n";
                     } // i=0...np


### PR DESCRIPTION
Update the ABLATR commit (including WarpX/AMReX update).

Pulls in:
- https://github.com/ECP-WarpX/WarpX/pull/3115

among others.

Diagnostics: Print globally unique particle ID.