### PR TITLE
Python: Fix Interactive Inspection

### DIFF
--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -133,7 +133,7 @@ def test_impactx_noshape():
 
     with pytest.raises(
         RuntimeError,
-        match="particle_shape is not set yet",
+        match="algo.particle_shape is not set yet",
     ):
         print(sim.particle_shape)
 


### PR DESCRIPTION
When autocompleting the `ImpactX()` Python class, IPython uses [Jedi](https://jedi.readthedocs.io) to look into the getters of [properties](https://jedi.readthedocs.io/en/latest/docs/features.html#supported-python-features).
> Jedi does execute properties and in general is not very careful to avoid code execution.

By default, the `ParmParse::get()` we use would throw an `amrex::Abort()`, which exits the interpreter.

We could and should use `amrex.throw_exception = 1` and `amrex.signal_handling = 0` to make this a `std::runtime_error`. Unfortunately, this is still not sufficient to catch it, because C++ exception handling across shared libraries needs extra care.

Thus, we just do a helper function, save some lines of code, and throw directly from ImpactX's Python module.

Thanks to @n01r for spotting this originally.
Follow-up to #260 and #223