### PR TITLE
Docs: Python API in the Manual

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,8 +68,8 @@ Usage
    :hidden:
 
    usage/how_to_run
-   usage/parameters
    usage/python
+   usage/parameters
    usage/examples
    usage/workflows
 

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1,7 +1,9 @@
 .. _running-cpp-parameters:
 
-Input Parameters
-================
+Parameters: Inputs File
+=======================
+
+This documents on how to use ImpactX with an inputs file (``impactx input_file.in``).
 
 .. note::
    The AMReX parser (see :ref:`running-cpp-parameters-parser`) is used for the right-hand-side of all input parameters that consist of one or more integers or floats, so expressions like ``<species_name>.density_max = "2.+1."`` and/or using user-defined constants are accepted.
@@ -356,11 +358,13 @@ Numerics and algorithms
 * ``algo.particle_shape`` (``integer``; ``1``, ``2``, or ``3``)
     The order of the shape factors (splines) for the macro-particles along all spatial directions: `1` for linear, `2` for quadratic, `3` for cubic.
     Low-order shape factors result in faster simulations, but may lead to more noisy results.
-    High-order shape factors are computationally more expensive, but may increase the overall accuracy of the results. For production runs it is generally safer to use high-order shape factors, such as cubic order.
+    High-order shape factors are computationally more expensive, but may increase the overall accuracy of the results.
+    For production runs it is generally safer to use high-order shape factors, such as cubic order.
 
 * ``algo.space_charge`` (``boolean``, optional, default: ``true``)
     Whether to calculate space charge effects.
-    This is in-development. At the moment, this flag only activates coordinate transformations and charge deposition.
+    This is in-development.
+    At the moment, this flag only activates coordinate transformations and charge deposition.
 
 .. _running-cpp-parameters-diagnostics:
 
@@ -376,7 +380,7 @@ Diagnostics and output
   Enabling this flag will write diagnostics every step and slice step
 
 * ``diag.file_min_digits`` (``integer``, optional, default: ``6``)
-    The minimum number of digits used for the iteration number appended to the diagnostic file names.
+    The minimum number of digits used for the step number appended to the diagnostic file names.
 
 .. _running-cpp-parameters-diagnostics-reduced:
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1,8 +1,377 @@
 .. _usage-picmi:
 
-Python (PICMI)
-==============
+Parameters: Python
+==================
 
-.. note::
+This documents on how to use ImpactX as a Python script (``python3 run_script.py``).
 
-   TODO :-)
+General
+-------
+
+.. py:class:: impactx.ImpactX
+
+   This is the central simulation class.
+
+   .. py:method:: set_particle_shape(order)
+
+      Set the particle B-spline order.
+
+      The order of the shape factors (splines) for the macro-particles along all spatial directions: `1` for linear, `2` for quadratic, `3` for cubic.
+      Low-order shape factors result in faster simulations, but may lead to more noisy results.
+      High-order shape factors are computationally more expensive, but may increase the overall accuracy of the results.
+      For production runs it is generally safer to use high-order shape factors, such as cubic order.
+
+      :param int order: B-spline order ``1``, ``2``, or ``3``
+
+
+   .. py:method:: set_space_charge(enable)
+
+      Enable or disable space charge calculations (default: enabled).
+
+      Whether to calculate space charge effects.
+      This is in-development.
+      At the moment, this flag only activates coordinate transformations and charge deposition.
+
+      :param bool enable: enable (true) or disable (false) space charge
+
+   .. py:method:: set_diagnostics(enable)
+
+      Enable or disable diagnostics generally (default: enabled).
+      Disabling this is mostly used for benchmarking.
+
+      :param bool enable: enable (true) or disable (false) all diagnostics
+
+   .. py:method:: set_slice_step_diagnostics(enable)
+
+      Enable or disable diagnostics every slice step in elements (default: disabled).
+
+      By default, diagnostics is performed at the beginning and end of the simulation.
+      Enabling this flag will write diagnostics every step and slice step.
+
+      :param bool enable: enable (true) or disable (false) all diagnostics
+
+   .. py:method:: set_diag_file_min_digits(file_min_digits)
+
+      The minimum number of digits (default: 6) used for the step
+      number appended to the diagnostic file names.
+
+      :param int file_min_digits: number of digits in filenames
+
+   .. py:method:: init_grids()
+
+      Initialize AMReX blocks/grids for domain decomposition & space charge mesh.
+
+      This must come first, before particle beams and lattice elements are initialized.
+
+   .. py:method:: add_particles(qm_qeeV, charge_C, distr, npart)
+
+      Generate and add n particles to the particle container.
+
+      Will also resize the geometry based on the updated particle distribution's extent and then redistribute particles in according AMReX grid boxes.
+
+      :param float qm_qeeV: charge/mass ratio (q_e/eV)
+      :param float charge_C: bunch charge (C)
+      :param distr: distribution function to draw from (object from :py:mod:`impactx.distribution`)
+      :param int npart: number of particles to draw
+
+   .. py:method:: particle_container()
+
+      Access the beam particle container (:py:class:`impactx.ParticleContainer`).
+
+   .. py:property:: lattice
+
+      Access the elements in the accelerator lattice.
+      See :py:mod:`impactx.elements` for lattice elements.
+
+   .. py:method:: evolve()
+
+      Run the main simulation loop for a number of steps.
+
+.. py:class:: impactx.Config
+
+      Configuration information on ImpactX that were set at compile-time.
+
+   .. py:property:: have_mpi
+
+      Indicates multi-process/multi-node support via the `message-passing interface (MPI) <https://www.mpi-forum.org>`__.
+      Possible values: ``True``/``False``
+
+      .. note::
+
+         Particle beam particles are not yet dynamically load balanced.
+         Please see the progress in `issue 198 <https://github.com/ECP-WarpX/impactx/issues/198>`__.
+
+   .. py:property:: have_gpu
+
+      Indicates GPU support.
+      Possible values: ``True``/``False``
+
+   .. py:property:: gpu_backend
+
+      Indicates the available GPU support.
+      Possible values: ``None``, ``"CUDA"`` (for Nvidia GPUs), ``"HIP"`` (for AMD GPUs) or ``"SYCL"`` (for Intel GPUs).
+
+   .. py:property:: have_omp
+
+      Indicates multi-threaded CPU support via `OpenMP <https://www.openmp.org>`__.
+      Possible values: ``True``/``False```
+
+      Set the environment variable ``OMP_NUM_THREADS`` to control the number of threads.
+
+      .. note::
+
+         Not yet implemented.
+         Please see the progress in `issue 195 <https://github.com/ECP-WarpX/impactx/issues/195>`__.
+
+      .. warning::
+
+         By default, OpenMP spawns as many threads as there are available virtual cores on a host.
+         When MPI and OpenMP support are used at the same time, it can easily happen that one over-subscribes the available physical CPU cores.
+         This will lead to a severe slow-down of the simulation.
+
+         By setting appropriate `environment variables for OpenMP <https://www.openmp.org/spec-html/5.0/openmpch6.html>`__, ensure that the number of MPI processes (ranks) per node multiplied with the number of OpenMP threads is equal to the number of physical (or virtual) CPU cores.
+         Please see our examples in the :ref:`high-performance computing (HPC) <install-hpc>` on how to run efficiently in parallel environments such as supercomputers.
+
+Particles
+---------
+
+.. py:class:: impactx.ParticleContainer
+
+   Beam Particles in ImpactX.
+
+   This class stores particles, distributed over MPI ranks.
+
+   .. py:method:: add_n_particles(lev, x, y, z, px, py, pyz, qm, bchchg)
+
+      Add new particles to the container
+
+      Note: This can only be used *after* the initialization (grids) have
+            been created, meaning after the call to :py:meth:`ImpactX.init_grids`
+            has been made in the ImpactX class.
+
+      :param lev: mesh-refinement level
+      :param x: positions in x
+      :param y: positions in y
+      :param z: positions in z
+      :param px: momentum in x
+      :param py: momentum in y
+      :param pz: momentum in z
+      :param qm: charge over mass in 1/eV
+      :param bchchg: total charge within a bunch in C
+
+   .. py:method:: ref_particle()
+
+      Access the reference particle (:py:class:`impactx.RefPart`).
+
+      :return: return a data reference to the reference particle
+      :rtype: impactx.RefPart
+
+   .. py:method:: set_ref_particle(refpart)
+
+      Set reference particle attributes.
+
+      :param impactx.RefPart refpart: a reference particle to copy all attributes from
+
+.. py:class:: impactx.RefPart
+
+   This struct stores the reference particle attributes stored in :py:class:`impactx.ParticleContainer`.
+
+   .. py:property:: s
+
+      integrated orbit path length, in meters
+
+   .. py:property:: x
+
+      horizontal position x, in meters
+
+   .. py:property:: y
+
+      vertical position y, in meters
+
+   .. py:property:: z
+
+      longitudinal position y, in meters
+
+   .. py:property:: t
+
+      clock time * c in meters
+
+   .. py:property:: px
+
+      momentum in x, normalized to proper velocity
+
+   .. py:property:: py
+
+      momentum in y, normalized to proper velocity
+
+   .. py:property:: pz
+
+      momentum in z, normalized to proper velocity
+
+   .. py:property:: pt
+
+      energy deviation, normalized by rest energy
+
+   .. py:property:: gamma
+
+      Read-only: Get reference particle relativistic gamma.
+
+   .. py:property:: beta
+
+      Read-only: Get reference particle relativistic beta.
+
+   .. py:property:: beta_gamma
+
+      Read-only: Get reference particle beta*gamma
+
+   .. py:method:: set_energy_MeV(energy_MeV, massE_MeV)
+
+      Write-only: Set reference particle energy.
+
+
+Initial Beam Distributions
+--------------------------
+
+This module provides particle beam distributions that can be used to initialize particle beams in an :py:class:`impactx.ParticleContainer`.
+
+.. py:module:: impactx.distribution
+   :synopsis: Particle beam distributions in ImpactX
+
+.. py:class:: impactx.distribution.Gaussian(sigx, sigy, sigt, sigpx, sigpy, sigpt, muxpx=0.0, muypy=0.0, mutpt=0.0)
+
+   A 6D Gaussian distribution.
+
+   :param sigx: for zero correlation, these are the related RMS sizes (in meters)
+   :param sigy: see sigx
+   :param sigt: see sigx
+   :param sigpx: RMS momentum
+   :param sigpy: see sigpx
+   :param sigpt: see sigpx
+   :param muxpx: correlation length-momentum
+   :param muypy: see muxpx
+   :param mutpt: see muxpx
+
+.. py:class:: impactx.distribution.Kurth4D(sigx, sigy, sigt, sigpx, sigpy, sigpt, muxpx=0.0, muypy=0.0, mutpt=0.0)
+
+   A 4D Kurth distribution transversely + a uniform distribution
+   it t + a Gaussian distribution in pt.
+
+.. py:class:: impactx.distribution.Kurth6D(sigx, sigy, sigt, sigpx, sigpy, sigpt, muxpx=0.0, muypy=0.0, mutpt=0.0)
+
+   A 6D Kurth distribution.
+
+   R. Kurth, Quarterly of Applied Mathematics vol. 32, pp. 325-329 (1978)
+   C. Mitchell, K. Hwang and R. D. Ryne, IPAC2021, WEPAB248 (2021)
+
+.. py:class:: impactx.distribution.KVdist(sigx, sigy, sigt, sigpx, sigpy, sigpt, muxpx=0.0, muypy=0.0, mutpt=0.0)
+
+   A K-V distribution transversely + a uniform distribution
+   it t + a Gaussian distribution in pt.
+
+.. py:class:: impactx.distribution.None
+
+   This distribution does nothing.
+
+.. py:class:: impactx.distribution.Semigaussian(sigx, sigy, sigt, sigpx, sigpy, sigpt, muxpx=0.0, muypy=0.0, mutpt=0.0)
+
+   A 6D Semi-Gaussian distribution (uniform in position, Gaussian in momentum).
+
+.. py:class:: impactx.distribution.Waterbag(sigx, sigy, sigt, sigpx, sigpy, sigpt, muxpx=0.0, muypy=0.0, mutpt=0.0)
+
+   A 6D Waterbag distribution.
+
+
+Lattice Elements
+----------------
+
+This module provides elements for the accelerator lattice.
+
+.. py:module:: impactx.elements
+   :synopsis: Accelerator lattice elements in ImpactX
+
+.. py:class:: impactx.elements.KnownElementsList
+
+   An iterable, ``list``-like type of elements.
+
+.. py:class:: impactx.elements.ConstF(ds, kx, ky, kt, nslice=1)
+
+   A linear Constant Focusing element.
+
+   :param ds: Segment length in m.
+   :param kx: Focusing strength for x in 1/m.
+   :param ky: Focusing strength for y in 1/m.
+   :param kt: Focusing strength for t in 1/m.
+   :param nslice: number of slices used for the application of space charge
+
+.. py:class:: impactx.elements.DipEdge(psi, rc, g, K2)
+
+   Edge focusing associated with bend entry or exit
+
+   This model assumes a first-order effect of nonzero gap.
+   Here we use the linear fringe field map, given to first order in g/rc (gap / radius of curvature).
+
+   References:
+   * K. L. Brown, SLAC Report No. 75 (1982).
+   * K. Hwang and S. Y. Lee, PRAB 18, 122401 (2015).
+
+   :param psi: Pole face angle in rad
+   :param rc: Radius of curvature in m
+   :param g: Gap parameter in m
+   :param K2: Fringe field integral (unitless)
+
+.. py:class:: impactx.elements.Drift(ds, nslice=1)
+
+   A drift.
+
+   :param ds: Segment length in m
+   :param nslice: number of slices used for the application of space charge
+
+.. py:class:: impactx.elements.Multipole(multipole, K_normal, K_skew)
+
+   A general thin multipole element.
+
+   :param multipole: index m (m=1 dipole, m=2 quadrupole, m=3 sextupole etc.)
+   :param K_normal: Integrated normal multipole coefficient (1/meter^m)
+   :param K_skew: Integrated skew multipole coefficient (1/meter^m)
+
+.. py::class:: impactx.elements.None
+
+   This element does nothing.
+
+.. py:class:: impactx.elements.NonlinearLens(knll, cnll)
+
+   Single short segment of the nonlinear magnetic insert element
+
+   A thin lens associated with a single short segment of the
+   nonlinear magnetic insert described by V. Danilov and
+   S. Nagaitsev, PRSTAB 13, 084002 (2010), Sect. V.A.  This
+   element appears in MAD-X as type NLLENS.
+
+   :param knll: integrated strength of the nonlinear lens (m)
+   :param cnll: distance of singularities from the origin (m)
+
+.. py:class:: impactx.elements.Quad(ds, k, nslice=1)
+
+   A Quadrupole magnet.
+
+   :param ds: Segment length in m.
+   :param k:  Quadrupole strength in m^(-2) (MADX convention)
+              = (gradient in T/m) / (rigidity in T-m)
+              k > 0 horizontal focusing
+              k < 0 horizontal defocusing
+   :param nslice: number of slices used for the application of space charge
+
+.. py:class:: impactx.elements.Sbend(ds, rc, nslice=1)
+
+   An ideal sector bend.
+
+   :param ds: Segment length in m.
+   :param rc: Radius of curvature in m.
+   :param nslice: number of slices used for the application of space charge
+
+.. py:class:: impactx.elements.ShortRF(V, k)
+
+   A short RF cavity element at zero crossing for bunching.
+
+   :param V: Normalized RF voltage drop V = Emax*L/(c*Brho)
+   :param k: Wavenumber of RF in 1/m

--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -43,7 +43,7 @@ namespace impactx
         void operator= (ImpactX const&) = delete;
         void operator= (ImpactX &&) = delete;
 
-        /** Initialize AMReX blocks/grids
+        /** Initialize AMReX blocks/grids for domain decomposition & space charge mesh.
          *
          * This must come first, before particle beams and lattice elements are
          * initialized.
@@ -124,10 +124,8 @@ namespace impactx
         /** charge per level */
         std::unordered_map<int, amrex::MultiFab> m_rho;
 
-        /** these are elements defining the lattice */
+        /** these are elements defining the accelerator lattice */
         std::list<KnownElements> m_lattice;
-
-        std::list<std::variant<int>> m_lattice_test;
     };
 
 } // namespace impactx

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -70,7 +70,7 @@ namespace impactx
         };
     };
 
-    /** This struct indexes the reference particle attributes
+    /** This struct stores the reference particle attributes
      *  stored in ImpactXParticleContainer
      */
     struct RefPart

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -32,8 +32,8 @@ namespace impactx
          *  S. Nagaitsev, PRSTAB 13, 084002 (2010), Sect. V.A.  This
          *  element appears in MAD-X as type NLLENS.
          *
-         * @param knll - integrated strength of the nonlinear lens (m)
-         * @param cnll - distance of singularities from the origin (m)
+         * @param knll integrated strength of the nonlinear lens (m)
+         * @param cnll distance of singularities from the origin (m)
          */
         NonlinearLens( amrex::ParticleReal const knll,
                    amrex::ParticleReal const cnll )

--- a/src/python/ImpactXParticleContainer.cpp
+++ b/src/python/ImpactXParticleContainer.cpp
@@ -20,14 +20,35 @@ void init_impactxparticlecontainer(py::module& m)
         amrex::ParticleContainer<0, 0, RealSoA::nattribs, IntSoA::nattribs>
     >(m, "ImpactXParticleContainer")
         //.def(py::init<>())
-        .def("add_n_particles", &ImpactXParticleContainer::AddNParticles)
+        .def("add_n_particles",
+             &ImpactXParticleContainer::AddNParticles,
+             py::arg("lev"),
+             py::arg("x"), py::arg("y"), py::arg("z"),
+             py::arg("px"), py::arg("py"), py::arg("pz"),
+             py::arg("qm"), py::arg("bchchg"),
+             "Add new particles to the container\n\n"
+             "Note: This can only be used *after* the initialization (grids) have\n"
+             "      been created, meaning after the call to ImpactX.init_grids\n"
+             "      has been made in the ImpactX class.\n\n"
+             ":param lev: mesh-refinement level\n"
+             ":param x: positions in x\n"
+             ":param y: positions in y\n"
+             ":param z: positions in z\n"
+             ":param px: momentum in x\n"
+             ":param py: momentum in y\n"
+             ":param pz: momentum in z\n"
+             ":param qm: charge over mass in 1/eV\n"
+             ":param bchchg: total charge within a bunch in C"
+        )
         .def("ref_particle",
             py::overload_cast<>(&ImpactXParticleContainer::GetRefParticle),
-            py::return_value_policy::reference_internal
+            py::return_value_policy::reference_internal,
+            "Access the reference particle."
         )
-        .def("set_ref_particle", &ImpactXParticleContainer::SetRefParticle)
-        .def("set_particle_shape",
-            py::overload_cast<int const>(&ImpactXParticleContainer::SetParticleShape)
+        .def("set_ref_particle",
+             &ImpactXParticleContainer::SetRefParticle,
+             py::arg("refpart"),
+             "Set reference particle attributes."
         )
     ;
 }

--- a/src/python/ReferenceParticle.cpp
+++ b/src/python/ReferenceParticle.cpp
@@ -15,7 +15,10 @@ using namespace impactx;
 void init_refparticle(py::module& m)
 {
     py::class_<RefPart>(m, "RefPart")
-        .def(py::init<>())
+        .def(py::init<>(),
+             "This struct stores the reference particle attributes\n"
+             "stored in ImpactXParticleContainer."
+        )
         .def_readwrite("s", &RefPart::s, "integrated orbit path length, in meters")
         .def_readwrite("x", &RefPart::x, "horizontal position x, in meters")
         .def_readwrite("y", &RefPart::y, "vertical position y, in meters")

--- a/src/python/distribution.cpp
+++ b/src/python/distribution.cpp
@@ -31,7 +31,8 @@ void init_distribution(py::module& m)
              >(),
              py::arg("sigmaX"), py::arg("sigmaY"), py::arg("sigmaT"),
              py::arg("sigmaPx"), py::arg("sigmaPy"), py::arg("sigmaPt"),
-             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0
+             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0,
+             "A 6D Gaussian distribution"
         );
 
     py::class_<distribution::Kurth4D>(md, "Kurth4D")
@@ -42,7 +43,9 @@ void init_distribution(py::module& m)
          >(),
              py::arg("sigmaX"), py::arg("sigmaY"), py::arg("sigmaT"),
              py::arg("sigmaPx"), py::arg("sigmaPy"), py::arg("sigmaPt"),
-             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0
+             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0,
+             "A 4D Kurth distribution transversely + a uniform distribution\n"
+             "it t + a Gaussian distribution in pt"
         );
 
     py::class_<distribution::Kurth6D>(md, "Kurth6D")
@@ -53,7 +56,10 @@ void init_distribution(py::module& m)
              >(),
              py::arg("sigmaX"), py::arg("sigmaY"), py::arg("sigmaT"),
              py::arg("sigmaPx"), py::arg("sigmaPy"), py::arg("sigmaPt"),
-             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0
+             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0,
+             "A 6D Kurth distribution\n\n"
+             "R. Kurth, Quarterly of Applied Mathematics vol. 32, pp. 325-329 (1978)\n"
+             "C. Mitchell, K. Hwang and R. D. Ryne, IPAC2021, WEPAB248 (2021)"
         );
 
     py::class_<distribution::KVdist>(md, "KVdist")
@@ -64,7 +70,14 @@ void init_distribution(py::module& m)
              >(),
              py::arg("sigmaX"), py::arg("sigmaY"), py::arg("sigmaT"),
              py::arg("sigmaPx"), py::arg("sigmaPy"), py::arg("sigmaPt"),
-             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0
+             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0,
+             "A K-V distribution transversely + a uniform distribution\n"
+             "it t + a Gaussian distribution in pt"
+        );
+
+    py::class_<distribution::None>(md, "None")
+        .def(py::init<>(),
+             "This distribution does nothing"
         );
 
     py::class_<distribution::Semigaussian>(md, "Semigaussian")
@@ -75,7 +88,8 @@ void init_distribution(py::module& m)
              >(),
              py::arg("sigmaX"), py::arg("sigmaY"), py::arg("sigmaT"),
              py::arg("sigmaPx"), py::arg("sigmaPy"), py::arg("sigmaPt"),
-             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0
+             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0,
+             "A 6D Semi-Gaussian distribution (uniform in position, Gaussian in momentum)."
         );
 
     py::class_<distribution::Waterbag>(md, "Waterbag")
@@ -86,6 +100,7 @@ void init_distribution(py::module& m)
              >(),
              py::arg("sigmaX"), py::arg("sigmaY"), py::arg("sigmaT"),
              py::arg("sigmaPx"), py::arg("sigmaPy"), py::arg("sigmaPt"),
-             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0
+             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0,
+             "A 6D Waterbag distribution"
         );
 }

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -62,7 +62,8 @@ void init_elements(py::module& m)
                 amrex::ParticleReal const,
                 amrex::ParticleReal const,
                 int const >(),
-             py::arg("ds"), py::arg("kx"), py::arg("ky"), py::arg("kt"), py::arg("nslice") = 1
+             py::arg("ds"), py::arg("kx"), py::arg("ky"), py::arg("kt"), py::arg("nslice") = 1,
+             "A linear Constant Focusing element."
         )
         .def_property_readonly("nslice", &ConstF::nslice)
     ;
@@ -73,7 +74,8 @@ void init_elements(py::module& m)
                 amrex::ParticleReal const,
                 amrex::ParticleReal const,
                 amrex::ParticleReal const>(),
-             py::arg("psi"), py::arg("rc"), py::arg("g"), py::arg("K2")
+             py::arg("psi"), py::arg("rc"), py::arg("g"), py::arg("K2"),
+             "Edge focusing associated with bend entry or exit."
         )
         .def_property_readonly("nslice", &DipEdge::nslice)
     ;
@@ -82,7 +84,8 @@ void init_elements(py::module& m)
         .def(py::init<
                 amrex::ParticleReal const,
                 int const >(),
-             py::arg("ds"), py::arg("nslice") = 1
+             py::arg("ds"), py::arg("nslice") = 1,
+             "A drift."
         )
         .def_property_readonly("nslice", &Drift::nslice)
     ;
@@ -92,18 +95,38 @@ void init_elements(py::module& m)
                 int const,
                 amrex::ParticleReal const,
                 amrex::ParticleReal const>(),
-             py::arg("multiple"), py::arg("K_normal"), py::arg("K_skew")
+             py::arg("multiple"), py::arg("K_normal"), py::arg("K_skew"),
+             "A general thin multipole element."
         )
         .def_property_readonly("nslice", &Multipole::nslice)
+    ;
+
+    py::class_<None>(me, "None")
+        .def(py::init<>(),
+             "This element does nothing."
+        )
+        .def_property_readonly("nslice", &None::nslice)
     ;
 
     py::class_<NonlinearLens>(me, "NonlinearLens")
         .def(py::init<
                 amrex::ParticleReal const,
                 amrex::ParticleReal const>(),
-             py::arg("knll"), py::arg("cnll")
+             py::arg("knll"), py::arg("cnll"),
+             "Single short segment of the nonlinear magnetic insert element."
         )
         .def_property_readonly("nslice", &NonlinearLens::nslice)
+    ;
+
+    py::class_<Quad>(me, "Quad")
+        .def(py::init<
+                amrex::ParticleReal const,
+                amrex::ParticleReal const,
+                int const>(),
+             py::arg("ds"), py::arg("k"), py::arg("nslice") = 1,
+             "A Quadrupole magnet."
+        )
+        .def_property_readonly("nslice", &Quad::nslice)
     ;
 
     py::class_<Sbend>(me, "Sbend")
@@ -111,7 +134,8 @@ void init_elements(py::module& m)
                 amrex::ParticleReal const,
                 amrex::ParticleReal const,
                 int const>(),
-             py::arg("ds"), py::arg("rc"), py::arg("nslice") = 1
+             py::arg("ds"), py::arg("rc"), py::arg("nslice") = 1,
+             "An ideal sector bend."
         )
         .def_property_readonly("nslice", &Sbend::nslice)
     ;
@@ -120,18 +144,9 @@ void init_elements(py::module& m)
         .def(py::init<
                 amrex::ParticleReal const,
                 amrex::ParticleReal const>(),
-             py::arg("V"), py::arg("k")
+             py::arg("V"), py::arg("k"),
+             "A short RF cavity element at zero crossing for bunching."
         )
         .def_property_readonly("nslice", &ShortRF::nslice)
-    ;
-
-    py::class_<Quad>(me, "Quad")
-        .def(py::init<
-                amrex::ParticleReal const,
-                amrex::ParticleReal const,
-                int const>(),
-             py::arg("ds"), py::arg("k"), py::arg("nslice") = 1
-        )
-        .def_property_readonly("nslice", &Quad::nslice)
     ;
 }


### PR DESCRIPTION
Document the Python API in the user-facing manual.

Sphinx Ref.:
- https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html

To do:
- [x] add each user-facing class, property & method
- [x] add docstrings and arguments

Follow-up:
- add a Python version of each example (and show py version first in docs) #202