### PR TITLE
CUDA: Fix Push (Invalid Lattice Element Members)

### DIFF
--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -100,6 +100,9 @@ namespace detail
 
         using namespace amrex::literals; // for _rt and _prt
 
+        // preparing to access reference particle data: RefPart
+        RefPart & ref_part = pc.GetRefParticle();
+
         // loop over refinement levels
         int const nLevel = pc.finestLevel();
         for (int lev = 0; lev <= nLevel; ++lev)
@@ -127,12 +130,9 @@ namespace detail
                 amrex::ParticleReal* const AMREX_RESTRICT part_py = soa_real[RealSoA::uy].dataPtr();
                 amrex::ParticleReal* const AMREX_RESTRICT part_pt = soa_real[RealSoA::pt].dataPtr();
 
-                // preparing to access reference particle data: RefPart
-                RefPart & ref_part = pc.GetRefParticle();
-
                 // here we just access the element by its respective type
                 std::visit(
-                    [=, &ref_part](auto&& element) {
+                    [=, &ref_part](auto element) {
                         // push beam particles relative to reference particle
                         detail::PushSingleParticle<decltype(element)> const pushSingleParticle(
                             element, aos_ptr, part_px, part_py, part_pt, ref_part);


### PR DESCRIPTION
`std::visit` has issues if we don't explicitly copy the `element` object. The symptoms are invalid memory accesses to simple fundamental members of the lattice elements on device, such as `m_ds`.

Fix #154

Seen on Perlmutter (NERSC) with:
```
Currently Loaded Modules:
  1) craype-x86-milan                      10) cray-dsmml/0.2.2
  2) libfabric/1.11.0.4.124                11) cray-mpich/8.1.17
  3) craype-network-ofi                    12) cray-libsci/21.08.1.2
  4) perftools-base/22.06.0                13) PrgEnv-gnu/8.3.3
  5) xpmem/2.3.2-2.2_7.5__g93dd7ee.shasta  14) Nsight-Compute/2022.1.1
  6) xalt/2.10.2                           15) Nsight-Systems/2022.2.1
  7) cmake/3.22.0                          16) cudatoolkit/11.5
  8) gcc/11.2.0                            17) cray-hdf5-parallel/1.12.1.1
  9) craype/2.7.16
```
```
$ nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2021 NVIDIA Corporation
Built on Thu_Nov_18_09:45:30_PST_2021
Cuda compilation tools, release 11.5, V11.5.119
Build cuda_11.5.r11.5/compiler.30672275_0
```
