### PR TITLE
Fix relative tolerance and targets for a few benchmark problems.

### DIFF
--- a/examples/cfchannel/analysis_cfchannel.py
+++ b/examples/cfchannel/analysis_cfchannel.py
@@ -70,7 +70,7 @@ print(
 )
 
 atol = 0.0  # a big number
-rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
+rtol = 1.5 * num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
@@ -97,7 +97,7 @@ print(
 )
 
 atol = 0.0  # a big number
-rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
+rtol = 1.5 * num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(

--- a/examples/cfchannel/analysis_cfchannel.py
+++ b/examples/cfchannel/analysis_cfchannel.py
@@ -69,19 +69,19 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
-rtol = num_particles**-0.5  # from random sampling of a smooth distribution
+atol = 0.0  # a big number
+rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
     [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
     [
-        1.0043885827109985e-003,
-        1.0042610595388732e-003,
-        3.1861216942650350e-004,
-        9.9797705036005654e-007,
-        1.0087507902003595e-006,
-        1.0006910428762258e-006,
+        1.0e-003,
+        1.0e-003,
+        3.369701494258956e-4,
+        1.0e-006,
+        1.0e-006,
+        1.0e-006,
     ],
     rtol=rtol,
     atol=atol,
@@ -96,19 +96,19 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
-rtol = num_particles**-0.5  # from random sampling of a smooth distribution
+atol = 0.0  # a big number
+rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
     [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
     [
-        9.9503447349890686e-004,
-        1.0058476385845527e-003,
-        3.2018775966211120e-004,
-        9.9797701930744223e-007,
-        1.0087507496985870e-006,
-        1.0006910509389394e-006,
+        1.0e-003,
+        1.0e-003,
+        3.369701494258956e-4,
+        1.0e-006,
+        1.0e-006,
+        1.0e-006,
     ],
     rtol=rtol,
     atol=atol,

--- a/examples/distgen/analysis_kvdist.py
+++ b/examples/distgen/analysis_kvdist.py
@@ -70,7 +70,7 @@ print(
 )
 
 atol = 0.0  # a big number
-rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
+rtol = 1.5 * num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
@@ -97,7 +97,7 @@ print(
 )
 
 atol = 0.0  # a big number
-rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
+rtol = 1.5 * num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(

--- a/examples/distgen/analysis_kvdist.py
+++ b/examples/distgen/analysis_kvdist.py
@@ -69,8 +69,8 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
-rtol = num_particles**-0.5  # from random sampling of a smooth distribution
+atol = 0.0  # a big number
+rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
@@ -96,8 +96,8 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
-rtol = num_particles**-0.5  # from random sampling of a smooth distribution
+atol = 0.0  # a big number
+rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(

--- a/examples/iota_lattice/analysis_iotalattice.py
+++ b/examples/iota_lattice/analysis_iotalattice.py
@@ -69,8 +69,8 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
-rtol = num_particles**-0.5  # from random sampling of a smooth distribution
+atol = 0.0  # a big number
+rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
@@ -89,8 +89,8 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
-rtol = num_particles**-0.5  # from random sampling of a smooth distribution
+atol = 0.0  # a big number
+rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
@@ -101,7 +101,7 @@ assert np.allclose(
         1.208202e-02,
         4.490897e-06,
         4.539378e-06,
-        6.384184e-16,
+        0.0,
     ],
     rtol=rtol,
     atol=atol,

--- a/examples/iota_lattice/analysis_iotalattice.py
+++ b/examples/iota_lattice/analysis_iotalattice.py
@@ -70,7 +70,7 @@ print(
 )
 
 atol = 0.0  # a big number
-rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
+rtol = 1.5 * num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
@@ -90,7 +90,7 @@ print(
 )
 
 atol = 0.0  # a big number
-rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
+rtol = 1.5 * num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(

--- a/examples/iota_lens/analysis_iotalens.py
+++ b/examples/iota_lens/analysis_iotalens.py
@@ -59,7 +59,7 @@ meanH, sigH, meanI, sigI = get_moments(initial)
 print(f"  meanH={meanH:e} sigH={sigH:e} meanI={meanI:e} sigI={sigI:e}")
 
 atol = 0.0  # a big number
-rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
+rtol = 1.5 * num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
@@ -76,7 +76,7 @@ meanH, sigH, meanI, sigI = get_moments(final)
 print(f"  meanH={meanH:e} sigH={sigH:e} meanI={meanI:e} sigI={sigI:e}")
 
 atol = 0.0  # a big number
-rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
+rtol = 1.5 * num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(

--- a/examples/iota_lens/analysis_iotalens.py
+++ b/examples/iota_lens/analysis_iotalens.py
@@ -58,13 +58,13 @@ print("Initial Beam:")
 meanH, sigH, meanI, sigI = get_moments(initial)
 print(f"  meanH={meanH:e} sigH={sigH:e} meanI={meanI:e} sigI={sigI:e}")
 
-atol = 1.0  # a big number
-rtol = num_particles**-0.5  # from random sampling of a smooth distribution
+atol = 0.0  # a big number
+rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
     [meanH, sigH, meanI, sigI],
-    [1.604948e-01, 1.757985e-01, 2.882956e-01, 3.844099e-01],
+    [4.122650e-02, 4.235181e-02, 7.356057e-02, 8.793753e-02],
     rtol=rtol,
     atol=atol,
 )
@@ -75,13 +75,13 @@ print("Final Beam:")
 meanH, sigH, meanI, sigI = get_moments(final)
 print(f"  meanH={meanH:e} sigH={sigH:e} meanI={meanI:e} sigI={sigI:e}")
 
-atol = 1.0  # a big number
-rtol = num_particles**-0.5  # from random sampling of a smooth distribution
+atol = 0.0  # a big number
+rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
     [meanH, sigH, meanI, sigI],
-    [1.605336e-01, 1.756235e-01, 2.880581e-01, 3.839625e-01],
+    [4.122704e-02, 4.230576e-02, 7.348275e-02, 8.783157e-02],
     rtol=rtol,
     atol=atol,
 )
@@ -95,7 +95,7 @@ beam_joined["dI"] = (beam_joined["I_initial"] - beam_joined["I_final"]).abs()
 
 # particle-wise comparison of H & I initial to final
 atol = 2.0e-3
-rtol = 1.0  # large number
+rtol = 0.0  # large number
 print()
 print(f"  atol={atol} (ignored: rtol~={rtol})")
 

--- a/examples/kurth/analysis_kurth.py
+++ b/examples/kurth/analysis_kurth.py
@@ -69,19 +69,19 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
-rtol = num_particles**-0.5  # from random sampling of a smooth distribution
+atol = 0.0  # a big number
+rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
     [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
     [
-        1.006098e-03,
-        9.973850e-04,
-        1.001599e-03,
-        9.958199e-07,
-        9.976684e-07,
-        9.896235e-07,
+        1.0e-03,
+        1.0e-03,
+        3.369701494258956e-4,
+        1.0e-6,
+        1.0e-6,
+        1.0e-6,
     ],
     rtol=rtol,
     atol=atol,
@@ -96,19 +96,19 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
 
-atol = 1.0  # a big number
-rtol = num_particles**-0.5  # from random sampling of a smooth distribution
+atol = 0.0  # a big number
+rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
     [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
     [
-        9.893263e-04,
-        9.991726e-04,
-        9.915850e-04,
-        9.958199e-07,
-        9.976684e-07,
-        9.896235e-07,
+        1.0e-03,
+        1.0e-03,
+        3.369701494258956e-4,
+        1.0e-6,
+        1.0e-6,
+        1.0e-6,
     ],
     rtol=rtol,
     atol=atol,

--- a/examples/kurth/analysis_kurth.py
+++ b/examples/kurth/analysis_kurth.py
@@ -70,7 +70,7 @@ print(
 )
 
 atol = 0.0  # a big number
-rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
+rtol = 1.5 * num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
@@ -97,7 +97,7 @@ print(
 )
 
 atol = 0.0  # a big number
-rtol = 1.5*num_particles**-0.5  # from random sampling of a smooth distribution
+rtol = 1.5 * num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(


### PR DESCRIPTION
This is a replacement for:  "Examples: Fix Absolute Tolerance in Analysis (Part 2) #248".  Changes are made to the analysis scripts for the following benchmark problems:

1) cfchannel
2) kurth
3) kvdist
4) iotalens
5) iotalattice

The relative tolerance was increased from 1% to 1.5%.  In some cases, target values were updated.