### PR TITLE
Docs: Fix FODO-RF Label

### DIFF
--- a/examples/fodo_rf/README.rst
+++ b/examples/fodo_rf/README.rst
@@ -1,4 +1,4 @@
-.. _examples-fodo:
+.. _examples-fodo-rf:
 
 FODO Cell with RF
 =================


### PR DESCRIPTION
Fix a duplicate sphinx internal label (anchor) for the FODO-RF example. The label wa copied from the FODO (w/o RF) example and was thus not unique to set links to.