### PR TITLE
Python: All Sim Options As Properties

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -12,9 +12,9 @@ General
 
    This is the central simulation class.
 
-   .. py:method:: set_particle_shape(order)
+   .. py:property:: particle_shape
 
-      Set the particle B-spline order.
+      Control the particle B-spline order.
 
       The order of the shape factors (splines) for the macro-particles along all spatial directions: `1` for linear, `2` for quadratic, `3` for cubic.
       Low-order shape factors result in faster simulations, but may lead to more noisy results.
@@ -43,38 +43,30 @@ General
 
       Use dynamic (``True``) resizing of the field mesh or static sizing (``False``).
 
-   .. py:method:: set_space_charge(enable)
+   .. py:property:: space_charge
 
-      Enable or disable space charge calculations (default: enabled).
+      Enable (``True``) or disable (``False``) space charge calculations (default: ``True``).
 
       Whether to calculate space charge effects.
       This is in-development.
       At the moment, this flag only activates coordinate transformations and charge deposition.
 
-      :param bool enable: enable (true) or disable (false) space charge
+   .. py:property:: diagnostics
 
-   .. py:method:: set_diagnostics(enable)
-
-      Enable or disable diagnostics generally (default: enabled).
+      Enable (``True``) or disable (``False``) diagnostics generally (default: ``True``).
       Disabling this is mostly used for benchmarking.
 
-      :param bool enable: enable (true) or disable (false) all diagnostics
+   .. py:property:: slice_step_diagnostics
 
-   .. py:method:: set_slice_step_diagnostics(enable)
-
-      Enable or disable diagnostics every slice step in elements (default: disabled).
+      Enable (``True``) or disable (``False``) diagnostics every slice step in elements  (default: ``True``).
 
       By default, diagnostics is performed at the beginning and end of the simulation.
       Enabling this flag will write diagnostics every step and slice step.
 
-      :param bool enable: enable (true) or disable (false) all diagnostics
+   .. py:property:: diag_file_min_digits
 
-   .. py:method:: set_diag_file_min_digits(file_min_digits)
-
-      The minimum number of digits (default: 6) used for the step
+      The minimum number of digits (default: ``6``) used for the step
       number appended to the diagnostic file names.
-
-      :param int file_min_digits: number of digits in filenames
 
    .. py:method:: init_grids()
 

--- a/examples/cfchannel/run_cfchannel.py
+++ b/examples/cfchannel/run_cfchannel.py
@@ -12,10 +12,10 @@ from impactx import ImpactX, RefPart, distribution, elements
 sim = ImpactX()
 
 # set numerical parameters and IO control
-sim.set_particle_shape(2)  # B-spline order
-sim.set_space_charge(False)
-# sim.set_diagnostics(False)  # benchmarking
-sim.set_slice_step_diagnostics(True)
+sim.particle_shape = 2  # B-spline order
+sim.space_charg = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/examples/cfchannel/run_cfchannel.py
+++ b/examples/cfchannel/run_cfchannel.py
@@ -13,7 +13,7 @@ sim = ImpactX()
 
 # set numerical parameters and IO control
 sim.particle_shape = 2  # B-spline order
-sim.space_charg = False
+sim.space_charge = False
 # sim.diagnostics = False  # benchmarking
 sim.slice_step_diagnostics = True
 

--- a/examples/chicane/run_chicane.py
+++ b/examples/chicane/run_chicane.py
@@ -12,10 +12,10 @@ from impactx import ImpactX, RefPart, distribution, elements
 sim = ImpactX()
 
 # set numerical parameters and IO control
-sim.set_particle_shape(2)  # B-spline order
-sim.set_space_charge(False)
-# sim.set_diagnostics(False)  # benchmarking
-sim.set_slice_step_diagnostics(True)
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/examples/chicane/run_chicane_madx.py
+++ b/examples/chicane/run_chicane_madx.py
@@ -13,10 +13,10 @@ from impactx import ImpactX, RefPart, distribution, elements
 sim = ImpactX()
 
 # set numerical parameters and IO control
-sim.set_particle_shape(2)  # B-spline order
-sim.set_space_charge(False)
-# sim.set_diagnostics(False)  # benchmarking
-sim.set_slice_step_diagnostics(True)
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/examples/expanding_beam/run_expanding.py
+++ b/examples/expanding_beam/run_expanding.py
@@ -15,14 +15,14 @@ pp_amr.addarr("n_cell", [40, 40, 32])
 sim = ImpactX()
 
 # set numerical parameters and IO control
-sim.set_particle_shape(2)  # B-spline order
-sim.set_space_charge(True)
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = True
 sim.dynamic_size = True
 sim.prob_relative = 1.0
 
 # beam diagnostics
-# sim.set_diagnostics(False)  # benchmarking
-sim.set_slice_step_diagnostics(False)
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = False
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/examples/fodo/run_fodo.py
+++ b/examples/fodo/run_fodo.py
@@ -12,10 +12,10 @@ from impactx import ImpactX, RefPart, distribution, elements
 sim = ImpactX()
 
 # set numerical parameters and IO control
-sim.set_particle_shape(2)  # B-spline order
-sim.set_space_charge(False)
-# sim.set_diagnostics(False)  # benchmarking
-sim.set_slice_step_diagnostics(True)
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/examples/fodo/run_fodo_madx.py
+++ b/examples/fodo/run_fodo_madx.py
@@ -13,10 +13,10 @@ from impactx import ImpactX, RefPart, distribution, elements
 sim = ImpactX()
 
 # set numerical parameters and IO control
-sim.set_particle_shape(2)  # B-spline order
-sim.set_space_charge(False)
-# sim.set_diagnostics(False)  # benchmarking
-sim.set_slice_step_diagnostics(True)
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/examples/fodo_rf/run_fodo_rf.py
+++ b/examples/fodo_rf/run_fodo_rf.py
@@ -12,10 +12,10 @@ from impactx import ImpactX, distribution, elements
 sim = ImpactX()
 
 # set numerical parameters and IO control
-sim.set_particle_shape(2)  # B-spline order
-sim.set_space_charge(False)
-# sim.set_diagnostics(False)  # benchmarking
-sim.set_slice_step_diagnostics(True)
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/examples/iota_lattice/run_iotalattice.py
+++ b/examples/iota_lattice/run_iotalattice.py
@@ -12,10 +12,10 @@ from impactx import ImpactX, RefPart, distribution, elements
 sim = ImpactX()
 
 # set numerical parameters and IO control
-sim.set_particle_shape(2)  # B-spline order
-sim.set_space_charge(False)
-# sim.set_diagnostics(False)  # benchmarking
-sim.set_slice_step_diagnostics(True)
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/examples/iota_lens/run_iotalens.py
+++ b/examples/iota_lens/run_iotalens.py
@@ -12,10 +12,10 @@ from impactx import ImpactX, distribution, elements
 sim = ImpactX()
 
 # set numerical parameters and IO control
-sim.set_particle_shape(2)  # B-spline order
-sim.set_space_charge(False)
-# sim.set_diagnostics(False)  # benchmarking
-sim.set_slice_step_diagnostics(True)
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/examples/kurth/run_kurth.py
+++ b/examples/kurth/run_kurth.py
@@ -12,10 +12,10 @@ from impactx import ImpactX, distribution, elements
 sim = ImpactX()
 
 # set numerical parameters and IO control
-sim.set_particle_shape(2)  # B-spline order
-sim.set_space_charge(False)
-# sim.set_diagnostics(False)  # benchmarking
-sim.set_slice_step_diagnostics(True)
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/examples/multipole/run_multipole.py
+++ b/examples/multipole/run_multipole.py
@@ -12,10 +12,10 @@ from impactx import ImpactX, distribution, elements
 sim = ImpactX()
 
 # set numerical parameters and IO control
-sim.set_particle_shape(2)  # B-spline order
-sim.set_space_charge(False)
-# sim.set_diagnostics(False)  # benchmarking
-sim.set_slice_step_diagnostics(True)
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -135,9 +135,9 @@ void init_ImpactX(py::module& m)
 
         .def_property("particle_shape",
             [](ImpactX & /* ix */) {
-                amrex::ParmParse pp_ago("algo");
+                amrex::ParmParse pp_algo("algo");
                 int order = 0;
-                bool const has_shape = pp_ago.query("particle_shape", order);
+                bool const has_shape = pp_algo.query("particle_shape", order);
                 if (!has_shape)
                     throw std::runtime_error("particle_shape is not set yet");
                 return order;

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -133,7 +133,15 @@ void init_ImpactX(py::module& m)
               "Use dynamic (``true``) resizing of the field mesh or static sizing (``false``)."
         )
 
-        .def("set_particle_shape",
+        .def_property("particle_shape",
+            [](ImpactX & /* ix */) {
+                amrex::ParmParse pp_ago("algo");
+                int order = 0;
+                bool const has_shape = pp_ago.query("particle_shape", order);
+                if (!has_shape)
+                    throw std::runtime_error("particle_shape is not set yet");
+                return order;
+            },
             [](ImpactX & ix, int const order) {
                 AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ix.m_particle_container,
                     "particle container not initialized");
@@ -145,39 +153,59 @@ void init_ImpactX(py::module& m)
             },
             "Whether to calculate space charge effects."
         )
-        .def("set_space_charge",
+        .def_property("space_charge",
+             [](ImpactX & /* ix */) {
+                 amrex::ParmParse pp_algo("algo");
+                 bool enable = false;
+                 pp_algo.get("space_charge", enable);
+                 return enable;
+             },
              [](ImpactX & /* ix */, bool const enable) {
                  amrex::ParmParse pp_algo("algo");
                  pp_algo.add("space_charge", enable);
              },
-             py::arg("enable"),
              "Enable or disable space charge calculations (default: enabled)."
         )
-        .def("set_diagnostics",
+        .def_property("diagnostics",
+             [](ImpactX & /* ix */) {
+                 amrex::ParmParse pp_diag("diag");
+                 bool enable = true;
+                 pp_diag.get("enable", enable);
+                 return enable;
+             },
              [](ImpactX & /* ix */, bool const enable) {
                  amrex::ParmParse pp_diag("diag");
                  pp_diag.add("enable", enable);
              },
-             py::arg("enable"),
              "Enable or disable diagnostics generally (default: enabled).\n"
              "Disabling this is mostly used for benchmarking."
          )
-        .def("set_slice_step_diagnostics",
+        .def_property("slice_step_diagnostics",
+             [](ImpactX & /* ix */) {
+                 amrex::ParmParse pp_diag("diag");
+                 bool enable = false;
+                 pp_diag.get("slice_step_diagnostics", enable);
+                 return enable;
+             },
              [](ImpactX & /* ix */, bool const enable) {
                  amrex::ParmParse pp_diag("diag");
                  pp_diag.add("slice_step_diagnostics", enable);
              },
-             py::arg("enable"),
              "Enable or disable diagnostics every slice step in elements (default: disabled).\n\n"
              "By default, diagnostics is performed at the beginning and end of the simulation.\n"
              "Enabling this flag will write diagnostics every step and slice step."
          )
-        .def("set_diag_file_min_digits",
+        .def_property("diag_file_min_digits",
+             [](ImpactX & /* ix */) {
+                 amrex::ParmParse pp_diag("diag");
+                 int file_min_digits = 6;
+                 pp_diag.get("file_min_digits", file_min_digits);
+                 return file_min_digits;
+             },
              [](ImpactX & /* ix */, int const file_min_digits) {
                  amrex::ParmParse pp_diag("diag");
                  pp_diag.add("file_min_digits", file_min_digits);
              },
-             py::arg("file_min_digits"),
              "The minimum number of digits (default: 6) used for the step\n"
              "number appended to the diagnostic file names."
          )

--- a/tests/python/test_charge_deposition.py
+++ b/tests/python/test_charge_deposition.py
@@ -29,8 +29,8 @@ def test_charge_deposition(save_png=True):
     assert sim.n_cell == [16, 24, 32]
 
     sim.load_inputs_file("examples/fodo/input_fodo.in")
-    sim.set_space_charge(True)
-    sim.set_slice_step_diagnostics(False)
+    sim.space_charge = True
+    sim.slice_step_diagnostics = False
 
     # Future:
     # sim.ncell = [25, 25, 45]

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -133,7 +133,7 @@ def test_impactx_noshape():
 
     with pytest.raises(
         RuntimeError,
-        match="particle_shape is not set yet.",
+        match="particle_shape is not set yet",
     ):
         print(sim.particle_shape)
 

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -34,8 +34,8 @@ def test_impactx_nofile():
     """
     sim = ImpactX()
 
-    sim.set_particle_shape(2)
-    sim.set_slice_step_diagnostics(True)
+    sim.particle_shape = 2
+    sim.slice_step_diagnostics = True
     sim.init_grids()
 
     # init particle beam
@@ -96,7 +96,7 @@ def test_impactx_noparticles():
     """
     sim = ImpactX()
 
-    sim.set_particle_shape(2)
+    sim.particle_shape = 2
     sim.init_grids()
 
     # init particle beam
@@ -123,7 +123,7 @@ def test_impactx_noshape():
     """
     sim = ImpactX()
 
-    # impactX.set_particle_shape intentionally missing
+    # "sim.particle_shape = order" is intentionally missing
 
     with pytest.raises(
         RuntimeError,
@@ -131,8 +131,14 @@ def test_impactx_noshape():
     ):
         sim.init_grids()
 
+    with pytest.raises(
+        RuntimeError,
+        match="particle_shape is not set yet.",
+    ):
+        print(sim.particle_shape)
+
     # correct the mistake and keep going
-    sim.set_particle_shape(2)
+    sim.particle_shape = 2
     sim.init_grids()
 
 
@@ -143,7 +149,7 @@ def test_impactx_resting_refparticle():
     """
     sim = ImpactX()
 
-    sim.set_particle_shape(2)
+    sim.particle_shape = 2
     sim.init_grids()
 
     # init particle beam
@@ -207,9 +213,9 @@ def test_impactx_change_resolution():
     # sim.ncell = [16, 24, 32]
     # sim.domain = amrex.RealBox([1., 2., 3.], [4., 5., 6.])
 
-    sim.set_particle_shape(2)
-    sim.set_slice_step_diagnostics(False)
-    sim.set_diagnostics(False)
+    sim.particle_shape = 2
+    sim.slice_step_diagnostics = False
+    sim.diagnostics = False
     sim.init_grids()
 
     assert sim.n_cell == [16, 24, 32]


### PR DESCRIPTION
Refactor `ImpactX` setters to be properties.
This is more Pythonic and also allows us to query values of options instead of only setting them.