### PR TITLE
Modified IOTA nonlinear lens example

### DIFF
--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -14,6 +14,7 @@ This section allows you to **download input files** that correspond to different
    examples/kurth/README.rst
    examples/fodo_rf/README.rst
    examples/multipole/README.rst
+   examples/iota_lens/README.rst
 
 
 Test Cases / Benchmarks

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -358,7 +358,7 @@ Diagnostics related to integrable optics in the IOTA nonlinear magnetic insert e
 
 * ``diag.tn`` (``float``, unitless) dimensionless strength of the IOTA nonlinear magnetic insert element used for computing H and I.
 
-* ``diag.cn`` (``float``, meters^(1/2)) scale factor of the IOTA nonlinear magnetic insert element used for computing H and I. 
+* ``diag.cn`` (``float``, meters^(1/2)) scale factor of the IOTA nonlinear magnetic insert element used for computing H and I.
 
 
 .. _running-cpp-parameters-diagnostics-insitu:

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -348,6 +348,19 @@ Numerics and algorithms
 Diagnostics and output
 ----------------------
 
+Diagnostics related to integrable optics in the IOTA nonlinear magnetic insert element:
+
+* ``diag.alpha`` (``float``, unitless) Twiss alpha of the bare linear lattice at the location of output for the nonlinear
+    IOTA invariants H and I.  Horizontal and vertical values must be equal.
+
+* ``diag.beta`` (``float``, meters) Twiss beta of the bare linear lattice at the location of output for the nonlinear
+    IOTA invariants H and I.  Horizontal and vertical values must be equal.
+
+* ``diag.tn`` (``float``, unitless) dimensionless strength of the IOTA nonlinear magnetic insert element used for computing H and I.
+
+* ``diag.cn`` (``float``, meters^(1/2)) scale factor of the IOTA nonlinear magnetic insert element used for computing H and I. 
+
+
 .. _running-cpp-parameters-diagnostics-insitu:
 
 In-situ visualization

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -174,3 +174,16 @@ add_test(NAME multipole.analysis
 )
 
 set_tests_properties(multipole.analysis PROPERTIES DEPENDS "multipole.run")
+
+# IOTA Nonlinear Focusing Channel Test ############################################################
+#
+add_test(NAME iotalens.run
+         COMMAND $<TARGET_FILE:app> ${ImpactX_SOURCE_DIR}/examples/iota_lens/input_iotalens.in
+         WORKING_DIRECTORY ${ImpactX_RUNTIME_OUTPUT_DIRECTORY}
+)
+add_test(NAME iotalens.analysis
+         COMMAND ${ImpactX_SOURCE_DIR}/examples/iota_lens/analysis_iotalens.py
+         WORKING_DIRECTORY ${ImpactX_RUNTIME_OUTPUT_DIRECTORY}
+)
+
+set_tests_properties(iotalens.analysis PROPERTIES DEPENDS "iotalens.run")

--- a/examples/iota_lens/README.rst
+++ b/examples/iota_lens/README.rst
@@ -1,0 +1,18 @@
+.. _examples-iotalens:
+
+A nonlinear focusing channel based on the IOTA nonlinear lens.
+====================================
+
+A constant focusing channel with nonlinear focusing, using a string of thin
+IOTA nonlinear lens elements alternating with constant focusing elements.
+
+We use a 2.5 MeV proton beam, corresponding to the nominal IOTA proton energy.
+
+The two functions H (Hamiltonian) and I (the second invariant) should remain unchanged for all particles.
+
+In this test, the initial and final values of :math:`\mu_H`, :math:`\sigma_H`, :math:`\mu_I`, :math:`\sigma_I` must agree with nominal values.
+
+
+.. literalinclude:: input_iotalens.in
+   :language: ini
+   :caption: You can copy this file from ``examples/iota_lens/input_iotalens.in``.

--- a/examples/iota_lens/README.rst
+++ b/examples/iota_lens/README.rst
@@ -1,7 +1,7 @@
 .. _examples-iotalens:
 
-A nonlinear focusing channel based on the IOTA nonlinear lens.
-====================================
+A nonlinear focusing channel based on the IOTA nonlinear lens
+=============================================================
 
 A constant focusing channel with nonlinear focusing, using a string of thin
 IOTA nonlinear lens elements alternating with constant focusing elements.

--- a/examples/iota_lens/analysis_iotalens.py
+++ b/examples/iota_lens/analysis_iotalens.py
@@ -43,7 +43,7 @@ def read_all_files(file_pattern):
         ),
         axis=0,
         ignore_index=True,
-    )
+    ).set_index('id')
 
 
 # initial/final beam on rank zero
@@ -89,9 +89,16 @@ assert np.allclose(
     atol=atol
 )
 
+# join tables on particle ID, so we can compare the same particle initial->final
+beam_joined = final.join(
+    initial,
+    lsuffix='_final',
+    rsuffix='_initial'
+)
 # add new columns: dH and dI
-final['dH'] = initial["H"] - final["H"]
-final['dI'] = initial["I"] - final["I"]
+beam_joined['dH'] = beam_joined["H_initial"] - beam_joined["H_final"]
+beam_joined['dI'] = beam_joined["I_initial"] - beam_joined["I_final"]
+#print(beam_joined)
 
 # particle-wise comparison of H & I initial to final
 atol = 0.076
@@ -99,10 +106,10 @@ rtol = 1.0  # large number
 print()
 print(f"  atol={atol} (ignored: rtol~={rtol})")
 
-print(f"  dH_min={final['dH'].min()}, dH_max={final['dH'].max()}")
-assert np.allclose(final['dH'], 0.0, rtol=rtol, atol=atol)
+print(f"  dH_min={beam_joined['dH'].min()}, dH_max={beam_joined['dH'].max()}")
+assert np.allclose(beam_joined['dH'], 0.0, rtol=rtol, atol=atol)
 
 atol = 0.151
 print(f"  atol={atol} (ignored: rtol~={rtol})")
-print(f"  dI_min={final['dI'].min()}, dI_max={final['dI'].max()}")
-assert np.allclose(final['dI'], 0.0, rtol=rtol, atol=atol)
+print(f"  dI_min={beam_joined['dI'].min()}, dI_max={beam_joined['dI'].max()}")
+assert np.allclose(beam_joined['dI'], 0.0, rtol=rtol, atol=atol)

--- a/examples/iota_lens/analysis_iotalens.py
+++ b/examples/iota_lens/analysis_iotalens.py
@@ -88,3 +88,21 @@ assert np.allclose(
     rtol=rtol,
     atol=atol
 )
+
+# add new columns: dH and dI
+final['dH'] = initial["H"] - final["H"]
+final['dI'] = initial["I"] - final["I"]
+
+# particle-wise comparison of H & I initial to final
+atol = 0.076
+rtol = 1.0  # large number
+print()
+print(f"  atol={atol} (ignored: rtol~={rtol})")
+
+print(f"  dH_min={final['dH'].min()}, dH_max={final['dH'].max()}")
+assert np.allclose(final['dH'], 0.0, rtol=rtol, atol=atol)
+
+atol = 0.151
+print(f"  atol={atol} (ignored: rtol~={rtol})")
+print(f"  dI_min={final['dI'].min()}, dI_max={final['dI'].max()}")
+assert np.allclose(final['dI'], 0.0, rtol=rtol, atol=atol)

--- a/examples/iota_lens/analysis_iotalens.py
+++ b/examples/iota_lens/analysis_iotalens.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 from scipy.stats import moment
 
+
 def get_moments(beam):
     """Calculate mean and std dev of functions defining the IOTA invariants
 

--- a/examples/iota_lens/analysis_iotalens.py
+++ b/examples/iota_lens/analysis_iotalens.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+import glob
+
+import numpy as np
+import pandas as pd
+from scipy.stats import moment
+
+def get_moments(beam):
+    """Calculate mean and std dev of functions defining the IOTA invariants
+
+    Returns
+    -------
+    meanH, sigH, meanI, sigI
+    """
+    meanH = np.mean(beam["H"])
+    sigH = moment(beam["H"],moment=2)**0.5
+    meanI = np.mean(beam["I"])
+    sigI = moment(beam["I"],moment=2)**0.5
+
+    return (
+        meanH, sigH, meanI, sigI)
+
+
+def read_all_files(file_pattern):
+    """Read in all CSV files from each MPI rank (and potentially OpenMP
+    thread). Concatenate into one Pandas dataframe.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    return pd.concat(
+        (
+            pd.read_csv(filename, delimiter=r"\s+")
+            for filename in glob.glob(file_pattern)
+        ),
+        axis=0,
+        ignore_index=True,
+    )
+
+
+# initial/final beam on rank zero
+initial = read_all_files("diags/initial_nonlinear_lens_invariants.txt.*")
+final = read_all_files("diags/output_nonlinear_lens_invariants.txt.*")
+
+# compare number of particles
+num_particles = 10000
+assert num_particles == len(initial)
+assert num_particles == len(final)
+
+print("Initial Beam:")
+meanH, sigH, \
+   meanI, sigI = get_moments(initial)
+print(f"  meanH={meanH:e} sigH={sigH:e} meanI={meanI:e} sigI={sigI:e}")
+
+atol = 1.0  # a big number
+rtol = num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [meanH, sigH, meanI, sigI],
+    [1.604948e-01, 1.757985e-01, 2.882956e-01, 3.844099e-01],
+    rtol=rtol,
+    atol=atol
+)
+
+
+print("")
+print("Final Beam:")
+meanH, sigH, \
+   meanI, sigI = get_moments(final)
+print(f"  meanH={meanH:e} sigH={sigH:e} meanI={meanI:e} sigI={sigI:e}")
+
+atol = 1.0  # a big number
+rtol = num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [meanH, sigH, meanI, sigI],
+    [1.605336e-01, 1.756235e-01, 2.880581e-01, 3.839625e-01],
+    rtol=rtol,
+    atol=atol
+)

--- a/examples/iota_lens/input_iotalens.in
+++ b/examples/iota_lens/input_iotalens.in
@@ -27,7 +27,7 @@ lattice.elements = const_end nllens const nllens const nllens const nllens const
                    const_end
 
 nllens.type = nonlinear_lens
-nllens.knll = 2.0e-7   
+nllens.knll = 2.0e-7
 nllens.cnll = 0.01
 
 const_end.type = constf

--- a/examples/iota_lens/input_iotalens.in
+++ b/examples/iota_lens/input_iotalens.in
@@ -1,0 +1,58 @@
+###############################################################################
+# Particle Beam(s)
+###############################################################################
+beam.npart = 10000
+beam.units = static
+beam.energy = 2.5
+beam.charge = 0.0
+beam.particle = proton
+beam.distribution = waterbag
+beam.sigmaX = 4.0e-3
+beam.sigmaY = 4.0e-3
+beam.sigmaT = 1.0e-3
+beam.sigmaPx = 3.0e-4
+beam.sigmaPy = 3.0e-4
+beam.sigmaPt = 0.0
+beam.muxpx = 0.0
+beam.muypy = 0.0
+beam.mutpt = 0.0
+
+
+###############################################################################
+# Beamline: lattice elements and segments
+###############################################################################
+
+lattice.elements = const_end nllens const nllens const nllens const nllens const
+                   nllens const nllens const nllens const nllens const nllens const nllens
+                   const_end
+
+nllens.type = nonlinear_lens
+nllens.knll = 2.0e-7   
+nllens.cnll = 0.01
+
+const_end.type = constf
+const_end.ds = 0.0025
+const_end.kx = 1.0
+const_end.ky = 1.0
+const_end.kt = 1.0e-12
+
+const.type = constf
+const.ds = 0.005
+const.kx = 1.0
+const.ky = 1.0
+const.kt = 1.0e-12
+
+
+###############################################################################
+# Algorithms
+###############################################################################
+algo.particle_shape = 2
+
+
+###############################################################################
+# Diagnostics
+###############################################################################
+diag.alpha = 0.0
+diag.beta = 1.0
+diag.tn = 0.4
+diag.cn = 0.01

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -49,6 +49,11 @@ namespace impactx
                                       diagnostics::OutputType::PrintParticles,
                                       "diags/initial_beam.txt");
 
+        // print the initial values of the two invariants H and I
+        diagnostics::DiagnosticOutput(*m_particle_container,
+                                      diagnostics::OutputType::PrintNonlinearLensInvariants,
+                                      "diags/initial_nonlinear_lens_invariants.txt");
+
         for (int step = 0; step < num_steps; ++step)
         {
             BL_PROFILE("ImpactX::evolve::step");
@@ -108,7 +113,7 @@ namespace impactx
                                       diagnostics::OutputType::PrintParticles,
                                       "diags/output_beam.txt");
 
-        // print the two invariants H and I
+        // print the final values of the two invariants H and I
         diagnostics::DiagnosticOutput(*m_particle_container,
                                       diagnostics::OutputType::PrintNonlinearLensInvariants,
                                       "diags/output_nonlinear_lens_invariants.txt");

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -11,8 +11,8 @@
 
 #include <AMReX_Extension.H>  // for AMREX_RESTRICT
 #include <AMReX_ParallelDescriptor.H>  // for ParallelDescriptor
-#include <AMReX_REAL.H>       // for ParticleReal
 #include <AMReX_ParmParse.H>  // for ParmParse
+#include <AMReX_REAL.H>       // for ParticleReal
 #include <AMReX_Print.H>      // for PrintToFile
 
 namespace impactx::diagnostics

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -12,6 +12,7 @@
 #include <AMReX_Extension.H>  // for AMREX_RESTRICT
 #include <AMReX_ParallelDescriptor.H>  // for ParallelDescriptor
 #include <AMReX_REAL.H>       // for ParticleReal
+#include <AMReX_ParmParse.H> // for ParmParse
 #include <AMReX_Print.H>      // for PrintToFile
 
 namespace impactx::diagnostics
@@ -81,10 +82,23 @@ namespace impactx::diagnostics
                 } // if( otype == OutputType::PrintParticles)
                 else if (otype == OutputType::PrintNonlinearLensInvariants) {
 
-                    amrex::ParticleReal const alpha = 0.0;
-                    amrex::ParticleReal const beta = 1.0;
-                    amrex::ParticleReal const tn = 0.4;
-                    amrex::ParticleReal const cn = 0.01;
+                    using namespace amrex::literals;
+
+                    // Parse the diagnostic parameters
+                    amrex::ParmParse pp_dist("diag");
+
+                    amrex::ParticleReal alpha = 0.0;
+                    pp_dist.query("alpha", alpha);
+                    
+                    amrex::ParticleReal beta = 1.0;
+                    pp_dist.query("beta", beta);
+                    
+                    amrex::ParticleReal tn = 0.4;
+                    pp_dist.query("tn", tn);
+                    
+                    amrex::ParticleReal cn = 0.01;
+                    pp_dist.query("cn", cn);
+
                     NonlinearLensInvariants const nonlinear_lens_invariants(alpha, beta, tn, cn);
 
                     // print out particles (this hack works only on CPU and on GPUs with

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -12,7 +12,7 @@
 #include <AMReX_Extension.H>  // for AMREX_RESTRICT
 #include <AMReX_ParallelDescriptor.H>  // for ParallelDescriptor
 #include <AMReX_REAL.H>       // for ParticleReal
-#include <AMReX_ParmParse.H> // for ParmParse
+#include <AMReX_ParmParse.H>  // for ParmParse
 #include <AMReX_Print.H>      // for PrintToFile
 
 namespace impactx::diagnostics

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -89,13 +89,13 @@ namespace impactx::diagnostics
 
                     amrex::ParticleReal alpha = 0.0;
                     pp_dist.query("alpha", alpha);
-                    
+
                     amrex::ParticleReal beta = 1.0;
                     pp_dist.query("beta", beta);
-                    
+
                     amrex::ParticleReal tn = 0.4;
                     pp_dist.query("tn", tn);
-                    
+
                     amrex::ParticleReal cn = 0.01;
                     pp_dist.query("cn", cn);
 


### PR DESCRIPTION
Significant changes to the example using the IOTA nonlinear lens:

1) now use a sequence of thin nonlinear lenses + constant linear focusing to approximate a thick nonlinear element
2) modified the input file to accept parameters needed to compute the (H,I) diagnostics
3) added as diagnostic output the invariant functions (H,I) in "diags/"
4) modified the example analysis script to compare the initial and final moments of H and I

This example could be further improved by comparing the initial and final values of (H,I) for every particle using the particle ID.  (To do.)
