### PR TITLE
Change tasks-per-node to tasks-per-gpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ cmake -S . -B build_perlmutter -DImpactX_COMPUTE=CUDA
 cmake --build build_perlmutter -j 10
 
 # test
-srun -N 1 --ntasks-per-node=4 -t 0:10:00 -C gpu -c 32 -G 4 --qos=debug -A m3906_g ctest --test-dir build_perlmutter --output-on-failure
+srun -N 1 --ntasks-per-gpu=1 -t 0:10:00 -C gpu -c 32 -G 4 --qos=debug -A m3906_g ctest --test-dir build_perlmutter --output-on-failure
 
 # run
 cd build_perlmutter/bin
-srun -N 1 --ntasks-per-node=4 -t 0:10:00 -C gpu -c 32 -G 4 --qos=debug -A m3906_g ./impactx ../../examples/fodo/input_fodo.in
+srun -N 1 --ntasks-per-gpu=1 -t 0:10:00 -C gpu -c 32 -G 4 --qos=debug -A m3906_g ./impactx ../../examples/fodo/input_fodo.in
 ```
 
 ### Cori KNL (NERSC)

--- a/docs/source/install/hpc/perlmutter.rst
+++ b/docs/source/install/hpc/perlmutter.rst
@@ -56,10 +56,10 @@ We use the following modules and environments on the system (``$HOME/perlmutter_
 
    # an alias to request an interactive batch node for one hour
    #   for parallel execution, start on the batch node: srun <command>
-   alias getNode="salloc -N 1 --ntasks-per-node=4 -t 1:00:00 -q interactive -C gpu --gpu-bind=single:1 -c 32 -G 4 -A $proj"
+   alias getNode="salloc -N 1 --ntasks-per-gpu=1 -t 1:00:00 -q interactive -C gpu --gpu-bind=single:1 -c 32 -G 4 -A $proj"
    # an alias to run a command on a batch node for up to 30min
    #   usage: runNode <command>
-   alias runNode="srun -N 1 --ntasks-per-node=4 -t 0:30:00 -q interactive -C gpu --gpu-bind=single:1 -c 32 -G 4 -A $proj"
+   alias runNode="srun -N 1 --ntasks-per-gpu=1 -t 0:30:00 -q interactive -C gpu --gpu-bind=single:1 -c 32 -G 4 -A $proj"
 
    # GPU-aware MPI
    export MPICH_GPU_SUPPORT_ENABLED=1
@@ -113,7 +113,7 @@ To run all tests, do:
 
 .. code-block:: bash
 
-   srun -N 1 --ntasks-per-node=4 -t 0:10:00 -C gpu -c 32 -G 4 --qos=debug -A m3906_g ctest --test-dir build_perlmutter --output-on-failure
+   srun -N 1 --ntasks-per-gpu=1 -t 0:10:00 -C gpu -c 32 -G 4 --qos=debug -A m3906_g ctest --test-dir build_perlmutter --output-on-failure
 
 The general :ref:`cmake compile-time options <building-cmake>` apply as usual.
 

--- a/etc/impactx/perlmutter-nersc/batch_perlmutter.sh
+++ b/etc/impactx/perlmutter-nersc/batch_perlmutter.sh
@@ -14,7 +14,7 @@
 #SBATCH -q regular
 #SBATCH -C gpu
 #SBATCH -c 32
-#SBATCH --ntasks-per-node=4
+#SBATCH --ntasks-per-gpu=1
 #SBATCH --gpus-per-node=4
 #SBATCH -o WarpX.o%j
 #SBATCH -e WarpX.e%j


### PR DESCRIPTION
On Perlmutter, the previous option led to warnings and crashes as described in https://github.com/ECP-WarpX/WarpX/issues/3356. In [WarpX PR#3375](https://github.com/ECP-WarpX/WarpX/pull/3375) this fix was first proposed.