### PR TITLE
add name to namespace for Config

### DIFF
--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -24,7 +24,7 @@
 namespace py = pybind11;
 using namespace impactx;
 
-namespace {
+namespace impactx {
     struct Config {};
 }
 


### PR DESCRIPTION
This is a fix for a bug that was observed when loading `pyImpactX`.  The `amrex` and `impactx` `Config` objects were both described in anonymous namespaces causing a conflict.  Here the namespace is explicitly named so that the `Config` object is `impactx.Config`.