### PR TITLE
Added integrated path length s as a reference particle attribute.

### DIFF
--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -203,6 +203,7 @@ namespace impactx
             massE = 0.510998950;  // default to electron
         }
         RefPart refPart;
+        refPart.s = 0.0;
         refPart.x = 0.0;
         refPart.y = 0.0;
         refPart.t = 0.0;

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -75,6 +75,7 @@ namespace impactx
      */
     struct RefPart
     {
+        amrex::ParticleReal s = 0.0;  ///< integrated orbit path length, in meters
         amrex::ParticleReal x = 0.0;  ///< horizontal position x, in meters
         amrex::ParticleReal y = 0.0;  ///< vertical position y, in meters
         amrex::ParticleReal z = 0.0;  ///< longitudinal position y, in meters

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -35,7 +35,7 @@ namespace impactx::diagnostics
             } else if (otype == OutputType::PrintNonlinearLensInvariants) {
                 amrex::AllPrintToFile(file_name) << "id H I\n";
             } else if (otype == OutputType::PrintRefParticle) {
-                amrex::AllPrintToFile(file_name) << "step x y z t px py pz pt\n";
+                amrex::AllPrintToFile(file_name) << "step s x y z t px py pz pt\n";
             }
         }
 
@@ -153,7 +153,7 @@ namespace impactx::diagnostics
 
                     // write particle data to file
                     amrex::AllPrintToFile(file_name)
-                            << step << " "
+                            << step << " " << s << " "
                             << x << " " << y << " " << z << " " << t << " "
                             << px << " " << py << " " << pz << " " << pt << "\n";
                 } // if( otype == OutputType::PrintRefParticle)

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -141,6 +141,7 @@ namespace impactx::diagnostics
                     // preparing to access reference particle data: RefPart
                     RefPart const ref_part = pc.GetRefParticle();
 
+                    amrex::ParticleReal const s = ref_part.s;
                     amrex::ParticleReal const x = ref_part.x;
                     amrex::ParticleReal const y = ref_part.y;
                     amrex::ParticleReal const z = ref_part.z;

--- a/src/particles/elements/ConstF.H
+++ b/src/particles/elements/ConstF.H
@@ -111,18 +111,23 @@ namespace impactx
             amrex::ParticleReal const pz = refpart.pz;
             amrex::ParticleReal const t = refpart.t;
             amrex::ParticleReal const pt = refpart.pt;
+            amrex::ParticleReal const s = refpart.s;
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const s = slice_ds / sqrt(pow(pt, 2)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds / sqrt(pow(pt, 2)-1.0_prt);
 
             // advance position and momentum (straight element)
-            refpart.x = x + s*px;
-            refpart.y = y + s*py;
-            refpart.z = z + s*pz;
-            refpart.t = t - s*pt;
+            refpart.x = x + step*px;
+            refpart.y = y + step*py;
+            refpart.z = z + step*pz;
+            refpart.t = t - step*pt;
+
+            // advance integrated path length
+            refpart.s = s + slice_ds;
+
         }
 
         /** Number of slices used for the application of space charge

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -103,18 +103,22 @@ namespace impactx
             amrex::ParticleReal const pz = refpart.pz;
             amrex::ParticleReal const t = refpart.t;
             amrex::ParticleReal const pt = refpart.pt;
+            amrex::ParticleReal const s = refpart.s;
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const s = slice_ds / sqrt(pow(pt,2)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds / sqrt(pow(pt,2)-1.0_prt);
 
             // advance position and momentum (drift)
-            refpart.x = x + s*px;
-            refpart.y = y + s*py;
-            refpart.z = z + s*pz;
-            refpart.t = t - s*pt;
+            refpart.x = x + step*px;
+            refpart.y = y + step*py;
+            refpart.z = z + step*pz;
+            refpart.t = t - step*pt;
+
+            // advance integrated path length
+            refpart.s = s + slice_ds;
 
         }
 

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -125,18 +125,22 @@ namespace impactx
             amrex::ParticleReal const pz = refpart.pz;
             amrex::ParticleReal const t = refpart.t;
             amrex::ParticleReal const pt = refpart.pt;
+            amrex::ParticleReal const s = refpart.s;
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const s = slice_ds / sqrt(pow(pt,2)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds / sqrt(pow(pt,2)-1.0_prt);
 
             // advance position and momentum (straight element)
-            refpart.x = x + s*px;
-            refpart.y = y + s*py;
-            refpart.z = z + s*pz;
-            refpart.t = t - s*pt;
+            refpart.x = x + step*px;
+            refpart.y = y + step*py;
+            refpart.z = z + step*pz;
+            refpart.t = t - step*pt;
+
+            // advance integrated path length
+            refpart.s = s + slice_ds;
 
         }
 

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -115,6 +115,7 @@ namespace impactx
             amrex::ParticleReal const pz = refpart.pz;
             amrex::ParticleReal const t = refpart.t;
             amrex::ParticleReal const pt = refpart.pt;
+            amrex::ParticleReal const s = refpart.s;
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
@@ -133,6 +134,9 @@ namespace impactx
             refpart.y = y + (theta/B)*py;
             refpart.z = z - (refpart.px - px)/B;
             refpart.t = t - (theta/B)*pt;
+
+            // advance integrated path length
+            refpart.s = s + slice_ds;
 
         }
 

--- a/src/python/ReferenceParticle.cpp
+++ b/src/python/ReferenceParticle.cpp
@@ -16,6 +16,7 @@ void init_refparticle(py::module& m)
 {
     py::class_<RefPart>(m, "RefPart")
         .def(py::init<>())
+        .def_readwrite("s", &RefPart::s, "integrated orbit path length, in meters")
         .def_readwrite("x", &RefPart::x, "horizontal position x, in meters")
         .def_readwrite("y", &RefPart::y, "vertical position y, in meters")
         .def_readwrite("z", &RefPart::z, "longitudinal position y, in meters")


### PR DESCRIPTION
The integrated path length "s" (m) is used in IMPACT-Z to identify the beam's location within the accelerator lattice.  

1) This has been added as an attribute of the reference particle.

2) The path length s is updated during each reference particle push.

The value of s is accessed in "DiagnosticOutput"~~, but it is not yet printed, in order to maintain compatibility with existing postprocessing scripts.  These can be modified as needed to use the value of "s".~~

- [x] add in Python bindings, too