### PR TITLE
pytest Plot Scripts: Non-interactive

### DIFF
--- a/cmake/ImpactXFunctions.cmake
+++ b/cmake/ImpactXFunctions.cmake
@@ -124,6 +124,24 @@ macro(impactx_set_default_install_dirs_python)
 endmacro()
 
 
+# function to set the PYTHONPATH on a test
+# this avoids that we need to install our python packages to run ctest
+#
+function(impactx_test_set_pythonpath test_name)
+    if(WIN32)
+        string(REPLACE ";" "\\;" WIN_PYTHONPATH "$ENV{PYTHONPATH}")
+        string(REGEX REPLACE "/" "\\\\" WIN_PYTHON_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY})
+        set_property(TEST ${test_name}
+            APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${WIN_PYTHON_OUTPUT_DIRECTORY}\;${WIN_PYTHONPATH}"
+        )
+    else()
+        set_property(TEST ${test_name}
+            APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_PYTHON_OUTPUT_DIRECTORY}:$ENV{PYTHONPATH}"
+        )
+    endif()
+endfunction()
+
+
 # change the default CMAKE_BUILD_TYPE
 # the default in CMake is Debug for historic reasons
 #

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,21 +19,6 @@ if(ImpactX_MPI)
 endif()
 
 
-function(impactx_test_set_pythonpath test_name)
-    if(WIN32)
-        string(REPLACE ";" "\\;" WIN_PYTHONPATH "$ENV{PYTHONPATH}")
-        string(REGEX REPLACE "/" "\\\\" WIN_PYTHON_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY})
-        set_property(TEST ${test_name}
-            APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${WIN_PYTHON_OUTPUT_DIRECTORY}\;${WIN_PYTHONPATH}"
-        )
-    else()
-        set_property(TEST ${test_name}
-            APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_PYTHON_OUTPUT_DIRECTORY}:$ENV{PYTHONPATH}"
-        )
-    endif()
-endfunction()
-
-
 function(add_impactx_test name input is_mpi is_python analysis_script plot_script)
     # make a unique run directory
     file(MAKE_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${name})

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -1,10 +1,21 @@
-# copy input files
-file(COPY ${ImpactX_SOURCE_DIR}/examples DESTINATION ${CMAKE_PYTHON_OUTPUT_DIRECTORY})
-
 # add pytest tests
-add_test(NAME pytest.ImpactX
+#
+set(pytest_name pytest.ImpactX)
+set(pytest_rundir ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${pytest_name})
+
+#   make a unique run directory
+file(MAKE_DIRECTORY ${pytest_rundir})
+
+#   copy input files
+file(COPY ${ImpactX_SOURCE_DIR}/examples
+     DESTINATION ${pytest_rundir})
+
+#   run
+add_test(NAME ${pytest_name}
     COMMAND ${Python_EXECUTABLE} -m pytest -s -vvvv
         ${ImpactX_SOURCE_DIR}/tests/python
-    WORKING_DIRECTORY
-        ${CMAKE_PYTHON_OUTPUT_DIRECTORY}
+    WORKING_DIRECTORY ${pytest_rundir}
 )
+
+#   set PYTHONPATH
+impactx_test_set_pythonpath(${pytest_name})

--- a/tests/python/test_charge_deposition.py
+++ b/tests/python/test_charge_deposition.py
@@ -10,7 +10,7 @@ import amrex
 import impactx
 
 
-def test_charge_deposition():
+def test_charge_deposition(save_png=True):
     """
     Deposit charge and access/plot it
     """
@@ -60,10 +60,13 @@ def test_charge_deposition():
         cb.set_label(r"charge density  [C/m$^3$]")
         ax.set_xlabel(r"$x$  [$\mu$m]")
         ax.set_ylabel(r"$y$  [$\mu$m]")
-        plt.show()
+        if save_png:
+            plt.savefig("charge_deposition.png")
+        else:
+            plt.show()
 
 
 # implement a direct script run mode, so we can run this directly too,
 # with interactive matplotlib windows, w/o pytest
 if __name__ == "__main__":
-    test_charge_deposition()
+    test_charge_deposition(save_png=False)


### PR DESCRIPTION
Same as #225 but for `pytest`: avoid popping up matplotlib windows in ctest calls.