### PR TITLE
Programmable Element: Thread Safety

### DIFF
--- a/examples/fodo/run_fodo_programmable.py
+++ b/examples/fodo/run_fodo_programmable.py
@@ -139,6 +139,7 @@ pge1.nslice = ns
 pge1.beam_particles = lambda pti, refpart: my_drift(pge1, pti, refpart)
 pge1.ref_particle = lambda refpart: my_ref_drift(pge1, refpart)
 pge1.ds = 0.25
+pge1.threadsafe = True  # allow OpenMP threading for speed
 
 # attention: assignment is a reference for pge2 = pge1
 
@@ -147,6 +148,7 @@ pge2.nslice = ns
 pge2.beam_particles = lambda pti, refpart: my_drift(pge2, pti, refpart)
 pge2.ref_particle = lambda refpart: my_ref_drift(pge2, refpart)
 pge2.ds = 0.5
+pge2.threadsafe = True  # allow OpenMP threading for speed
 
 # design the accelerator lattice
 fodo = [

--- a/src/particles/PushAll.H
+++ b/src/particles/PushAll.H
@@ -24,12 +24,14 @@ namespace impactx
      * @param[in,out] pc particle container to push
      * @param[in,out] element the beamline element
      * @param[in] step global step for diagnostics
+     * @param[in] omp_parallel allow threading via OpenMP for the particle iterator loop (note: if OMP backend is active)
      */
     template<typename T_Element>
     void push_all (
             ImpactXParticleContainer & pc,
             T_Element & element,
-            [[maybe_unused]] int step
+            [[maybe_unused]] int step,
+            [[maybe_unused]] bool omp_parallel = true
     )
     {
         // preparing to access reference particle data: RefPart
@@ -45,7 +47,7 @@ namespace impactx
             // loop over all particle boxes
             using ParIt = ImpactXParticleContainer::iterator;
 #ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion() && omp_parallel)
 #endif
             for (ParIt pti(pc, lev); pti.isValid(); ++pti) {
                 // push beam particles relative to reference particle

--- a/src/particles/elements/Programmable.H
+++ b/src/particles/elements/Programmable.H
@@ -80,6 +80,15 @@ namespace impactx
         amrex::ParticleReal m_ds = 0.0; //! segment length in m
         int m_nslice = 1; //! number of slices used for the application of space charge
 
+        /** Allow threading via OpenMP for the particle iterator loop
+         *
+         * This will only affect threading if the OMP backend is active.
+         *
+         * The default value is false to do the safe thing by default. Users
+         * must opt-in their guarantee that their code is thread-safe.
+         */
+        bool m_threadsafe = false;
+
         std::function<void(ImpactXParticleContainer *, int)> m_push; //! hook for push of whole container
         std::function<void(ImpactXParticleContainer::iterator *, RefPart &)> m_beam_particles; //! hook for beam particles
         std::function<void(RefPart &)> m_ref_particle; //! hook for reference particle

--- a/src/particles/elements/Programmable.cpp
+++ b/src/particles/elements/Programmable.cpp
@@ -21,7 +21,7 @@ namespace impactx
     ) const
     {
         if (m_push == nullptr) {
-            push_all(pc, *this, step);
+            push_all(pc, *this, step, m_threadsafe);
         }
         else {
             m_push(&pc, step);

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -162,6 +162,11 @@ void init_elements(py::module& m)
               [](Programmable & p) { return p.ds(); },
               [](Programmable & p, amrex::ParticleReal ds) { p.m_ds = ds; }
         )
+        .def_property("threadsafe",
+            [](Programmable & p) { return p.m_threadsafe; },
+            [](Programmable & p, bool threadsafe) { p.m_threadsafe = threadsafe; },
+            "allow threading via OpenMP for the particle iterator loop, default=False (note: if OMP backend is active)"
+        )
         .def_property("push",
               [](Programmable & p) { return p.m_push; },
               [](Programmable & p,


### PR DESCRIPTION
Expose an option to opt-in into thread safety for the programmable element. This controls if the particle iterator loop is performed in serial, even when the OpenMP backend is used.

Thread-safety is easy to achive for regular beamline elements that are implemented via maps or intergrators.

Thread-safety is not easily guaranteed for interaction with external libraries, e.g., I/O or ML packages.