### PR TITLE
ParticleContainer: Delay Shape Init

### DIFF
--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -94,7 +94,7 @@ namespace impactx
 
         /** Resize the mesh, based on the extent of the bunch of particle
          *
-         * This only changes thes physical extent of the mesh, but not the
+         * This only changes the physical extent of the mesh, but not the
          * number of grid cells.
          */
         void ResizeMesh ();

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -36,6 +36,11 @@ namespace impactx
 
     void ImpactX::initGrids ()
     {
+        // this is the earliest point that we need to know the particle shape,
+        // so that we can initialize the guard size of our MultiFabs
+        m_particle_container->SetParticleShape();
+
+        // init blocks / grids & MultiFabs
         AmrCore::InitFromScratch(0.0);
         amrex::Print() << "boxArray(0) " << boxArray(0) << std::endl;
 

--- a/src/particles/ChargeDeposition.cpp
+++ b/src/particles/ChargeDeposition.cpp
@@ -77,7 +77,8 @@ namespace impactx
                     ablastr::particles::deposit_charge<ImpactXParticleContainer>
                             (pti, wp, charge, ion_lev, &rho_at_level,
                              local_rho_fab,
-                             m_particle_shape, dx, xyzmin, n_rz_azimuthal_modes);
+                             m_particle_shape.value(),
+                             dx, xyzmin, n_rz_azimuthal_modes);
                 }
             }
         }

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -19,6 +19,7 @@
 #include <AMReX_IntVect.H>
 #include <AMReX_Vector.H>
 
+#include <optional>
 #include <tuple>
 #include <unordered_map>
 
@@ -147,7 +148,15 @@ namespace impactx
         /** Get particle shape
          */
         int
-        GetParticleShape () const { return m_particle_shape; }
+        GetParticleShape () const { return m_particle_shape.value(); }
+
+        /** Set Particle Shape from amrex::ParmParse inputs
+         *
+         * Note: this can only be called once. All later calls are a logic error.
+         * The reason for that is that subsequent calls would need to change
+         * the guard size of all our MultiFabs, which is not implemented.
+         */
+        void SetParticleShape ();
 
         /** Compute the min and max of the particle position in each dimension
          *
@@ -187,7 +196,7 @@ namespace impactx
         RefPart m_refpart;
 
         //! the particle shape
-        int m_particle_shape = 0;
+        std::optional<int> m_particle_shape;
 
     }; // ImpactXParticleContainer
 

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -18,6 +18,8 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_ParticleTile.H>
 
+#include <stdexcept>
+
 
 namespace impactx
 {
@@ -25,13 +27,22 @@ namespace impactx
         : amrex::ParticleContainer<0, 0, RealSoA::nattribs, IntSoA::nattribs>(amr_core->GetParGDB())
     {
         SetParticleSize();
+    }
 
-        // particle shapes
-        amrex::ParmParse pp_algo("algo");
-        pp_algo.get("particle_shape", m_particle_shape);
-        if (m_particle_shape < 1 || m_particle_shape > 3)
+    void ImpactXParticleContainer::SetParticleShape ()
+    {
+        if (m_particle_shape.has_value()) {
+            throw std::logic_error(
+                "ImpactXParticleContainer::SetParticleShape This was already called before and cannot be changed.");
+        } else
         {
-            amrex::Abort("algo.particle_shape can be only 1, 2, or 3");
+            amrex::ParmParse pp_algo("algo");
+            int v = 0;
+            pp_algo.get("particle_shape", v);
+            m_particle_shape = v;
+            if (m_particle_shape.value() < 1 || m_particle_shape.value() > 3) {
+                amrex::Abort("algo.particle_shape can be only 1, 2, or 3");
+            }
         }
     }
 
@@ -54,7 +65,6 @@ namespace impactx
         AMREX_ALWAYS_ASSERT(x.size() == px.size());
         AMREX_ALWAYS_ASSERT(x.size() == py.size());
         AMREX_ALWAYS_ASSERT(x.size() == pz.size());
-
 
         // number of particles to add
         int const np = x.size();


### PR DESCRIPTION
Delay reading the required shape parameter. This allows us to load a runtime inputs file in Python (#123) before initializing the grids and MultiFabs with the respective guard size, which depends on the particle shape.