### PR TITLE
Elements: RefParticle ByRef

### DIFF
--- a/src/particles/elements/ConstF.H
+++ b/src/particles/elements/ConstF.H
@@ -55,7 +55,7 @@ namespace impactx
                 amrex::ParticleReal & AMREX_RESTRICT px,
                 amrex::ParticleReal & AMREX_RESTRICT py,
                 amrex::ParticleReal & AMREX_RESTRICT pt,
-                RefPart const refpart) const {
+                RefPart const & refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 
@@ -98,8 +98,7 @@ namespace impactx
          * @param[in,out] refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void operator() (
-                RefPart & AMREX_RESTRICT refpart) const {
+        void operator() (RefPart & AMREX_RESTRICT refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -60,7 +60,7 @@ namespace impactx
                 amrex::ParticleReal & AMREX_RESTRICT px,
                 amrex::ParticleReal & AMREX_RESTRICT py,
                 [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT pt,
-                [[maybe_unused]] RefPart const refpart) const {
+                [[maybe_unused]] RefPart const & refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 
@@ -90,8 +90,7 @@ namespace impactx
          * @param[in,out] refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void operator() (
-                [[maybe_unused]] RefPart & AMREX_RESTRICT refpart) const {
+        void operator() ([[maybe_unused]] RefPart & AMREX_RESTRICT refpart) const {
 
             // nothing to do: this is a zero-length element
         }

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -49,7 +49,7 @@ namespace impactx
                 amrex::ParticleReal & AMREX_RESTRICT px,
                 amrex::ParticleReal & AMREX_RESTRICT py,
                 amrex::ParticleReal & AMREX_RESTRICT pt,
-                RefPart const refpart) const {
+                RefPart const & refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 
@@ -90,8 +90,7 @@ namespace impactx
          * @param[in,out] refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void operator() (
-                RefPart & AMREX_RESTRICT refpart) const {
+        void operator() (RefPart & AMREX_RESTRICT refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 

--- a/src/particles/elements/Multipole.H
+++ b/src/particles/elements/Multipole.H
@@ -59,7 +59,7 @@ namespace impactx
                 amrex::ParticleReal & AMREX_RESTRICT px,
                 amrex::ParticleReal & AMREX_RESTRICT py,
                 amrex::ParticleReal & AMREX_RESTRICT pt,
-                [[maybe_unused]] RefPart const refpart) const {
+                [[maybe_unused]] RefPart const & refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 
@@ -113,8 +113,7 @@ namespace impactx
          * @param[in,out] refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void operator() (
-                [[maybe_unused]] RefPart & AMREX_RESTRICT refpart) const {
+        void operator() ([[maybe_unused]] RefPart & AMREX_RESTRICT refpart) const {
 
             // nothing to do: this is a zero-length element
         }

--- a/src/particles/elements/None.H
+++ b/src/particles/elements/None.H
@@ -43,7 +43,7 @@ namespace impactx
                 [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT px,
                 [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT py,
                 [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT pt,
-                [[maybe_unused]] RefPart const refpart) const
+                [[maybe_unused]] RefPart const & refpart) const
         {
             // nothing to do
         }
@@ -53,8 +53,7 @@ namespace impactx
          * @param[in,out] refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void operator() (
-                [[maybe_unused]] RefPart & AMREX_RESTRICT refpart) const {
+        void operator() ([[maybe_unused]] RefPart & AMREX_RESTRICT refpart) const {
 
             // nothing to do: this is a zero-length element
 

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -36,7 +36,7 @@ namespace impactx
          * @param cnll distance of singularities from the origin (m)
          */
         NonlinearLens( amrex::ParticleReal const knll,
-                   amrex::ParticleReal const cnll )
+                       amrex::ParticleReal const cnll )
         : m_knll(knll), m_cnll(cnll)
         {
         }
@@ -56,7 +56,7 @@ namespace impactx
                 amrex::ParticleReal & AMREX_RESTRICT px,
                 amrex::ParticleReal & AMREX_RESTRICT py,
                 amrex::ParticleReal & AMREX_RESTRICT pt,
-                [[maybe_unused]] RefPart const refpart) const {
+                [[maybe_unused]] RefPart const & refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 
@@ -122,8 +122,7 @@ namespace impactx
          * @param[in,out] refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void operator() (
-                [[maybe_unused]] RefPart & AMREX_RESTRICT refpart) const {
+        void operator() ([[maybe_unused]] RefPart & AMREX_RESTRICT refpart) const {
 
             // nothing to do: this is a zero-length element
         }

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -54,7 +54,7 @@ namespace impactx
                 amrex::ParticleReal & AMREX_RESTRICT px,
                 amrex::ParticleReal & AMREX_RESTRICT py,
                 amrex::ParticleReal & AMREX_RESTRICT pt,
-                RefPart const refpart) const {
+                RefPart const & refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 
@@ -112,8 +112,7 @@ namespace impactx
          * @param[in,out] refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void operator() (
-                RefPart & AMREX_RESTRICT refpart) const {
+        void operator() (RefPart & AMREX_RESTRICT refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 
@@ -142,7 +141,6 @@ namespace impactx
 
             // advance integrated path length
             refpart.s = s + slice_ds;
-
         }
 
         /** Number of slices used for the application of space charge

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -51,7 +51,7 @@ namespace impactx
                 amrex::ParticleReal & AMREX_RESTRICT px,
                 amrex::ParticleReal & AMREX_RESTRICT py,
                 amrex::ParticleReal & AMREX_RESTRICT pt,
-                RefPart const refpart) const {
+                RefPart const & refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 
@@ -106,8 +106,7 @@ namespace impactx
          * @param[in,out] refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void operator() (
-                RefPart & AMREX_RESTRICT refpart) const {
+        void operator() (RefPart & AMREX_RESTRICT refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 

--- a/src/particles/elements/ShortRF.H
+++ b/src/particles/elements/ShortRF.H
@@ -50,7 +50,7 @@ namespace impactx
                 amrex::ParticleReal & AMREX_RESTRICT px,
                 amrex::ParticleReal & AMREX_RESTRICT py,
                 amrex::ParticleReal & AMREX_RESTRICT pt,
-                RefPart const refpart) const {
+                RefPart const & refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
 
@@ -90,8 +90,7 @@ namespace impactx
          * @param[in,out] refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void operator() (
-                [[maybe_unused]] RefPart & AMREX_RESTRICT refpart) const {
+        void operator() ([[maybe_unused]] RefPart & AMREX_RESTRICT refpart) const {
 
             // nothing to do: this is a zero-length element
 


### PR DESCRIPTION
Pass the reference particle (88 bytes in DP) as reference to a constant instead of a by-value constant to avoid an unnecessary copy.