### PR TITLE
CI: CUDA Test on Ubuntu 20.04

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -13,7 +13,7 @@ jobs:
 #   https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/
   build_nvcc:
     name: NVCC 11.0.2 SP
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event.pull_request.draft == false
     env:
       CXXFLAGS: "-Werror"

--- a/.github/workflows/dependencies/nvcc11-openmpi.sh
+++ b/.github/workflows/dependencies/nvcc11-openmpi.sh
@@ -22,8 +22,8 @@ sudo apt-get install -y \
     pkg-config          \
     wget
 
-sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
-echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" \
+sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /" \
     | sudo tee /etc/apt/sources.list.d/cuda.list
 
 sudo apt-get update


### PR DESCRIPTION
Transition the Ubuntu OS from 18 to 20 LTS for the CUDA compile tests.