### PR TITLE
Quad: Fix Abs Math Truncation

### DIFF
--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -65,7 +65,7 @@ namespace impactx
             amrex::ParticleReal const betgam2 = pow(pt_ref, 2) - 1.0_prt;
 
             // compute phase advance per unit length in s (in rad/m)
-            amrex::ParticleReal const omega = sqrt(abs(m_k));
+            amrex::ParticleReal const omega = sqrt(std::abs(m_k));
 
             // intialize output values of momenta
             amrex::ParticleReal pxout = px;


### PR DESCRIPTION
Fix warning that truncated precision:
```
src/particles/elements/Quad.H:68:52: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
            amrex::ParticleReal const omega = sqrt(abs(m_k));
                                                   ^
```
Seen with Clang 10.

We could generally prefix all math functions with `std::` to be explicit.

Refs.:
- C++ Math Functions: https://en.cppreference.com/w/cpp/header/cmath (`std::abs`)
- C Math Functions: https://en.cppreference.com/w/c/numeric/math (`abs/fabs`)