### PR TITLE
Reference Particle: Store Charge & Mass

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -63,13 +63,13 @@ General
 
       This must come first, before particle beams and lattice elements are initialized.
 
-   .. py:method:: add_particles(qm_qeeV, charge_C, distr, npart)
+   .. py:method:: add_particles(charge_C, distr, npart)
 
       Generate and add n particles to the particle container.
+      Note: Set the reference particle properties (charge, mass, energy) first.
 
       Will also resize the geometry based on the updated particle distribution's extent and then redistribute particles in according AMReX grid boxes.
 
-      :param float qm_qeeV: charge/mass ratio (q_e/eV)
       :param float charge_C: bunch charge (C)
       :param distr: distribution function to draw from (object from :py:mod:`impactx.distribution`)
       :param int npart: number of particles to draw
@@ -224,7 +224,19 @@ Particles
 
       Read-only: Get reference particle beta*gamma
 
-   .. py:method:: set_energy_MeV(energy_MeV, massE_MeV)
+   .. py:property:: qm_qeeV
+
+      Read-only: Get reference particle charge to mass ratio (elementary charge/eV)
+
+   .. py:method:: set_charge_qe(charge_qe)
+
+      Write-only: Set reference particle charge in (positive) elementary charges.
+
+   .. py:method:: set_mass_MeV(massE)
+
+      Write-only: Set reference particle rest mass (MeV/c^2).
+
+   .. py:method:: set_energy_MeV(energy_MeV)
 
       Write-only: Set reference particle energy.
 

--- a/examples/chicane/run_chicane.py
+++ b/examples/chicane/run_chicane.py
@@ -23,11 +23,14 @@ sim.init_grids()
 # load a 5 GeV electron beam with an initial
 # normalized transverse rms emittance of 1 um
 energy_MeV = 5.0e3  # reference energy
-charge_C = 1.0e-9  # used with space charge
-mass_MeV = 0.510998950
-qm_qeeV = -1.0e-6 / mass_MeV  # charge/mass
+bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
+#   reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+
+#   particle bunch
 distr = distribution.Waterbag(
     sigmaX=2.2951017632e-5,
     sigmaY=1.3084093142e-5,
@@ -39,10 +42,7 @@ distr = distribution.Waterbag(
     muypy=0.933345606203060,
     mutpt=0.999999961419755,
 )
-sim.add_particles(qm_qeeV, charge_C, distr, npart)
-
-# set the energy in the reference particle
-sim.particle_container().ref_particle().set_energy_MeV(energy_MeV, mass_MeV)
+sim.add_particles(bunch_charge_C, distr, npart)
 
 # design the accelerator lattice
 ns = 25  # number of slices per ds in the element

--- a/examples/fodo/run_fodo.py
+++ b/examples/fodo/run_fodo.py
@@ -23,11 +23,14 @@ sim.init_grids()
 # load a 2 GeV electron beam with an initial
 # unnormalized rms emittance of 2 nm
 energy_MeV = 2.0e3  # reference energy
-charge_C = 1.0e-9  # used with space charge
-mass_MeV = 0.510998950
-qm_qeeV = -1.0e-6 / mass_MeV  # charge/mass
+bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
+#   reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+
+#   particle bunch
 distr = distribution.Waterbag(
     sigmaX=3.9984884770e-5,
     sigmaY=3.9984884770e-5,
@@ -39,10 +42,7 @@ distr = distribution.Waterbag(
     muypy=0.846574929020762,
     mutpt=0.0,
 )
-sim.add_particles(qm_qeeV, charge_C, distr, npart)
-
-# set the energy in the reference particle
-sim.particle_container().ref_particle().set_energy_MeV(energy_MeV, mass_MeV)
+sim.add_particles(bunch_charge_C, distr, npart)
 
 # design the accelerator lattice
 ns = 25  # number of slices per ds in the element

--- a/examples/iota_lattice/run_iotalattice.py
+++ b/examples/iota_lattice/run_iotalattice.py
@@ -22,11 +22,14 @@ sim.init_grids()
 
 # init particle beam
 energy_MeV = 2.5
-charge_C = 1.0e-9  # assign zero weighting to particles
-mass_MeV = 938.27208816
-qm_qeeV = 1.0e-6 / mass_MeV
+bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000
 
+#   reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_energy_MeV(energy_MeV)
+
+#   particle bunch
 distr = distribution.Waterbag(
     sigmaX=1.588960728035e-3,
     sigmaY=2.496625268437e-3,
@@ -35,10 +38,7 @@ distr = distribution.Waterbag(
     sigmaPy=1.802433091137e-3,
     sigmaPt=0.0,
 )
-sim.add_particles(qm_qeeV, charge_C, distr, npart)
-
-# set the energy in the reference particle
-sim.particle_container().ref_particle().set_energy_MeV(energy_MeV, mass_MeV)
+sim.add_particles(bunch_charge_C, distr, npart)
 
 # init accelerator lattice
 ns = 10  # number of slices per ds in the element

--- a/examples/iota_lens/run_iotalens.py
+++ b/examples/iota_lens/run_iotalens.py
@@ -22,11 +22,14 @@ sim.init_grids()
 
 # load a 2.5 MeV proton beam
 energy_MeV = 2.5  # reference energy
-charge_C = 1.0e-9  # used with space charge
-mass_MeV = 938.27208816
-qm_qeeV = 1.0e-6 / mass_MeV  # charge/mass
+bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
+#   reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_energy_MeV(energy_MeV)
+
+#   particle bunch
 distr = distribution.Waterbag(
     sigmaX=2.0e-3,
     sigmaY=2.0e-3,
@@ -34,14 +37,8 @@ distr = distribution.Waterbag(
     sigmaPx=3.0e-4,
     sigmaPy=3.0e-4,
     sigmaPt=0.0,
-    muxpx=0.0,
-    muypy=0.0,
-    mutpt=0.0,
 )
-sim.add_particles(qm_qeeV, charge_C, distr, npart)
-
-# set the energy in the reference particle
-sim.particle_container().ref_particle().set_energy_MeV(energy_MeV, mass_MeV)
+sim.add_particles(bunch_charge_C, distr, npart)
 
 constEnd = elements.ConstF(ds=0.0025, kx=1.0, ky=1.0, kt=1.0e-12)
 nllens = elements.NonlinearLens(knll=2.0e-7, cnll=0.01)

--- a/examples/kurth/run_kurth.py
+++ b/examples/kurth/run_kurth.py
@@ -24,11 +24,14 @@ sim.init_grids()
 # unnormalized rms emittance of 1 um in each
 # coordinate plane
 energy_MeV = 2.0e3  # reference energy
-charge_C = 1.0e-9  # used with space charge
-mass_MeV = 938.27208816
-qm_qeeV = 1.0e-6 / mass_MeV  # charge/mass
+bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
+#   reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_energy_MeV(energy_MeV)
+
+#   particle bunch
 distr = distribution.Kurth6D(
     sigmaX=1.0e-3,
     sigmaY=1.0e-3,
@@ -36,14 +39,8 @@ distr = distribution.Kurth6D(
     sigmaPx=1.0e-3,
     sigmaPy=1.0e-3,
     sigmaPt=2.9676219145931020e-3,
-    muxpx=0.0,
-    muypy=0.0,
-    mutpt=0.0,
 )
-sim.add_particles(qm_qeeV, charge_C, distr, npart)
-
-# set the energy in the reference particle
-sim.particle_container().ref_particle().set_energy_MeV(energy_MeV, mass_MeV)
+sim.add_particles(bunch_charge_C, distr, npart)
 
 # design the accelerator lattice: here we just assign a single element
 sim.lattice.append(elements.ConstF(ds=2.0, kx=1.0, ky=1.0, kt=1.0))

--- a/examples/multipole/run_multipole.py
+++ b/examples/multipole/run_multipole.py
@@ -23,11 +23,14 @@ sim.init_grids()
 # load a 2 GeV electron beam with an initial
 # unnormalized rms emittance of  nm
 energy_MeV = 2.0e3  # reference energy
-charge_C = 1.0e-9  # used without space charge
-mass_MeV = 0.510998950
-qm_qeeV = -1.0e-6 / mass_MeV  # charge/mass
+bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
+#   reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+
+#   particle bunch
 distr = distribution.Waterbag(
     sigmaX=4.0e-3,
     sigmaY=4.0e-3,
@@ -36,10 +39,7 @@ distr = distribution.Waterbag(
     sigmaPy=3.0e-4,
     sigmaPt=2.0e-3,
 )
-sim.add_particles(qm_qeeV, charge_C, distr, npart)
-
-# set the energy in the reference particle
-sim.particle_container().ref_particle().set_energy_MeV(energy_MeV, mass_MeV)
+sim.add_particles(bunch_charge_C, distr, npart)
 
 # design the accelerator lattice
 multipole = [

--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -71,14 +71,12 @@ namespace impactx
          * distribution's extent and then redistribute particles in according
          * AMReX grid boxes.
          *
-         * @param qm charge/mass ratio (q_e/eV)
          * @param bunch_charge bunch charge (C)
          * @param distr distribution function to draw from (object)
          * @param npart number of particles to draw
          */
         void
         add_particles (
-            amrex::ParticleReal qm,
             amrex::ParticleReal bunch_charge,
             distribution::KnownDistributions distr,
             int npart

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -34,8 +34,8 @@ namespace impactx
         auto const & ref = m_particle_container->GetRefParticle();
         AMREX_ASSERT_WITH_MESSAGE(ref.charge_qe() != 0.0,
                                   "add_particles: Reference particle charge not yet set!");
-        AMREX_ASSERT_WITH_MESSAGE(ref.energy_MeV() != 0.0,
-                                  "add_particles: Reference particle energy not yet set!");
+        AMREX_ASSERT_WITH_MESSAGE(ref.mass_MeV() != 0.0,
+                                  "add_particles: Reference particle mass not yet set!");
         AMREX_ASSERT_WITH_MESSAGE(ref.energy_MeV() != 0.0,
                                   "add_particles: Reference particle energy not yet set!");
 

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -24,13 +24,20 @@ namespace impactx
 {
     void
     ImpactX::add_particles (
-        amrex::ParticleReal qm,
         amrex::ParticleReal bunch_charge,
         distribution::KnownDistributions distr,
         int npart
     )
     {
         BL_PROFILE("ImpactX::add_particles");
+
+        auto const & ref = m_particle_container->GetRefParticle();
+        AMREX_ASSERT_WITH_MESSAGE(ref.charge_qe() != 0.0,
+                                  "add_particles: Reference particle charge not yet set!");
+        AMREX_ASSERT_WITH_MESSAGE(ref.energy_MeV() != 0.0,
+                                  "add_particles: Reference particle energy not yet set!");
+        AMREX_ASSERT_WITH_MESSAGE(ref.energy_MeV() != 0.0,
+                                  "add_particles: Reference particle energy not yet set!");
 
         amrex::Vector<amrex::ParticleReal> x, y, t;
         amrex::Vector<amrex::ParticleReal> px, py, pt;
@@ -70,7 +77,8 @@ namespace impactx
 
         int const lev = 0;
         m_particle_container->AddNParticles(lev, x, y, t, px, py, pt,
-                                            qm, bunch_charge * rel_part_this_proc);
+                                            ref.qm_qeeV(),
+                                            bunch_charge * rel_part_this_proc);
 
         // Resize the mesh to fit the spatial extent of the beam and then
         // redistribute particles, so they reside on the MPI rank that is
@@ -97,15 +105,23 @@ namespace impactx
         std::string particle_type;  // Particle type
         pp_dist.get("particle", particle_type);
 
-        amrex::ParticleReal qm = 0.0; // charge/mass ratio (q_e/eV)
+        amrex::ParticleReal qe;     // charge (elementary charge)
+        amrex::ParticleReal massE;  // MeV/c^2
         if(particle_type == "electron") {
-            qm = -1.0/0.510998950e6;
+            qe = -1.0;
+            massE = 0.510998950;
         } else if(particle_type == "proton") {
-            qm = 1.0/938.27208816e6;
+            qe = 1.0;
+            massE = 938.27208816;
         }
-        else {
-            qm = 0.0;
+        else {  // default to electron
+            qe = -1.0;
+            massE = 0.510998950;
         }
+
+        // set charge and mass and energy of ref particle
+        m_particle_container->GetRefParticle()
+            .set_charge_qe(qe).set_mass_MeV(massE).set_energy_MeV(energy);
 
         int npart = 1;  // Number of simulation particles
         pp_dist.get("npart", npart);
@@ -134,7 +150,7 @@ namespace impactx
               sigpx, sigpy, sigpt,
               muxpx, muypy, mutpt));
 
-          add_particles(qm, bunch_charge, waterbag, npart);
+          add_particles(bunch_charge, waterbag, npart);
 
         } else if (distribution_type == "kurth6d") {
           amrex::ParticleReal sigx,sigy,sigt,sigpx,sigpy,sigpt;
@@ -154,7 +170,7 @@ namespace impactx
             sigpx, sigpy, sigpt,
             muxpx, muypy, mutpt));
 
-          add_particles(qm, bunch_charge, kurth6D, npart);
+          add_particles(bunch_charge, kurth6D, npart);
 
         } else if (distribution_type == "gaussian") {
           amrex::ParticleReal sigx,sigy,sigt,sigpx,sigpy,sigpt;
@@ -174,7 +190,7 @@ namespace impactx
             sigpx, sigpy, sigpt,
             muxpx, muypy, mutpt));
 
-          add_particles(qm, bunch_charge, gaussian, npart);
+          add_particles(bunch_charge, gaussian, npart);
 
         } else if (distribution_type == "kvdist") {
           amrex::ParticleReal sigx,sigy,sigt,sigpx,sigpy,sigpt;
@@ -194,7 +210,7 @@ namespace impactx
             sigpx, sigpy, sigpt,
             muxpx, muypy, mutpt));
 
-          add_particles(qm, bunch_charge, kvDist, npart);
+          add_particles(bunch_charge, kvDist, npart);
 
         } else if (distribution_type == "kurth4d") {
           amrex::ParticleReal sigx,sigy,sigt,sigpx,sigpy,sigpt;
@@ -214,7 +230,7 @@ namespace impactx
             sigpx, sigpy, sigpt,
             muxpx, muypy, mutpt));
 
-          add_particles(qm, bunch_charge, kurth4D, npart);
+          add_particles(bunch_charge, kurth4D, npart);
         } else if (distribution_type == "semigaussian") {
           amrex::ParticleReal sigx,sigy,sigt,sigpx,sigpy,sigpt;
           amrex::ParticleReal muxpx = 0.0, muypy = 0.0, mutpt = 0.0;
@@ -233,23 +249,10 @@ namespace impactx
             sigpx, sigpy, sigpt,
             muxpx, muypy, mutpt));
 
-          add_particles(qm, bunch_charge, semigaussian, npart);
+          add_particles(bunch_charge, semigaussian, npart);
         } else {
             amrex::Abort("Unknown distribution: " + distribution_type);
         }
-
-        // reference particle
-        amrex::ParticleReal massE;  // MeV
-        if (particle_type == "electron") {
-            massE = 0.510998950;
-        } else if (particle_type == "proton") {
-            massE = 938.27208816;
-        } else {
-            massE = 0.510998950;  // default to electron
-        }
-
-        // set the energy in the reference particle
-        m_particle_container->GetRefParticle().set_energy_MeV(energy, massE);
 
         // print information on the initialized beam
         amrex::Print() << "Beam kinetic energy (MeV): " << energy << std::endl;

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -84,6 +84,8 @@ namespace impactx
         amrex::ParticleReal py = 0.0; ///< momentum in y, normalized to proper velocity
         amrex::ParticleReal pz = 0.0; ///< momentum in z, normalized to proper velocity
         amrex::ParticleReal pt = 0.0; ///< energy deviation, normalized by rest energy
+        amrex::ParticleReal mass = 0.0; ///< reference rest mass, in kg
+        amrex::ParticleReal charge = 0.0; ///< reference charge, in C
 
         /** Get reference particle relativistic gamma
          *
@@ -106,23 +108,54 @@ namespace impactx
         amrex::ParticleReal
         beta_gamma () const;
 
+        /** Get reference particle rest mass
+         *
+         * @returns rest mass in MeV/c^2
+         */
+        amrex::ParticleReal
+        mass_MeV () const;
+
+        /** Set reference particle rest mass
+         *
+         * @param massE particle rest mass (MeV/c^2)
+         */
+        RefPart &
+        set_mass_MeV (amrex::ParticleReal const massE);
+
         /** Get reference particle energy
          *
          * @returns kinetic energy in MeV
          */
         amrex::ParticleReal
-        energy_MeV (amrex::ParticleReal massE) const;
+        energy_MeV () const;
 
         /** Set reference particle energy
          *
          * @param energy initial kinetic energy (MeV)
-         * @param massE particle rest energy (MeV)
          */
-        void
-        set_energy_MeV (
-            amrex::ParticleReal const energy,
-            amrex::ParticleReal const massE);
+        RefPart &
+        set_energy_MeV (amrex::ParticleReal const energy);
 
+        /** Get reference particle charge
+         *
+         * @returns charge in multiples of the (positive) elementary charge
+         */
+        amrex::ParticleReal
+        charge_qe () const;
+
+        /** Set reference particle charge
+         *
+         * @param charge_qe in multiples of the (positive) elementary charge
+         */
+        RefPart &
+        set_charge_qe (amrex::ParticleReal const charge_qe);
+
+        /** Get reference particle charge to mass ratio
+         *
+         * @returns charge to mass ratio (elementary charge/eV)
+         */
+        amrex::ParticleReal
+        qm_qeeV () const;
     };
 
     /** Beam Particles in ImpactX

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -109,7 +109,7 @@ void init_ImpactX(py::module& m)
         .def("init_beam_distribution_from_inputs", &ImpactX::initBeamDistributionFromInputs)
         .def("init_lattice_elements_from_inputs", &ImpactX::initLatticeElementsFromInputs)
         .def("add_particles", &ImpactX::add_particles,
-             py::arg("qm"), py::arg("bunch_charge"),
+             py::arg("bunch_charge"),
              py::arg("distr"), py::arg("npart"),
              "Generate and add n particles to the particle container.\n\n"
              "Will also resize the geometry based on the updated particle\n"

--- a/src/python/ReferenceParticle.cpp
+++ b/src/python/ReferenceParticle.cpp
@@ -31,15 +31,22 @@ void init_refparticle(py::module& m)
         .def_readwrite("mass", &RefPart::charge, "reference rest mass, in kg")
         .def_readwrite("charge", &RefPart::mass, "reference charge, in C")
 
+        .def_property_readonly("charge_qe", &RefPart::charge_qe, "Get reference particle charge (positive elementary charge)")
         .def_property_readonly("gamma", &RefPart::gamma, "Get reference particle relativistic gamma")
         .def_property_readonly("beta", &RefPart::beta, "Get reference particle relativistic beta")
         .def_property_readonly("beta_gamma", &RefPart::beta_gamma, "Get reference particle beta*gamma")
         .def_property_readonly("mass_MeV", &RefPart::mass_MeV, "Get reference particle rest mass (MeV/c^2)")
-        .def("set_charge_qe", &RefPart::set_mass_MeV, "Set reference particle charge (positive elementary charge)", py::arg("charge_qe"))
-        .def_property_readonly("charge_qe", &RefPart::energy_MeV, "Get reference particle charge (positive elementary charge)")
-        .def("set_mass_MeV", &RefPart::set_mass_MeV, "Set reference particle rest mass (MeV/c^2)", py::arg("mass_MeV"))
         .def_property_readonly("energy_MeV", &RefPart::energy_MeV, "Get reference particle energy (MeV)")
-        .def("set_energy_MeV", &RefPart::set_energy_MeV, "Set reference particle energy (MeV)", py::arg("energy_MeV"))
         .def_property_readonly("qm_qeeV", &RefPart::qm_qeeV, "Get reference particle charge to mass ratio (charge/eV)")
+
+        .def("set_charge_qe", &RefPart::set_charge_qe,
+             py::return_value_policy::reference_internal,
+             "Set reference particle charge (positive elementary charge)", py::arg("charge_qe"))
+        .def("set_mass_MeV", &RefPart::set_mass_MeV,
+             py::return_value_policy::reference_internal,
+             "Set reference particle rest mass (MeV/c^2)", py::arg("mass_MeV"))
+        .def("set_energy_MeV", &RefPart::set_energy_MeV,
+             py::return_value_policy::reference_internal,
+             "Set reference particle energy (MeV)", py::arg("energy_MeV"))
     ;
 }

--- a/src/python/ReferenceParticle.cpp
+++ b/src/python/ReferenceParticle.cpp
@@ -28,14 +28,18 @@ void init_refparticle(py::module& m)
         .def_readwrite("py", &RefPart::py, "momentum in y, normalized to proper velocity")
         .def_readwrite("pz", &RefPart::pz, "momentum in z, normalized to proper velocity")
         .def_readwrite("pt", &RefPart::pt, "energy deviation, normalized by rest energy")
+        .def_readwrite("mass", &RefPart::charge, "reference rest mass, in kg")
+        .def_readwrite("charge", &RefPart::mass, "reference charge, in C")
 
         .def_property_readonly("gamma", &RefPart::gamma, "Get reference particle relativistic gamma")
         .def_property_readonly("beta", &RefPart::beta, "Get reference particle relativistic beta")
         .def_property_readonly("beta_gamma", &RefPart::beta_gamma, "Get reference particle beta*gamma")
-        .def("energy_MeV", &RefPart::energy_MeV, "Get reference particle energy",
-             py::arg("massE_MeV"))
-
-        .def("set_energy_MeV", &RefPart::set_energy_MeV, "Set reference particle energy",
-             py::arg("energy_MeV"), py::arg("massE_MeV"))
+        .def_property_readonly("mass_MeV", &RefPart::mass_MeV, "Get reference particle rest mass (MeV/c^2)")
+        .def("set_charge_qe", &RefPart::set_mass_MeV, "Set reference particle charge (positive elementary charge)", py::arg("charge_qe"))
+        .def_property_readonly("charge_qe", &RefPart::energy_MeV, "Get reference particle charge (positive elementary charge)")
+        .def("set_mass_MeV", &RefPart::set_mass_MeV, "Set reference particle rest mass (MeV/c^2)", py::arg("mass_MeV"))
+        .def_property_readonly("energy_MeV", &RefPart::energy_MeV, "Get reference particle energy (MeV)")
+        .def("set_energy_MeV", &RefPart::set_energy_MeV, "Set reference particle energy (MeV)", py::arg("energy_MeV"))
+        .def_property_readonly("qm_qeeV", &RefPart::qm_qeeV, "Get reference particle charge to mass ratio (charge/eV)")
     ;
 }

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -7,34 +7,37 @@ def test_impactx_fodo_file():
     """
     This tests an equivalent to main.cpp in C++
     """
-    impactX = ImpactX()
+    sim = ImpactX()
 
-    impactX.load_inputs_file("examples/fodo/input_fodo.in")
+    sim.load_inputs_file("examples/fodo/input_fodo.in")
 
-    impactX.init_grids()
-    impactX.init_beam_distribution_from_inputs()
-    impactX.init_lattice_elements_from_inputs()
+    sim.init_grids()
+    sim.init_beam_distribution_from_inputs()
+    sim.init_lattice_elements_from_inputs()
 
-    impactX.evolve()
+    sim.evolve()
 
 
 def test_impactx_nofile():
     """
     This tests using ImpactX without an inputs file
     """
-    impactX = ImpactX()
+    sim = ImpactX()
 
-    impactX.set_particle_shape(2)
-    impactX.set_slice_step_diagnostics(True)
-    impactX.init_grids()
+    sim.set_particle_shape(2)
+    sim.set_slice_step_diagnostics(True)
+    sim.init_grids()
 
     # init particle beam
     energy_MeV = 2.0e3
-    charge_C = 0.0
-    mass_MeV = 0.510998950
-    qm_qeeV = -1.0 / 0.510998950e6
+    bunch_charge_C = 1.0e-9
     npart = 10000
 
+    #   reference particle
+    ref = sim.particle_container().ref_particle()
+    ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+
+    #   particle bunch
     distr = distribution.Waterbag(
         sigmaX=3.9984884770e-5,
         sigmaY=3.9984884770e-5,
@@ -46,16 +49,9 @@ def test_impactx_nofile():
         muypy=0.846574929020762,
         mutpt=0.0,
     )
-    impactX.add_particles(qm_qeeV, charge_C, distr, npart)
+    sim.add_particles(bunch_charge_C, distr, npart)
 
-    # init reference particle
-    refPart = RefPart()
-    # make the next two lines a helper function?
-    refPart.pt = -energy_MeV / mass_MeV - 1.0
-    refPart.pz = (refPart.pt**2 - 1.0) ** 0.5
-    impactX.particle_container().set_ref_particle(refPart)
-
-    assert impactX.particle_container().TotalNumberOfParticles() == npart
+    assert sim.particle_container().TotalNumberOfParticles() == npart
 
     # init accelerator lattice
     fodo = [
@@ -66,18 +62,18 @@ def test_impactx_nofile():
         elements.Drift(0.25),
     ]
     #  assign a fodo segment
-    # impactX.lattice = fodo
+    # sim.lattice = fodo
 
     #  add 4 more FODO segments
     for i in range(4):
-        impactX.lattice.extend(fodo)
+        sim.lattice.extend(fodo)
 
     # add 2 more drifts
     for i in range(4):
-        impactX.lattice.append(elements.Drift(0.25))
+        sim.lattice.append(elements.Drift(0.25))
 
-    print(impactX.lattice)
-    print(len(impactX.lattice))
-    assert len(impactX.lattice) > 5
+    print(sim.lattice)
+    print(len(sim.lattice))
+    assert len(sim.lattice) > 5
 
-    impactX.evolve()
+    sim.evolve()


### PR DESCRIPTION
Store the mass and charge of the reference particle.
This simplifies init logic and is useful for later I/O tasks of meta data.

Needed for #162 and #214.