### PR TITLE
Python: Test Catch User Errors

### DIFF
--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -82,6 +82,10 @@ namespace impactx
             int npart
         );
 
+        /** Validate the simulation is ready to run via @see evolve
+         */
+        void validate ();
+
         /** Run the main simulation loop for a number of steps
          */
         void evolve ();

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -55,23 +55,11 @@ namespace impactx
     {
         BL_PROFILE("ImpactX::evolve");
 
+        validate();
+
         // a global step for diagnostics including space charge slice steps in elements
         //   before we start the evolve loop, we are in "step 0" (initial state)
         int global_step = 0;
-
-        // count particles - if no particles are found in our particle container, then a lot of
-        // AMReX routines over ParIter won't work and we have nothing to do here anyways
-        {
-            int const nLevelPC = finestLevel();
-            amrex::Long nParticles = 0;
-            for (int lev = 0; lev <= nLevelPC; ++lev) {
-                nParticles += m_particle_container->NumberOfParticlesAtLevel(lev);
-            }
-            if (nParticles == 0) {
-                amrex::Abort("No particles found. Cannot run evolve without a beam.");
-                return;
-            }
-        }
 
         amrex::ParmParse pp_diag("diag");
         bool diag_enable = true;

--- a/src/initialization/CMakeLists.txt
+++ b/src/initialization/CMakeLists.txt
@@ -7,4 +7,5 @@ target_sources(ImpactX
     InitMeshRefinement.cpp
     InitOneBoxPerRank.cpp
     InitParser.cpp
+    Validate.cpp
 )

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -11,6 +11,8 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/distribution/All.H"
 
+#include <ablastr/warn_manager/WarnManager.H>
+
 #include <AMReX.H>
 #include <AMReX_BLProfiler.H>
 #include <AMReX_REAL.H>
@@ -32,12 +34,25 @@ namespace impactx
         BL_PROFILE("ImpactX::add_particles");
 
         auto const & ref = m_particle_container->GetRefParticle();
-        AMREX_ASSERT_WITH_MESSAGE(ref.charge_qe() != 0.0,
-                                  "add_particles: Reference particle charge not yet set!");
-        AMREX_ASSERT_WITH_MESSAGE(ref.mass_MeV() != 0.0,
-                                  "add_particles: Reference particle mass not yet set!");
-        AMREX_ASSERT_WITH_MESSAGE(ref.energy_MeV() != 0.0,
-                                  "add_particles: Reference particle energy not yet set!");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ref.charge_qe() != 0.0,
+            "add_particles: Reference particle charge not yet set!");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ref.mass_MeV() != 0.0,
+            "add_particles: Reference particle mass not yet set!");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ref.energy_MeV() != 0.0,
+            "add_particles: Reference particle energy not yet set!");
+
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(bunch_charge >= 0.0,
+            "add_particles: the bunch charge should be positive. "
+            "For negatively charge bunches, please change the reference particle's charge.");
+        if (bunch_charge == 0.0) {
+            ablastr::warn_manager::WMRecordWarning(
+                "ImpactX::add_particles",
+                "The bunch charge is set to zero. ImpactX will run with "
+                "zero-weighted particles. Did you mean to set the space "
+                "charge algorithm to off instead?",
+                ablastr::warn_manager::WarnPriority::low
+            );
+        }
 
         amrex::Vector<amrex::ParticleReal> x, y, t;
         amrex::Vector<amrex::ParticleReal> px, py, pt;

--- a/src/initialization/InitMeshRefinement.cpp
+++ b/src/initialization/InitMeshRefinement.cpp
@@ -16,6 +16,7 @@
 #include <AMReX_REAL.H>
 #include <AMReX_Utility.H>
 
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -109,6 +110,12 @@ namespace impactx
 
         // Extract the min and max of the particle positions
         auto const [x_min, y_min, z_min, x_max, y_max, z_max] = m_particle_container->MinAndMaxPositions();
+
+        // guard for flat beams:
+        //   https://github.com/ECP-WarpX/impactx/issues/44
+        if (x_min == x_max || y_min == y_max || z_min == z_max)
+            throw std::runtime_error("Flat beam detected. This is not yet supported: https://github.com/ECP-WarpX/impactx/issues/44");
+
         // Resize the domain size
         // The box is expanded slightly beyond the min and max of particles.
         // This controlled by the variable `frac` below.

--- a/src/initialization/Validate.cpp
+++ b/src/initialization/Validate.cpp
@@ -1,0 +1,49 @@
+/* Copyright 2022 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl, Chad Mitchell, Ji Qiang
+ * License: BSD-3-Clause-LBNL
+ */
+#include "ImpactX.H"
+
+#include <AMReX.H>
+#include <AMReX_BLProfiler.H>
+#include <AMReX_INT.H>
+
+#include <stdexcept>
+
+
+namespace impactx
+{
+    void ImpactX::validate ()
+    {
+        BL_PROFILE("ImpactX::validate");
+
+        // reference particle initialized?
+        auto const & ref = m_particle_container->GetRefParticle();
+        if (ref.energy_MeV() == 0.0)
+            throw std::runtime_error("The reference particle energy is zero. Not yet initialized?");
+
+        // particles in the beam bunch
+        // count particles - if no particles are found in our particle container, then a lot of
+        // AMReX routines over ParIter won't work, and we have nothing to do here anyway
+        {
+            int const nLevelPC = finestLevel();
+            amrex::Long nParticles = 0;
+            for (int lev = 0; lev <= nLevelPC; ++lev) {
+                nParticles += m_particle_container->NumberOfParticlesAtLevel(lev);
+            }
+            if (nParticles == 0)
+                throw std::runtime_error("No particles found. Cannot run evolve without a beam.");
+            if (nParticles == 1)
+                throw std::runtime_error("Only one particle found. This is not yet supported: https://github.com/ECP-WarpX/impactx/issues/44");
+        }
+
+        // elements
+        if (m_lattice.size() == 0u)
+            throw std::runtime_error("Beamline lattice has zero elements. Not yet initialized?");
+    }
+} // namespace impactx

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -47,7 +47,9 @@ namespace impactx
     {
         amrex::ParmParse pp_algo("algo");
         int v = 0;
-        pp_algo.get("particle_shape", v);
+        bool has_shape = pp_algo.query("particle_shape", v);
+        if (!has_shape)
+            throw std::runtime_error("particle_shape is not set, cannot initialize grids with guard cells.");
         SetParticleShape(v);
     }
 

--- a/src/particles/transformation/ToFixedS.H
+++ b/src/particles/transformation/ToFixedS.H
@@ -63,7 +63,7 @@ namespace transformation
 
             // compute value of reference ptd = -gamma
             amrex::ParticleReal const argd = 1.0_prt + pow(m_pzd, 2);
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(argd > 0.0_prt, "invalid ptd arg (<=0)");
+            AMREX_ASSERT_WITH_MESSAGE(argd > 0.0_prt, "invalid ptd arg (<=0)");
             amrex::ParticleReal const ptdf = argd > 0.0_prt ? -sqrt(argd) : -1.0_prt;
 
             // transform momenta to dynamic units (e.g., so that momenta are

--- a/src/particles/transformation/ToFixedT.H
+++ b/src/particles/transformation/ToFixedT.H
@@ -63,7 +63,7 @@ namespace transformation
 
             // compute value of reference pzd = beta*gamma
             amrex::ParticleReal const argd = -1.0_prt + pow(m_ptd, 2);
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(argd > 0.0_prt, "invalid pzd arg (<=0)");
+            AMREX_ASSERT_WITH_MESSAGE(argd > 0.0_prt, "invalid pzd arg (<=0)");
             amrex::ParticleReal const pzd = argd > 0.0_prt ? sqrt(argd) : 0.0_prt;
 
             // transform momenta to dynamic units (eg, so that momenta are

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -47,7 +47,7 @@ void init_ImpactX(py::module& m)
                     inputs_file_exists = true;
                 }
                 AMREX_ALWAYS_ASSERT_WITH_MESSAGE(inputs_file_exists,
-                    "load_inputs_file: invalid filename");
+                    "load_inputs_file: file does not exist: " + filename);
 #endif
 
                 amrex::ParmParse::addfile(filename);

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -13,7 +13,7 @@ else:
     print("NO mpi4py load")
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=True, scope="function")
 def amrex_init():
     amrex.initialize(
         [


### PR DESCRIPTION
Test multiple possible usage errors from Python. We want to make sure that these errors throw exceptions and do not abort/terminate the Python process. That way, the user-experience in IPython/Jupyter notebooks will be better (no session restart needed).

- [x] depends on https://github.com/AMReX-Codes/amrex/pull/2936 (via #238)
- [x] depends on https://github.com/AMReX-Codes/amrex/pull/2944 (via ...)