### PR TITLE
Examples: Simplify Finalize

### DIFF
--- a/examples/cfchannel/run_cfchannel.py
+++ b/examples/cfchannel/run_cfchannel.py
@@ -6,7 +6,6 @@
 #
 # -*- coding: utf-8 -*-
 
-import amrex
 from impactx import ImpactX, RefPart, distribution, elements
 
 sim = ImpactX()
@@ -46,7 +45,3 @@ sim.lattice.append(elements.ConstF(ds=2.0, kx=1.0, ky=1.0, kt=1.0))
 
 # run simulation
 sim.evolve()
-
-# clean shutdown
-del sim
-amrex.finalize()

--- a/examples/chicane/run_chicane.py
+++ b/examples/chicane/run_chicane.py
@@ -6,7 +6,6 @@
 #
 # -*- coding: utf-8 -*-
 
-import amrex
 from impactx import ImpactX, RefPart, distribution, elements
 
 sim = ImpactX()
@@ -73,7 +72,3 @@ sim.lattice.append(dr3)
 
 # run simulation
 sim.evolve()
-
-# clean shutdown
-del sim
-amrex.finalize()

--- a/examples/chicane/run_chicane_madx.py
+++ b/examples/chicane/run_chicane_madx.py
@@ -6,8 +6,6 @@
 #
 # -*- coding: utf-8 -*-
 
-
-import amrex
 from impactx import ImpactX, RefPart, distribution, elements
 
 sim = ImpactX()
@@ -48,7 +46,3 @@ sim.lattice.load_file("chicane.madx", nslice=25)
 
 # run simulation
 sim.evolve()
-
-# clean shutdown
-del sim
-amrex.finalize()

--- a/examples/expanding_beam/run_expanding.py
+++ b/examples/expanding_beam/run_expanding.py
@@ -53,7 +53,3 @@ sim.lattice.append(elements.Drift(ds=6.0, nslice=30))
 
 # run simulation
 sim.evolve()
-
-# clean shutdown
-del sim
-amrex.finalize()

--- a/examples/fodo/run_fodo.py
+++ b/examples/fodo/run_fodo.py
@@ -6,7 +6,6 @@
 #
 # -*- coding: utf-8 -*-
 
-import amrex
 from impactx import ImpactX, RefPart, distribution, elements
 
 sim = ImpactX()
@@ -58,7 +57,3 @@ sim.lattice.extend(fodo)
 
 # run simulation
 sim.evolve()
-
-# clean shutdown
-del sim
-amrex.finalize()

--- a/examples/fodo/run_fodo_madx.py
+++ b/examples/fodo/run_fodo_madx.py
@@ -6,8 +6,6 @@
 #
 # -*- coding: utf-8 -*-
 
-
-import amrex
 from impactx import ImpactX, RefPart, distribution, elements
 
 sim = ImpactX()
@@ -49,7 +47,3 @@ sim.lattice.load_file("fodo.madx", nslice=25)
 
 # run simulation
 sim.evolve()
-
-# clean shutdown
-del sim
-amrex.finalize()

--- a/examples/fodo_rf/run_fodo_rf.py
+++ b/examples/fodo_rf/run_fodo_rf.py
@@ -6,7 +6,6 @@
 #
 # -*- coding: utf-8 -*-
 
-import amrex
 from impactx import ImpactX, distribution, elements
 
 sim = ImpactX()
@@ -61,7 +60,3 @@ for element in lattice_no_drifts[1:]:
 
 # run simulation
 sim.evolve()
-
-# clean shutdown
-del sim
-amrex.finalize()

--- a/examples/iota_lattice/run_iotalattice.py
+++ b/examples/iota_lattice/run_iotalattice.py
@@ -6,7 +6,6 @@
 #
 # -*- coding: utf-8 -*-
 
-import amrex
 from impactx import ImpactX, RefPart, distribution, elements
 
 sim = ImpactX()
@@ -114,7 +113,3 @@ sim.lattice.extend(lattice_half)
 
 # run simulation
 sim.evolve()
-
-# clean shutdown
-del sim
-amrex.finalize()

--- a/examples/iota_lens/run_iotalens.py
+++ b/examples/iota_lens/run_iotalens.py
@@ -6,7 +6,6 @@
 #
 # -*- coding: utf-8 -*-
 
-import amrex
 from impactx import ImpactX, distribution, elements
 
 sim = ImpactX()
@@ -52,7 +51,3 @@ sim.lattice.extend(nllens_lattice)
 
 # run simulation
 sim.evolve()
-
-# clean shutdown
-del sim
-amrex.finalize()

--- a/examples/kurth/run_kurth.py
+++ b/examples/kurth/run_kurth.py
@@ -6,7 +6,6 @@
 #
 # -*- coding: utf-8 -*-
 
-import amrex
 from impactx import ImpactX, distribution, elements
 
 sim = ImpactX()
@@ -47,7 +46,3 @@ sim.lattice.append(elements.ConstF(ds=2.0, kx=1.0, ky=1.0, kt=1.0))
 
 # run simulation
 sim.evolve()
-
-# clean shutdown
-del sim
-amrex.finalize()

--- a/examples/multipole/run_multipole.py
+++ b/examples/multipole/run_multipole.py
@@ -6,7 +6,6 @@
 #
 # -*- coding: utf-8 -*-
 
-import amrex
 from impactx import ImpactX, distribution, elements
 
 sim = ImpactX()
@@ -52,7 +51,3 @@ sim.lattice.extend(multipole)
 
 # run simulation
 sim.evolve()
-
-# clean shutdown
-del sim
-amrex.finalize()


### PR DESCRIPTION
We don't really need to call this, the order should be done automatically and correctly at shutdown.

Exception: MPI runs that need to call finalize:
```
--------------------------------------------------------------------------
mpiexec has exited due to process rank 1 with PID 0 on
node fv-az205-415 exiting improperly. There are three reasons this could occur:

1. this process did not call "init" before exiting, but others in
the job did. This can cause a job to hang indefinitely while it waits
for all processes to call "init". By rule, if one process calls "init",
then ALL processes must call "init" prior to termination.

2. this process called "init", but exited without calling "finalize".
By rule, all processes that call "init" MUST call "finalize" prior to
exiting or it will be considered an "abnormal termination"

3. this process called "MPI_Abort" or "orte_abort" and the mca parameter
orte_create_session_dirs is set to false. In this case, the run-time cannot
detect that the abort call was an abnormal termination. Hence, the only
error message you will receive is this one.

This may have caused other processes in the application to be
terminated by signals sent by mpiexec (as reported here).

You can avoid this message by specifying -quiet on the mpiexec command line.
--------------------------------------------------------------------------
```