### PR TITLE
Added operator to push reference particle in global coordinates to all elements

### DIFF
--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -144,8 +144,8 @@ namespace impactx
          *
          * @returns refpart
          */
-        RefPart
-        GetRefParticle () const;
+        RefPart &
+        GetRefParticle ();
 
         /** Get particle shape
          */

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -123,8 +123,8 @@ namespace impactx
         m_refpart = refpart;
     }
 
-    RefPart
-    ImpactXParticleContainer::GetRefParticle () const
+    RefPart &
+    ImpactXParticleContainer::GetRefParticle ()
     {
         return m_refpart;
     }

--- a/src/particles/elements/ConstF.H
+++ b/src/particles/elements/ConstF.H
@@ -88,6 +88,32 @@ namespace impactx
 
         }
 
+        void operator() (
+                RefPart refpart) const {
+
+            using namespace amrex::literals; // for _rt and _prt
+
+            // assign input reference particle values
+            amrex::ParticleReal const x = refpart.x;
+            amrex::ParticleReal const px = refpart.px;
+            amrex::ParticleReal const y = refpart.y;
+            amrex::ParticleReal const py = refpart.py;
+            amrex::ParticleReal const z = refpart.z;
+            amrex::ParticleReal const pz = refpart.pz;
+            amrex::ParticleReal const t = refpart.t;
+            amrex::ParticleReal const pt = refpart.pt;
+
+            // assign intermediate parameter
+            amrex::ParticleReal const s = m_ds/sqrt(pow(pt,2)-1.0_prt);
+
+            // advance position and momentum (straight element)
+            refpart.x = x + s*px;
+            refpart.y = y + s*py;
+            refpart.z = z + s*pz;
+            refpart.t = t - s*pt;
+
+        }
+
     private:
         amrex::ParticleReal m_ds; //! segment length in m
         amrex::ParticleReal m_kx; //! focusing x strength in 1/m

--- a/src/particles/elements/ConstF.H
+++ b/src/particles/elements/ConstF.H
@@ -88,8 +88,13 @@ namespace impactx
 
         }
 
+        /** This pushes the reference particle.
+         *
+         * @param[in,out] refpart reference particle
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                RefPart refpart) const {
+                RefPart & AMREX_RESTRICT refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -84,6 +84,34 @@ namespace impactx
             py = py + R43*y;
         }
 
+        void operator() (
+                RefPart refpart) const {
+
+            using namespace amrex::literals; // for _rt and _prt
+
+            // assign input reference particle values
+            amrex::ParticleReal const x = refpart.x;
+            amrex::ParticleReal const px = refpart.px;
+            amrex::ParticleReal const y = refpart.y;
+            amrex::ParticleReal const py = refpart.py;
+            amrex::ParticleReal const z = refpart.z;
+            amrex::ParticleReal const pz = refpart.pz;
+            amrex::ParticleReal const t = refpart.t;
+            amrex::ParticleReal const pt = refpart.pt;
+
+            // advance position and momentum (zero-length element)
+            refpart.x = x;
+            refpart.y = y;
+            refpart.z = z;
+            refpart.t = t;
+
+            refpart.px = px;
+            refpart.py = py;
+            refpart.pz = pz;
+            refpart.pt = pt;
+
+        }
+
     private:
         amrex::ParticleReal m_psi; //! pole face angle in rad
         amrex::ParticleReal m_rc; //! bend radius in m

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -84,32 +84,15 @@ namespace impactx
             py = py + R43*y;
         }
 
+        /** This pushes the reference particle.
+         *
+         * @param[in,out] refpart reference particle
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                RefPart refpart) const {
+                [[maybe_unused]] RefPart & AMREX_RESTRICT refpart) const {
 
-            using namespace amrex::literals; // for _rt and _prt
-
-            // assign input reference particle values
-            amrex::ParticleReal const x = refpart.x;
-            amrex::ParticleReal const px = refpart.px;
-            amrex::ParticleReal const y = refpart.y;
-            amrex::ParticleReal const py = refpart.py;
-            amrex::ParticleReal const z = refpart.z;
-            amrex::ParticleReal const pz = refpart.pz;
-            amrex::ParticleReal const t = refpart.t;
-            amrex::ParticleReal const pt = refpart.pt;
-
-            // advance position and momentum (zero-length element)
-            refpart.x = x;
-            refpart.y = y;
-            refpart.z = z;
-            refpart.t = t;
-
-            refpart.px = px;
-            refpart.py = py;
-            refpart.pz = pz;
-            refpart.pt = pt;
-
+            // nothing to do: this is a zero-length element
         }
 
     private:

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -77,6 +77,33 @@ namespace impactx
             px = pxout;
             py = pyout;
             pt = ptout;
+
+        }
+
+        void operator() (
+                RefPart refpart) const {
+
+            using namespace amrex::literals; // for _rt and _prt
+
+            // assign input reference particle values
+            amrex::ParticleReal const x = refpart.x;
+            amrex::ParticleReal const px = refpart.px;
+            amrex::ParticleReal const y = refpart.y;
+            amrex::ParticleReal const py = refpart.py;
+            amrex::ParticleReal const z = refpart.z;
+            amrex::ParticleReal const pz = refpart.pz;
+            amrex::ParticleReal const t = refpart.t;
+            amrex::ParticleReal const pt = refpart.pt;
+
+            // assign intermediate parameter
+            amrex::ParticleReal const s = m_ds/sqrt(pow(pt,2)-1.0_prt);
+
+            // advance position and momentum (drift)
+            refpart.x = x + s*px;
+            refpart.y = y + s*py;
+            refpart.z = z + s*pz;
+            refpart.t = t - s*pt;
+
         }
 
     private:

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -56,7 +56,7 @@ namespace impactx
             amrex::ParticleReal const y = p.pos(1);
             amrex::ParticleReal const t = p.pos(2);
 
-            // intialize output values of momenta
+            // initialize output values of momenta
             amrex::ParticleReal pxout = px;
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;
@@ -80,8 +80,13 @@ namespace impactx
 
         }
 
+        /** This pushes the reference particle.
+         *
+         * @param[in,out] refpart reference particle
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                RefPart refpart) const {
+                RefPart & AMREX_RESTRICT refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 

--- a/src/particles/elements/Multipole.H
+++ b/src/particles/elements/Multipole.H
@@ -108,32 +108,15 @@ namespace impactx
 
         }
 
+        /** This pushes the reference particle.
+         *
+         * @param[in,out] refpart reference particle
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                RefPart refpart) const {
+                [[maybe_unused]] RefPart & AMREX_RESTRICT refpart) const {
 
-            using namespace amrex::literals; // for _rt and _prt
-
-            // assign input reference particle values
-            amrex::ParticleReal const x = refpart.x;
-            amrex::ParticleReal const px = refpart.px;
-            amrex::ParticleReal const y = refpart.y;
-            amrex::ParticleReal const py = refpart.py;
-            amrex::ParticleReal const z = refpart.z;
-            amrex::ParticleReal const pz = refpart.pz;
-            amrex::ParticleReal const t = refpart.t;
-            amrex::ParticleReal const pt = refpart.pt;
-
-            // advance position and momentum (zero-length element)
-            refpart.x = x;
-            refpart.y = y;
-            refpart.z = z;
-            refpart.t = t;
-
-            refpart.px = px;
-            refpart.py = py;
-            refpart.pz = pz;
-            refpart.pt = pt;
-
+            // nothing to do: this is a zero-length element
         }
 
     private:

--- a/src/particles/elements/Multipole.H
+++ b/src/particles/elements/Multipole.H
@@ -108,6 +108,34 @@ namespace impactx
 
         }
 
+        void operator() (
+                RefPart refpart) const {
+
+            using namespace amrex::literals; // for _rt and _prt
+
+            // assign input reference particle values
+            amrex::ParticleReal const x = refpart.x;
+            amrex::ParticleReal const px = refpart.px;
+            amrex::ParticleReal const y = refpart.y;
+            amrex::ParticleReal const py = refpart.py;
+            amrex::ParticleReal const z = refpart.z;
+            amrex::ParticleReal const pz = refpart.pz;
+            amrex::ParticleReal const t = refpart.t;
+            amrex::ParticleReal const pt = refpart.pt;
+
+            // advance position and momentum (zero-length element)
+            refpart.x = x;
+            refpart.y = y;
+            refpart.z = z;
+            refpart.t = t;
+
+            refpart.px = px;
+            refpart.py = py;
+            refpart.pz = pz;
+            refpart.pt = pt;
+
+        }
+
     private:
         int m_multipole; //! multipole index
         int m_mfactorial; //! factorial of multipole index

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -117,32 +117,15 @@ namespace impactx
 
         }
 
+        /** This pushes the reference particle.
+         *
+         * @param[in,out] refpart reference particle
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                RefPart refpart) const {
+                [[maybe_unused]] RefPart & AMREX_RESTRICT refpart) const {
 
-            using namespace amrex::literals; // for _rt and _prt
-
-            // assign input reference particle values
-            amrex::ParticleReal const x = refpart.x;
-            amrex::ParticleReal const px = refpart.px;
-            amrex::ParticleReal const y = refpart.y;
-            amrex::ParticleReal const py = refpart.py;
-            amrex::ParticleReal const z = refpart.z;
-            amrex::ParticleReal const pz = refpart.pz;
-            amrex::ParticleReal const t = refpart.t;
-            amrex::ParticleReal const pt = refpart.pt;
-
-            // advance position and momentum (zero-length element)
-            refpart.x = x;
-            refpart.y = y;
-            refpart.z = z;
-            refpart.t = t;
-
-            refpart.px = px;
-            refpart.py = py;
-            refpart.pz = pz;
-            refpart.pt = pt;
-
+            // nothing to do: this is a zero-length element
         }
 
     private:

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -117,6 +117,34 @@ namespace impactx
 
         }
 
+        void operator() (
+                RefPart refpart) const {
+
+            using namespace amrex::literals; // for _rt and _prt
+
+            // assign input reference particle values
+            amrex::ParticleReal const x = refpart.x;
+            amrex::ParticleReal const px = refpart.px;
+            amrex::ParticleReal const y = refpart.y;
+            amrex::ParticleReal const py = refpart.py;
+            amrex::ParticleReal const z = refpart.z;
+            amrex::ParticleReal const pz = refpart.pz;
+            amrex::ParticleReal const t = refpart.t;
+            amrex::ParticleReal const pt = refpart.pt;
+
+            // advance position and momentum (zero-length element)
+            refpart.x = x;
+            refpart.y = y;
+            refpart.z = z;
+            refpart.t = t;
+
+            refpart.px = px;
+            refpart.py = py;
+            refpart.pz = pz;
+            refpart.pt = pt;
+
+        }
+
     private:
         amrex::ParticleReal m_knll; //! integrated strength of the nonlinear lens (m)
         amrex::ParticleReal m_cnll; //! distance of singularities from the origin (m)

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -101,8 +101,13 @@ namespace impactx
 
         }
 
+        /** This pushes the reference particle.
+         *
+         * @param[in,out] refpart reference particle
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                RefPart refpart) const {
+                RefPart & AMREX_RESTRICT refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -101,6 +101,32 @@ namespace impactx
 
         }
 
+        void operator() (
+                RefPart refpart) const {
+
+            using namespace amrex::literals; // for _rt and _prt
+
+            // assign input reference particle values
+            amrex::ParticleReal const x = refpart.x;
+            amrex::ParticleReal const px = refpart.px;
+            amrex::ParticleReal const y = refpart.y;
+            amrex::ParticleReal const py = refpart.py;
+            amrex::ParticleReal const z = refpart.z;
+            amrex::ParticleReal const pz = refpart.pz;
+            amrex::ParticleReal const t = refpart.t;
+            amrex::ParticleReal const pt = refpart.pt;
+
+            // assign intermediate parameter
+            amrex::ParticleReal const s = m_ds/sqrt(pow(pt,2)-1.0_prt);
+
+            // advance position and momentum (straight element)
+            refpart.x = x + s*px;
+            refpart.y = y + s*py;
+            refpart.z = z + s*pz;
+            refpart.t = t - s*pt;
+
+        }
+
     private:
         amrex::ParticleReal m_ds; //! segment length in m
         amrex::ParticleReal m_k; //! quadrupole strength in 1/m

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -91,8 +91,13 @@ namespace impactx
 
         }
 
+        /** This pushes the reference particle.
+         *
+         * @param[in,out] refpart reference particle
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                RefPart refpart) const {
+                RefPart & AMREX_RESTRICT refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -91,6 +91,38 @@ namespace impactx
 
         }
 
+        void operator() (
+                RefPart refpart) const {
+
+            using namespace amrex::literals; // for _rt and _prt
+
+            // assign input reference particle values
+            amrex::ParticleReal const x = refpart.x;
+            amrex::ParticleReal const px = refpart.px;
+            amrex::ParticleReal const y = refpart.y;
+            amrex::ParticleReal const py = refpart.py;
+            amrex::ParticleReal const z = refpart.z;
+            amrex::ParticleReal const pz = refpart.pz;
+            amrex::ParticleReal const t = refpart.t;
+            amrex::ParticleReal const pt = refpart.pt;
+
+            // assign intermediate parameter
+            amrex::ParticleReal const theta = m_ds/m_rc;
+            amrex::ParticleReal const B = sqrt(pow(pt,2)-1.0_prt)/m_rc;
+
+            // advance position and momentum (bend)
+            refpart.px = px*cos(theta) - pz*sin(theta);
+            refpart.py = py;
+            refpart.pz = pz*cos(theta) + px*sin(theta);
+            refpart.pt = pt;
+
+            refpart.x = x + (refpart.pz - pz)/B;
+            refpart.y = y + (theta/B)*py;
+            refpart.z = z - (refpart.px - px)/B;
+            refpart.t = t - (theta/B)*pt;
+
+        }
+
     private:
         amrex::ParticleReal m_ds; //! segment length in m
         amrex::ParticleReal m_rc; //! bend radius in m

--- a/src/particles/elements/ShortRF.H
+++ b/src/particles/elements/ShortRF.H
@@ -85,6 +85,34 @@ namespace impactx
 
         }
 
+        void operator() (
+                RefPart refpart) const {
+
+            using namespace amrex::literals; // for _rt and _prt
+
+            // assign input reference particle values
+            amrex::ParticleReal const x = refpart.x;
+            amrex::ParticleReal const px = refpart.px;
+            amrex::ParticleReal const y = refpart.y;
+            amrex::ParticleReal const py = refpart.py;
+            amrex::ParticleReal const z = refpart.z;
+            amrex::ParticleReal const pz = refpart.pz;
+            amrex::ParticleReal const t = refpart.t;
+            amrex::ParticleReal const pt = refpart.pt;
+
+            // advance position and momentum (zero-length element)
+            refpart.x = x;
+            refpart.y = y;
+            refpart.z = z;
+            refpart.t = t;
+
+            refpart.px = px;
+            refpart.py = py;
+            refpart.pz = pz;
+            refpart.pt = pt;
+
+        }
+
     private:
         amrex::ParticleReal m_V; //! normalized (max) RF voltage drop.
         amrex::ParticleReal m_k; //! RF wavenumber in 1/m.

--- a/src/particles/elements/ShortRF.H
+++ b/src/particles/elements/ShortRF.H
@@ -85,31 +85,15 @@ namespace impactx
 
         }
 
+        /** This pushes the reference particle.
+         *
+         * @param[in,out] refpart reference particle
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                RefPart refpart) const {
+                [[maybe_unused]] RefPart & AMREX_RESTRICT refpart) const {
 
-            using namespace amrex::literals; // for _rt and _prt
-
-            // assign input reference particle values
-            amrex::ParticleReal const x = refpart.x;
-            amrex::ParticleReal const px = refpart.px;
-            amrex::ParticleReal const y = refpart.y;
-            amrex::ParticleReal const py = refpart.py;
-            amrex::ParticleReal const z = refpart.z;
-            amrex::ParticleReal const pz = refpart.pz;
-            amrex::ParticleReal const t = refpart.t;
-            amrex::ParticleReal const pt = refpart.pt;
-
-            // advance position and momentum (zero-length element)
-            refpart.x = x;
-            refpart.y = y;
-            refpart.z = z;
-            refpart.t = t;
-
-            refpart.px = px;
-            refpart.py = py;
-            refpart.pz = pz;
-            refpart.pt = pt;
+            // nothing to do: this is a zero-length element
 
         }
 


### PR DESCRIPTION
Modified structs for "Drift.H", "Quad.H", etc. to include operator to update the reference particle in global laboratory coordinates (x,px,y,py,z,pz,t,pt).

Next step:

- [x] Add a call to this operator within `Push.cpp`.

