### PR TITLE
Chicane Benchmark: Fix Axis Label

### DIFF
--- a/examples/chicane/README.rst
+++ b/examples/chicane/README.rst
@@ -46,5 +46,5 @@ You can run the following script to visualize the beam evolution over time:
 .. figure:: https://user-images.githubusercontent.com/1353258/180332191-f9ce11fc-8c56-4713-a91a-2ad12ab09805.png
  :alt: Chicane beam width and emittance evolution
 
-.. figure:: https://user-images.githubusercontent.com/1353258/180332189-a0e6933b-d3c6-4170-acd0-d79b366602e0.png
+.. figure:: https://user-images.githubusercontent.com/1353258/181611473-754dde72-3281-453b-9d9a-43317a5a49f2.png
  :alt: Chicane phase space evolution

--- a/examples/chicane/plot_chicane.py
+++ b/examples/chicane/plot_chicane.py
@@ -228,7 +228,7 @@ for step in print_steps:
         beam_at_step.px.multiply(mrad),
         s=0.01
     )
-    ax.set_xlabel(r"$x$ [mm]")
+    ax.set_xlabel(r"$ct$ [mm]")
 
 axs[(0, 0)].set_ylabel(r"$p_t$ [mrad]")
 axs[(1, 0)].set_ylabel(r"$p_x$ [mrad]")


### PR DESCRIPTION
The last row is `t-px`.

![chicane_scatter](https://user-images.githubusercontent.com/1353258/181611473-754dde72-3281-453b-9d9a-43317a5a49f2.png)

Follow-up to #167