### PR TITLE
Push: Move RefParticle in Constructor

### DIFF
--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -13,6 +13,8 @@
 #include <AMReX_Extension.H>  // for AMREX_RESTRICT
 #include <AMReX_REAL.H>       // for ParticleReal
 
+#include <utility>
+
 
 namespace impactx
 {
@@ -53,7 +55,7 @@ namespace detail
                             RefPart ref_part)
             : m_element(element), m_aos_ptr(aos_ptr),
               m_part_px(part_px), m_part_py(part_py), m_part_pt(part_pt),
-              m_ref_part(ref_part)
+              m_ref_part(std::move(ref_part))
         {
         }
 

--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -53,7 +53,7 @@ namespace detail
                             amrex::ParticleReal* AMREX_RESTRICT part_py,
                             amrex::ParticleReal* AMREX_RESTRICT part_pt,
                             RefPart ref_part)
-            : m_element(element), m_aos_ptr(aos_ptr),
+            : m_element(std::move(element)), m_aos_ptr(aos_ptr),
               m_part_px(part_px), m_part_py(part_py), m_part_pt(part_pt),
               m_ref_part(std::move(ref_part))
         {


### PR DESCRIPTION
The RefPart is 88 bytes and should not be copied twice.