### PR TITLE
Added (optional) input per element - number of space charge slices.

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -175,7 +175,7 @@ Lattice Elements
 * ``<element_name>.type`` (``string``)
     Indicates the element type for this lattice element. This should be one of:
 
-        * ``drift`` for free drift. This requires this additional parameters:
+        * ``drift`` for free drift. This requires these additional parameters:
 
             * ``<element_name>.ds`` (``float``, in meters) the segment length
 

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -364,6 +364,13 @@ Numerics and algorithms
 Diagnostics and output
 ----------------------
 
+* ``diag.slice_step_diagnostics`` (``boolean``, default: ``false``)
+  By default, diagnostics is performed at the beginning and end of the simulation.
+  Enabling this flag will write diagnostics every step and slice step
+
+* ``diag.file_min_digits`` (``integer``, optional, default: ``6``)
+    The minimum number of digits used for the iteration number appended to the diagnostic file names.
+
 Diagnostics related to integrable optics in the IOTA nonlinear magnetic insert element:
 
 * ``diag.alpha`` (``float``, unitless) Twiss alpha of the bare linear lattice at the location of output for the nonlinear

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -175,9 +175,12 @@ Lattice Elements
 * ``<element_name>.type`` (``string``)
     Indicates the element type for this lattice element. This should be one of:
 
-        * ``drift`` for free drift. This requires this additional parameter:
+        * ``drift`` for free drift. This requires this additional parameters:
 
             * ``<element_name>.ds`` (``float``, in meters) the segment length
+
+            * ``<element_name>.nslice`` (``integer``) number of slices used
+              for the application of space charge (default = 1)
 
         * ``quad`` for a quadrupole. This requires these additional parameters:
 
@@ -189,11 +192,17 @@ Lattice Elements
               * k > 0 horizontal focusing
               * k < 0 horizontal defocusing
 
+            * ``<element_name>.nslice`` (``integer``) number of slices used
+              for the application of space charge (default = 1)
+
         * ``sbend`` for a bending magnet. This requires these additional parameters:
 
             * ``<element_name>.ds`` (``float``, in meters) the segment length
 
             * ``<element_name>.rc`` (``float``, in meters) the bend radius
+
+            * ``<element_name>.nslice`` (``integer``) number of slices used
+              for the application of space charge (default = 1)
 
         * ``dipedge`` for dipole edge focusing. This requires these additional parameters:
 
@@ -219,6 +228,9 @@ Lattice Elements
 
             * ``<element_name>.kt`` (``float``, in 1/meters) the
               longitudinal focusing strength
+
+            * ``<element_name>.nslice`` (``integer``) number of slices used
+              for the application of space charge (default = 1)
 
         * ``shortrf`` for a short RF (bunching) cavity element. This requires these additional parameters:
 

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -172,9 +172,9 @@ Lattice Elements
     A list of names (one name per lattice element), in the order that they
     appear in the lattice.
 
-* ``lattice.num_steps`` (``integer``) optional (default: 1)
+* ``lattice.nslice`` (``integer``) optional (default: ``1`` unless thin element)
     A positive integer specifying the number of slices used for the application of
-    space charge in all elements; overloaded by element parameter "nslice"
+    space charge in all elements; overwritten by element parameter "nslice"
 
 * ``<element_name>.type`` (``string``)
     Indicates the element type for this lattice element. This should be one of:
@@ -184,7 +184,7 @@ Lattice Elements
             * ``<element_name>.ds`` (``float``, in meters) the segment length
 
             * ``<element_name>.nslice`` (``integer``) number of slices used
-              for the application of space charge (default = 1)
+              for the application of space charge (default: ``1``)
 
         * ``quad`` for a quadrupole. This requires these additional parameters:
 
@@ -197,7 +197,7 @@ Lattice Elements
               * k < 0 horizontal defocusing
 
             * ``<element_name>.nslice`` (``integer``) number of slices used
-              for the application of space charge (default = 1)
+              for the application of space charge (default: ``1``)
 
         * ``sbend`` for a bending magnet. This requires these additional parameters:
 
@@ -206,7 +206,7 @@ Lattice Elements
             * ``<element_name>.rc`` (``float``, in meters) the bend radius
 
             * ``<element_name>.nslice`` (``integer``) number of slices used
-              for the application of space charge (default = 1)
+              for the application of space charge (default: ``1``)
 
         * ``dipedge`` for dipole edge focusing. This requires these additional parameters:
 
@@ -234,7 +234,7 @@ Lattice Elements
               longitudinal focusing strength
 
             * ``<element_name>.nslice`` (``integer``) number of slices used
-              for the application of space charge (default = 1)
+              for the application of space charge (default: ``1``)
 
         * ``shortrf`` for a short RF (bunching) cavity element. This requires these additional parameters:
 
@@ -268,7 +268,7 @@ Lattice Elements
 Distribution across MPI ranks and parallelization
 -------------------------------------------------
 
-* ``amr.max_grid_size`` (``integer``) optional (default ``128``)
+* ``amr.max_grid_size`` (``integer``) optional (default: ``128``)
     Maximum allowable size of each **subdomain**
     (expressed in number of grid points, in each direction).
     Each subdomain has its own ghost cells, and can be handled by a

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -172,7 +172,7 @@ Lattice Elements
     A list of names (one name per lattice element), in the order that they
     appear in the lattice.
 
-* ``lattice.nslice`` (``integer``) optional (default: ``1`` unless thin element)
+* ``lattice.nslice`` (``integer``) optional (default: ``1``)
     A positive integer specifying the number of slices used for the application of
     space charge in all elements; overwritten by element parameter "nslice"
 
@@ -364,7 +364,7 @@ Numerics and algorithms
 Diagnostics and output
 ----------------------
 
-* ``diag.slice_step_diagnostics`` (``boolean``, default: ``false``)
+* ``diag.slice_step_diagnostics`` (``boolean``, optional, default: ``false``)
   By default, diagnostics is performed at the beginning and end of the simulation.
   Enabling this flag will write diagnostics every step and slice step
 

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -172,6 +172,10 @@ Lattice Elements
     A list of names (one name per lattice element), in the order that they
     appear in the lattice.
 
+* ``lattice.num_steps`` (``integer``) optional (default: 1)
+    A positive integer specifying the number of slices used for the application of 
+    space charge in all elements; overloaded by element parameter "nslice"
+
 * ``<element_name>.type`` (``string``)
     Indicates the element type for this lattice element. This should be one of:
 

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -173,7 +173,7 @@ Lattice Elements
     appear in the lattice.
 
 * ``lattice.num_steps`` (``integer``) optional (default: 1)
-    A positive integer specifying the number of slices used for the application of 
+    A positive integer specifying the number of slices used for the application of
     space charge in all elements; overloaded by element parameter "nslice"
 
 * ``<element_name>.type`` (``string``)

--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -64,10 +64,8 @@ namespace impactx
         void initLatticeElementsFromInputs ();
 
         /** Run the main simulation loop for a number of steps
-         *
-         * @param num_steps number of steps to evolve
          */
-        void evolve (int num_steps);
+        void evolve ();
 
       private:
         //! Tag cells for refinement.  TagBoxArray tags is built on level lev grids.

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -51,7 +51,7 @@ namespace impactx
         amrex::UtilCreateCleanDirectory("diags", true);
     }
 
-    void ImpactX::evolve (int num_steps)
+    void ImpactX::evolve ()
     {
         BL_PROFILE("ImpactX::evolve");
 
@@ -73,8 +73,12 @@ namespace impactx
         // loop over all beamline elements
         for (auto & element_variant : m_lattice)
         {
+            // number of slices used for the application of space charge
+            int nslice = 1;
+            std::visit([&nslice](auto&& element){ nslice = element.nslice(); }, element_variant);
+
             // sub-steps for space charge within the element
-            for (int step = 0; step < num_steps; ++step)
+            for (int step = 0; step < nslice; ++step)
             {
                 BL_PROFILE("ImpactX::evolve::step");
                 amrex::Print() << " ++++ Starting step=" << step << "\n";

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -34,33 +34,42 @@ namespace impactx
         std::vector<std::string> lattice_elements;
         pp_lattice.queryarr("elements", lattice_elements);
 
+        // Input default number of slices per element
+        int num_steps = 1;
+        pp_lattice.query("num_steps", num_steps);
+
         // Loop through lattice elements
         for (std::string const & element_name : lattice_elements) {
             // Check the element type
             amrex::ParmParse pp_element(element_name);
             std::string element_type;
             pp_element.get("type", element_type);
+
+            // Input default number of slices per element
+//            int num_steps = 1;
+//            pp_element.query("num_steps", num_steps);
+
             // Initialize the corresponding element according to its type
             if (element_type == "quad") {
                 amrex::Real ds, k;
-                int nslice = 1;
+                int nslice = num_steps;
                 pp_element.get("ds", ds);
                 pp_element.get("k", k);
                 pp_element.query("nslice", nslice);
-                m_lattice.emplace_back( Quad(ds, k) );
+                m_lattice.emplace_back( Quad(ds, k, nslice) );
             } else if (element_type == "drift") {
                 amrex::Real ds;
-                int nslice = 1;
+                int nslice = num_steps;
                 pp_element.get("ds", ds);
                 pp_element.query("nslice", nslice);
-                m_lattice.emplace_back( Drift(ds) );
+                m_lattice.emplace_back( Drift(ds, nslice) );
             } else if (element_type == "sbend") {
                 amrex::Real ds, rc;
-                int nslice = 1;
+                int nslice = num_steps;
                 pp_element.get("ds", ds);
                 pp_element.get("rc", rc);
                 pp_element.query("nslice", nslice);
-                m_lattice.emplace_back( Sbend(ds, rc) );
+                m_lattice.emplace_back( Sbend(ds, rc, nslice) );
             } else if (element_type == "dipedge") {
                 amrex::Real psi, rc, g, K2;
                 pp_element.get("psi", psi);
@@ -70,13 +79,13 @@ namespace impactx
                 m_lattice.emplace_back( DipEdge(psi, rc, g, K2) );
             } else if (element_type == "constf") {
                 amrex::Real ds, kx, ky, kt;
-                int nslice = 1;
+                int nslice = num_steps;
                 pp_element.get("ds", ds);
                 pp_element.get("kx", kx);
                 pp_element.get("ky", ky);
                 pp_element.get("kt", kt);
                 pp_element.query("nslice", nslice);
-                m_lattice.emplace_back( ConstF(ds, kx, ky, kt) );
+                m_lattice.emplace_back( ConstF(ds, kx, ky, kt, nslice) );
             } else if (element_type == "shortrf") {
                 amrex::Real V, k;
                 pp_element.get("V", V);

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -34,9 +34,9 @@ namespace impactx
         std::vector<std::string> lattice_elements;
         pp_lattice.queryarr("elements", lattice_elements);
 
-        // Input default number of slices per element
-        int num_steps = 1;
-        pp_lattice.query("num_steps", num_steps);
+        // Default number of slices per element
+        int nslice_default = 1;
+        pp_lattice.query("nslice", nslice_default);
 
         // Loop through lattice elements
         for (std::string const & element_name : lattice_elements) {
@@ -45,30 +45,26 @@ namespace impactx
             std::string element_type;
             pp_element.get("type", element_type);
 
-            // Input default number of slices per element
-//            int num_steps = 1;
-//            pp_element.query("num_steps", num_steps);
-
             // Initialize the corresponding element according to its type
             if (element_type == "quad") {
                 amrex::Real ds, k;
-                int nslice = num_steps;
+                int nslice = nslice_default;
                 pp_element.get("ds", ds);
                 pp_element.get("k", k);
-                pp_element.query("nslice", nslice);
+                pp_element.queryAdd("nslice", nslice);
                 m_lattice.emplace_back( Quad(ds, k, nslice) );
             } else if (element_type == "drift") {
                 amrex::Real ds;
-                int nslice = num_steps;
+                int nslice = nslice_default;
                 pp_element.get("ds", ds);
-                pp_element.query("nslice", nslice);
+                pp_element.queryAdd("nslice", nslice);
                 m_lattice.emplace_back( Drift(ds, nslice) );
             } else if (element_type == "sbend") {
                 amrex::Real ds, rc;
-                int nslice = num_steps;
+                int nslice = nslice_default;
                 pp_element.get("ds", ds);
                 pp_element.get("rc", rc);
-                pp_element.query("nslice", nslice);
+                pp_element.queryAdd("nslice", nslice);
                 m_lattice.emplace_back( Sbend(ds, rc, nslice) );
             } else if (element_type == "dipedge") {
                 amrex::Real psi, rc, g, K2;
@@ -79,12 +75,12 @@ namespace impactx
                 m_lattice.emplace_back( DipEdge(psi, rc, g, K2) );
             } else if (element_type == "constf") {
                 amrex::Real ds, kx, ky, kt;
-                int nslice = num_steps;
+                int nslice = nslice_default;
                 pp_element.get("ds", ds);
                 pp_element.get("kx", kx);
                 pp_element.get("ky", ky);
                 pp_element.get("kt", kt);
-                pp_element.query("nslice", nslice);
+                pp_element.queryAdd("nslice", nslice);
                 m_lattice.emplace_back( ConstF(ds, kx, ky, kt, nslice) );
             } else if (element_type == "shortrf") {
                 amrex::Real V, k;

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -43,17 +43,23 @@ namespace impactx
             // Initialize the corresponding element according to its type
             if (element_type == "quad") {
                 amrex::Real ds, k;
+                int nslice = 1;
                 pp_element.get("ds", ds);
                 pp_element.get("k", k);
+                pp_element.query("nslice", nslice);
                 m_lattice.emplace_back( Quad(ds, k) );
             } else if (element_type == "drift") {
                 amrex::Real ds;
+                int nslice = 1;
                 pp_element.get("ds", ds);
+                pp_element.query("nslice", nslice);
                 m_lattice.emplace_back( Drift(ds) );
             } else if (element_type == "sbend") {
                 amrex::Real ds, rc;
+                int nslice = 1;
                 pp_element.get("ds", ds);
                 pp_element.get("rc", rc);
+                pp_element.query("nslice", nslice);
                 m_lattice.emplace_back( Sbend(ds, rc) );
             } else if (element_type == "dipedge") {
                 amrex::Real psi, rc, g, K2;
@@ -64,10 +70,12 @@ namespace impactx
                 m_lattice.emplace_back( DipEdge(psi, rc, g, K2) );
             } else if (element_type == "constf") {
                 amrex::Real ds, kx, ky, kt;
+                int nslice = 1;
                 pp_element.get("ds", ds);
                 pp_element.get("kx", kx);
                 pp_element.get("ky", ky);
                 pp_element.get("kt", kt);
+                pp_element.query("nslice", nslice);
                 m_lattice.emplace_back( ConstF(ds, kx, ky, kt) );
             } else if (element_type == "shortrf") {
                 amrex::Real V, k;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char* argv[])
         impactX.initGrids();
         impactX.initBeamDistributionFromInputs();
         impactX.initLatticeElementsFromInputs();
-        impactX.evolve( /* num_steps = */ 1);
+        impactX.evolve();
     }
     BL_PROFILE_VAR_STOP(pmain);
 

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -90,19 +90,19 @@ namespace impactx::diagnostics
                     using namespace amrex::literals;
 
                     // Parse the diagnostic parameters
-                    amrex::ParmParse pp_dist("diag");
+                    amrex::ParmParse pp_diag("diag");
 
                     amrex::ParticleReal alpha = 0.0;
-                    pp_dist.query("alpha", alpha);
+                    pp_diag.queryAdd("alpha", alpha);
 
                     amrex::ParticleReal beta = 1.0;
-                    pp_dist.query("beta", beta);
+                    pp_diag.queryAdd("beta", beta);
 
                     amrex::ParticleReal tn = 0.4;
-                    pp_dist.query("tn", tn);
+                    pp_diag.queryAdd("tn", tn);
 
                     amrex::ParticleReal cn = 0.01;
-                    pp_dist.query("cn", cn);
+                    pp_diag.queryAdd("cn", cn);
 
                     NonlinearLensInvariants const nonlinear_lens_invariants(alpha, beta, tn, cn);
 

--- a/src/particles/elements/ConstF.H
+++ b/src/particles/elements/ConstF.H
@@ -33,8 +33,9 @@ namespace impactx
          *
          */
         ConstF( amrex::ParticleReal const ds, amrex::ParticleReal const kx,
-                amrex::ParticleReal const ky, amrex::ParticleReal const kt )
-        : m_ds(ds), m_kx(kx), m_ky(ky), m_kt(kt)
+                amrex::ParticleReal const ky, amrex::ParticleReal const kt,
+                int nslice )
+        : m_ds(ds), m_kx(kx), m_ky(ky), m_kt(kt), m_nslice(nslice)
         {
         }
 
@@ -124,6 +125,7 @@ namespace impactx
         amrex::ParticleReal m_kx; //! focusing x strength in 1/m
         amrex::ParticleReal m_ky; //! focusing y strength in 1/m
         amrex::ParticleReal m_kt; //! focusing t strength in 1/m
+        int m_nslice; //! number of slices
 
     };
 

--- a/src/particles/elements/ConstF.H
+++ b/src/particles/elements/ConstF.H
@@ -34,7 +34,7 @@ namespace impactx
          */
         ConstF( amrex::ParticleReal const ds, amrex::ParticleReal const kx,
                 amrex::ParticleReal const ky, amrex::ParticleReal const kt,
-                int nslice )
+                int const nslice )
         : m_ds(ds), m_kx(kx), m_ky(ky), m_kt(kt), m_nslice(nslice)
         {
         }

--- a/src/particles/elements/ConstF.H
+++ b/src/particles/elements/ConstF.H
@@ -120,6 +120,16 @@ namespace impactx
 
         }
 
+        /** Number of slices used for the application of space charge
+         *
+         * @return positive integer
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        int nslice () const
+        {
+            return m_nslice;
+        }
+
     private:
         amrex::ParticleReal m_ds; //! segment length in m
         amrex::ParticleReal m_kx; //! focusing x strength in 1/m

--- a/src/particles/elements/ConstF.H
+++ b/src/particles/elements/ConstF.H
@@ -30,7 +30,7 @@ namespace impactx
          * @param kx Focusing strength for x in 1/m.
          * @param ky Focusing strength for y in 1/m.
          * @param kt Focusing strength for t in 1/m.
-         *
+         * @param nslice number of slices used for the application of space charge
          */
         ConstF( amrex::ParticleReal const ds, amrex::ParticleReal const kx,
                 amrex::ParticleReal const ky, amrex::ParticleReal const kt,
@@ -125,8 +125,7 @@ namespace impactx
         amrex::ParticleReal m_kx; //! focusing x strength in 1/m
         amrex::ParticleReal m_ky; //! focusing y strength in 1/m
         amrex::ParticleReal m_kt; //! focusing t strength in 1/m
-        int m_nslice; //! number of slices
-
+        int m_nslice; //! number of slices used for the application of space charge
     };
 
 } // namespace impactx

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -38,8 +38,8 @@ namespace impactx
          * @param g Gap parameter in m.
          * @param K2 Fringe field integral (unitless).
          */
-        DipEdge( amrex::ParticleReal const psi, amrex::ParticleReal const rc, amrex::ParticleReal const
-        g, amrex::ParticleReal const K2)
+        DipEdge( amrex::ParticleReal const psi, amrex::ParticleReal const rc,
+                 amrex::ParticleReal const g, amrex::ParticleReal const K2 )
         : m_psi(psi), m_rc(rc), m_g(g), m_K2(K2)
         {
         }

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -97,12 +97,12 @@ namespace impactx
 
         /** Number of slices used for the application of space charge
          *
-         * @return zero, because this is a zero-length element
+         * @return one, because this is a zero-length element
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         int nslice () const
         {
-            return 0;
+            return 1;
         }
 
     private:

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -95,6 +95,16 @@ namespace impactx
             // nothing to do: this is a zero-length element
         }
 
+        /** Number of slices used for the application of space charge
+         *
+         * @return zero, because this is a zero-length element
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        int nslice () const
+        {
+            return 0;
+        }
+
     private:
         amrex::ParticleReal m_psi; //! pole face angle in rad
         amrex::ParticleReal m_rc; //! bend radius in m

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -29,7 +29,7 @@ namespace impactx
          * @param ds Segment length in m
          * @param nslice number of slices used for the application of space charge
          */
-        Drift( amrex::ParticleReal const ds, int nslice )
+        Drift( amrex::ParticleReal const ds, int const nslice )
         : m_ds(ds), m_nslice(nslice)
         {
         }

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -28,8 +28,8 @@ namespace impactx
          *
          * @param ds Segment length in m.
          */
-        Drift( amrex::ParticleReal const ds )
-        : m_ds(ds)
+        Drift( amrex::ParticleReal const ds, int nslice )
+        : m_ds(ds), m_nslice(nslice)
         {
         }
 
@@ -112,7 +112,8 @@ namespace impactx
         }
 
     private:
-        amrex::ParticleReal m_ds;
+        amrex::ParticleReal m_ds; //! segment length in m
+        int m_nslice;  //! number of slices
     };
 
 } // namespace impactx

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -26,7 +26,8 @@ namespace impactx
 
         /** A drift
          *
-         * @param ds Segment length in m.
+         * @param ds Segment length in m
+         * @param nslice number of slices used for the application of space charge
          */
         Drift( amrex::ParticleReal const ds, int nslice )
         : m_ds(ds), m_nslice(nslice)
@@ -113,7 +114,7 @@ namespace impactx
 
     private:
         amrex::ParticleReal m_ds; //! segment length in m
-        int m_nslice;  //! number of slices
+        int m_nslice; //! number of slices used for the application of space charge
     };
 
 } // namespace impactx

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -112,6 +112,16 @@ namespace impactx
 
         }
 
+        /** Number of slices used for the application of space charge
+         *
+         * @return positive integer
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        int nslice () const
+        {
+            return m_nslice;
+        }
+
     private:
         amrex::ParticleReal m_ds; //! segment length in m
         int m_nslice; //! number of slices used for the application of space charge

--- a/src/particles/elements/Multipole.H
+++ b/src/particles/elements/Multipole.H
@@ -118,6 +118,16 @@ namespace impactx
             // nothing to do: this is a zero-length element
         }
 
+        /** Number of slices used for the application of space charge
+         *
+         * @return zero, because this is a zero-length element
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        int nslice () const
+        {
+            return 0;
+        }
+
     private:
         int m_multipole; //! multipole index
         int m_mfactorial; //! factorial of multipole index

--- a/src/particles/elements/Multipole.H
+++ b/src/particles/elements/Multipole.H
@@ -120,12 +120,12 @@ namespace impactx
 
         /** Number of slices used for the application of space charge
          *
-         * @return zero, because this is a zero-length element
+         * @return one, because this is a zero-length element
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         int nslice () const
         {
-            return 0;
+            return 1;
         }
 
     private:

--- a/src/particles/elements/Multipole.H
+++ b/src/particles/elements/Multipole.H
@@ -29,7 +29,6 @@ namespace impactx
          * @param multipole index m (m=1 dipole, m=2 quadrupole, m=3 sextupole etc.)
          * @param K_normal Integrated normal multipole coefficient (1/meter^m)
          * @param K_skew Integrated skew multipole coefficient (1/meter^m)
-         *
          */
         Multipole( int const multipole,
                    amrex::ParticleReal const K_normal,

--- a/src/particles/elements/None.H
+++ b/src/particles/elements/None.H
@@ -47,7 +47,6 @@ namespace impactx
             // nothing to do
         }
 
-
         /** This pushes the reference particle.
          *
          * @param[in,out] refpart reference particle
@@ -62,14 +61,13 @@ namespace impactx
 
         /** Number of slices used for the application of space charge
          *
-         * @return zero, because this is a zero-length element
+         * @return one, because this is a zero-length element
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         int nslice () const
         {
-            return 0;
+            return 1;
         }
-
     };
 
 } // namespace impactx

--- a/src/particles/elements/None.H
+++ b/src/particles/elements/None.H
@@ -60,6 +60,16 @@ namespace impactx
 
         }
 
+        /** Number of slices used for the application of space charge
+         *
+         * @return zero, because this is a zero-length element
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        int nslice () const
+        {
+            return 0;
+        }
+
     };
 
 } // namespace impactx

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -127,6 +127,16 @@ namespace impactx
             // nothing to do: this is a zero-length element
         }
 
+        /** Number of slices used for the application of space charge
+         *
+         * @return zero, because this is a zero-length element
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        int nslice () const
+        {
+            return 0;
+        }
+
     private:
         amrex::ParticleReal m_knll; //! integrated strength of the nonlinear lens (m)
         amrex::ParticleReal m_cnll; //! distance of singularities from the origin (m)

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -33,7 +33,6 @@ namespace impactx
          *
          * @param knll - integrated strength of the nonlinear lens (m)
          * @param cnll - distance of singularities from the origin (m)
-         *
          */
         NonlinearLens( amrex::ParticleReal const knll,
                    amrex::ParticleReal const cnll )
@@ -131,7 +130,6 @@ namespace impactx
     private:
         amrex::ParticleReal m_knll; //! integrated strength of the nonlinear lens (m)
         amrex::ParticleReal m_cnll; //! distance of singularities from the origin (m)
-
     };
 
 } // namespace impactx

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -129,12 +129,12 @@ namespace impactx
 
         /** Number of slices used for the application of space charge
          *
-         * @return zero, because this is a zero-length element
+         * @return one, because this is a zero-length element
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         int nslice () const
         {
-            return 0;
+            return 1;
         }
 
     private:

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -32,8 +32,9 @@ namespace impactx
          *           k > 0 horizontal focusing
          *           k < 0 horizontal defocusing
          */
-        Quad( amrex::ParticleReal const ds, amrex::ParticleReal const k )
-        : m_ds(ds), m_k(k)
+        Quad( amrex::ParticleReal const ds, amrex::ParticleReal const k, 
+           int nslice )
+        : m_ds(ds), m_k(k), m_nslice(nslice)
         {
         }
 
@@ -135,6 +136,7 @@ namespace impactx
     private:
         amrex::ParticleReal m_ds; //! segment length in m
         amrex::ParticleReal m_k; //! quadrupole strength in 1/m
+        int m_nslice; //! number of slices
     };
 
 } // namespace impactx

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -31,9 +31,10 @@ namespace impactx
          *           = (gradient in T/m) / (rigidity in T-m)
          *           k > 0 horizontal focusing
          *           k < 0 horizontal defocusing
+         * @param nslice number of slices used for the application of space charge
          */
         Quad( amrex::ParticleReal const ds, amrex::ParticleReal const k,
-           int nslice )
+              int nslice )
         : m_ds(ds), m_k(k), m_nslice(nslice)
         {
         }
@@ -136,7 +137,7 @@ namespace impactx
     private:
         amrex::ParticleReal m_ds; //! segment length in m
         amrex::ParticleReal m_k; //! quadrupole strength in 1/m
-        int m_nslice; //! number of slices
+        int m_nslice; //! number of slices used for the application of space charge
     };
 
 } // namespace impactx

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -32,7 +32,7 @@ namespace impactx
          *           k > 0 horizontal focusing
          *           k < 0 horizontal defocusing
          */
-        Quad( amrex::ParticleReal const ds, amrex::ParticleReal const k, 
+        Quad( amrex::ParticleReal const ds, amrex::ParticleReal const k,
            int nslice )
         : m_ds(ds), m_k(k), m_nslice(nslice)
         {

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -34,7 +34,7 @@ namespace impactx
          * @param nslice number of slices used for the application of space charge
          */
         Quad( amrex::ParticleReal const ds, amrex::ParticleReal const k,
-              int nslice )
+              int const nslice )
         : m_ds(ds), m_k(k), m_nslice(nslice)
         {
         }

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -134,6 +134,16 @@ namespace impactx
 
         }
 
+        /** Number of slices used for the application of space charge
+         *
+         * @return positive integer
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        int nslice () const
+        {
+            return m_nslice;
+        }
+
     private:
         amrex::ParticleReal m_ds; //! segment length in m
         amrex::ParticleReal m_k; //! quadrupole strength in 1/m

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -28,9 +28,10 @@ namespace impactx
          *
          * @param ds Segment length in m.
          * @param rc Radius of curvature in m.
+         * @param nslice number of slices used for the application of space charge
          */
         Sbend( amrex::ParticleReal const ds, amrex::ParticleReal const rc,
-            int nslice)
+               int nslice)
         : m_ds(ds), m_rc(rc), m_nslice(nslice)
         {
         }
@@ -132,7 +133,7 @@ namespace impactx
     private:
         amrex::ParticleReal m_ds; //! segment length in m
         amrex::ParticleReal m_rc; //! bend radius in m
-        int m_nslice; //! number of slices
+        int m_nslice; //! number of slices used for the application of space charge
     };
 
 } // namespace impactx

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -130,6 +130,16 @@ namespace impactx
 
         }
 
+        /** Number of slices used for the application of space charge
+         *
+         * @return positive integer
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        int nslice () const
+        {
+            return m_nslice;
+        }
+
     private:
         amrex::ParticleReal m_ds; //! segment length in m
         amrex::ParticleReal m_rc; //! bend radius in m

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -31,7 +31,7 @@ namespace impactx
          * @param nslice number of slices used for the application of space charge
          */
         Sbend( amrex::ParticleReal const ds, amrex::ParticleReal const rc,
-               int nslice)
+               int const nslice)
         : m_ds(ds), m_rc(rc), m_nslice(nslice)
         {
         }

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -29,8 +29,9 @@ namespace impactx
          * @param ds Segment length in m.
          * @param rc Radius of curvature in m.
          */
-        Sbend( amrex::ParticleReal const ds, amrex::ParticleReal const rc)
-        : m_ds(ds), m_rc(rc)
+        Sbend( amrex::ParticleReal const ds, amrex::ParticleReal const rc,
+            int nslice)
+        : m_ds(ds), m_rc(rc), m_nslice(nslice)
         {
         }
 
@@ -131,6 +132,7 @@ namespace impactx
     private:
         amrex::ParticleReal m_ds; //! segment length in m
         amrex::ParticleReal m_rc; //! bend radius in m
+        int m_nslice; //! number of slices
     };
 
 } // namespace impactx

--- a/src/particles/elements/ShortRF.H
+++ b/src/particles/elements/ShortRF.H
@@ -98,12 +98,12 @@ namespace impactx
 
         /** Number of slices used for the application of space charge
          *
-         * @return zero, because this is a zero-length element
+         * @return one, because this is a zero-length element
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         int nslice () const
         {
-            return 0;
+            return 1;
         }
 
     private:

--- a/src/particles/elements/ShortRF.H
+++ b/src/particles/elements/ShortRF.H
@@ -27,8 +27,7 @@ namespace impactx
         /** A short RF cavity element at zero crossing for bunching
          *
          * @param V Normalized RF voltage drop V = Emax*L/(c*Brho)
-         * @param k Wavenumber of RF in 1/m.
-         *
+         * @param k Wavenumber of RF in 1/m
          */
         ShortRF( amrex::ParticleReal const V, amrex::ParticleReal const k )
         : m_V(V), m_k(k)
@@ -100,7 +99,6 @@ namespace impactx
     private:
         amrex::ParticleReal m_V; //! normalized (max) RF voltage drop.
         amrex::ParticleReal m_k; //! RF wavenumber in 1/m.
-
     };
 
 } // namespace impactx

--- a/src/particles/elements/ShortRF.H
+++ b/src/particles/elements/ShortRF.H
@@ -96,6 +96,16 @@ namespace impactx
 
         }
 
+        /** Number of slices used for the application of space charge
+         *
+         * @return zero, because this is a zero-length element
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        int nslice () const
+        {
+            return 0;
+        }
+
     private:
         amrex::ParticleReal m_V; //! normalized (max) RF voltage drop.
         amrex::ParticleReal m_k; //! RF wavenumber in 1/m.

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -63,7 +63,7 @@ void init_ImpactX(py::module& m)
         .def("init_grids", &ImpactX::initGrids)
         .def("init_beam_distribution_from_inputs", &ImpactX::initBeamDistributionFromInputs)
         .def("init_lattice_elements_from_inputs", &ImpactX::initLatticeElementsFromInputs)
-        .def("evolve", &ImpactX::evolve, py::arg("num_steps"))
+        .def("evolve", &ImpactX::evolve)
 
         //.def_property("particle_container", &ImpactX::m_particle_container)
         //.def_readwrite("rho", &ImpactX::m_rho)

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -50,6 +50,7 @@ void init_ImpactX(py::module& m)
 
                 amrex::ParmParse::addfile(filename);
             })
+
         .def("set_particle_shape",
             [](ImpactX & ix, int const order) {
                 AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ix.m_particle_container,
@@ -60,6 +61,17 @@ void init_ImpactX(py::module& m)
                 amrex::ParmParse pp_ago("algo");
                 pp_ago.add("particle_shape", order);
             })
+        .def("set_diags_slice_step_diagnostics",
+             [](ImpactX & /* ix */, bool const slice_step_diagnostics) {
+                 amrex::ParmParse pp_diag("diag");
+                 pp_diag.add("slice_step_diagnostics", slice_step_diagnostics);
+             })
+        .def("set_diags_file_min_digits",
+             [](ImpactX & /* ix */, int const file_min_digits) {
+                 amrex::ParmParse pp_diag("diag");
+                 pp_diag.add("file_min_digits", file_min_digits);
+             })
+
         .def("init_grids", &ImpactX::initGrids)
         .def("init_beam_distribution_from_inputs", &ImpactX::initBeamDistributionFromInputs)
         .def("init_lattice_elements_from_inputs", &ImpactX::initLatticeElementsFromInputs)

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -60,9 +60,12 @@ void init_elements(py::module& m)
                 amrex::ParticleReal const,
                 amrex::ParticleReal const,
                 amrex::ParticleReal const,
-                amrex::ParticleReal const>(),
-             py::arg("ds"), py::arg("kx"), py::arg("ky"), py::arg("kt")
-        );
+                amrex::ParticleReal const,
+                int const >(),
+             py::arg("ds"), py::arg("kx"), py::arg("ky"), py::arg("kt"), py::arg("nslice") = 1
+        )
+        .def_property_readonly("nslice", &ConstF::nslice)
+    ;
 
     py::class_<DipEdge>(me, "DipEdge")
         .def(py::init<
@@ -71,12 +74,18 @@ void init_elements(py::module& m)
                 amrex::ParticleReal const,
                 amrex::ParticleReal const>(),
              py::arg("psi"), py::arg("rc"), py::arg("g"), py::arg("K2")
-        );
+        )
+        .def_property_readonly("nslice", &DipEdge::nslice)
+    ;
 
     py::class_<Drift>(me, "Drift")
-        .def(py::init<amrex::ParticleReal const>(),
-             py::arg("ds")
-        );
+        .def(py::init<
+                amrex::ParticleReal const,
+                int const >(),
+             py::arg("ds"), py::arg("nslice") = 1
+        )
+        .def_property_readonly("nslice", &Drift::nslice)
+    ;
 
     py::class_<Multipole>(me, "Multipole")
         .def(py::init<
@@ -84,33 +93,45 @@ void init_elements(py::module& m)
                 amrex::ParticleReal const,
                 amrex::ParticleReal const>(),
              py::arg("multiple"), py::arg("K_normal"), py::arg("K_skew")
-        );
+        )
+        .def_property_readonly("nslice", &Multipole::nslice)
+    ;
 
     py::class_<NonlinearLens>(me, "NonlinearLens")
         .def(py::init<
                 amrex::ParticleReal const,
                 amrex::ParticleReal const>(),
              py::arg("knll"), py::arg("cnll")
-        );
+        )
+        .def_property_readonly("nslice", &NonlinearLens::nslice)
+    ;
 
     py::class_<Sbend>(me, "Sbend")
         .def(py::init<
                 amrex::ParticleReal const,
-                amrex::ParticleReal const>(),
-             py::arg("ds"), py::arg("rc")
-        );
+                amrex::ParticleReal const,
+                int const>(),
+             py::arg("ds"), py::arg("rc"), py::arg("nslice") = 1
+        )
+        .def_property_readonly("nslice", &Sbend::nslice)
+    ;
 
     py::class_<ShortRF>(me, "ShortRF")
         .def(py::init<
                 amrex::ParticleReal const,
                 amrex::ParticleReal const>(),
              py::arg("V"), py::arg("k")
-        );
+        )
+        .def_property_readonly("nslice", &ShortRF::nslice)
+    ;
 
     py::class_<Quad>(me, "Quad")
         .def(py::init<
                 amrex::ParticleReal const,
-                amrex::ParticleReal const>(),
-             py::arg("ds"), py::arg("k")
-        );
+                amrex::ParticleReal const,
+                int const>(),
+             py::arg("ds"), py::arg("k"), py::arg("nslice") = 1
+        )
+        .def_property_readonly("nslice", &Quad::nslice)
+    ;
 }

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -15,7 +15,7 @@ def test_impactx_fodo_file():
     impactX.init_beam_distribution_from_inputs()
     impactX.init_lattice_elements_from_inputs()
 
-    impactX.evolve(num_steps=1)
+    impactX.evolve()
 
 
 def test_impactx_nofile():
@@ -53,4 +53,4 @@ def test_impactx_nofile():
     print(len(impactX.lattice))
     assert(len(impactX.lattice) > 5)
 
-    #impactX.evolve(num_steps=1)
+    #impactX.evolve()

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -25,6 +25,7 @@ def test_impactx_nofile():
     impactX = ImpactX()
 
     impactX.set_particle_shape(2)
+    impactX.set_diags_slice_step_diagnostics(True)
     impactX.init_grids()
 
     # init particle beam
@@ -53,4 +54,4 @@ def test_impactx_nofile():
     print(len(impactX.lattice))
     assert(len(impactX.lattice) > 5)
 
-    #impactX.evolve()
+    impactX.evolve()

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -54,4 +54,5 @@ def test_impactx_nofile():
     print(len(impactX.lattice))
     assert(len(impactX.lattice) > 5)
 
-    impactX.evolve()
+    # TODO: enable once particle beam is loaded
+    #impactX.evolve()


### PR DESCRIPTION
For each thick element, an optional parameter "nslice" was added at input.

To be used as the number of slices (here = the number of space charge kicks) per element.

### To Do

- [x] add `nslice` to each element's constructor
- [x] use it in our evolve loop: https://github.com/ECP-WarpX/impactx/blob/81684134057d43b9f4ecf8b6dcf9221b84e4b9f8/src/ImpactX.cpp#L77
```c++
int num_steps = 1;
std::visit([&num_steps](auto & element){ num_steps = element.nslice; }, element_variant);
```
- [x] add diagnostics in each sub-step for now so we can plot distribution evolutions