### PR TITLE
Beam Monitor: Output Name

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -354,8 +354,13 @@ Lattice Elements
 
                 = c parameter * sqrt(Twiss beta)
 
-        * ``BeamMonitor`` a beam monitor, writing all beam particles at fixed ``s`` to openPMD files.
+        * ``beam_monitor`` a beam monitor, writing all beam particles at fixed ``s`` to openPMD files.
           If the same element name is used multiple times, then an output series is created with multiple outputs.
+
+            * ``<element_name>.name`` (``string``, default value: ``<element_name>``)
+
+                The output series name to use.
+                By default, output is created under ``diags/openPMD/<element_name>.<backend>``.
 
             * ``<element_name>.backend`` (``string``, default value: ``default``)
 

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -180,11 +180,13 @@ namespace detail
                 detail::queryAddResize(pp_element, "sin_coefficients", sin_coef);
                 m_lattice.emplace_back( SoftQuadrupole(ds, gscale, cos_coef, sin_coef, mapsteps, nslice) );
             } else if (element_type == "beam_monitor") {
+                std::string openpmd_name = element_name;
+                pp_element.queryAdd("name", openpmd_name);
                 std::string openpmd_backend = "default";
                 pp_element.queryAdd("backend", openpmd_backend);
                 std::string  openpmd_encoding {"g"};
                 pp_element.queryAdd("encoding", openpmd_encoding);
-                m_lattice.emplace_back( diagnostics::BeamMonitor(element_name, openpmd_backend, openpmd_encoding) );
+                m_lattice.emplace_back( diagnostics::BeamMonitor(openpmd_name, openpmd_backend, openpmd_encoding) );
             } else {
                 amrex::Abort("Unknown type for lattice element " + element_name + ": " + element_type);
             }


### PR DESCRIPTION
Allow to change the output name from the default `<element_name>` in inputs files, similar to the option exposed in Python.

Follow-up to #299