### PR TITLE
`isort`: AMReX and ImpactX as First Party

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -34,3 +34,4 @@ indent_size = unset
 [*.py]
 # isort config
 force_sort_within_sections = true
+known_first_party = amrex,impactx,picmistandard,pywarpx,warpx

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
 import amrex
 import impactx
-import pytest
 
 if impactx.Config.have_mpi:
     from mpi4py import MPI

--- a/tests/python/test_charge_deposition.py
+++ b/tests/python/test_charge_deposition.py
@@ -3,10 +3,11 @@
 
 import math
 
-import amrex
-import impactx
 import matplotlib.pyplot as plt
 import numpy as np
+
+import amrex
+import impactx
 
 
 def test_charge_deposition():


### PR DESCRIPTION
Mark the `amrex` and `impactx` imports as first party, so that they do not change if run locally or remotely pre/post install.

- https://pycqa.github.io/isort/docs/configuration/custom_sections_and_ordering.html
- https://github.com/PyCQA/isort/issues/448#issuecomment-456595042