### PR TITLE
Analysis: Id as Pandas Dataframe Index

### DIFF
--- a/examples/cfchannel/analysis_cfchannel.py
+++ b/examples/cfchannel/analysis_cfchannel.py
@@ -52,7 +52,7 @@ def read_all_files(file_pattern):
         ),
         axis=0,
         ignore_index=True,
-    )
+    ).set_index('id')
 
 
 # initial/final beam on rank zero

--- a/examples/chicane/analysis_chicane.py
+++ b/examples/chicane/analysis_chicane.py
@@ -52,7 +52,7 @@ def read_all_files(file_pattern):
         ),
         axis=0,
         ignore_index=True,
-    )
+    ).set_index('id')
 
 
 # initial/final beam on rank zero

--- a/examples/distgen/analysis_gaussian.py
+++ b/examples/distgen/analysis_gaussian.py
@@ -52,7 +52,7 @@ def read_all_files(file_pattern):
         ),
         axis=0,
         ignore_index=True,
-    )
+    ).set_index('id')
 
 
 # initial/final beam on rank zero

--- a/examples/distgen/analysis_kurth4d.py
+++ b/examples/distgen/analysis_kurth4d.py
@@ -52,7 +52,7 @@ def read_all_files(file_pattern):
         ),
         axis=0,
         ignore_index=True,
-    )
+    ).set_index('id')
 
 
 # initial/final beam on rank zero

--- a/examples/distgen/analysis_kvdist.py
+++ b/examples/distgen/analysis_kvdist.py
@@ -52,7 +52,7 @@ def read_all_files(file_pattern):
         ),
         axis=0,
         ignore_index=True,
-    )
+    ).set_index('id')
 
 
 # initial/final beam on rank zero

--- a/examples/distgen/analysis_semigaussian.py
+++ b/examples/distgen/analysis_semigaussian.py
@@ -52,7 +52,7 @@ def read_all_files(file_pattern):
         ),
         axis=0,
         ignore_index=True,
-    )
+    ).set_index('id')
 
 
 # initial/final beam on rank zero

--- a/examples/fodo/analysis_fodo.py
+++ b/examples/fodo/analysis_fodo.py
@@ -52,7 +52,7 @@ def read_all_files(file_pattern):
         ),
         axis=0,
         ignore_index=True,
-    )
+    ).set_index('id')
 
 
 # initial/final beam on rank zero

--- a/examples/fodo_rf/analysis_fodo_rf.py
+++ b/examples/fodo_rf/analysis_fodo_rf.py
@@ -52,7 +52,7 @@ def read_all_files(file_pattern):
         ),
         axis=0,
         ignore_index=True,
-    )
+    ).set_index('id')
 
 
 # initial/final beam on rank zero

--- a/examples/kurth/analysis_kurth.py
+++ b/examples/kurth/analysis_kurth.py
@@ -52,7 +52,7 @@ def read_all_files(file_pattern):
         ),
         axis=0,
         ignore_index=True,
-    )
+    ).set_index('id')
 
 
 # initial/final beam on rank zero

--- a/examples/multipole/analysis_multipole.py
+++ b/examples/multipole/analysis_multipole.py
@@ -52,7 +52,7 @@ def read_all_files(file_pattern):
         ),
         axis=0,
         ignore_index=True,
-    )
+    ).set_index('id')
 
 
 # initial/final beam on rank zero


### PR DESCRIPTION
Use the unique particle ID (#135) as pandas column index. This is more useful instead of adding an auto-generated, zero-based index in the pandas dataframe: joins of multiple time steps can be done on the default index (#137) and there is no confusion by having an extra column.