### PR TITLE
Examples: Fix Absolute Tolerance in Analysis (Part 2)

### DIFF
--- a/examples/cfchannel/analysis_cfchannel.py
+++ b/examples/cfchannel/analysis_cfchannel.py
@@ -69,7 +69,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
@@ -96,7 +96,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 

--- a/examples/distgen/analysis_kvdist.py
+++ b/examples/distgen/analysis_kvdist.py
@@ -69,7 +69,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
@@ -96,7 +96,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 

--- a/examples/iota_lattice/analysis_iotalattice.py
+++ b/examples/iota_lattice/analysis_iotalattice.py
@@ -69,7 +69,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
@@ -89,7 +89,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 

--- a/examples/iota_lens/analysis_iotalens.py
+++ b/examples/iota_lens/analysis_iotalens.py
@@ -58,7 +58,7 @@ print("Initial Beam:")
 meanH, sigH, meanI, sigI = get_moments(initial)
 print(f"  meanH={meanH:e} sigH={sigH:e} meanI={meanI:e} sigI={sigI:e}")
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
@@ -75,7 +75,7 @@ print("Final Beam:")
 meanH, sigH, meanI, sigI = get_moments(final)
 print(f"  meanH={meanH:e} sigH={sigH:e} meanI={meanI:e} sigI={sigI:e}")
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 

--- a/examples/kurth/analysis_kurth.py
+++ b/examples/kurth/analysis_kurth.py
@@ -69,7 +69,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
@@ -96,7 +96,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 


### PR DESCRIPTION
In `np.allclose`, the absolute and relative tolerances are added. We meant to disable the term with the absolute one, so this should be zero and not one.

Ref.: https://numpy.org/doc/stable/reference/generated/numpy.allclose.html