### PR TITLE
Update ABLASTR: ComputePhi

### DIFF
--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -118,7 +118,7 @@ set(ImpactX_ablastr_src ""
 set(ImpactX_ablastr_repo "https://github.com/ECP-WarpX/WarpX.git"
     CACHE STRING
     "Repository URI to pull and build ABLASTR from if(ImpactX_ablastr_internal)")
-set(ImpactX_ablastr_branch "3c2d0ee2815ab1df21b9f78d899fe7b1a9651758"
+set(ImpactX_ablastr_branch "95e92ff51599b685af4d09f867af4c49a42f2a72"
     CACHE STRING
     "Repository branch for ImpactX_ablastr_repo if(ImpactX_ablastr_internal)")
 


### PR DESCRIPTION
Update the ABLATR commit (including WarpX/AMReX update).

Pulls in:
- `ComputePhi` https://github.com/ECP-WarpX/WarpX/pull/2994
- Msg/Warning Logger https://github.com/ECP-WarpX/WarpX/pull/3154
- Improved CMake logic for Python superbuilds

among others.