### PR TITLE
New Element: Line

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -196,8 +196,10 @@ Lattice Elements
 ----------------
 
 * ``lattice.elements`` (``list of strings``) optional (default: no elements)
-    A list of names (one name per lattice element), in the order that they
-    appear in the lattice.
+    A list of names (one name per lattice element), in the order that they appear in the lattice.
+
+* ``lattice.reverse`` (``boolean``) optional (default: ``false``)
+    Reverse the list of elements in the lattice.
 
 * ``lattice.nslice`` (``integer``) optional (default: ``1``)
     A positive integer specifying the number of slices used for the application of
@@ -379,6 +381,14 @@ Lattice Elements
 
                 openPMD `iteration encoding <https://openpmd-api.readthedocs.io/en/0.14.0/usage/concepts.html#iteration-and-series>`__: (v)ariable based, (f)ile based, (g)roup based (default)
                 variable based is an `experimental feature with ADIOS2 <https://openpmd-api.readthedocs.io/en/0.14.0/backends/adios2.html#experimental-new-adios2-schema>`__.
+
+        * ``line`` a sub-lattice (line) of elements to append to the lattice.
+
+            * ``<element_name>.elements`` (``list of strings``) optional (default: no elements)
+              A list of names (one name per lattice element), in the order that they appear in the lattice.
+
+            * ``<element_name>.reverse`` (``boolean``) optional (default: ``false``)
+              Reverse the list of elements in the line before appending to the lattice.
 
 
 .. _running-cpp-parameters-parallelization:

--- a/examples/iota_lattice/input_iotalattice.in
+++ b/examples/iota_lattice/input_iotalattice.in
@@ -22,20 +22,30 @@ beam.mutpt = 0.0
 # Beamline: lattice elements and segments
 ###############################################################################
 lattice.elements = monitor
-                   dra1 qa1 dra2 qa2 dra3 qa3 dra4 qa4 dra5
-                   edge30 sbend30 edge30 drb1 qb1 drb2 qb2 drb2 qb3
-                   drb3 dnll drb3 qb4 drb2 qb5 drb2 qb6 drb4
-                   edge60 sbend60 edge60 drc1 qc1 drc2 qc2 drc2 qc3 drc1
-                   edge60 sbend60 edge60 drd1 qd1 drd2 qd2 drd3 qd3 drd2 qd4 drd4
-                   edge30 sbend30 edge30 dre1 qe1 dre2 qe2 dre3 qe3
-                   dre3 qe2 dre2 qe1 dre1 edge30 sbend30 edge30
-                   drd4 qd4 drd2 qd3 drd3 qd2 drd2 qd1 drd1 edge60 sbend60 edge60
-                   drc1 qc3 drc2 qc2 drc2 qc1 drc1 edge60 sbend60 edge60
-                   drb4 qb6 drb2 qb5 drb2 qb4 drb3 dnll drb3
-                   qb3 drb2 qb2 drb2 qb1 drb1 edge30 sbend30 edge30
-                   dra5 qa4 dra4 qa3 dra3 qa2 dra2 qa1 dra1
+                   first_half
+                   qe3
+                   second_half
                    monitor
 
+# lines
+first_half.type = line
+first_half.elements = dra1 qa1 dra2 qa2 dra3 qa3 dra4 qa4 dra5
+                      edge30 sbend30 edge30 drb1 qb1 drb2 qb2 drb2 qb3
+                      drb3 dnll drb3 qb4 drb2 qb5 drb2 qb6 drb4
+                      edge60 sbend60 edge60 drc1 qc1 drc2 qc2 drc2 qc3 drc1
+                      edge60 sbend60 edge60 drd1 qd1 drd2 qd2 drd3 qd3 drd2 qd4 drd4
+                      edge30 sbend30 edge30 dre1 qe1 dre2 qe2 dre3
+
+second_half.type = line
+second_half.reverse = true
+second_half.elements = dra1 qa1 dra2 qa2 dra3 qa3 dra4 qa4 dra5
+                       edge30 sbend30 edge30 drb1 qb1 drb2 qb2 drb2 qb3
+                       drb3 dnll drb3 qb4 drb2 qb5 drb2 qb6 drb4
+                       edge60 sbend60 edge60 drc1 qc1 drc2 qc2 drc2 qc3 drc1
+                       edge60 sbend60 edge60 drd1 qd1 drd2 qd2 drd3 qd3 drd2 qd4 drd4
+                       edge30 sbend30 edge30 dre1 qe1 dre2 qe2 dre3
+
+# thick element splitting for space charge
 lattice.nslice = 10
 
 

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -16,6 +16,7 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_Print.H>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -48,6 +49,162 @@ namespace detail
     }
 } // namespace detail
 
+    /** Read a lattice element
+     *
+     * Read a lattice element from amrex::ParmParse, initialize it and append it to m_lattice.
+     *
+     * @param[in] element_name element name
+     * @param[inout] m_lattice the accelerator lattice
+     * @param[in] nslice_default
+     * @param[in] mapsteps_default
+     */
+    void read_element (std::string element_name,
+                       std::list<KnownElements> & m_lattice,
+                       int nslice_default,
+                       int mapsteps_default)
+    {
+        // Check the element type
+        amrex::ParmParse pp_element(element_name);
+        std::string element_type;
+        pp_element.get("type", element_type);
+
+        // Initialize the corresponding element according to its type
+        if (element_type == "quad") {
+            amrex::Real ds, k;
+            int nslice = nslice_default;
+            pp_element.get("ds", ds);
+            pp_element.get("k", k);
+            pp_element.queryAdd("nslice", nslice);
+            m_lattice.emplace_back( Quad(ds, k, nslice) );
+        } else if (element_type == "drift") {
+            amrex::Real ds;
+            int nslice = nslice_default;
+            pp_element.get("ds", ds);
+            pp_element.queryAdd("nslice", nslice);
+            m_lattice.emplace_back( Drift(ds, nslice) );
+        } else if (element_type == "sbend") {
+            amrex::Real ds, rc;
+            int nslice = nslice_default;
+            pp_element.get("ds", ds);
+            pp_element.get("rc", rc);
+            pp_element.queryAdd("nslice", nslice);
+            m_lattice.emplace_back( Sbend(ds, rc, nslice) );
+        } else if (element_type == "dipedge") {
+            amrex::Real psi, rc, g, K2;
+            pp_element.get("psi", psi);
+            pp_element.get("rc", rc);
+            pp_element.get("g", g);
+            pp_element.get("K2", K2);
+            m_lattice.emplace_back( DipEdge(psi, rc, g, K2) );
+        } else if (element_type == "constf") {
+            amrex::Real ds, kx, ky, kt;
+            int nslice = nslice_default;
+            pp_element.get("ds", ds);
+            pp_element.get("kx", kx);
+            pp_element.get("ky", ky);
+            pp_element.get("kt", kt);
+            pp_element.queryAdd("nslice", nslice);
+            m_lattice.emplace_back( ConstF(ds, kx, ky, kt, nslice) );
+        } else if (element_type == "shortrf") {
+            amrex::Real V, k;
+            pp_element.get("V", V);
+            pp_element.get("k", k);
+            m_lattice.emplace_back( ShortRF(V, k) );
+        } else if (element_type == "multipole") {
+            int m;
+            amrex::Real k_normal, k_skew;
+            pp_element.get("multipole", m);
+            pp_element.get("k_normal", k_normal);
+            pp_element.get("k_skew", k_skew);
+            m_lattice.emplace_back( Multipole(m, k_normal, k_skew) );
+        } else if (element_type == "nonlinear_lens") {
+            amrex::Real knll, cnll;
+            pp_element.get("knll", knll);
+            pp_element.get("cnll", cnll);
+            m_lattice.emplace_back( NonlinearLens(knll, cnll) );
+        } else if (element_type == "rfcavity") {
+            amrex::Real ds, escale, freq, phase;
+            int nslice = nslice_default;
+            int mapsteps = mapsteps_default;
+            RF_field_data ez;
+            std::vector<amrex::ParticleReal> cos_coef = ez.default_cos_coef;
+            std::vector<amrex::ParticleReal> sin_coef = ez.default_sin_coef;
+            pp_element.get("ds", ds);
+            pp_element.get("escale", escale);
+            pp_element.get("freq", freq);
+            pp_element.get("phase", phase);
+            pp_element.queryAdd("mapsteps", mapsteps);
+            pp_element.queryAdd("nslice", nslice);
+            detail::queryAddResize(pp_element, "cos_coefficients", cos_coef);
+            detail::queryAddResize(pp_element, "sin_coefficients", sin_coef);
+            m_lattice.emplace_back( RFCavity(ds, escale, freq, phase, cos_coef, sin_coef, mapsteps, nslice) );
+        } else if (element_type == "solenoid") {
+            amrex::Real ds, ks;
+            int nslice = nslice_default;
+            pp_element.get("ds", ds);
+            pp_element.get("ks", ks);
+            pp_element.queryAdd("nslice", nslice);
+            m_lattice.emplace_back( Sol(ds, ks, nslice) );
+        } else if (element_type == "prot") {
+            amrex::ParticleReal phi_in, phi_out;
+            pp_element.get("phi_in", phi_in);
+            pp_element.get("phi_out", phi_out);
+            m_lattice.emplace_back( PRot(phi_in, phi_out) );
+        } else if (element_type == "solenoid_softedge") {
+            amrex::Real ds, bscale;
+            int nslice = nslice_default;
+            int mapsteps = mapsteps_default;
+            Sol_field_data bz;
+            std::vector<amrex::ParticleReal> cos_coef = bz.default_cos_coef;
+            std::vector<amrex::ParticleReal> sin_coef = bz.default_sin_coef;
+            pp_element.get("ds", ds);
+            pp_element.get("bscale", bscale);
+            pp_element.queryAdd("mapsteps", mapsteps);
+            pp_element.queryAdd("nslice", nslice);
+            detail::queryAddResize(pp_element, "cos_coefficients", cos_coef);
+            detail::queryAddResize(pp_element, "sin_coefficients", sin_coef);
+            m_lattice.emplace_back( SoftSolenoid(ds, bscale, cos_coef, sin_coef, mapsteps, nslice) );
+        } else if (element_type == "quadrupole_softedge") {
+            amrex::Real ds, gscale;
+            int nslice = nslice_default;
+            int mapsteps = mapsteps_default;
+            Quad_field_data gz;
+            std::vector<amrex::ParticleReal> cos_coef = gz.default_cos_coef;
+            std::vector<amrex::ParticleReal> sin_coef = gz.default_sin_coef;
+            pp_element.get("ds", ds);
+            pp_element.get("gscale", gscale);
+            pp_element.queryAdd("mapsteps", mapsteps);
+            pp_element.queryAdd("nslice", nslice);
+            detail::queryAddResize(pp_element, "cos_coefficients", cos_coef);
+            detail::queryAddResize(pp_element, "sin_coefficients", sin_coef);
+            m_lattice.emplace_back( SoftQuadrupole(ds, gscale, cos_coef, sin_coef, mapsteps, nslice) );
+        } else if (element_type == "beam_monitor") {
+            std::string openpmd_name = element_name;
+            pp_element.queryAdd("name", openpmd_name);
+            std::string openpmd_backend = "default";
+            pp_element.queryAdd("backend", openpmd_backend);
+            std::string openpmd_encoding{"g"};
+            pp_element.queryAdd("encoding", openpmd_encoding);
+            m_lattice.emplace_back(diagnostics::BeamMonitor(openpmd_name, openpmd_backend, openpmd_encoding));
+        } else if (element_type == "line") {
+            // Parse the lattice elements
+            amrex::ParmParse pp_sub_lattice(element_name);
+            std::vector<std::string> sub_lattice_elements;
+            pp_sub_lattice.queryarr("elements", sub_lattice_elements);
+            bool reverse = false;
+            pp_sub_lattice.queryAdd("reverse", reverse);
+
+            if (reverse)
+                std::reverse(sub_lattice_elements.begin(), sub_lattice_elements.end());
+
+            for (std::string const & sub_element_name : sub_lattice_elements) {
+                read_element(sub_element_name, m_lattice, nslice_default, mapsteps_default);
+            }
+        } else {
+            amrex::Abort("Unknown type for lattice element " + element_name + ": " + element_type);
+        }
+    }
+
     void ImpactX::initLatticeElementsFromInputs ()
     {
         BL_PROFILE("ImpactX::initLatticeElementsFromInputs");
@@ -60,6 +217,12 @@ namespace detail
         std::vector<std::string> lattice_elements;
         pp_lattice.queryarr("elements", lattice_elements);
 
+        // reverse the lattice order
+        bool reverse = false;
+        pp_lattice.queryAdd("reverse", reverse);
+        if (reverse)
+            std::reverse(lattice_elements.begin(), lattice_elements.end());
+
         // Default number of slices per element
         int nslice_default = 1;
         pp_lattice.query("nslice", nslice_default);
@@ -69,132 +232,7 @@ namespace detail
 
         // Loop through lattice elements
         for (std::string const & element_name : lattice_elements) {
-            // Check the element type
-            amrex::ParmParse pp_element(element_name);
-            std::string element_type;
-            pp_element.get("type", element_type);
-
-            // Initialize the corresponding element according to its type
-            if (element_type == "quad") {
-                amrex::Real ds, k;
-                int nslice = nslice_default;
-                pp_element.get("ds", ds);
-                pp_element.get("k", k);
-                pp_element.queryAdd("nslice", nslice);
-                m_lattice.emplace_back( Quad(ds, k, nslice) );
-            } else if (element_type == "drift") {
-                amrex::Real ds;
-                int nslice = nslice_default;
-                pp_element.get("ds", ds);
-                pp_element.queryAdd("nslice", nslice);
-                m_lattice.emplace_back( Drift(ds, nslice) );
-            } else if (element_type == "sbend") {
-                amrex::Real ds, rc;
-                int nslice = nslice_default;
-                pp_element.get("ds", ds);
-                pp_element.get("rc", rc);
-                pp_element.queryAdd("nslice", nslice);
-                m_lattice.emplace_back( Sbend(ds, rc, nslice) );
-            } else if (element_type == "dipedge") {
-                amrex::Real psi, rc, g, K2;
-                pp_element.get("psi", psi);
-                pp_element.get("rc", rc);
-                pp_element.get("g", g);
-                pp_element.get("K2", K2);
-                m_lattice.emplace_back( DipEdge(psi, rc, g, K2) );
-            } else if (element_type == "constf") {
-                amrex::Real ds, kx, ky, kt;
-                int nslice = nslice_default;
-                pp_element.get("ds", ds);
-                pp_element.get("kx", kx);
-                pp_element.get("ky", ky);
-                pp_element.get("kt", kt);
-                pp_element.queryAdd("nslice", nslice);
-                m_lattice.emplace_back( ConstF(ds, kx, ky, kt, nslice) );
-            } else if (element_type == "shortrf") {
-                amrex::Real V, k;
-                pp_element.get("V", V);
-                pp_element.get("k", k);
-                m_lattice.emplace_back( ShortRF(V, k) );
-            } else if (element_type == "multipole") {
-                int m;
-                amrex::Real k_normal, k_skew;
-                pp_element.get("multipole", m);
-                pp_element.get("k_normal", k_normal);
-                pp_element.get("k_skew", k_skew);
-                m_lattice.emplace_back( Multipole(m, k_normal, k_skew) );
-            } else if (element_type == "nonlinear_lens") {
-                amrex::Real knll, cnll;
-                pp_element.get("knll", knll);
-                pp_element.get("cnll", cnll);
-                m_lattice.emplace_back( NonlinearLens(knll, cnll) );
-            } else if (element_type == "rfcavity") {
-                amrex::Real ds, escale, freq, phase;
-                int nslice = nslice_default;
-                int mapsteps = mapsteps_default;
-                RF_field_data ez;
-                std::vector<amrex::ParticleReal> cos_coef = ez.default_cos_coef;
-                std::vector<amrex::ParticleReal> sin_coef = ez.default_sin_coef;
-                pp_element.get("ds", ds);
-                pp_element.get("escale", escale);
-                pp_element.get("freq", freq);
-                pp_element.get("phase", phase);
-                pp_element.queryAdd("mapsteps", mapsteps);
-                pp_element.queryAdd("nslice", nslice);
-                detail::queryAddResize(pp_element, "cos_coefficients", cos_coef);
-                detail::queryAddResize(pp_element, "sin_coefficients", sin_coef);
-                m_lattice.emplace_back( RFCavity(ds, escale, freq, phase, cos_coef, sin_coef, mapsteps, nslice) );
-            } else if (element_type == "solenoid") {
-                amrex::Real ds, ks;
-                int nslice = nslice_default;
-                pp_element.get("ds", ds);
-                pp_element.get("ks", ks);
-                pp_element.queryAdd("nslice", nslice);
-                m_lattice.emplace_back( Sol(ds, ks, nslice) );
-            } else if (element_type == "prot") {
-                amrex::ParticleReal phi_in, phi_out;
-                pp_element.get("phi_in", phi_in);
-                pp_element.get("phi_out", phi_out);
-                m_lattice.emplace_back( PRot(phi_in, phi_out) );
-            } else if (element_type == "solenoid_softedge") {
-                amrex::Real ds, bscale;
-                int nslice = nslice_default;
-                int mapsteps = mapsteps_default;
-                Sol_field_data bz;
-                std::vector<amrex::ParticleReal> cos_coef = bz.default_cos_coef;
-                std::vector<amrex::ParticleReal> sin_coef = bz.default_sin_coef;
-                pp_element.get("ds", ds);
-                pp_element.get("bscale", bscale);
-                pp_element.queryAdd("mapsteps", mapsteps);
-                pp_element.queryAdd("nslice", nslice);
-                detail::queryAddResize(pp_element, "cos_coefficients", cos_coef);
-                detail::queryAddResize(pp_element, "sin_coefficients", sin_coef);
-                m_lattice.emplace_back( SoftSolenoid(ds, bscale, cos_coef, sin_coef, mapsteps, nslice) );
-            } else if (element_type == "quadrupole_softedge") {
-                amrex::Real ds, gscale;
-                int nslice = nslice_default;
-                int mapsteps = mapsteps_default;
-                Quad_field_data gz;
-                std::vector<amrex::ParticleReal> cos_coef = gz.default_cos_coef;
-                std::vector<amrex::ParticleReal> sin_coef = gz.default_sin_coef;
-                pp_element.get("ds", ds);
-                pp_element.get("gscale", gscale);
-                pp_element.queryAdd("mapsteps", mapsteps);
-                pp_element.queryAdd("nslice", nslice);
-                detail::queryAddResize(pp_element, "cos_coefficients", cos_coef);
-                detail::queryAddResize(pp_element, "sin_coefficients", sin_coef);
-                m_lattice.emplace_back( SoftQuadrupole(ds, gscale, cos_coef, sin_coef, mapsteps, nslice) );
-            } else if (element_type == "beam_monitor") {
-                std::string openpmd_name = element_name;
-                pp_element.queryAdd("name", openpmd_name);
-                std::string openpmd_backend = "default";
-                pp_element.queryAdd("backend", openpmd_backend);
-                std::string  openpmd_encoding {"g"};
-                pp_element.queryAdd("encoding", openpmd_encoding);
-                m_lattice.emplace_back( diagnostics::BeamMonitor(openpmd_name, openpmd_backend, openpmd_encoding) );
-            } else {
-                amrex::Abort("Unknown type for lattice element " + element_name + ": " + element_type);
-            }
+            read_element(element_name, m_lattice, nslice_default, mapsteps_default);
         }
 
         amrex::Print() << "Initialized element list" << std::endl;


### PR DESCRIPTION
Add a new `<element_name>.type = line` to the inputs elements options.

Did not add this to Python, since we already use standard Python lists to build lines.

In sync with WarpX:
- https://github.com/ECP-WarpX/WarpX/pull/3063
- https://github.com/ECP-WarpX/WarpX/pull/3815

Close #284