### PR TITLE
Element Push: Restructure

### DIFF
--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -183,7 +183,7 @@ namespace impactx
                 // assuming that the distribution did not change
 
                 // push all particles with external maps
-                Push(*m_particle_container, element_variant);
+                Push(*m_particle_container, element_variant, global_step);
 
                 // just prints an empty newline at the end of the slice_step
                 amrex::Print() << "\n";

--- a/src/particles/Push.H
+++ b/src/particles/Push.H
@@ -20,11 +20,13 @@ namespace impactx
 {
     /** Push particles
      *
-     * @param pc container of the particles to push
-     * @param element_variant a single element to push the particles through
+     * @param[inout] pc container of the particles to push
+     * @param[inout] element_variant a single element to push the particles through
+     * @param[in] step global step for diagnostics
      */
     void Push (ImpactXParticleContainer & pc,
-               KnownElements const & element_variant);
+               KnownElements & element_variant,
+               int step);
 
 } // namespace impactx
 

--- a/src/particles/PushAll.H
+++ b/src/particles/PushAll.H
@@ -1,0 +1,59 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_PUSH_ALL_H
+#define IMPACTX_PUSH_ALL_H
+
+#include "particles/ImpactXParticleContainer.H"
+
+
+namespace impactx
+{
+    /** Push all particles in a particle container.
+     *
+     * This element pushes first the reference particle, then all other particles.
+     * All particles are pushed independently with the same logic.
+     * Particles are relative to the reference particle.
+     *
+     * @param[in,out] pc particle container to push
+     * @param[in,out] element the beamline element
+     * @param[in] step global step for diagnostics
+     */
+    template<typename T_Element>
+    void push_all (
+            ImpactXParticleContainer & pc,
+            T_Element & element,
+            [[maybe_unused]] int step
+    )
+    {
+        // preparing to access reference particle data: RefPart
+        RefPart & ref_part = pc.GetRefParticle();
+
+        // loop over refinement levels
+        int const nLevel = pc.finestLevel();
+        for (int lev = 0; lev <= nLevel; ++lev)
+        {
+            // loop over all particle boxes
+            using ParIt = ImpactXParticleContainer::iterator;
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            for (ParIt pti(pc, lev); pti.isValid(); ++pti) {
+                // push reference particle in global coordinates
+                element(ref_part);
+
+                // push beam particles relative to reference particle
+                element(pti, ref_part);
+            } // end loop over all particle boxes
+        } // env mesh-refinement level loop
+    }
+
+} // namespace impactx
+
+#endif // IMPACTX_PUSH_ALL_H

--- a/src/particles/elements/None.H
+++ b/src/particles/elements/None.H
@@ -33,6 +33,14 @@ namespace impactx
 
         /** Push all particles - nothing to do here */
         void operator() (
+                ImpactXParticleContainer & /* pc */,
+                int /* step */
+        ) {
+            // nothing to do
+        }
+
+        /** Push all particles - nothing to do here */
+        void operator() (
             ImpactXParticleContainer::iterator & /* pti */,
             RefPart & AMREX_RESTRICT /* ref_part */
         ) {

--- a/src/particles/elements/Programmable.H
+++ b/src/particles/elements/Programmable.H
@@ -26,9 +26,21 @@ namespace impactx
         static constexpr auto name = "Programmable";
         using PType = ImpactXParticleContainer::ParticleType;
 
-        /** This element writes the particle beam out to openPMD data.
+        /** This element can be programmed
          */
-        Programmable () {}
+        Programmable (amrex::ParticleReal ds=0.0, int nslice=1)
+            : m_ds(ds), m_nslice(nslice)
+        {}
+
+        /** Push all particles relative to the reference particle
+         *
+         * @param[in,out] pc particle container to push
+         * @param[in] step global step for diagnostics
+         */
+        void operator() (
+            ImpactXParticleContainer & pc,
+            int step
+        ) const;
 
         /** Push all particles relative to the reference particle */
         void operator() (
@@ -68,6 +80,7 @@ namespace impactx
         amrex::ParticleReal m_ds = 0.0; //! segment length in m
         int m_nslice = 1; //! number of slices used for the application of space charge
 
+        std::function<void(ImpactXParticleContainer *, int)> m_push; //! hook for push of whole container
         std::function<void(ImpactXParticleContainer::iterator *, RefPart &)> m_beam_particles; //! hook for beam particles
         std::function<void(RefPart &)> m_ref_particle; //! hook for reference particle
     };

--- a/src/particles/elements/Programmable.cpp
+++ b/src/particles/elements/Programmable.cpp
@@ -9,10 +9,25 @@
  */
 
 #include "Programmable.H"
+#include "particles/PushAll.H"
 
 
 namespace impactx
 {
+    void
+    Programmable::operator() (
+        ImpactXParticleContainer & pc,
+        int step
+    ) const
+    {
+        if (m_push == nullptr) {
+            push_all(pc, *this, step);
+        }
+        else {
+            m_push(&pc, step);
+        }
+    }
+
     void
     Programmable::operator() (
         ImpactXParticleContainer::iterator & pti,
@@ -20,6 +35,7 @@ namespace impactx
     ) const
     {
         if (m_beam_particles == nullptr)
+            // TODO: only if verbose mode is set
             amrex::AllPrint() << "Programmable element - all particles: NO HOOK\n";
         else
             m_beam_particles(&pti, ref_part);
@@ -29,6 +45,7 @@ namespace impactx
     Programmable::operator() (RefPart & ref_part) const
     {
         if (m_ref_particle == nullptr)
+            // TODO: only if verbose mode is set
             amrex::AllPrint() << "Programmable element - ref particles: NO HOOK\n";
         else
             m_ref_particle(ref_part);

--- a/src/particles/elements/mixin/beamoptic.H
+++ b/src/particles/elements/mixin/beamoptic.H
@@ -11,9 +11,12 @@
 #define IMPACTX_ELEMENTS_MIXIN_BEAMOPTIC_H
 
 #include "particles/ImpactXParticleContainer.H"
+#include "particles/PushAll.H"
 
-#include <AMReX_Extension.H>
+#include <AMReX_Extension.H> // for AMREX_RESTRICT
 #include <AMReX_REAL.H>
+
+#include <type_traits>
 
 
 namespace impactx::elements
@@ -130,6 +133,21 @@ namespace detail
     template<typename T_Element>
     struct BeamOptic
     {
+        /** Push first the reference particle, then all other particles */
+        void operator() (
+            ImpactXParticleContainer & pc,
+            int step
+        )
+        {
+            static_assert(
+                std::is_base_of_v<BeamOptic, T_Element>,
+                "BeamOptic can only be used as a mixin class!"
+            );
+
+            T_Element& element = *static_cast<T_Element*>(this);
+            push_all(pc, element, step);
+        }
+
         /** This pushes the particles on a particle iterator tile or box.
          *
          * Particles are relative to the reference particle.
@@ -140,7 +158,13 @@ namespace detail
          void operator() (
             ImpactXParticleContainer::iterator & pti,
             RefPart & AMREX_RESTRICT ref_part
-         ) {
+         )
+         {
+            static_assert(
+                std::is_base_of_v<BeamOptic, T_Element>,
+                "BeamOptic can only be used as a mixin class!"
+            );
+
             T_Element& element = *static_cast<T_Element*>(this);
             detail::push_all_particles<T_Element>(pti, ref_part, element);
          }

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -88,7 +88,7 @@ void init_elements(py::module& m)
         .def_property_readonly("ds", &elements::Thin::ds)
     ;
 
-    // beam optics below
+    // beam optics
 
     py::class_<ConstF, elements::Thick>(me, "ConstF")
         .def(py::init<
@@ -148,7 +148,10 @@ void init_elements(py::module& m)
     ;
 
     py::class_<Programmable>(me, "Programmable")
-        .def(py::init<>(),
+        .def(py::init<
+                 amrex::ParticleReal,
+                 int>(),
+             py::arg("ds") = 0.0, py::arg("nslice") = 1,
              "A programmable beam optics element."
         )
         .def_property("nslice",
@@ -159,17 +162,26 @@ void init_elements(py::module& m)
               [](Programmable & p) { return p.ds(); },
               [](Programmable & p, amrex::ParticleReal ds) { p.m_ds = ds; }
         )
+        .def_property("push",
+              [](Programmable & p) { return p.m_push; },
+              [](Programmable & p,
+                 std::function<void(ImpactXParticleContainer *, int)> new_hook
+              ) { p.m_push = new_hook; },
+              "hook for push of whole container (pc, step)"
+        )
         .def_property("beam_particles",
               [](Programmable & p) { return p.m_beam_particles; },
               [](Programmable & p,
                  std::function<void(ImpactXParticleContainer::iterator *, RefPart &)> new_hook
-              ) { p.m_beam_particles = new_hook; }
+              ) { p.m_beam_particles = new_hook; },
+              "hook for beam particles (pti, RefPart)"
         )
         .def_property("ref_particle",
               [](Programmable & p) { return p.m_ref_particle; },
               [](Programmable & p,
                  std::function<void(RefPart &)> new_hook
-              ) { p.m_ref_particle = new_hook; }
+              ) { p.m_ref_particle = new_hook; },
+              "hook for reference particle (RefPart)"
         )
     ;
 


### PR DESCRIPTION
## Element Push: Restructure

Add an overarching particle container push operator to each element. This one by default pushes the reference particle and then the particle beam, as before.

## Purpose

This is a preparation for diagnostics in #299 and ML elements, which will operate on the whole particle container. It's also a preparation to simplify the bug fixes introduced for elements with dynamically allocated state from #320.