### PR TITLE
Default 1D Domain Decomposition: z

### DIFF
--- a/src/initialization/InitAmrCore.cpp
+++ b/src/initialization/InitAmrCore.cpp
@@ -116,7 +116,7 @@ namespace details
         amrex::AmrInfo amr_info;
         const int nprocs = amrex::ParallelDescriptor::NProcs();
         const amrex::IntVect high_end = amr_info.blocking_factor[0]
-                                        * amrex::IntVect(AMREX_D_DECL(nprocs,1,1)) - amrex::IntVect(1);
+                                        * amrex::IntVect(AMREX_D_DECL(1,1,nprocs)) - amrex::IntVect(1);
         amrex::Box domain(amrex::IntVect(0), high_end);
         //   adding amr.n_cell for consistency
         amrex::ParmParse pp_amr("amr");


### PR DESCRIPTION
Change the default domain decomposition from x to z.

## To Do

- [ ] check if that is smarter
- [ ] check if that is faster for most of our long-ish bunches