### PR TITLE
Examples: Fix Absolute Tolerance in Analysis (Part 1)

### DIFF
--- a/examples/chicane/analysis_chicane.py
+++ b/examples/chicane/analysis_chicane.py
@@ -69,7 +69,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
@@ -96,7 +96,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 

--- a/examples/distgen/analysis_gaussian.py
+++ b/examples/distgen/analysis_gaussian.py
@@ -69,7 +69,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
@@ -96,7 +96,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 

--- a/examples/distgen/analysis_kurth4d.py
+++ b/examples/distgen/analysis_kurth4d.py
@@ -69,7 +69,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
@@ -96,7 +96,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 

--- a/examples/distgen/analysis_semigaussian.py
+++ b/examples/distgen/analysis_semigaussian.py
@@ -69,7 +69,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
@@ -96,7 +96,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 

--- a/examples/fodo/analysis_fodo.py
+++ b/examples/fodo/analysis_fodo.py
@@ -69,7 +69,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
@@ -96,7 +96,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 

--- a/examples/fodo_rf/analysis_fodo_rf.py
+++ b/examples/fodo_rf/analysis_fodo_rf.py
@@ -69,7 +69,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
@@ -96,7 +96,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 

--- a/examples/multipole/analysis_multipole.py
+++ b/examples/multipole/analysis_multipole.py
@@ -69,7 +69,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
@@ -96,7 +96,7 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
+atol = 0.0  # ignored
 rtol = num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 


### PR DESCRIPTION
In `np.allclose`, the absolute and relative tolerances are added. We meant to disable the term with the absolute one, so this should be zero and not one.

This updates all tests that are passing with the change. All other tests go in #248