### PR TITLE
CI: Clean Up & HDF5

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: install dependencies
       run: |
-        .github/workflows/dependencies/nvcc11.sh
+        .github/workflows/dependencies/nvcc11-openmpi.sh
 
     - name: CCache Cache
       uses: actions/cache@v3

--- a/.github/workflows/dependencies/clang-san-openmpi.sh
+++ b/.github/workflows/dependencies/clang-san-openmpi.sh
@@ -13,9 +13,10 @@ sudo apt-get install -y \
     ca-certificates     \
     ccache              \
     clang               \
-    clang-tidy          \
     cmake               \
     gnupg               \
+    libc++-dev          \
+    libc++abi-dev       \
     libhdf5-openmpi-dev \
     libomp-dev          \
     libopenmpi-dev      \

--- a/.github/workflows/dependencies/gcc-openmpi.sh
+++ b/.github/workflows/dependencies/gcc-openmpi.sh
@@ -12,12 +12,9 @@ sudo apt-get install -y \
     build-essential     \
     ca-certificates     \
     ccache              \
-    clang               \
     cmake               \
     gnupg               \
-    libc++-dev          \
-    libc++abi-dev       \
-    libomp-dev          \
+    libhdf5-openmpi-dev \
     libopenmpi-dev      \
     ninja-build         \
     pkg-config          \

--- a/.github/workflows/dependencies/gcc.sh
+++ b/.github/workflows/dependencies/gcc.sh
@@ -14,7 +14,7 @@ sudo apt-get install -y \
     ccache              \
     cmake               \
     gnupg               \
-    libopenmpi-dev      \
+    libhdf5-dev         \
     ninja-build         \
     pkg-config          \
     python3             \
@@ -23,5 +23,4 @@ sudo apt-get install -y \
 
 python3 -m pip install -U pip setuptools wheel
 python3 -m pip install -U cmake pytest
-python3 -m pip install -r requirements_mpi.txt
 python3 -m pip install -r examples/requirements.txt

--- a/.github/workflows/dependencies/hip-openmpi.sh
+++ b/.github/workflows/dependencies/hip-openmpi.sh
@@ -26,6 +26,7 @@ sudo apt-get update
 sudo apt-get install -y --no-install-recommends \
     build-essential \
     gfortran        \
+    libhdf5-openmpi-dev \
     libhiredis-dev  \
     libnuma-dev     \
     libopenmpi-dev  \

--- a/.github/workflows/dependencies/nvcc11-openmpi.sh
+++ b/.github/workflows/dependencies/nvcc11-openmpi.sh
@@ -13,6 +13,7 @@ sudo apt-get install -y \
     ca-certificates     \
     cmake               \
     gnupg               \
+    libhdf5-openmpi-dev \
     libhiredis-dev      \
     libopenmpi-dev      \
     libzstd-dev         \

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: install dependencies
       shell: bash
-      run: .github/workflows/dependencies/hip.sh
+      run: .github/workflows/dependencies/hip-openmpi.sh
 
     - name: CCache Cache
       uses: actions/cache@v3

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: install dependencies
       run: |
-        .github/workflows/dependencies/clang-san.sh
+        .github/workflows/dependencies/clang-san-openmpi.sh
 
     - name: CCache Cache
       uses: actions/cache@v3

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: install dependencies
       run: |
-        .github/workflows/dependencies/gcc.sh
+        .github/workflows/dependencies/gcc-openmpi.sh
 
     - name: CCache Cache
       uses: actions/cache@v3
@@ -39,6 +39,7 @@ jobs:
       run: |
         cmake -S . -B build            \
           -DCMAKE_BUILD_TYPE=Debug     \
+          -DBUILD_SHARED_LIBS=ON       \
           -DCMAKE_INSTALL_PREFIX=/usr  \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DImpactX_PYTHON=ON
@@ -96,6 +97,7 @@ jobs:
     - name: build ImpactX
       run: |
         cmake -S . -B build            \
+          -DBUILD_SHARED_LIBS=ON       \
           -DCMAKE_BUILD_TYPE=Debug     \
           -DCMAKE_INSTALL_PREFIX=/usr  \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,12 +29,22 @@ jobs:
         restore-keys: |
           ccache-windows-winmsvc-${{ hashFiles('.github/workflows/windows.yml') }}-
           ccache-windows-winmsvc-
+    - name: install dependencies
+      run: |
+        Invoke-WebRequest https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_12_2.tar.gz -OutFile hdf5-1_12_2.tar.gz
+        7z.exe x -r hdf5-1_12_2.tar.gz
+        7z.exe x -r hdf5-1_12_2.tar
+        cmake -S hdf5-hdf5-1_12_2 -B build_hdf5 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF -DHDF5_BUILD_EXAMPLES=OFF
+        if(!$?) { Exit $LASTEXITCODE }
+        cmake --build build_hdf5 --config RelWithDebInfo --target install --parallel 2
+        if(!$?) { Exit $LASTEXITCODE }
     - name: Build
       run: |
         python3 -m pip install -U pip setuptools wheel pytest
         python3 -m pip install -r requirements.txt
         python3 -m pip install -r examples/requirements.txt
 
+        $env:HDF5_DIR = "C:/Program Files (x86)/hdf5/"
         cmake -S . -B build               `
               -DBUILD_SHARED_LIBS=ON      `
               -DCMAKE_BUILD_TYPE=RelWithDebInfo  `
@@ -80,6 +90,15 @@ jobs:
           ccache-windows-winclang-${{ hashFiles('.github/workflows/windows.yml') }}-
           ccache-windows-winclang-
     - uses: seanmiddleditch/gha-setup-ninja@master
+    - name: install dependencies
+      run: |
+        Invoke-WebRequest https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_12_2.tar.gz -OutFile hdf5-1_12_2.tar.gz
+        7z.exe x -r hdf5-1_12_2.tar.gz
+        7z.exe x -r hdf5-1_12_2.tar
+        cmake -S hdf5-hdf5-1_12_2 -B build_hdf5 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF -DHDF5_BUILD_EXAMPLES=OFF
+        if(!$?) { Exit $LASTEXITCODE }
+        cmake --build build_hdf5 --config RelWithDebInfo --target install --parallel 2
+        if(!$?) { Exit $LASTEXITCODE }
     - name: Build
       shell: cmd
       run: |
@@ -88,6 +107,8 @@ jobs:
         python3 -m pip install -r examples/requirements.txt
 
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+
+        set "HDF5_DIR=C:/Program Files (x86)/hdf5/"
         cmake -S . -B build   ^
               -G "Ninja"      ^
               -DCMAKE_C_COMPILER=clang-cl   ^


### PR DESCRIPTION
Clean up script names for dependencies.

Add a few shared library builds, to ensure that dependent libraries that we build on the fly are also properly installed.

Add HDF5 as preparation for #299.