### PR TITLE
Preparing to push the global reference particle.

### DIFF
--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -261,9 +261,11 @@ namespace impactx
         refPart.x = 0.0;
         refPart.y = 0.0;
         refPart.t = 0.0;
+        refPart.z = 0.0;
         refPart.px = 0.0;
         refPart.py = 0.0;
         refPart.pt = -energy/massE - 1.0_prt;
+        refPart.pz = sqrt(pow(refPart.pt,2) - 1.0_prt);
         m_particle_container->SetRefParticle(refPart);
 
         // print information on the initialized beam

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -77,9 +77,11 @@ namespace impactx
     {
         amrex::ParticleReal x = 0.0;  ///< horizontal position x, in meters
         amrex::ParticleReal y = 0.0;  ///< vertical position y, in meters
-        amrex::ParticleReal t = 0.0;  ///< arrival time * c in meters
+        amrex::ParticleReal z = 0.0;  ///< longitudinal position y, in meters
+        amrex::ParticleReal t = 0.0;  ///< clock time * c in meters
         amrex::ParticleReal px = 0.0; ///< momentum in x, normalized to proper velocity
         amrex::ParticleReal py = 0.0; ///< momentum in y, normalized to proper velocity
+        amrex::ParticleReal pz = 0.0; ///< momentum in z, normalized to proper velocity
         amrex::ParticleReal pt = 0.0; ///< energy deviation, normalized by rest energy
     };
 


### PR DESCRIPTION
Modified the reference particle to an 8-tuple in the extended phase space:

(x,px,y,py,z,pz,t,pt)

and initialized the coordinates.  This is done in preparation for pushing the reference particle in
global coordinates.

Next steps:
1) add a global reference particle push function to each element struct
2) add a call to global reference particle push inside "Push.cpp"
