### PR TITLE
Use the new SoA Data Structure

### DIFF
--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -166,18 +166,18 @@ set(ImpactX_openpmd_src ""
     "Local path to openPMD-api source directory (preferred if set)")
 
 # Git fetcher
-set(ImpactX_ablastr_repo "https://github.com/ECP-WarpX/WarpX.git"
+set(ImpactX_ablastr_repo "https://github.com/Thierry992/WarpX.git"
     CACHE STRING
     "Repository URI to pull and build ABLASTR from if(ImpactX_ablastr_internal)")
-set(ImpactX_ablastr_branch "23.04"
+set(ImpactX_ablastr_branch "soa-particle"
     CACHE STRING
     "Repository branch for ImpactX_ablastr_repo if(ImpactX_ablastr_internal)")
 
 # AMReX is transitively pulled through ABLASTR
-set(ImpactX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
+set(ImpactX_amrex_repo "https://github.com/Thierry992/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(ImpactX_amrex_internal)")
-set(ImpactX_amrex_branch ""
+set(ImpactX_amrex_branch "particle_soa_refactor"
     CACHE STRING
     "Repository branch for ImpactX_amrex_repo if(ImpactX_amrex_internal)")
 

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -17,6 +17,7 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_ParIter.H>
 #include <AMReX_Particles.H>
+#include <AMReX_ParticleTile.H>
 
 #include <AMReX_IntVect.H>
 #include <AMReX_Vector.H>
@@ -35,6 +36,7 @@ namespace impactx
      * because we change the meaning of these "positions" depending on the
      * coordinate system we are currently in.
      */
+    /*
     struct RealAoS
     {
         enum
@@ -52,6 +54,7 @@ namespace impactx
         static_assert(names_t.size() == nattribs);
         static_assert(names_s.size() == nattribs);
     };
+    */
 
     /** This struct indexes the additional Real attributes
      *  stored in an SoA in ImpactXParticleContainer
@@ -60,18 +63,21 @@ namespace impactx
     {
         enum
         {
+            x,   ///< position in x [m] (at fixed t OR fixed s)
+            y,   ///< position in y [m] (at fixed t OR fixed s)
+            z,   ///< position in z [m] (at fixed t) OR time-of-flight ct [m] (at fixed s)
             ux,  ///< momentum in x, scaled by the magnitude of the reference momentum [unitless] (at fixed t or s)
             uy,  ///< momentum in y, scaled by the magnitude of the reference momentum [unitless] (at fixed t or s)
             pt,  ///< momentum in z, scaled by the magnitude of the reference momentum [unitless] (at fixed t) OR energy deviation, scaled by speed of light * the magnitude of the reference momentum [unitless] (at fixed s)
             m_qm, ///< charge to mass ratio, in q_e/m_e (q_e/eV) TODO: rename to qm_m
-            w,   ///< particle weight, unitless
+            w,    ///< particle weight, unitless
             nattribs ///< the number of attributes above (always last)
         };
 
         //! named labels for fixed t
-        static constexpr auto names_t = { "momentum_x", "momentum_y", "momentum_z", "qmm", "weighting" };
+        static constexpr auto names_t = { "position_x", "position_y", "position_z", "momentum_x", "momentum_y", "momentum_z", "qmm", "weighting" };
         //! named labels for fixed s
-        static constexpr auto names_s = { "momentum_x", "momentum_y", "momentum_t", "qmm", "weighting" };
+        static constexpr auto names_s = { "position_x", "position_y", "position_ct", "momentum_x", "momentum_y", "momentum_t", "qmm", "weighting" };
         static_assert(names_t.size() == nattribs);
         static_assert(names_s.size() == nattribs);
     };
@@ -83,7 +89,9 @@ namespace impactx
     {
         enum
         {
-            nattribs ///< the number of particles above (always last)
+            id,
+            cpu,
+            nattribs ///< the number of attributes above (always last)
         };
     };
 
@@ -92,15 +100,15 @@ namespace impactx
      * We subclass here to change the default threading strategy, which is
      * `static` in AMReX, to `dynamic` in ImpactX.
      */
-    class ParIter
-        : public amrex::ParIter<0, 0, RealSoA::nattribs, IntSoA::nattribs>
+    class ParIterSoA
+        : public amrex::ParIterSoA<RealSoA::nattribs, IntSoA::nattribs>
     {
     public:
-        using amrex::ParIter<0, 0, RealSoA::nattribs, IntSoA::nattribs>::ParIter;
+        using amrex::ParIterSoA<RealSoA::nattribs, IntSoA::nattribs>::ParIterSoA;
 
-        ParIter (ContainerType& pc, int level);
+        ParIterSoA (ContainerType& pc, int level);
 
-        ParIter (ContainerType& pc, int level, amrex::MFItInfo& info);
+        ParIterSoA (ContainerType& pc, int level, amrex::MFItInfo& info);
     };
 
     /** Const AMReX iterator for particle boxes - data is read only.
@@ -108,15 +116,15 @@ namespace impactx
      * We subclass here to change the default threading strategy, which is
      * `static` in AMReX, to `dynamic` in ImpactX.
      */
-    class ParConstIter
-        : public amrex::ParConstIter<0, 0, RealSoA::nattribs, IntSoA::nattribs>
+    class ParConstIterSoA
+        : public amrex::ParConstIterSoA<RealSoA::nattribs, IntSoA::nattribs>
     {
     public:
-        using amrex::ParConstIter<0, 0, RealSoA::nattribs, IntSoA::nattribs>::ParConstIter;
+        using amrex::ParConstIterSoA<RealSoA::nattribs, IntSoA::nattribs>::ParConstIterSoA;
 
-        ParConstIter (ContainerType& pc, int level);
+        ParConstIterSoA (ContainerType& pc, int level);
 
-        ParConstIter (ContainerType& pc, int level, amrex::MFItInfo& info);
+        ParConstIterSoA (ContainerType& pc, int level, amrex::MFItInfo& info);
     };
 
     /** Beam Particles in ImpactX
@@ -124,14 +132,14 @@ namespace impactx
      * This class stores particles, distributed over MPI ranks.
      */
     class ImpactXParticleContainer
-        : public amrex::ParticleContainer<0, 0, RealSoA::nattribs, IntSoA::nattribs>
+        : public amrex::ParticleContainerPureSoA<RealSoA::nattribs, IntSoA::nattribs>
     {
     public:
         //! amrex iterator for particle boxes
-        using iterator = impactx::ParIter;
+        using iterator = impactx::ParIterSoA;
 
         //! amrex constant iterator for particle boxes (read-only)
-        using const_iterator = impactx::ParConstIter;
+        using const_iterator = impactx::ParConstIterSoA;
 
         //! Construct a new particle container
         ImpactXParticleContainer (amrex::AmrCore* amr_core);

--- a/src/particles/elements/mixin/beamoptic.H
+++ b/src/particles/elements/mixin/beamoptic.H
@@ -40,23 +40,25 @@ namespace detail
     struct PushSingleParticle
     {
         using PType = ImpactXParticleContainer::ParticleType;
+        using ParticleTileType = amrex::ParticleTile<amrex::SoAParticle<RealSoA::nattribs, IntSoA::nattribs>,RealSoA::nattribs, IntSoA::nattribs>;
+        using ParticleTileDataType = amrex::ParticleTileData<ParticleTileType::StorageParticleType,RealSoA::nattribs, IntSoA::nattribs>;
 
         /** Constructor taking in pointers to particle data
          *
          * @param element the beamline element to push through
-         * @param aos_ptr the array-of-struct with position and ids
+         * @param ptd particle data tile
          * @param part_px the array to the particle momentum (x)
          * @param part_py the array to the particle momentum (y)
          * @param part_pt the array to the particle momentum (t)
          * @param ref_part the struct containing the reference particle
          */
         PushSingleParticle (T_Element element,
-                            PType* AMREX_RESTRICT aos_ptr,
+                            ParticleTileDataType ptd,
                             amrex::ParticleReal* AMREX_RESTRICT part_px,
                             amrex::ParticleReal* AMREX_RESTRICT part_py,
                             amrex::ParticleReal* AMREX_RESTRICT part_pt,
                             RefPart ref_part)
-                : m_element(std::move(element)), m_aos_ptr(aos_ptr),
+                : m_element(std::move(element)), m_ptd(ptd),
                   m_part_px(part_px), m_part_py(part_py), m_part_pt(part_pt),
                   m_ref_part(std::move(ref_part))
         {
@@ -75,8 +77,7 @@ namespace detail
         void
         operator() (long i) const
         {
-            // access AoS data such as positions and cpu/id
-            PType& AMREX_RESTRICT p = m_aos_ptr[i];
+            PType p(m_ptd, i);
 
             // access SoA Real data
             amrex::ParticleReal & AMREX_RESTRICT px = m_part_px[i];
@@ -90,7 +91,7 @@ namespace detail
 
     private:
         T_Element const m_element;
-        PType* const AMREX_RESTRICT m_aos_ptr;
+        ParticleTileDataType const m_ptd;
         amrex::ParticleReal* const AMREX_RESTRICT m_part_px;
         amrex::ParticleReal* const AMREX_RESTRICT m_part_py;
         amrex::ParticleReal* const AMREX_RESTRICT m_part_pt;
@@ -107,10 +108,12 @@ namespace detail
     ) {
         const int np = pti.numParticles();
 
-        // preparing access to particle data: AoS
+        // preparing access to particle data
         using PType = ImpactXParticleContainer::ParticleType;
-        auto& aos = pti.GetArrayOfStructs();
-        PType* AMREX_RESTRICT aos_ptr = aos().dataPtr();
+        using ParticleTile = amrex::ParticleTile<amrex::SoAParticle<RealSoA::nattribs, IntSoA::nattribs>,RealSoA::nattribs, IntSoA::nattribs>;
+        using ParticleTileDataType = amrex::ParticleTileData<ParticleTile::StorageParticleType,RealSoA::nattribs, IntSoA::nattribs>;
+
+        ParticleTileDataType tile_data = pti.GetParticleTile().getParticleTileData();
 
         // preparing access to particle data: SoA of Reals
         auto& soa_real = pti.GetStructOfArrays().GetRealData();
@@ -119,7 +122,7 @@ namespace detail
         amrex::ParticleReal* const AMREX_RESTRICT part_pt = soa_real[RealSoA::pt].dataPtr();
 
         detail::PushSingleParticle<T_Element> const pushSingleParticle(
-                element, aos_ptr, part_px, part_py, part_pt, ref_part);
+                element, tile_data, part_px, part_py, part_pt, ref_part);
         //   loop over beam particles in the box
         amrex::ParallelFor(np, pushSingleParticle);
     }


### PR DESCRIPTION
Adapting the impactx code with the new SoA Particle structure we created in AMReX. Main changes are related to the structures declarations and to the Parallel-for-loops where we access the particles data. 

## To Do
- [x] replace container & iterator
- [x] replace loops
- [ ] update Python

Third-party:
- AMReX:
  - [x] depends on https://github.com/AMReX-Codes/amrex/pull/2878
- ABLASTR:
  - [x] depends on https://github.com/ECP-WarpX/WarpX/pull/3393
  - [ ] depends on https://github.com/ECP-WarpX/WarpX/pull/3417
- pyAMReX (`-DImpactX_PYTHON=ON`):
  - [ ] todo