### PR TITLE
Elements: slice `ds`

### DIFF
--- a/src/particles/elements/ConstF.H
+++ b/src/particles/elements/ConstF.H
@@ -72,15 +72,18 @@ namespace impactx
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;
 
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
             // advance position and momentum
-            p.pos(0) = cos(m_kx*m_ds)*x + sin(m_kx*m_ds)/m_kx*px;
-            pxout = -m_kx*sin(m_kx*m_ds)*x + cos(m_kx*m_ds)*px;
+            p.pos(0) = cos(m_kx*slice_ds)*x + sin(m_kx*slice_ds)/m_kx*px;
+            pxout = -m_kx*sin(m_kx*slice_ds)*x + cos(m_kx*slice_ds)*px;
 
-            p.pos(1) = cos(m_ky*m_ds)*y + sin(m_ky*m_ds)/m_ky*py;
-            pyout = -m_ky*sin(m_ky*m_ds)*y + cos(m_ky*m_ds)*py;
+            p.pos(1) = cos(m_ky*slice_ds)*y + sin(m_ky*slice_ds)/m_ky*py;
+            pyout = -m_ky*sin(m_ky*slice_ds)*y + cos(m_ky*slice_ds)*py;
 
-            p.pos(2) = cos(m_kt*m_ds)*t + sin(m_kt*m_ds)/(betgam2*m_kt)*pt;
-            ptout = -(m_kt*betgam2)*sin(m_kt*m_ds)*t + cos(m_kt*m_ds)*pt;
+            p.pos(2) = cos(m_kt*slice_ds)*t + sin(m_kt*slice_ds)/(betgam2*m_kt)*pt;
+            ptout = -(m_kt*betgam2)*sin(m_kt*slice_ds)*t + cos(m_kt*slice_ds)*pt;
 
             // assign updated momenta
             px = pxout;
@@ -109,15 +112,17 @@ namespace impactx
             amrex::ParticleReal const t = refpart.t;
             amrex::ParticleReal const pt = refpart.pt;
 
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
             // assign intermediate parameter
-            amrex::ParticleReal const s = m_ds/sqrt(pow(pt,2)-1.0_prt);
+            amrex::ParticleReal const s = slice_ds / sqrt(pow(pt, 2)-1.0_prt);
 
             // advance position and momentum (straight element)
             refpart.x = x + s*px;
             refpart.y = y + s*py;
             refpart.z = z + s*pz;
             refpart.t = t - s*pt;
-
         }
 
         /** Number of slices used for the application of space charge

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -62,16 +62,19 @@ namespace impactx
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;
 
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
             amrex::ParticleReal const betgam2 = pow(pt_ref, 2) - 1.0_prt;
 
             // advance position and momentum (drift)
-            p.pos(0) = x + m_ds * px;
+            p.pos(0) = x + slice_ds * px;
             // pxout = px;
-            p.pos(1) = y + m_ds * py;
+            p.pos(1) = y + slice_ds * py;
             // pyout = py;
-            p.pos(2) = t + (m_ds/betgam2) * pt;
+            p.pos(2) = t + (slice_ds/betgam2) * pt;
             // ptout = pt;
 
             // assign updated momenta
@@ -101,8 +104,11 @@ namespace impactx
             amrex::ParticleReal const t = refpart.t;
             amrex::ParticleReal const pt = refpart.pt;
 
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
             // assign intermediate parameter
-            amrex::ParticleReal const s = m_ds/sqrt(pow(pt,2)-1.0_prt);
+            amrex::ParticleReal const s = slice_ds / sqrt(pow(pt,2)-1.0_prt);
 
             // advance position and momentum (drift)
             refpart.x = x + s*px;

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -62,6 +62,9 @@ namespace impactx
             amrex::ParticleReal const y = p.pos(1);
             amrex::ParticleReal const t = p.pos(2);
 
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
             amrex::ParticleReal const betgam2 = pow(pt_ref, 2) - 1.0_prt;
@@ -76,23 +79,23 @@ namespace impactx
 
             if(m_k > 0.0) {
                // advance position and momentum (focusing quad)
-               p.pos(0) = cos(omega*m_ds)*x + sin(omega*m_ds)/omega*px;
-               pxout = -omega*sin(omega*m_ds)*x + cos(omega*m_ds)*px;
+               p.pos(0) = cos(omega*slice_ds)*x + sin(omega*slice_ds)/omega*px;
+               pxout = -omega*sin(omega*slice_ds)*x + cos(omega*slice_ds)*px;
 
-               p.pos(1) = cosh(omega*m_ds)*y + sinh(omega*m_ds)/omega*py;
-               pyout = omega*sinh(omega*m_ds)*y + cosh(omega*m_ds)*py;
+               p.pos(1) = cosh(omega*slice_ds)*y + sinh(omega*slice_ds)/omega*py;
+               pyout = omega*sinh(omega*slice_ds)*y + cosh(omega*slice_ds)*py;
 
-               p.pos(2) = t + (m_ds/betgam2)*pt;
+               p.pos(2) = t + (slice_ds/betgam2)*pt;
                // ptout = pt;
             } else {
                // advance position and momentum (defocusing quad)
-               p.pos(0) = cosh(omega*m_ds)*x + sinh(omega*m_ds)/omega*px;
-               pxout = omega*sinh(omega*m_ds)*x + cosh(omega*m_ds)*px;
+               p.pos(0) = cosh(omega*slice_ds)*x + sinh(omega*slice_ds)/omega*px;
+               pxout = omega*sinh(omega*slice_ds)*x + cosh(omega*slice_ds)*px;
 
-               p.pos(1) = cos(omega*m_ds)*y + sin(omega*m_ds)/omega*py;
-               pyout = -omega*sin(omega*m_ds)*y + cos(omega*m_ds)*py;
+               p.pos(1) = cos(omega*slice_ds)*y + sin(omega*slice_ds)/omega*py;
+               pyout = -omega*sin(omega*slice_ds)*y + cos(omega*slice_ds)*py;
 
-               p.pos(2) = t + (m_ds/betgam2)*pt;
+               p.pos(2) = t + (slice_ds/betgam2)*pt;
                // ptout = pt;
             }
 
@@ -123,8 +126,11 @@ namespace impactx
             amrex::ParticleReal const t = refpart.t;
             amrex::ParticleReal const pt = refpart.pt;
 
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
             // assign intermediate parameter
-            amrex::ParticleReal const s = m_ds/sqrt(pow(pt,2)-1.0_prt);
+            amrex::ParticleReal const s = slice_ds / sqrt(pow(pt,2)-1.0_prt);
 
             // advance position and momentum (straight element)
             refpart.x = x + s*px;

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -64,11 +64,14 @@ namespace impactx
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;
 
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
             amrex::ParticleReal const betgam2 = pow(pt_ref, 2) - 1.0_prt;
             amrex::ParticleReal const bet = sqrt(betgam2/(1.0_prt + betgam2));
-            amrex::ParticleReal const theta = m_ds/m_rc;
+            amrex::ParticleReal const theta = slice_ds/m_rc;
 
             // advance position and momentum (sector bend)
 
@@ -113,8 +116,11 @@ namespace impactx
             amrex::ParticleReal const t = refpart.t;
             amrex::ParticleReal const pt = refpart.pt;
 
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
             // assign intermediate parameter
-            amrex::ParticleReal const theta = m_ds/m_rc;
+            amrex::ParticleReal const theta = slice_ds/m_rc;
             amrex::ParticleReal const B = sqrt(pow(pt,2)-1.0_prt)/m_rc;
 
             // advance position and momentum (bend)


### PR DESCRIPTION
Slice the segment length `ds` per push according to the number of slices we use between space charge pushes.

Follow-up to #160