### PR TITLE
Fix: Python List Iteration

### DIFF
--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -26,7 +26,7 @@ void init_elements(py::module& m)
         .def(py::init<KnownElements>())
         .def(py::init([](py::list l){
             auto v = new KnownElementsList;
-            for (auto &handle : l)
+            for (auto const & handle : l)
                 v->push_back(handle.cast<KnownElements>());
             return v;
         }))
@@ -34,12 +34,12 @@ void init_elements(py::module& m)
         .def("append", [](KnownElementsList &v, KnownElements el) { v.emplace_back(el); })
 
         .def("extend", [](KnownElementsList &v, KnownElementsList l) {
-            for (auto &el : l)
+            for (auto const & el : l)
                 v.push_back(el);
             return v;
         })
         .def("extend", [](KnownElementsList &v, py::list l) {
-            for (auto &handle : l)
+            for (auto const & handle : l)
             {
                 auto el = handle.cast<KnownElements>();
                 v.push_back(el);


### PR DESCRIPTION
Fix an error of the kind:
```
/home/conda/feedstock_root/build_artifacts/impactx_1661553464649/work/src/python/elements.cpp:29:33: error: cannot bind non-const lvalue reference of type 'pybind11::detail::accessor<pybind11::detail::accessor_policies::sequence_item>&' to an rvalue of type 'pybind11::detail::generic_iterator<pybind11::detail::iterator_policies::sequence_slow_readwrite>::reference' {aka 'pybind11::detail::accessor<pybind11::detail::accessor_policies::sequence_item>'}
   29 |             for (auto &handle : l)
      |                                 ^
```

Seen with GNU 10.4.0 and PyPy3.8/7.3 on Conda-Forge: https://github.com/conda-forge/impactx-feedstock/pull/1