### PR TITLE
Space Charge Solver

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -286,7 +286,7 @@ add_impactx_test(expanding_beam
     examples/expanding_beam/input_expanding.in
       OFF  # ImpactX MPI-parallel
       OFF  # ImpactX Python interface
-    OFF  # examples/expanding_beam/analysis_expanding.py
+    examples/expanding_beam/analysis_expanding.py
     OFF  # no plot script yet
 )
 
@@ -296,7 +296,7 @@ add_impactx_test(expanding_beam.py
     examples/expanding_beam/run_expanding.py
       OFF  # ImpactX MPI-parallel
       ON   # ImpactX Python interface
-    OFF  # examples/expanding_beam/analysis_expanding.py
+    examples/expanding_beam/analysis_expanding.py
     OFF  # no plot script yet
 )
 

--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -128,8 +128,8 @@ namespace impactx
         std::unordered_map<int, amrex::MultiFab> m_rho;
         /** scalar potential per level */
         std::unordered_map<int, amrex::MultiFab> m_phi;
-        /** space charge force (vector) per level */
-        std::unordered_map<int, std::unordered_map<std::string, amrex::MultiFab> > m_space_charge_force;
+        /** space charge field (vector) per level */
+        std::unordered_map<int, std::unordered_map<std::string, amrex::MultiFab> > m_space_charge_field;
 
         /** these are elements defining the accelerator lattice */
         std::list<KnownElements> m_lattice;

--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -124,8 +124,12 @@ namespace impactx
         /** these are the physical/beam particles of the simulation */
         std::unique_ptr<ImpactXParticleContainer> m_particle_container;
 
-        /** charge per level */
+        /** charge density per level */
         std::unordered_map<int, amrex::MultiFab> m_rho;
+        /** scalar potential per level */
+        std::unordered_map<int, amrex::MultiFab> m_phi;
+        /** space charge force (vector) per level */
+        std::unordered_map<int, std::unordered_map<std::string, amrex::MultiFab> > m_space_charge_force;
 
         /** these are elements defining the accelerator lattice */
         std::list<KnownElements> m_lattice;

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -138,7 +138,7 @@ namespace impactx
                     spacecharge::PoissonSolve(*m_particle_container, m_rho, m_phi);
 
                     // calculate force in x,y,z
-                    spacecharge::ForceFromSelfFields(m_space_charge_force,
+                    spacecharge::ForceFromSelfFields(m_space_charge_field,
                                                      m_phi,
                                                      this->geom);
 

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -13,6 +13,7 @@
 #include "particles/Push.H"
 #include "particles/diagnostics/DiagnosticOutput.H"
 #include "particles/spacecharge/PoissonSolve.H"
+#include "particles/spacecharge/ForceFromSelfFields.H"
 #include "particles/transformation/CoordinateTransformation.H"
 
 #include <AMReX.H>
@@ -136,9 +137,10 @@ namespace impactx
                     // poisson solve in x,y,z
                     spacecharge::PoissonSolve(*m_particle_container, m_rho, m_phi);
 
-                    // calculate force
-                    // TODO: FDTD stencil m_phi -> m_space_charge
-                    // nodal: (-1 and +1) / 2dx
+                    // calculate force in x,y,z
+                    spacecharge::ForceFromSelfFields(m_space_charge_force,
+                                                     m_phi,
+                                                     this->geom);
 
                     // gather and space-charge push in x,y,z , assuming the space-charge
                     // field is the same before/after transformation

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -12,8 +12,9 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/Push.H"
 #include "particles/diagnostics/DiagnosticOutput.H"
-#include "particles/spacecharge/PoissonSolve.H"
 #include "particles/spacecharge/ForceFromSelfFields.H"
+#include "particles/spacecharge/GatherAndPush.H"
+#include "particles/spacecharge/PoissonSolve.H"
 #include "particles/transformation/CoordinateTransformation.H"
 
 #include <AMReX.H>
@@ -103,7 +104,11 @@ namespace impactx
         {
             // number of slices used for the application of space charge
             int nslice = 1;
-            std::visit([&nslice](auto&& element){ nslice = element.nslice(); }, element_variant);
+            amrex::ParticleReal slice_ds; // in meters
+            std::visit([&nslice, &slice_ds](auto&& element){
+                nslice = element.nslice();
+                slice_ds = element.ds() / nslice;
+            }, element_variant);
 
             // sub-steps for space charge within the element
             for (int slice_step = 0; slice_step < nslice; ++slice_step)
@@ -144,7 +149,8 @@ namespace impactx
 
                     // gather and space-charge push in x,y,z , assuming the space-charge
                     // field is the same before/after transformation
-                    //   TODO
+                    // TODO: This is currently using linear order.
+                    spacecharge::GatherAndPush(*m_particle_container, m_space_charge_field, this->geom, slice_ds);
 
                     // transform from x,y,z to x',y',t
                     transformation::CoordinateTransformation(*m_particle_container,

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -11,8 +11,9 @@
 #include "initialization/InitAmrCore.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/Push.H"
-#include "particles/transformation/CoordinateTransformation.H"
 #include "particles/diagnostics/DiagnosticOutput.H"
+#include "particles/spacecharge/PoissonSolve.H"
+#include "particles/transformation/CoordinateTransformation.H"
 
 #include <AMReX.H>
 #include <AMReX_AmrParGDB.H>
@@ -133,7 +134,11 @@ namespace impactx
                     m_particle_container->DepositCharge(m_rho, this->refRatio());
 
                     // poisson solve in x,y,z
-                    //   TODO
+                    spacecharge::PoissonSolve(*m_particle_container, m_rho, m_phi);
+
+                    // calculate force
+                    // TODO: FDTD stencil m_phi -> m_space_charge
+                    // nodal: (-1 and +1) / 2dx
 
                     // gather and space-charge push in x,y,z , assuming the space-charge
                     // field is the same before/after transformation

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -124,8 +124,9 @@ namespace impactx
                 {
 
                     // transform from x',y',t to x,y,z
-                    transformation::CoordinateTransformation(*m_particle_container,
-                                                             transformation::Direction::to_fixed_t);
+                    transformation::CoordinateTransformation(
+                        *m_particle_container,
+                        transformation::Direction::to_fixed_t);
 
                     // Note: The following operation assume that
                     // the particles are in x, y, z coordinates.
@@ -150,7 +151,10 @@ namespace impactx
                     // gather and space-charge push in x,y,z , assuming the space-charge
                     // field is the same before/after transformation
                     // TODO: This is currently using linear order.
-                    spacecharge::GatherAndPush(*m_particle_container, m_space_charge_field, this->geom, slice_ds);
+                    spacecharge::GatherAndPush(*m_particle_container,
+                                               m_space_charge_field,
+                                               this->geom,
+                                               slice_ds);
 
                     // transform from x,y,z to x',y',t
                     transformation::CoordinateTransformation(*m_particle_container,

--- a/src/initialization/InitMeshRefinement.cpp
+++ b/src/initialization/InitMeshRefinement.cpp
@@ -81,11 +81,10 @@ namespace impactx
             amrex::MultiFab{amrex::convert(cba, phi_nodal_flag), dm, num_components_phi, num_guards_phi, tag("phi")});
 
         // space charge force
+        std::unordered_map<std::string, amrex::MultiFab> f_comp;
         for (std::string const comp : {"x", "y", "z"})
         {
             std::string const str_tag = "space_charge_force_" + comp;
-
-            std::unordered_map<std::string, amrex::MultiFab> f_comp;
             f_comp.emplace(
                 comp,
                 amrex::MultiFab{
@@ -96,8 +95,8 @@ namespace impactx
                     tag(str_tag)
                 }
             );
-            m_space_charge_force.emplace(lev, std::move(f_comp));
         }
+        m_space_charge_force.emplace(lev, std::move(f_comp));
     }
 
     /** Make a new level using provided BoxArray and DistributionMapping and fill

--- a/src/initialization/InitMeshRefinement.cpp
+++ b/src/initialization/InitMeshRefinement.cpp
@@ -84,7 +84,7 @@ namespace impactx
         std::unordered_map<std::string, amrex::MultiFab> f_comp;
         for (std::string const comp : {"x", "y", "z"})
         {
-            std::string const str_tag = "space_charge_force_" + comp;
+            std::string const str_tag = "space_charge_field_" + comp;
             f_comp.emplace(
                 comp,
                 amrex::MultiFab{
@@ -96,7 +96,7 @@ namespace impactx
                 }
             );
         }
-        m_space_charge_force.emplace(lev, std::move(f_comp));
+        m_space_charge_field.emplace(lev, std::move(f_comp));
     }
 
     /** Make a new level using provided BoxArray and DistributionMapping and fill
@@ -129,7 +129,7 @@ namespace impactx
     {
         m_rho.erase(lev);
         m_phi.erase(lev);
-        m_space_charge_force.erase(lev);
+        m_space_charge_field.erase(lev);
     }
 
     void ImpactX::ResizeMesh ()

--- a/src/initialization/InitMeshRefinement.cpp
+++ b/src/initialization/InitMeshRefinement.cpp
@@ -68,8 +68,36 @@ namespace impactx
         else  // odd shape orders
             num_guards_rho = (particle_shape + 1) / 2;
 
-        m_rho.emplace(lev,
-                      amrex::MultiFab{amrex::convert(cba, rho_nodal_flag), dm, num_components_rho, num_guards_rho, tag("rho")});
+        m_rho.emplace(
+            lev,
+            amrex::MultiFab{amrex::convert(cba, rho_nodal_flag), dm, num_components_rho, num_guards_rho, tag("rho")});
+
+        // scalar potential
+        auto const phi_nodal_flag = rho_nodal_flag;
+        int const num_components_phi = 1;
+        int const num_guards_phi = num_guards_rho + 1; // todo: I think this just depends on max(MLMG, force calc)
+        m_phi.emplace(
+            lev,
+            amrex::MultiFab{amrex::convert(cba, phi_nodal_flag), dm, num_components_phi, num_guards_phi, tag("phi")});
+
+        // space charge force
+        for (std::string const comp : {"x", "y", "z"})
+        {
+            std::string const str_tag = "space_charge_force_" + comp;
+
+            std::unordered_map<std::string, amrex::MultiFab> f_comp;
+            f_comp.emplace(
+                comp,
+                amrex::MultiFab{
+                    amrex::convert(cba, rho_nodal_flag),
+                    dm,
+                    num_components_rho,
+                    num_guards_rho,
+                    tag(str_tag)
+                }
+            );
+            m_space_charge_force.emplace(lev, std::move(f_comp));
+        }
     }
 
     /** Make a new level using provided BoxArray and DistributionMapping and fill
@@ -101,6 +129,8 @@ namespace impactx
     void ImpactX::ClearLevel (int lev)
     {
         m_rho.erase(lev);
+        m_phi.erase(lev);
+        m_space_charge_force.erase(lev);
     }
 
     void ImpactX::ResizeMesh ()

--- a/src/particles/CMakeLists.txt
+++ b/src/particles/CMakeLists.txt
@@ -5,5 +5,6 @@ target_sources(ImpactX
     Push.cpp
 )
 
-add_subdirectory(transformation)
 add_subdirectory(diagnostics)
+add_subdirectory(spacecharge)
+add_subdirectory(transformation)

--- a/src/particles/spacecharge/CMakeLists.txt
+++ b/src/particles/spacecharge/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(ImpactX
+  PRIVATE
+    PoissonSolve.cpp
+)

--- a/src/particles/spacecharge/CMakeLists.txt
+++ b/src/particles/spacecharge/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(ImpactX
   PRIVATE
     PoissonSolve.cpp
+    ForceFromSelfFields.cpp
 )

--- a/src/particles/spacecharge/CMakeLists.txt
+++ b/src/particles/spacecharge/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(ImpactX
   PRIVATE
-    PoissonSolve.cpp
     ForceFromSelfFields.cpp
+    GatherAndPush.cpp
+    PoissonSolve.cpp
 )

--- a/src/particles/spacecharge/ForceFromSelfFields.H
+++ b/src/particles/spacecharge/ForceFromSelfFields.H
@@ -26,12 +26,12 @@ namespace impactx::spacecharge
      * This resets the values in scf_<component> to zero and then calculates the space
      * charge force field.
      *
-     * @param[inout] space_charge_force space charge force component in x,y,z per level
+     * @param[inout] space_charge_field space charge force component in x,y,z per level
      * @param[in] phi scalar potential per level
      * @param[in] geom geometry object
      */
     void ForceFromSelfFields (
-        std::unordered_map<int, std::unordered_map<std::string, amrex::MultiFab> > & space_charge_force,
+        std::unordered_map<int, std::unordered_map<std::string, amrex::MultiFab> > & space_charge_field,
         std::unordered_map<int, amrex::MultiFab> const & phi,
         const amrex::Vector<amrex::Geometry>& geom
     );

--- a/src/particles/spacecharge/ForceFromSelfFields.H
+++ b/src/particles/spacecharge/ForceFromSelfFields.H
@@ -1,0 +1,41 @@
+/* Copyright 2022 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Marco Garten, Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_FORCEFROMSELFFIELDS_H
+#define IMPACTX_FORCEFROMSELFFIELDS_H
+
+#include "particles/ImpactXParticleContainer.H"
+
+#include <AMReX_Geometry.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_Vector.H>
+
+#include <unordered_map>
+
+
+namespace impactx::spacecharge
+{
+    /** Calculate the space charge force field from the electric potential
+     *
+     * This resets the values in scf_<component> to zero and then calculates the space
+     * charge force field.
+     *
+     * @param[inout] space_charge_force space charge force component in x,y,z per level
+     * @param[in] phi scalar potential per level
+     * @param[in] geom geometry object
+     */
+    void ForceFromSelfFields (
+        std::unordered_map<int, std::unordered_map<std::string, amrex::MultiFab> > & space_charge_force,
+        std::unordered_map<int, amrex::MultiFab> const & phi,
+        const amrex::Vector<amrex::Geometry>& geom
+    );
+
+} // namespace impactx
+
+#endif // IMPACTX_FORCEFROMSELFFIELDS_H

--- a/src/particles/spacecharge/ForceFromSelfFields.cpp
+++ b/src/particles/spacecharge/ForceFromSelfFields.cpp
@@ -1,0 +1,62 @@
+/* Copyright 2022 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Marco Garten, Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "ForceFromSelfFields.H"
+
+#include <ablastr/fields/PoissonSolver.H>
+
+#include <AMReX_BLProfiler.H>
+#include <AMReX_REAL.H>       // for Real
+#include <AMReX_SPACE.H>      // for AMREX_D_DECL
+
+
+namespace impactx::spacecharge
+{
+    void ForceFromSelfFields (
+        std::unordered_map<int, std::unordered_map<std::string, amrex::MultiFab> > & space_charge_force,
+        std::unordered_map<int, amrex::MultiFab> const & phi,
+        amrex::Vector<amrex::Geometry> const & geom
+    )
+    {
+        BL_PROFILE("impactx::spacecharge::ForceFromSelfFields");
+
+        using namespace amrex::literals;
+
+        // loop over refinement levels
+        int const finest_level = phi.size() - 1u;
+        for (int lev = 0; lev <= finest_level; ++lev) {
+
+            // stencil coefficients: 0.5 * inverse cell size
+            auto const &gm = geom[lev];
+            auto const dr = gm.CellSizeArray();
+            amrex::GpuArray<amrex::Real, 3> const inv2dr{AMREX_D_DECL(0.5_rt/dr[0], 0.5_rt/dr[1], 0.5_rt/dr[2])};
+
+            // reset the values in space_charge_force to zero
+            space_charge_force.at(lev).at("x").setVal(0.);
+            space_charge_force.at(lev).at("y").setVal(0.);
+            space_charge_force.at(lev).at("z").setVal(0.);
+
+            for (amrex::MFIter mfi(phi.at(lev)); mfi.isValid(); ++mfi) {
+
+                amrex::Box bx = mfi.validbox();
+                auto const phi_arr = (phi.at(lev))[mfi].const_array();
+
+                auto scf_arr_x = space_charge_force[lev]["x"][mfi].array();
+                auto scf_arr_y = space_charge_force[lev]["y"][mfi].array();
+                auto scf_arr_z = space_charge_force[lev]["z"][mfi].array();
+
+                amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                    scf_arr_x(i, j, k) = inv2dr[0] * (phi_arr(i-1, j, k) - phi_arr(i+1, j, k));
+                    scf_arr_y(i, j, k) = inv2dr[1] * (phi_arr(i, j-1, k) - phi_arr(i, j+1, k));
+                    scf_arr_z(i, j, k) = inv2dr[2] * (phi_arr(i, j, k-1) - phi_arr(i, j, k+1));
+                });
+            }
+        }
+    }
+} // namespace impactx::spacecharge

--- a/src/particles/spacecharge/ForceFromSelfFields.cpp
+++ b/src/particles/spacecharge/ForceFromSelfFields.cpp
@@ -19,7 +19,7 @@
 namespace impactx::spacecharge
 {
     void ForceFromSelfFields (
-        std::unordered_map<int, std::unordered_map<std::string, amrex::MultiFab> > & space_charge_force,
+        std::unordered_map<int, std::unordered_map<std::string, amrex::MultiFab> > & space_charge_field,
         std::unordered_map<int, amrex::MultiFab> const & phi,
         amrex::Vector<amrex::Geometry> const & geom
     )
@@ -37,19 +37,19 @@ namespace impactx::spacecharge
             auto const dr = gm.CellSizeArray();
             amrex::GpuArray<amrex::Real, 3> const inv2dr{AMREX_D_DECL(0.5_rt/dr[0], 0.5_rt/dr[1], 0.5_rt/dr[2])};
 
-            // reset the values in space_charge_force to zero
-            space_charge_force.at(lev).at("x").setVal(0.);
-            space_charge_force.at(lev).at("y").setVal(0.);
-            space_charge_force.at(lev).at("z").setVal(0.);
+            // reset the values in space_charge_field to zero
+            space_charge_field.at(lev).at("x").setVal(0.);
+            space_charge_field.at(lev).at("y").setVal(0.);
+            space_charge_field.at(lev).at("z").setVal(0.);
 
             for (amrex::MFIter mfi(phi.at(lev)); mfi.isValid(); ++mfi) {
 
                 amrex::Box bx = mfi.validbox();
                 auto const phi_arr = (phi.at(lev))[mfi].const_array();
 
-                auto scf_arr_x = space_charge_force[lev]["x"][mfi].array();
-                auto scf_arr_y = space_charge_force[lev]["y"][mfi].array();
-                auto scf_arr_z = space_charge_force[lev]["z"][mfi].array();
+                auto scf_arr_x = space_charge_field[lev]["x"][mfi].array();
+                auto scf_arr_y = space_charge_field[lev]["y"][mfi].array();
+                auto scf_arr_z = space_charge_field[lev]["z"][mfi].array();
 
                 amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                     scf_arr_x(i, j, k) = inv2dr[0] * (phi_arr(i-1, j, k) - phi_arr(i+1, j, k));

--- a/src/particles/spacecharge/ForceFromSelfFields.cpp
+++ b/src/particles/spacecharge/ForceFromSelfFields.cpp
@@ -9,8 +9,6 @@
  */
 #include "ForceFromSelfFields.H"
 
-#include <ablastr/fields/PoissonSolver.H>
-
 #include <AMReX_BLProfiler.H>
 #include <AMReX_REAL.H>       // for Real
 #include <AMReX_SPACE.H>      // for AMREX_D_DECL

--- a/src/particles/spacecharge/GatherAndPush.H
+++ b/src/particles/spacecharge/GatherAndPush.H
@@ -22,9 +22,12 @@
 
 namespace impactx::spacecharge
 {
-    /** Gather force fields and push particles
+    /** Gather force fields and push particles in x,y,z
      *
-     * details ... ...
+     * This gathers the space charge field with respect to particle position
+     * and shape. The momentum of all particles is then pushed using a common
+     * time step given by the reference particle speed and ds slice. The
+     * position push is done in the lattice elements and not here.
      *
      * @param[inout] pc container of the particles that deposited rho
      * @param[in] space_charge_field space charge force component in x,y,z per level

--- a/src/particles/spacecharge/GatherAndPush.H
+++ b/src/particles/spacecharge/GatherAndPush.H
@@ -1,0 +1,43 @@
+/* Copyright 2022 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl, Remi Lehe
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_GATHER_AND_PUSH_H
+#define IMPACTX_GATHER_AND_PUSH_H
+
+#include "particles/ImpactXParticleContainer.H"
+
+#include <AMReX_Geometry.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_Vector.H>
+
+#include <unordered_map>
+#include <string>
+
+
+namespace impactx::spacecharge
+{
+    /** Gather force fields and push particles
+     *
+     * details ... ...
+     *
+     * @param[inout] pc container of the particles that deposited rho
+     * @param[in] space_charge_field space charge force component in x,y,z per level
+     * @param[in] geom geometry object
+     * @param[in] slice_ds segment length in meters
+     */
+    void GatherAndPush (
+        ImpactXParticleContainer & pc,
+        std::unordered_map<int, std::unordered_map<std::string, amrex::MultiFab> > const & space_charge_field,
+        const amrex::Vector<amrex::Geometry>& geom,
+        amrex::ParticleReal const slice_ds
+    );
+
+} // namespace impactx
+
+#endif // IMPACTX_GATHER_AND_PUSH_H

--- a/src/particles/spacecharge/GatherAndPush.cpp
+++ b/src/particles/spacecharge/GatherAndPush.cpp
@@ -1,0 +1,107 @@
+/* Copyright 2022 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Marco Garten, Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "GatherAndPush.H"
+
+#include <ablastr/particles/NodalFieldGather.H>
+
+#include <AMReX_BLProfiler.H>
+#include <AMReX_REAL.H>       // for Real
+#include <AMReX_SPACE.H>      // for AMREX_D_DECL
+
+
+namespace impactx::spacecharge
+{
+    void GatherAndPush (
+            ImpactXParticleContainer & pc,
+            std::unordered_map<int, std::unordered_map<std::string, amrex::MultiFab> > const & space_charge_field,
+            const amrex::Vector<amrex::Geometry>& geom,
+            amrex::ParticleReal const slice_ds
+    )
+    {
+        BL_PROFILE("impactx::spacecharge::GatherAndPush");
+
+        using namespace amrex::literals;
+
+        amrex::ParticleReal const charge = pc.GetRefParticle().charge;
+
+        // loop over refinement levels
+        int const nLevel = pc.finestLevel();
+        for (int lev = 0; lev <= nLevel; ++lev)
+        {
+            // get simulation geometry information
+            auto const &gm = geom[lev];
+            auto const dr = gm.CellSizeArray();
+            amrex::GpuArray<amrex::Real, 3> const invdr{AMREX_D_DECL(1_rt/dr[0], 1_rt/dr[1], 1_rt/dr[2])};
+            const auto prob_lo = gm.ProbLoArray();
+
+            // loop over all particle boxes
+            using ParIt = ImpactXParticleContainer::iterator;
+            for (ParIt pti(pc, lev); pti.isValid(); ++pti) {
+                const int np = pti.numParticles();
+                //const auto t_lev = pti.GetLevel();
+                //const auto index = pti.GetPairIndex();
+                // ...
+
+                //
+                auto scf_arr_x = space_charge_field.at(lev).at("x")[pti].array();
+                auto scf_arr_y = space_charge_field.at(lev).at("y")[pti].array();
+                auto scf_arr_z = space_charge_field.at(lev).at("z")[pti].array();
+
+                // ...
+                amrex::ParticleReal const c0_SI = 2.99792458e8;  // TODO move out
+                amrex::ParticleReal const mc_SI = pc.GetRefParticle().mass * c0_SI;
+                amrex::ParticleReal const pz_ref_SI = pc.GetRefParticle().beta_gamma() * mc_SI;
+                amrex::ParticleReal const gamma = pc.GetRefParticle().gamma();
+                amrex::ParticleReal const inv_gamma2 = 1.0_prt / (gamma * gamma);
+
+                amrex::ParticleReal const dt = slice_ds / pc.GetRefParticle().beta() / c0_SI;
+
+                // preparing access to particle data: AoS
+                using PType = ImpactXParticleContainer::ParticleType;
+                auto& aos = pti.GetArrayOfStructs();
+                PType* AMREX_RESTRICT aos_ptr = aos().dataPtr();
+
+                // preparing access to particle data: SoA of Reals
+                auto& soa_real = pti.GetStructOfArrays().GetRealData();
+                amrex::ParticleReal* const AMREX_RESTRICT part_px = soa_real[RealSoA::ux].dataPtr();
+                amrex::ParticleReal* const AMREX_RESTRICT part_py = soa_real[RealSoA::uy].dataPtr();
+                amrex::ParticleReal* const AMREX_RESTRICT part_pz = soa_real[RealSoA::pt].dataPtr(); // note: currently in z
+
+                // ...
+                amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) {
+                    // access AoS data such as positions and cpu/id
+                    PType const & AMREX_RESTRICT p = aos_ptr[i];
+
+                    // access SoA Real data
+                    amrex::ParticleReal & AMREX_RESTRICT px = part_px[i];
+                    amrex::ParticleReal & AMREX_RESTRICT py = part_py[i];
+                    amrex::ParticleReal & AMREX_RESTRICT pz = part_pz[i];
+
+                    // force gather
+                    amrex::GpuArray<amrex::Real, 3> const field_interp =
+                        ablastr::particles::doGatherVectorFieldNodal (
+                            p.pos(0), p.pos(1), p.pos(2),
+                            scf_arr_x, scf_arr_y, scf_arr_z,
+                            invdr,
+                            prob_lo);
+
+                    // push momentum
+                    px += dt * charge * field_interp[0] * inv_gamma2 / pz_ref_SI;
+                    py += dt * charge * field_interp[1] * inv_gamma2 / pz_ref_SI;
+                    pz += dt * charge * field_interp[2] * inv_gamma2 / pz_ref_SI;
+
+                    // push position is done in the lattice elements
+                });
+
+
+            } // end loop over all particle boxes
+        } // env mesh-refinement level loop
+    }
+} // namespace impactx::spacecharge

--- a/src/particles/spacecharge/PoissonSolve.H
+++ b/src/particles/spacecharge/PoissonSolve.H
@@ -1,0 +1,39 @@
+/* Copyright 2022 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_POISSONSOLVE_H
+#define IMPACTX_POISSONSOLVE_H
+
+#include "particles/ImpactXParticleContainer.H"
+
+#include <AMReX_MultiFab.H>
+
+#include <unordered_map>
+
+
+namespace impactx::spacecharge
+{
+    /** Calculate the electric potential from charge density
+     *
+     * This resets the values in phi to zero and then calculates the space
+     * charge potential phi.
+     *
+     * @param[in] pc container of the particles that deposited rho
+     * @param[in] rho charge per level
+     * @param[inout] phi scalar potential per level
+     */
+    void PoissonSolve (
+        ImpactXParticleContainer const & pc,
+        std::unordered_map<int, amrex::MultiFab> & rho,
+        std::unordered_map<int, amrex::MultiFab> & phi
+    );
+
+} // namespace impactx
+
+#endif // IMPACTX_POISSONSOLVE_H

--- a/src/particles/spacecharge/PoissonSolve.cpp
+++ b/src/particles/spacecharge/PoissonSolve.cpp
@@ -1,0 +1,116 @@
+/* Copyright 2022 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "PoissonSolve.H"
+
+#include <ablastr/fields/PoissonSolver.H>
+
+#include <AMReX_BLProfiler.H>
+#include <AMReX_Extension.H>  // for AMREX_RESTRICT
+#include <AMReX_LO_BCTYPES.H>
+#include <AMReX_REAL.H>       // for ParticleReal
+
+#include <cmath>
+
+
+namespace impactx::spacecharge
+{
+    void PoissonSolve (
+        ImpactXParticleContainer const & pc,
+        std::unordered_map<int, amrex::MultiFab> & rho,
+        std::unordered_map<int, amrex::MultiFab> & phi
+    )
+    {
+        using namespace amrex::literals;
+
+        // set space charge field to zero
+        //   loop over refinement levels
+        int const finest_level = phi.size() - 1u;
+        for (int lev = 0; lev <= finest_level; ++lev) {
+            amrex::MultiFab &phi_at_level = phi.at(lev);
+            // reset the values in phi to zero
+            phi_at_level.setVal(0.);
+        }
+
+        // prepare parameters of the MLMG Poisson Solver
+        //   relativistic beta=v/c of the reference particle
+        amrex::ParticleReal const pt_ref = pc.GetRefParticle().pt;
+        amrex::ParticleReal const beta_s = std::sqrt(1.0_prt - 1.0_prt/std::pow(pt_ref, 2));
+        // The beam particles and the corresponding box are all given in local coordinates
+        // in which z is the direction of motion - this coincides with the direction of the momentum
+        // of the reference particle.
+        // After every T-to-Z transformation, Z aligns with the tangential vector of our reference
+        // particle.
+        std::array<amrex::Real, 3> const beta_xyz = {0.0, 0.0, beta_s};
+
+        amrex::Real const mlmg_relative_tolerance = 1.e-7; // relative TODO: make smaller for SP
+        amrex::Real const mlmg_absolute_tolerance = 0.0;   // ignored
+
+        int const mlmg_max_iters = 100;
+        int const mlmg_verbosity = 1;
+
+        struct PoissonBoundaryHandler {
+            amrex::Array<amrex::LinOpBCType, AMREX_SPACEDIM> const lobc = {
+                amrex::LinOpBCType::Dirichlet,
+                amrex::LinOpBCType::Dirichlet,
+                amrex::LinOpBCType::Dirichlet
+            };
+            amrex::Array<amrex::LinOpBCType, AMREX_SPACEDIM> const hibc = {
+                amrex::LinOpBCType::Dirichlet,
+                amrex::LinOpBCType::Dirichlet,
+                amrex::LinOpBCType::Dirichlet
+            };
+            //bool bcs_set = false;
+            //std::array<bool, AMREX_SPACEDIM * 2> dirichlet_flag;
+            //bool has_non_periodic = false;
+        } poisson_boundary_handler;
+
+        // create a vector to our fields, sorted by level
+        amrex::Vector<amrex::MultiFab*> sorted_rho;
+        amrex::Vector<amrex::MultiFab*> sorted_phi;
+
+        for (int lev = 0; lev <= finest_level; ++lev) {
+            sorted_rho.emplace_back(&rho[lev]);
+            sorted_phi.emplace_back(&phi[lev]);
+        }
+
+        ablastr::fields::computePhi(
+            sorted_rho,
+            sorted_phi,
+            beta_xyz,
+            mlmg_relative_tolerance,
+            mlmg_absolute_tolerance,
+            mlmg_max_iters,
+            mlmg_verbosity,
+            pc.GetParGDB()->Geom(),
+            pc.GetParGDB()->DistributionMap(),
+            pc.GetParGDB()->boxArray(),
+            poisson_boundary_handler
+            /*
+            do_single_precision_comms,
+            this->ref_ratio,
+            post_phi_calculation,
+            gett_new(0),
+            eb_farray_box_factory
+            */
+        );
+
+        // fix side effect on rho from previous call
+        for (int lev=0; lev<=finest_level; lev++) {
+            rho[lev].mult(-1._rt * PhysConst::ep0);
+        }
+
+        // fill boundary
+        for (int lev=0; lev<=finest_level; lev++)
+        {
+            amrex::MultiFab & phi_at_level = phi.at(lev);
+            phi_at_level.FillBoundary(pc.GetParGDB()->Geom()[lev].periodicity());
+        }
+    }
+} // impactx::spacecharge

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -221,9 +221,9 @@ void init_ImpactX(py::module& m)
             "scalar potential per level"
         )
         .def(
-            "space_charge_force",
+            "space_charge_field",
             [](ImpactX & ix, int const lev, std::string const comp) {
-                return &ix.m_space_charge_force.at(lev).at(comp);
+                return &ix.m_space_charge_field.at(lev).at(comp);
             },
             py::arg("lev"), py::arg("comp"),
             py::return_value_policy::reference_internal,

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -210,7 +210,24 @@ void init_ImpactX(py::module& m)
             "rho",
             [](ImpactX & ix, int const lev) { return &ix.m_rho.at(lev); },
             py::arg("lev"),
-            py::return_value_policy::reference_internal
+            py::return_value_policy::reference_internal,
+            "charge density per level"
+        )
+        .def(
+            "phi",
+            [](ImpactX & ix, int const lev) { return &ix.m_phi.at(lev); },
+            py::arg("lev"),
+            py::return_value_policy::reference_internal,
+            "scalar potential per level"
+        )
+        .def(
+            "space_charge_force",
+            [](ImpactX & ix, int const lev, std::string const comp) {
+                return &ix.m_space_charge_force.at(lev).at(comp);
+            },
+            py::arg("lev"), py::arg("comp"),
+            py::return_value_policy::reference_internal,
+            "space charge force (vector: x,y,z) per level"
         )
         .def_readwrite("lattice",
             &ImpactX::m_lattice,


### PR DESCRIPTION
Implement the space charge solver.
Close #101

- [x] update exact charge: https://github.com/ECP-WarpX/impactx/blob/81684134057d43b9f4ecf8b6dcf9221b84e4b9f8/src/particles/ChargeDeposition.cpp#L69
- [x] Poisson solve
  - [x] depends on https://github.com/ECP-WarpX/WarpX/pull/3243 (via #164)
  - [x] depends on https://github.com/ECP-WarpX/WarpX/pull/3357 (via #235)
  - [x] depends on https://github.com/ECP-WarpX/WarpX/pull/3374 (via  #246)
  - [x] depends on #242
  - [x] debug why this is zero - mismatched phi and rho in the call
  - [x] fix sign of deposited charge #251
- [x] space charge force: via stencil on phi https://github.com/ax3l/impactx/pull/1
- [x] space charge kick: gather fields and
  - [x] push particles (in momentum): dt = ds / v_ref
    - [ ] Skip space charge calc for zero-sized elements
    - [x] Skip position push? (because it is handled in the external elements)
- [x] expose control over number of cells to use to user: #240
- [ ] follow-up PR: MR #102
- [ ] tests
  - [ ] #141
  - [x] #244
  - [x] make sure the test's bunch charge is non-zero, otherwise weighting & thus charge deposited is zero: https://github.com/ECP-WarpX/impactx/blob/81684134057d43b9f4ecf8b6dcf9221b84e4b9f8/src/particles/ChargeDeposition.cpp#L51 -> #165

### Update Evolve Loop for Leap-Frog

- [x] #160
```
Loop over elements in the lattice
     Loop over steps through element
          Loop over all particles to apply element map half-step
          Z-to-T transformation
                Solve Poisson equation
          T-to-Z transformation
          Loop over all particles to apply space charge full step
          Loop over all particles to apply element half-step
     End loop over steps through element
End loop over elements
```