### PR TITLE
Added output of reference particle information

### DIFF
--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -57,6 +57,11 @@ namespace impactx
                                       diagnostics::OutputType::PrintParticles,
                                       "diags/initial_beam.txt");
 
+        // print initial reference particle to file
+        diagnostics::DiagnosticOutput(*m_particle_container,
+                                      diagnostics::OutputType::PrintRefParticle,
+                                      "diags/ref_particle.txt");
+
         // print the initial values of the two invariants H and I
         diagnostics::DiagnosticOutput(*m_particle_container,
                                       diagnostics::OutputType::PrintNonlinearLensInvariants,
@@ -120,6 +125,11 @@ namespace impactx
         diagnostics::DiagnosticOutput(*m_particle_container,
                                       diagnostics::OutputType::PrintParticles,
                                       "diags/output_beam.txt");
+
+        // print final reference particle to file
+        diagnostics::DiagnosticOutput(*m_particle_container,
+                                      diagnostics::OutputType::PrintRefParticle,
+                                      "diags/ref_particle.txt");
 
         // print the final values of the two invariants H and I
         diagnostics::DiagnosticOutput(*m_particle_container,

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -60,7 +60,7 @@ namespace impactx
         // print initial reference particle to file
         diagnostics::DiagnosticOutput(*m_particle_container,
                                       diagnostics::OutputType::PrintRefParticle,
-                                      "diags/ref_particle.txt");
+                                      "diags/initial_ref_particle.txt");
 
         // print the initial values of the two invariants H and I
         diagnostics::DiagnosticOutput(*m_particle_container,
@@ -129,7 +129,7 @@ namespace impactx
         // print final reference particle to file
         diagnostics::DiagnosticOutput(*m_particle_container,
                                       diagnostics::OutputType::PrintRefParticle,
-                                      "diags/ref_particle.txt");
+                                      "diags/output_ref_particle.txt");
 
         // print the final values of the two invariants H and I
         diagnostics::DiagnosticOutput(*m_particle_container,

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -147,6 +147,13 @@ namespace impactx
         RefPart &
         GetRefParticle ();
 
+        /** Get a copy to the reference particle attributes
+         *
+         * @returns refpart
+         */
+        RefPart const
+        GetRefParticle () const;
+
         /** Get particle shape
          */
         int

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -134,6 +134,12 @@ namespace impactx
         return m_refpart;
     }
 
+    RefPart const
+    ImpactXParticleContainer::GetRefParticle () const
+    {
+        return m_refpart;
+    }
+
     std::tuple<
             amrex::ParticleReal, amrex::ParticleReal,
             amrex::ParticleReal, amrex::ParticleReal,

--- a/src/particles/diagnostics/DiagnosticOutput.H
+++ b/src/particles/diagnostics/DiagnosticOutput.H
@@ -22,7 +22,8 @@ namespace impactx::diagnostics
     enum class OutputType
     {
         PrintParticles, ///< ASCII diagnostics, for small tests only
-        PrintNonlinearLensInvariants ///< ASCII diagnostics for the IOTA nonlinear lens, for small tests only
+        PrintNonlinearLensInvariants, ///< ASCII diagnostics for the IOTA nonlinear lens, for small tests only
+        PrintRefParticle ///< ASCII diagnostics, for small tests only
     };
 
     /** ASCII output diagnostics associated with the beam.
@@ -35,7 +36,7 @@ namespace impactx::diagnostics
      * @param otype the type of output to produce
      * @param file_name the file name to write to
      */
-    void DiagnosticOutput (ImpactXParticleContainer const & pc,
+    void DiagnosticOutput (ImpactXParticleContainer & pc,
                            OutputType const otype,
                            std::string file_name);
 

--- a/src/particles/diagnostics/DiagnosticOutput.H
+++ b/src/particles/diagnostics/DiagnosticOutput.H
@@ -36,7 +36,7 @@ namespace impactx::diagnostics
      * @param otype the type of output to produce
      * @param file_name the file name to write to
      */
-    void DiagnosticOutput (ImpactXParticleContainer & pc,
+    void DiagnosticOutput (ImpactXParticleContainer const & pc,
                            OutputType const otype,
                            std::string file_name);
 

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -20,7 +20,7 @@
 
 namespace impactx::diagnostics
 {
-    void DiagnosticOutput (ImpactXParticleContainer & pc,
+    void DiagnosticOutput (ImpactXParticleContainer const & pc,
                            OutputType const otype,
                            std::string file_name)
     {
@@ -135,7 +135,7 @@ namespace impactx::diagnostics
                     // print reference particle to file
 
                     // preparing to access reference particle data: RefPart
-                    RefPart & ref_part = pc.GetRefParticle();
+                    RefPart const ref_part = pc.GetRefParticle();
 
                     amrex::ParticleReal const x = ref_part.x;
                     amrex::ParticleReal const y = ref_part.y;

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -20,7 +20,7 @@
 
 namespace impactx::diagnostics
 {
-    void DiagnosticOutput (ImpactXParticleContainer const & pc,
+    void DiagnosticOutput (ImpactXParticleContainer & pc,
                            OutputType const otype,
                            std::string file_name)
     {
@@ -38,6 +38,8 @@ namespace impactx::diagnostics
             amrex::AllPrintToFile(file_name) << "id x y t px py pt\n";
         } else if (otype == OutputType::PrintNonlinearLensInvariants) {
             amrex::AllPrintToFile(file_name) << "id H I\n";
+        } else if (otype == OutputType::PrintRefParticle) {
+            amrex::AllPrintToFile(file_name) << "x y z t px py pz pt\n";
         }
 
         // loop over refinement levels
@@ -129,6 +131,26 @@ namespace impactx::diagnostics
 
                     } // i=0...np
                 } // if( otype == OutputType::PrintInvariants)
+                if (otype == OutputType::PrintRefParticle) {
+                    // print reference particle to file
+
+                    // preparing to access reference particle data: RefPart
+                    RefPart & ref_part = pc.GetRefParticle();
+
+                    amrex::ParticleReal const x = ref_part.x;
+                    amrex::ParticleReal const y = ref_part.y;
+                    amrex::ParticleReal const z = ref_part.z;
+                    amrex::ParticleReal const t = ref_part.t;
+                    amrex::ParticleReal const px = ref_part.px;
+                    amrex::ParticleReal const py = ref_part.py;
+                    amrex::ParticleReal const pz = ref_part.pz;
+                    amrex::ParticleReal const pt = ref_part.pt;
+
+                    // write particle data to file
+                    amrex::AllPrintToFile(file_name)
+                            << x << " " << y << " " << z << " " << t << " "
+                            << px << " " << py << " " << pz << " " << pt << "\n";
+                } // if( otype == OutputType::PrintRefParticle)
             } // end loop over all particle boxes
         } // env mesh-refinement level loop
     }


### PR DESCRIPTION
Added an additional diagnostic function in DiagnosticOutput.cpp to print the global reference particle coordinates to file.

- [x] This required access to "GetRefPart()".  To do:  Check const correctness.