### PR TITLE
Replace Hard-Coded Constants with ABLASTR

### DIFF
--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -134,7 +134,7 @@ set(ImpactX_ablastr_src ""
 set(ImpactX_ablastr_repo "https://github.com/ECP-WarpX/WarpX.git"
     CACHE STRING
     "Repository URI to pull and build ABLASTR from if(ImpactX_ablastr_internal)")
-set(ImpactX_ablastr_branch "425d22a5b596eb1ceb8e5a07d1ed3766870f9d9e"
+set(ImpactX_ablastr_branch "5deed41b5788a7f59da1cdc55cb30b2cea781441"
     CACHE STRING
     "Repository branch for ImpactX_ablastr_repo if(ImpactX_ablastr_internal)")
 

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -11,6 +11,7 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/distribution/All.H"
 
+#include <ablastr/constant.H>
 #include <ablastr/warn_manager/WarnManager.H>
 
 #include <AMReX.H>
@@ -122,16 +123,21 @@ namespace impactx
 
         amrex::ParticleReal qe;     // charge (elementary charge)
         amrex::ParticleReal massE;  // MeV/c^2
-        if(particle_type == "electron") {
+        if (particle_type == "electron") {
             qe = -1.0;
-            massE = 0.510998950;
-        } else if(particle_type == "proton") {
+            massE = ablastr::constant::SI::m_e / ablastr::constant::SI::MeV_invc2;
+        } else if (particle_type == "proton") {
             qe = 1.0;
-            massE = 938.27208816;
+            massE = ablastr::constant::SI::m_p / ablastr::constant::SI::MeV_invc2;
         }
         else {  // default to electron
+            ablastr::warn_manager::WMRecordWarning(
+                "ImpactX::initBeamDistributionFromInputs",
+                "No beam.particle specified, defaulting to electrons.",
+                ablastr::warn_manager::WarnPriority::low
+            );
             qe = -1.0;
-            massE = 0.510998950;
+            massE = ablastr::constant::SI::m_e / ablastr::constant::SI::MeV_invc2;
         }
 
         // set charge and mass and energy of ref particle

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -9,6 +9,7 @@
  */
 #include "ImpactXParticleContainer.H"
 
+#include <ablastr/constant.H>
 #include <ablastr/particles/ParticleMoments.H>
 
 #include <AMReX.H>
@@ -111,8 +112,7 @@ namespace impactx
         pinned_tile.push_back_real(RealSoA::uy, py);
         pinned_tile.push_back_real(RealSoA::pt, pz);
         pinned_tile.push_back_real(RealSoA::m_qm, np, qm);
-        amrex::ParticleReal const q_e = 1.60217662e-19;  // TODO move out
-        pinned_tile.push_back_real(RealSoA::w, np, bchchg/q_e/np);
+        pinned_tile.push_back_real(RealSoA::w, np, bchchg/ablastr::constant::SI::q_e/np);
 
         /* Redistributes particles to their respective tiles (spatial bucket
          * sort per box over MPI ranks)

--- a/src/particles/ReferenceParticle.H
+++ b/src/particles/ReferenceParticle.H
@@ -91,7 +91,7 @@ namespace impactx
         {
             using namespace amrex::literals;
 
-            constexpr amrex::ParticleReal inv_MeV_invc2 = ablastr::constant::SI::MeV_invc2;
+            constexpr amrex::ParticleReal inv_MeV_invc2 = 1.0_prt /  ablastr::constant::SI::MeV_invc2;
             return amrex::ParticleReal(mass * inv_MeV_invc2);
         }
 
@@ -166,7 +166,7 @@ namespace impactx
         {
             using namespace amrex::literals;
 
-            constexpr amrex::ParticleReal inv_qe = ablastr::constant::SI::q_e;
+            constexpr amrex::ParticleReal inv_qe = 1.0_prt / ablastr::constant::SI::q_e;
             return amrex::ParticleReal(charge * inv_qe);
         }
 

--- a/src/particles/ReferenceParticle.H
+++ b/src/particles/ReferenceParticle.H
@@ -10,6 +10,8 @@
 #ifndef IMPACTX_REFERENCE_PARTICLE_H
 #define IMPACTX_REFERENCE_PARTICLE_H
 
+#include <ablastr/constant.H>
+
 #include <AMReX_BLassert.H>
 #include <AMReX_Extension.H>
 #include <AMReX_GpuQualifiers.H>
@@ -89,8 +91,8 @@ namespace impactx
         {
             using namespace amrex::literals;
 
-            constexpr double MeVc2_kg = 1.78266192e-30;
-            return amrex::ParticleReal(mass / MeVc2_kg);
+            constexpr amrex::ParticleReal inv_MeV_invc2 = ablastr::constant::SI::MeV_invc2;
+            return amrex::ParticleReal(mass * inv_MeV_invc2);
         }
 
         /** Set reference particle rest mass
@@ -106,8 +108,7 @@ namespace impactx
             AMREX_ASSERT_WITH_MESSAGE(massE != 0.0_prt,
                                       "set_mass_MeV: Mass cannot be zero!");
 
-            constexpr amrex::ParticleReal MeVc2_kg = 1.78266192e-30;
-            mass = massE * MeVc2_kg;
+            mass = massE * ablastr::constant::SI::MeV_invc2;
 
             // re-scale pt and pz
             if (pt != 0.0_prt)
@@ -165,8 +166,8 @@ namespace impactx
         {
             using namespace amrex::literals;
 
-            constexpr double qe = 1.602176634e-19;
-            return amrex::ParticleReal(charge / qe);
+            constexpr amrex::ParticleReal inv_qe = ablastr::constant::SI::q_e;
+            return amrex::ParticleReal(charge * inv_qe);
         }
 
         /** Set reference particle charge
@@ -179,8 +180,7 @@ namespace impactx
         {
             using namespace amrex::literals;
 
-            constexpr double qe = 1.602176634e-19;
-            this->charge = charge_qe * qe;
+            this->charge = charge_qe * ablastr::constant::SI::q_e;
 
             return *this;
         }


### PR DESCRIPTION
Replace hard-coded constants with constants from ABLASTR. This provides us with a single source of truth and avoids nifty issues with slightly-off numerical values depending on the precision used in multiple locations.

- [x] depends on https://github.com/ECP-WarpX/WarpX/pull/3405