### PR TITLE
openPMD: Use Steps

### DIFF
--- a/src/particles/elements/diagnostics/openPMD.cpp
+++ b/src/particles/elements/diagnostics/openPMD.cpp
@@ -196,6 +196,7 @@ namespace detail
 #   if openPMD_HAVE_MPI==1
                 , amrex::ParallelDescriptor::Communicator()
 #   endif
+                , "adios2.engine.usesteps = true"
             );
             series.setIterationEncoding( series_encoding );
             m_series = series;


### PR DESCRIPTION
- [x] Default for variable based encoding.
- [x] Better default for memory overhead & reading of crashed sims in group based.
- [x] test if file-based works, too

Follow-up to #299