### PR TITLE
Diagnostics: Benchmark Control

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -367,6 +367,10 @@ Numerics and algorithms
 Diagnostics and output
 ----------------------
 
+* ``diag.enable`` (``boolean``, optional, default: ``true``)
+  Enable or disable diagnostics generally.
+  Disabling this is mostly used for benchmarking.
+
 * ``diag.slice_step_diagnostics`` (``boolean``, optional, default: ``false``)
   By default, diagnostics is performed at the beginning and end of the simulation.
   Enabling this flag will write diagnostics every step and slice step

--- a/examples/fodo/run_fodo.py
+++ b/examples/fodo/run_fodo.py
@@ -14,7 +14,8 @@ sim = ImpactX()
 # set numerical parameters and IO control
 sim.set_particle_shape(2)  # B-spline order
 sim.set_space_charge(False)
-sim.set_diags_slice_step_diagnostics(True)
+#sim.set_diagnostics(False)  # benchmarking
+sim.set_slice_step_diagnostics(True)
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/examples/iota_lattice/run_iotalattice.py
+++ b/examples/iota_lattice/run_iotalattice.py
@@ -14,7 +14,8 @@ sim = ImpactX()
 # set numerical parameters and IO control
 sim.set_particle_shape(2)  # B-spline order
 sim.set_space_charge(False)
-sim.set_diags_slice_step_diagnostics(True)
+#sim.set_diagnostics(False)  # benchmarking
+sim.set_slice_step_diagnostics(True)
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -74,7 +74,12 @@ namespace impactx
         }
 
         amrex::ParmParse pp_diag("diag");
+        bool diag_enable = true;
+        pp_diag.queryAdd("enable", diag_enable);
+        amrex::Print() << " Diagnostics: " << diag_enable << "\n";
+
         int file_min_digits = 6;
+        if (diag_enable)
         {
             pp_diag.queryAdd("file_min_digits", file_min_digits);
 
@@ -171,7 +176,7 @@ namespace impactx
                 bool slice_step_diagnostics = false;
                 pp_diag.queryAdd("slice_step_diagnostics", slice_step_diagnostics);
 
-                if (slice_step_diagnostics)
+                if (diag_enable && slice_step_diagnostics)
                 {
                     // print slice step particle distribution to file
                     std::string diag_name = amrex::Concatenate("diags/beam_", global_step, file_min_digits);
@@ -192,23 +197,26 @@ namespace impactx
             } // end in-element space-charge slice-step loop
         } // end beamline element loop
 
-        // print final particle distribution to file
-        diagnostics::DiagnosticOutput(*m_particle_container,
-                                      diagnostics::OutputType::PrintParticles,
-                                      "diags/beam_final",
-                                      global_step);
+        if (diag_enable)
+        {
+            // print final particle distribution to file
+            diagnostics::DiagnosticOutput(*m_particle_container,
+                                          diagnostics::OutputType::PrintParticles,
+                                          "diags/beam_final",
+                                          global_step);
 
-        // print final reference particle to file
-        diagnostics::DiagnosticOutput(*m_particle_container,
-                                      diagnostics::OutputType::PrintRefParticle,
-                                      "diags/ref_particle_final",
-                                      global_step);
+            // print final reference particle to file
+            diagnostics::DiagnosticOutput(*m_particle_container,
+                                          diagnostics::OutputType::PrintRefParticle,
+                                          "diags/ref_particle_final",
+                                          global_step);
 
-        // print the final values of the two invariants H and I
-        diagnostics::DiagnosticOutput(*m_particle_container,
-                                      diagnostics::OutputType::PrintNonlinearLensInvariants,
-                                      "diags/nonlinear_lens_invariants_final",
-                                      global_step);
+            // print the final values of the two invariants H and I
+            diagnostics::DiagnosticOutput(*m_particle_container,
+                                          diagnostics::OutputType::PrintNonlinearLensInvariants,
+                                          "diags/nonlinear_lens_invariants_final",
+                                          global_step);
+        }
 
     }
 } // namespace impactx

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -70,20 +70,33 @@ void init_ImpactX(py::module& m)
                 pp_ago.add("particle_shape", order);
             })
         .def("set_space_charge",
-             [](ImpactX & /* ix */, bool const space_charge) {
+             [](ImpactX & /* ix */, bool const enable) {
                  amrex::ParmParse pp_algo("algo");
-                 pp_algo.add("space_charge", space_charge);
-             })
-        .def("set_diags_slice_step_diagnostics",
-             [](ImpactX & /* ix */, bool const slice_step_diagnostics) {
+                 pp_algo.add("space_charge", enable);
+             },
+             py::arg("enable")
+         )
+        .def("set_diagnostics",
+             [](ImpactX & /* ix */, bool const enable) {
                  amrex::ParmParse pp_diag("diag");
-                 pp_diag.add("slice_step_diagnostics", slice_step_diagnostics);
-             })
-        .def("set_diags_file_min_digits",
+                 pp_diag.add("enable", enable);
+             },
+             py::arg("enable")
+         )
+        .def("set_slice_step_diagnostics",
+             [](ImpactX & /* ix */, bool const enable) {
+                 amrex::ParmParse pp_diag("diag");
+                 pp_diag.add("slice_step_diagnostics", enable);
+             },
+             py::arg("enable")
+         )
+        .def("set_diag_file_min_digits",
              [](ImpactX & /* ix */, int const file_min_digits) {
                  amrex::ParmParse pp_diag("diag");
                  pp_diag.add("file_min_digits", file_min_digits);
-             })
+             },
+             py::arg("file_min_digits")
+         )
 
         .def("init_grids", &ImpactX::initGrids)
         .def("init_beam_distribution_from_inputs", &ImpactX::initBeamDistributionFromInputs)

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -25,7 +25,7 @@ def test_impactx_nofile():
     impactX = ImpactX()
 
     impactX.set_particle_shape(2)
-    impactX.set_diags_slice_step_diagnostics(True)
+    impactX.set_slice_step_diagnostics(True)
     impactX.init_grids()
 
     # init particle beam


### PR DESCRIPTION
Since our diagnostics are currently slow ASCII outputs, we want to disable them during benchmarks. This adds this option via `diag.enable = 0` / `sim.set_diagnostics(False)`.

Also simplifies the existing option `sim.set_diags_slice_step_diagnostics` to `sim.set_slice_step_diagnostics`.

- [x] rebase after #189 was merged