### PR TITLE
amrex.the_arena_is_managed=0

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -25,7 +25,13 @@ Overall simulation parameters
     When running on GPUs, memory that does not fit on the device will be automatically swapped to host memory when this option is set to ``0``.
     This will cause severe performance drops.
     Note that even with this set to ``1`` ImpactX will not catch all out-of-memory events yet when operating close to maximum device memory.
-    `Please also see the documentation in AMReX <https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters>`_.
+    `Please also see the documentation in AMReX <https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters>`__.
+
+* ``amrex.the_arena_is_managed``  (``0`` or ``1``; default is ``0`` for false)
+    When running on GPUs, device memory that is accessed from the host will automatically be transferred with managed memory.
+    This is useful for convenience during development, but has sometimes severe performance and memory footprint implications if relied on (and sometimes vendor bugs).
+    For all regular ImpactX operations, we therefore do explicit memory transfers without the need for managed memory and thus changed the AMReX default to false.
+    `Please also see the documentation in AMReX <https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters>`__.
 
 * ``amrex.abort_on_unused_inputs`` (``0`` or ``1``; default is ``0`` for false)
     When set to ``1``, this option causes the simulation to fail *after* its completion if there were unused parameters.
@@ -39,7 +45,7 @@ Overall simulation parameters
     Optional threshold to abort as soon as a warning is raised.
     If the threshold is set, warning messages with priority greater than or equal to the threshold trigger an immediate abort.
     It is mainly intended for debug purposes, and is best used with ``impactx.always_warn_immediately=1``.
-    For more information on the warning logger, see `this section <https://warpx.readthedocs.io/en/latest/developers/warning_logger.html>`_ of the WarpX documentation.
+    For more information on the warning logger, see `this section <https://warpx.readthedocs.io/en/latest/developers/warning_logger.html>`__ of the WarpX documentation.
 
 .. _running-cpp-parameters-box:
 

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -221,9 +221,9 @@ namespace impactx
         // loop over all beamline elements & finalize them
         for (auto & element_variant : m_lattice)
         {
-            auto bd = std::get_if<diagnostics::BeamMonitor>(&element_variant);
-            if (bd)
-                bd->finalize();
+            std::visit([](auto&& element){
+                element.finalize();
+            }, element_variant);
         }
 
     }

--- a/src/initialization/InitParser.cpp
+++ b/src/initialization/InitParser.cpp
@@ -20,8 +20,10 @@ namespace impactx::initialization
 
         // https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters
         bool abort_on_out_of_gpu_memory = true; // AMReX' default: false
-        pp_amrex.query("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
-        pp_amrex.add("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
+        pp_amrex.queryAdd("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
+
+        bool the_arena_is_managed = false; // AMReX' default: true
+        pp_amrex.queryAdd("the_arena_is_managed", the_arena_is_managed);
 
         // Here we override the default tiling option for particles, which is always
         // "false" in AMReX, to "false" if compiling for GPU execution and "true"

--- a/src/particles/PushAll.H
+++ b/src/particles/PushAll.H
@@ -12,6 +12,8 @@
 
 #include "particles/ImpactXParticleContainer.H"
 
+#include <AMReX_BLProfiler.H>
+
 
 namespace impactx
 {
@@ -38,7 +40,10 @@ namespace impactx
         RefPart & ref_part = pc.GetRefParticle();
 
         // push reference particle in global coordinates
-        element(ref_part);
+        {
+            BL_PROFILE("impactx::Push::RefPart");
+            element(ref_part);
+        }
 
         // loop over refinement levels
         int const nLevel = pc.finestLevel();

--- a/src/particles/elements/ConstF.H
+++ b/src/particles/elements/ConstF.H
@@ -13,6 +13,7 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/beamoptic.H"
 #include "mixin/thick.H"
+#include "mixin/nofinalize.H"
 
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
@@ -24,7 +25,8 @@ namespace impactx
 {
     struct ConstF
     : public elements::BeamOptic<ConstF>,
-      public elements::Thick
+      public elements::Thick,
+      public elements::NoFinalize
     {
         static constexpr auto name = "ConstF";
         using PType = ImpactXParticleContainer::ParticleType;

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -13,6 +13,7 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/beamoptic.H"
 #include "mixin/thin.H"
+#include "mixin/nofinalize.H"
 
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
@@ -24,7 +25,8 @@ namespace impactx
 {
     struct DipEdge
     : public elements::BeamOptic<DipEdge>,
-      public elements::Thin
+      public elements::Thin,
+      public elements::NoFinalize
     {
         static constexpr auto name = "DipEdge";
         using PType = ImpactXParticleContainer::ParticleType;

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -13,6 +13,7 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/beamoptic.H"
 #include "mixin/thick.H"
+#include "mixin/nofinalize.H"
 
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
@@ -24,7 +25,8 @@ namespace impactx
 {
     struct Drift
     : public elements::BeamOptic<Drift>,
-      public elements::Thick
+      public elements::Thick,
+      public elements::NoFinalize
     {
         static constexpr auto name = "Drift";
         using PType = ImpactXParticleContainer::ParticleType;

--- a/src/particles/elements/Multipole.H
+++ b/src/particles/elements/Multipole.H
@@ -13,6 +13,7 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/beamoptic.H"
 #include "mixin/thin.H"
+#include "mixin/nofinalize.H"
 
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
@@ -24,7 +25,8 @@ namespace impactx
 {
     struct Multipole
     : public elements::BeamOptic<Multipole>,
-      public elements::Thin
+      public elements::Thin,
+      public elements::NoFinalize
     {
         static constexpr auto name = "Multipole";
         using PType = ImpactXParticleContainer::ParticleType;

--- a/src/particles/elements/None.H
+++ b/src/particles/elements/None.H
@@ -12,6 +12,7 @@
 
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/thin.H"
+#include "mixin/nofinalize.H"
 
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
@@ -20,7 +21,8 @@
 namespace impactx
 {
     struct None
-    : public elements::Thin
+    : public elements::Thin,
+      public elements::NoFinalize
     {
         static constexpr auto name = "None";
         using PType = ImpactXParticleContainer::ParticleType;

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -13,6 +13,7 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/beamoptic.H"
 #include "mixin/thin.H"
+#include "mixin/nofinalize.H"
 
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
@@ -24,7 +25,8 @@ namespace impactx
 {
     struct NonlinearLens
     : public elements::BeamOptic<NonlinearLens>,
-      public elements::Thin
+      public elements::Thin,
+      public elements::NoFinalize
     {
         static constexpr auto name = "NonlinearLens";
         using PType = ImpactXParticleContainer::ParticleType;

--- a/src/particles/elements/PRot.H
+++ b/src/particles/elements/PRot.H
@@ -13,6 +13,7 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/beamoptic.H"
 #include "mixin/thin.H"
+#include "mixin/nofinalize.H"
 
 #include <ablastr/constant.H>
 
@@ -26,7 +27,8 @@ namespace impactx
 {
     struct PRot
     : public elements::BeamOptic<PRot>,
-      public elements::Thin
+      public elements::Thin,
+      public elements::NoFinalize
     {
         static constexpr auto name = "PRot";
         using PType = ImpactXParticleContainer::ParticleType;

--- a/src/particles/elements/Programmable.H
+++ b/src/particles/elements/Programmable.H
@@ -76,7 +76,11 @@ namespace impactx
             return m_ds;
         }
 
-    public:
+        /** Close and deallocate all data and handles.
+         */
+        void
+        finalize ();
+
         amrex::ParticleReal m_ds = 0.0; //! segment length in m
         int m_nslice = 1; //! number of slices used for the application of space charge
 
@@ -92,6 +96,7 @@ namespace impactx
         std::function<void(ImpactXParticleContainer *, int)> m_push; //! hook for push of whole container
         std::function<void(ImpactXParticleContainer::iterator *, RefPart &)> m_beam_particles; //! hook for beam particles
         std::function<void(RefPart &)> m_ref_particle; //! hook for reference particle
+        std::function<void()> m_finalize; //! hook for finalize cleanup
     };
 
 } // namespace impactx

--- a/src/particles/elements/Programmable.cpp
+++ b/src/particles/elements/Programmable.cpp
@@ -21,6 +21,7 @@ namespace impactx
     ) const
     {
         if (m_push == nullptr) {
+            // TODO: print if verbose mode is set
             push_all(pc, *this, step, m_threadsafe);
         }
         else {
@@ -49,6 +50,14 @@ namespace impactx
             amrex::AllPrint() << "Programmable element - ref particles: NO HOOK\n";
         else
             m_ref_particle(ref_part);
+    }
+
+    void
+    Programmable::finalize ()
+    {
+        if (m_finalize != nullptr)
+            m_finalize();
+        // TODO: else - print if verbose mode is set
     }
 
 } // namespace impactx

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -12,7 +12,8 @@
 
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/beamoptic.H"
-#include "mixin/beamoptic.H"
+#include "mixin/thick.H"
+#include "mixin/nofinalize.H"
 
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
@@ -24,7 +25,8 @@ namespace impactx
 {
     struct Quad
     : public elements::BeamOptic<Quad>,
-      public elements::Thick
+      public elements::Thick,
+      public elements::NoFinalize
     {
         static constexpr auto name = "Quad";
         using PType = ImpactXParticleContainer::ParticleType;

--- a/src/particles/elements/RFCavity.H
+++ b/src/particles/elements/RFCavity.H
@@ -77,40 +77,32 @@ namespace impactx
         };
     };
 
-namespace data
+/** Dynamic data for the RFCavity elements
+ *
+ * Since we copy the element to the device, we cannot store this data on the element itself.
+ * But we can store pointers to this data with the element and keep a lookup table here,
+ * which we clean up in the end.
+ */
+namespace RFCavityData
 {
-    /** Data members we can copy to device with a memcpy.
-     */
-    struct RFCavity_device_copyable
-    {
-        amrex::ParticleReal m_escale; //! scaling factor for RF electric field
-        amrex::ParticleReal m_freq; //! RF frequency in Hz
-        amrex::ParticleReal m_phase; //! RF driven phase in deg
-        int m_mapsteps; //! number of map integration steps per slice
+    //! last used id for a created RF cavity
+    static inline int next_id = 0;
 
-        int m_ncoef = 0; //! number of Fourier coefficients
-        amrex::ParticleReal* m_cos_data = nullptr; //! non-owning pointer to device cosine coefficients
-        amrex::ParticleReal* m_sin_data = nullptr; //! non-owning pointer to device sine coefficients
+    //! host: cosine coefficients in Fourier expansion of on-axis electric field Ez
+    static inline std::map<int, std::vector<amrex::ParticleReal>> h_cos_coef = {};
+    //! host: sine coefficients in Fourier expansion of on-axis electric field Ez
+    static inline std::map<int, std::vector<amrex::ParticleReal>> h_sin_coef = {};
 
-        RFCavity_device_copyable(
-            amrex::ParticleReal escale,
-            amrex::ParticleReal freq,
-            amrex::ParticleReal phase,
-            int mapsteps = 1
-        ) : m_escale(escale), m_freq(freq), m_phase(phase), m_mapsteps(mapsteps)
-        {}
+    //! device: cosine coefficients in Fourier expansion of on-axis electric field Ez
+    static inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_cos_coef = {};
+    //! device: sine coefficients in Fourier expansion of on-axis electric field Ez
+    static inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_sin_coef = {};
 
-        RFCavity_device_copyable(RFCavity_device_copyable const &) = default;
-        RFCavity_device_copyable& operator=(RFCavity_device_copyable const &) = default;
-        RFCavity_device_copyable(RFCavity_device_copyable &&) = default;
-        RFCavity_device_copyable& operator=(RFCavity_device_copyable &&) = default;
-    };
-} // namespace data
+} // namespace RFCavityData
 
     struct RFCavity
     : public elements::BeamOptic<RFCavity>,
-      public elements::Thick,
-      public data::RFCavity_device_copyable
+      public elements::Thick
     {
         static constexpr auto name = "RFCavity";
         using PType = ImpactXParticleContainer::ParticleType;
@@ -127,8 +119,7 @@ namespace data
          *        map and reference particle push in applied fields
          * @param nslice number of slices used for the application of space charge
          */
-        AMREX_GPU_HOST
-        RFCavity(
+        RFCavity (
             amrex::ParticleReal ds,
             amrex::ParticleReal escale,
             amrex::ParticleReal freq,
@@ -139,64 +130,37 @@ namespace data
             int nslice = 1
         )
           : Thick(ds, nslice),
-            RFCavity_device_copyable(escale, freq, phase, mapsteps)
+            m_escale(escale), m_freq(freq), m_phase(phase), m_mapsteps(mapsteps)
         {
+            // next created RF cavity has another id for its data
+            RFCavityData::next_id++;
+
+            // validate sin and cos coefficients are the same length
             m_ncoef = cos_coef.size();
-            if (m_ncoef !=  int(sin_coef.size()))
+            if (m_ncoef != int(sin_coef.size()))
                 throw std::runtime_error("RFCavity: cos and sin coefficients must have same length!");
 
-            m_cos_coef.resize(m_ncoef);
-            m_sin_coef.resize(m_ncoef);
+            // host data
+            RFCavityData::h_cos_coef[m_id] = cos_coef;
+            RFCavityData::h_sin_coef[m_id] = sin_coef;
+            m_cos_h_data = RFCavityData::h_cos_coef[m_id].data();
+            m_sin_h_data = RFCavityData::h_sin_coef[m_id].data();
+
+            // device data
+            RFCavityData::d_cos_coef.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
+            RFCavityData::d_sin_coef.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
             amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
                                   cos_coef.begin(), cos_coef.end(),
-                                  m_cos_coef.begin());
+                                  RFCavityData::d_cos_coef[m_id].begin());
             amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
                                   sin_coef.begin(), sin_coef.end(),
-                                  m_sin_coef.begin());
-            amrex::Gpu::synchronize();
+                                  RFCavityData::d_sin_coef[m_id].begin());
+            amrex::Gpu::streamSynchronize();
 
-            m_cos_data = m_cos_coef.data();
-            m_sin_data = m_sin_coef.data();
+            // low-level objects we can use on device
+            m_cos_d_data = RFCavityData::d_cos_coef[m_id].data();
+            m_sin_d_data = RFCavityData::d_sin_coef[m_id].data();
         }
-
-        // copy and move constructors
-        RFCavity(RFCavity const & other)
-            : Thick(other.m_ds, other.m_nslice),
-              RFCavity_device_copyable(other.m_escale, other.m_freq, other.m_phase, other.m_mapsteps)
-        {
-#if !AMREX_DEVICE_COMPILE
-            // copy the data container if we copy the host element
-            m_cos_coef = other.m_cos_coef;
-            m_sin_coef = other.m_sin_coef;
-            amrex::Gpu::synchronize();
-#endif
-            m_ncoef = m_cos_coef.size();
-            m_cos_data = m_cos_coef.data();
-            m_sin_data = m_sin_coef.data();
-        }
-        RFCavity& operator=(RFCavity const& other)
-        {
-            if (this == &other)
-                return *this;
-
-            Thick::operator=(other);
-            RFCavity_device_copyable::operator=(other);
-#if !AMREX_DEVICE_COMPILE
-            // copy the data container if we copy the host element
-            m_cos_coef = other.m_cos_coef;
-            m_sin_coef = other.m_sin_coef;
-            amrex::Gpu::synchronize();
-#endif
-            m_ncoef = m_cos_coef.size();
-            m_cos_data = m_cos_coef.data();
-            m_sin_data = m_sin_coef.data();
-            return *this;
-        }
-        RFCavity(RFCavity && other) = default;
-        RFCavity& operator=(RFCavity && other) = default;
-
-        AMREX_GPU_HOST
-        ~RFCavity() = default;
 
         /** Push all particles */
         using BeamOptic::operator();
@@ -264,7 +228,7 @@ namespace data
          *
          * @param[in,out] refpart reference particle
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -351,6 +315,16 @@ namespace data
         {
             using namespace amrex::literals; // for _rt and _prt
 
+            // pick the right data depending if we are on the host side
+            // (reference particle push) or device side (particles):
+#if AMREX_DEVICE_COMPILE
+            amrex::ParticleReal* cos_data = m_cos_d_data;
+            amrex::ParticleReal* sin_data = m_sin_d_data;
+#else
+            amrex::ParticleReal* cos_data = m_cos_h_data;
+            amrex::ParticleReal* sin_data = m_sin_h_data;
+#endif
+
             // specify constants
             using ablastr::constant::math::pi;
             amrex::ParticleReal const zlen = m_ds;
@@ -365,18 +339,18 @@ namespace data
 
             if (abs(z)<=zmid)
             {
-               efield = 0.5_prt*m_cos_data[0];
+               efield = 0.5_prt*cos_data[0];
                efieldint = z*efield;
                for (int j=1; j < m_ncoef; ++j)
                {
-                 efield = efield + m_cos_data[j]*cos(j*2*pi*z/zlen) +
-                      m_sin_data[j]*sin(j*2*pi*z/zlen);
-                 efieldp = efieldp-j*2*pi*m_cos_data[j]*sin(j*2*pi*z/zlen)/zlen +
-                      j*2*pi*m_sin_data[j]*cos(j*2*pi*z/zlen)/zlen;
-                 efieldpp = efieldpp- pow(j*2*pi*m_cos_data[j]/zlen,2) *cos(j*2*pi*z/zlen) -
-                      pow(j*2*pi*m_sin_data[j]/zlen,2) *sin(j*2*pi*z/zlen);
-                 efieldint = efieldint + zlen*m_cos_data[j]*sin(j*2*pi*z/zlen)/(j*2*pi) -
-                      zlen*m_sin_data[j]*cos(j*2*pi*z/zlen)/(j*2*pi);
+                 efield = efield + cos_data[j]*cos(j*2*pi*z/zlen) +
+                     sin_data[j]*sin(j*2*pi*z/zlen);
+                 efieldp = efieldp-j*2*pi*cos_data[j]*sin(j*2*pi*z/zlen)/zlen +
+                      j*2*pi*sin_data[j]*cos(j*2*pi*z/zlen)/zlen;
+                 efieldpp = efieldpp- pow(j*2*pi*cos_data[j]/zlen,2) *cos(j*2*pi*z/zlen) -
+                      pow(j*2*pi*sin_data[j]/zlen,2) *sin(j*2*pi*z/zlen);
+                 efieldint = efieldint + zlen*cos_data[j]*sin(j*2*pi*z/zlen)/(j*2*pi) -
+                      zlen*sin_data[j]*cos(j*2*pi*z/zlen)/(j*2*pi);
                }
             }
             return std::make_tuple(efield, efieldp, efieldint);
@@ -517,10 +491,35 @@ namespace data
             refpart.map(6,6) = M*R(5,6) + R(6,6);
         }
 
+        /** Close and deallocate all data and handles.
+         */
+        void
+        finalize ()
+        {
+            // remove from unique data map
+            if (RFCavityData::h_cos_coef.count(m_id) != 0u)
+                RFCavityData::h_cos_coef.erase(m_id);
+            if (RFCavityData::h_sin_coef.count(m_id) != 0u)
+                RFCavityData::h_sin_coef.erase(m_id);
+
+            if (RFCavityData::d_cos_coef.count(m_id) != 0u)
+                RFCavityData::d_cos_coef.erase(m_id);
+            if (RFCavityData::d_sin_coef.count(m_id) != 0u)
+                RFCavityData::d_sin_coef.erase(m_id);
+        }
+
     private:
-        // we cannot copy these to device with a memcpy when we copy the element class
-        amrex::Gpu::DeviceVector<amrex::ParticleReal> m_cos_coef; //! cosine coefficients in Fourier expansion of on-axis electric field Ez
-        amrex::Gpu::DeviceVector<amrex::ParticleReal> m_sin_coef; //! sine coefficients in Fourier expansion of on-axis electric field Ez
+        amrex::ParticleReal m_escale; //! scaling factor for RF electric field
+        amrex::ParticleReal m_freq; //! RF frequency in Hz
+        amrex::ParticleReal m_phase; //! RF driven phase in deg
+        int m_mapsteps; //! number of map integration steps per slice
+        int m_id; //! unique RF cavity id used for data lookup map
+
+        int m_ncoef = 0; //! number of Fourier coefficients
+        amrex::ParticleReal* m_cos_h_data = nullptr; //! non-owning pointer to host cosine coefficients
+        amrex::ParticleReal* m_sin_h_data = nullptr; //! non-owning pointer to host sine coefficients
+        amrex::ParticleReal* m_cos_d_data = nullptr; //! non-owning pointer to device cosine coefficients
+        amrex::ParticleReal* m_sin_d_data = nullptr; //! non-owning pointer to device sine coefficients
     };
 
 } // namespace impactx

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -13,6 +13,7 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/beamoptic.H"
 #include "mixin/thick.H"
+#include "mixin/nofinalize.H"
 
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
@@ -24,7 +25,8 @@ namespace impactx
 {
     struct Sbend
     : public elements::BeamOptic<Sbend>,
-      public elements::Thick
+      public elements::Thick,
+      public elements::NoFinalize
     {
         static constexpr auto name = "Sbend";
         using PType = ImpactXParticleContainer::ParticleType;

--- a/src/particles/elements/ShortRF.H
+++ b/src/particles/elements/ShortRF.H
@@ -13,6 +13,7 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/beamoptic.H"
 #include "mixin/thin.H"
+#include "mixin/nofinalize.H"
 
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
@@ -24,7 +25,8 @@ namespace impactx
 {
     struct ShortRF
     : public elements::BeamOptic<ShortRF>,
-      public elements::Thin
+      public elements::Thin,
+      public elements::NoFinalize
     {
         static constexpr auto name = "ShortRF";
         using PType = ImpactXParticleContainer::ParticleType;

--- a/src/particles/elements/SoftQuad.H
+++ b/src/particles/elements/SoftQuad.H
@@ -86,37 +86,32 @@ namespace impactx
             };
     };
 
-namespace data
+/** Dynamic data for the SoftQuadrupole elements
+ *
+ * Since we copy the element to the device, we cannot store this data on the element itself.
+ * But we can store pointers to this data with the element and keep a lookup table here,
+ * which we clean up in the end.
+ */
+namespace SoftQuadrupoleData
 {
-    /** Data members we can copy to device with a memcpy.
-     */
-    struct SoftQuadrupole_device_copyable
-    {
-        amrex::ParticleReal m_gscale; //! scaling factor for quad field gradient
-        int m_mapsteps; //! number of map integration steps per slice
+    //! last used id for a created soft quad
+    static inline int next_id = 0;
 
-        int m_ncoef = 0; //! number of Fourier coefficients
-        amrex::ParticleReal* m_cos_data = nullptr; //! non-owning pointer to device cosine coefficients
-        amrex::ParticleReal* m_sin_data = nullptr; //! non-owning pointer to device sine coefficients
+    //! host: cosine coefficients in Fourier expansion of on-axis magnetic field Bz
+    static inline std::map<int, std::vector<amrex::ParticleReal>> h_cos_coef = {};
+    //! host: sine coefficients in Fourier expansion of on-axis magnetic field Bz
+    static inline std::map<int, std::vector<amrex::ParticleReal>> h_sin_coef = {};
 
-        SoftQuadrupole_device_copyable(
-            amrex::ParticleReal gscale,
-            int mapsteps = 1
-        ) : m_gscale(gscale), m_mapsteps(mapsteps)
-        {}
+    //! device: cosine coefficients in Fourier expansion of on-axis magnetic field Bz
+    static inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_cos_coef = {};
+    //! device: sine coefficients in Fourier expansion of on-axis magnetic field Bz
+    static inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_sin_coef = {};
 
-        SoftQuadrupole_device_copyable(SoftQuadrupole_device_copyable const &) = default;
-        SoftQuadrupole_device_copyable& operator=(SoftQuadrupole_device_copyable const &) = default;
-        SoftQuadrupole_device_copyable(SoftQuadrupole_device_copyable &&) = default;
-        SoftQuadrupole_device_copyable& operator=(SoftQuadrupole_device_copyable &&) = default;
-
-    };
-} // namespace data
+} // namespace SoftQuadrupoleData
 
     struct SoftQuadrupole
     : public elements::BeamOptic<SoftQuadrupole>,
-      public elements::Thick,
-      public data::SoftQuadrupole_device_copyable
+      public elements::Thick
     {
         static constexpr auto name = "SoftQuadrupole";
         using PType = ImpactXParticleContainer::ParticleType;
@@ -125,14 +120,13 @@ namespace data
          *
          * @param ds Segment length in m
          * @param gscale Scaling factor for on-axis field gradient Bz in 1/m^2
-         * @param cos_coef TODO
-         * @param sin_coef TODO
+         * @param cos_coef cosine coefficients in Fourier expansion of on-axis magnetic field Bz
+         * @param sin_coef sine coefficients in Fourier expansion of on-axis magnetic field Bz
          * @param mapsteps number of integration steps per slice used for
          *        map and reference particle push in applied fields
          * @param nslice number of slices used for the application of space charge
          */
-        AMREX_GPU_HOST
-        SoftQuadrupole(
+        SoftQuadrupole (
             amrex::ParticleReal ds,
             amrex::ParticleReal gscale,
             std::vector<amrex::ParticleReal> cos_coef,
@@ -141,65 +135,37 @@ namespace data
             int nslice = 1
         )
           : Thick(ds, nslice),
-            SoftQuadrupole_device_copyable(gscale, mapsteps)
-       {
-           m_ncoef = cos_coef.size();
-           if (m_ncoef !=  int(sin_coef.size()))
+            m_gscale(gscale), m_mapsteps(mapsteps), m_id(SoftQuadrupoleData::next_id)
+        {
+            // next created soft quad has another id for its data
+            SoftQuadrupoleData::next_id++;
+
+            // validate sin and cos coefficients are the same length
+            m_ncoef = cos_coef.size();
+            if (m_ncoef != int(sin_coef.size()))
                 throw std::runtime_error("SoftQuadrupole: cos and sin coefficients must have same length!");
 
-            m_cos_coef.resize(m_ncoef);
-            m_sin_coef.resize(m_ncoef);
+            // host data
+            SoftQuadrupoleData::h_cos_coef[m_id] = cos_coef;
+            SoftQuadrupoleData::h_sin_coef[m_id] = sin_coef;
+            m_cos_h_data = SoftQuadrupoleData::h_cos_coef[m_id].data();
+            m_sin_h_data = SoftQuadrupoleData::h_sin_coef[m_id].data();
+
+            // device data
+            SoftQuadrupoleData::d_cos_coef.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
+            SoftQuadrupoleData::d_sin_coef.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
             amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
                                   cos_coef.begin(), cos_coef.end(),
-                                  m_cos_coef.begin());
+                                  SoftQuadrupoleData::d_cos_coef[m_id].begin());
             amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
                                   sin_coef.begin(), sin_coef.end(),
-                                  m_sin_coef.begin());
-            amrex::Gpu::synchronize();
+                                  SoftQuadrupoleData::d_sin_coef[m_id].begin());
+            amrex::Gpu::streamSynchronize();
 
             // low-level objects we can use on device
-            m_cos_data = m_cos_coef.data();
-            m_sin_data = m_sin_coef.data();
-        }
-
-        // copy and move constructors
-        SoftQuadrupole(SoftQuadrupole const & other)
-          : Thick(other.m_ds, other.m_nslice),
-            SoftQuadrupole_device_copyable(other.m_gscale, other.m_mapsteps)
-        {
-#if !AMREX_DEVICE_COMPILE
-            // copy the data container if we copy the host element
-            m_cos_coef = other.m_cos_coef;
-            m_sin_coef = other.m_sin_coef;
-            amrex::Gpu::synchronize();
-#endif
-            m_ncoef = m_cos_coef.size();
-            m_cos_data = m_cos_coef.data();
-            m_sin_data = m_sin_coef.data();
-        }
-        SoftQuadrupole& operator=(SoftQuadrupole const& other)
-        {
-            if (this == &other)
-                return *this;
-
-            Thick::operator=(other);
-            SoftQuadrupole_device_copyable::operator=(other);
-#if !AMREX_DEVICE_COMPILE
-            // copy the data container if we copy the host element
-            m_cos_coef = other.m_cos_coef;
-            m_sin_coef = other.m_sin_coef;
-            amrex::Gpu::synchronize();
-#endif
-            m_ncoef = m_cos_coef.size();
-            m_cos_data = m_cos_coef.data();
-            m_sin_data = m_sin_coef.data();
-            return *this;
-        }
-        SoftQuadrupole(SoftQuadrupole && other) = default;
-        SoftQuadrupole& operator=(SoftQuadrupole && other) = default;
-
-        AMREX_GPU_HOST
-        ~SoftQuadrupole() = default;
+            m_cos_d_data = SoftQuadrupoleData::d_cos_coef[m_id].data();
+            m_sin_d_data = SoftQuadrupoleData::d_sin_coef[m_id].data();
+       }
 
         /** Push all particles */
         using BeamOptic::operator();
@@ -267,7 +233,7 @@ namespace data
          *
          * @param[in,out] refpart reference particle
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -345,6 +311,16 @@ namespace data
         {
             using namespace amrex::literals; // for _rt and _prt
 
+            // pick the right data depending if we are on the host side
+            // (reference particle push) or device side (particles):
+#if AMREX_DEVICE_COMPILE
+            amrex::ParticleReal* cos_data = m_cos_d_data;
+            amrex::ParticleReal* sin_data = m_sin_d_data;
+#else
+            amrex::ParticleReal* cos_data = m_cos_h_data;
+            amrex::ParticleReal* sin_data = m_sin_h_data;
+#endif
+
             // specify constants
             using ablastr::constant::math::pi;
             amrex::ParticleReal const zlen = m_ds;
@@ -358,16 +334,16 @@ namespace data
 
             if (abs(z)<=zmid)
             {
-               bfield = 0.5_prt*m_cos_data[0];
+               bfield = 0.5_prt*cos_data[0];
                bfieldint = z*bfield;
                for (int j=1; j < m_ncoef; ++j)
                {
-                 bfield = bfield + m_cos_data[j]*cos(j*2*pi*z/zlen) +
-                      m_sin_data[j]*sin(j*2*pi*z/zlen);
-                 bfieldp = bfieldp-j*2*pi*m_cos_data[j]*sin(j*2*pi*z/zlen)/zlen +
-                      j*2*pi*m_sin_data[j]*cos(j*2*pi*z/zlen)/zlen;
-                 bfieldint = bfieldint + zlen*m_cos_data[j]*sin(j*2*pi*z/zlen)/(j*2*pi) -
-                      zlen*m_sin_data[j]*cos(j*2*pi*z/zlen)/(j*2*pi);
+                 bfield = bfield + cos_data[j] * cos(j * 2 * pi * z / zlen) +
+                         sin_data[j] * sin(j * 2 * pi * z / zlen);
+                 bfieldp = bfieldp - j * 2 * pi * cos_data[j] * sin(j * 2 * pi * z / zlen) / zlen +
+                           j * 2 * pi * sin_data[j] * cos(j * 2 * pi * z / zlen) / zlen;
+                 bfieldint = bfieldint + zlen * cos_data[j] * sin(j * 2 * pi * z / zlen) / (j * 2 * pi) -
+                             zlen * sin_data[j] * cos(j * 2 * pi * z / zlen) / (j * 2 * pi);
                }
             }
             return std::make_tuple(bfield, bfieldp, bfieldint);
@@ -467,11 +443,33 @@ namespace data
 
         }
 
+        /** Close and deallocate all data and handles.
+         */
+        void
+        finalize ()
+        {
+            // remove from unique data map
+            if (SoftQuadrupoleData::h_cos_coef.count(m_id) != 0u)
+                SoftQuadrupoleData::h_cos_coef.erase(m_id);
+            if (SoftQuadrupoleData::h_sin_coef.count(m_id) != 0u)
+                SoftQuadrupoleData::h_sin_coef.erase(m_id);
+
+            if (SoftQuadrupoleData::d_cos_coef.count(m_id) != 0u)
+                SoftQuadrupoleData::d_cos_coef.erase(m_id);
+            if (SoftQuadrupoleData::d_sin_coef.count(m_id) != 0u)
+                SoftQuadrupoleData::d_sin_coef.erase(m_id);
+        }
 
     private:
-        // we cannot copy these to device with a memcpy when we copy the element class
-        amrex::Gpu::DeviceVector<amrex::ParticleReal> m_cos_coef; //! cosine coefficients in Fourier expansion of on-axis magnetic field Bz
-        amrex::Gpu::DeviceVector<amrex::ParticleReal> m_sin_coef; //! sine coefficients in Fourier expansion of on-axis magnetic  field Bz
+        amrex::ParticleReal m_gscale; //! scaling factor for quad field gradient
+        int m_mapsteps; //! number of map integration steps per slice
+        int m_id; //! unique soft quad id used for data lookup map
+
+        int m_ncoef = 0; //! number of Fourier coefficients
+        amrex::ParticleReal* m_cos_h_data = nullptr; //! non-owning pointer to host cosine coefficients
+        amrex::ParticleReal* m_sin_h_data = nullptr; //! non-owning pointer to host sine coefficients
+        amrex::ParticleReal* m_cos_d_data = nullptr; //! non-owning pointer to device cosine coefficients
+        amrex::ParticleReal* m_sin_d_data = nullptr; //! non-owning pointer to device sine coefficients
     };
 
 } // namespace impactx

--- a/src/particles/elements/SoftSol.H
+++ b/src/particles/elements/SoftSol.H
@@ -91,37 +91,32 @@ namespace impactx
             };
     };
 
-namespace data
+/** Dynamic data for the SoftSolenoid elements
+ *
+ * Since we copy the element to the device, we cannot store this data on the element itself.
+ * But we can store pointers to this data with the element and keep a lookup table here,
+ * which we clean up in the end.
+ */
+namespace SoftSolenoidData
 {
-    /** Data members we can copy to device with a memcpy.
-     */
-    struct SoftSolenoid_device_copyable
-    {
-        amrex::ParticleReal m_bscale; //! scaling factor for solenoid Bz field
-        int m_mapsteps; //! number of map integration steps per slice
+    //! last used id for a created soft solenoid
+    static inline int next_id = 0;
 
-        int m_ncoef = 0; //! number of Fourier coefficients
-        amrex::ParticleReal* m_cos_data = nullptr; //! non-owning pointer to device cosine coefficients
-        amrex::ParticleReal* m_sin_data = nullptr; //! non-owning pointer to device sine coefficients
+    //! host: cosine coefficients in Fourier expansion of on-axis magnetic field Bz
+    static inline std::map<int, std::vector<amrex::ParticleReal>> h_cos_coef = {};
+    //! host: sine coefficients in Fourier expansion of on-axis magnetic field Bz
+    static inline std::map<int, std::vector<amrex::ParticleReal>> h_sin_coef = {};
 
-        SoftSolenoid_device_copyable(
-            amrex::ParticleReal bscale,
-            int mapsteps = 1
-        ) : m_bscale(bscale), m_mapsteps(mapsteps)
-        {}
+    //! device: cosine coefficients in Fourier expansion of on-axis magnetic field Bz
+    static inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_cos_coef = {};
+    //! device: sine coefficients in Fourier expansion of on-axis magnetic field Bz
+    static inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_sin_coef = {};
 
-        SoftSolenoid_device_copyable(SoftSolenoid_device_copyable const &) = default;
-        SoftSolenoid_device_copyable& operator=(SoftSolenoid_device_copyable const &) = default;
-        SoftSolenoid_device_copyable(SoftSolenoid_device_copyable &&) = default;
-        SoftSolenoid_device_copyable& operator=(SoftSolenoid_device_copyable &&) = default;
-
-    };
-} // namespace data
+} // namespace SoftSolenoidData
 
     struct SoftSolenoid
     : public elements::BeamOptic<SoftSolenoid>,
-      public elements::Thick,
-      public data::SoftSolenoid_device_copyable
+      public elements::Thick
     {
         static constexpr auto name = "SoftSolenoid";
         using PType = ImpactXParticleContainer::ParticleType;
@@ -130,14 +125,13 @@ namespace data
          *
          * @param ds Segment length in m
          * @param bscale Scaling factor for on-axis magnetic field Bz in 1/m
-         * @param cos_coef TODO
-         * @param sin_coef TODO
+         * @param cos_coef cosine coefficients in Fourier expansion of on-axis magnetic field Bz
+         * @param sin_coef sine coefficients in Fourier expansion of on-axis magnetic field Bz
          * @param mapsteps number of integration steps per slice used for
          *        map and reference particle push in applied fields
          * @param nslice number of slices used for the application of space charge
          */
-        AMREX_GPU_HOST
-        SoftSolenoid(
+        SoftSolenoid (
             amrex::ParticleReal ds,
             amrex::ParticleReal bscale,
             std::vector<amrex::ParticleReal> cos_coef,
@@ -146,65 +140,37 @@ namespace data
             int nslice = 1
         )
           : Thick(ds, nslice),
-            SoftSolenoid_device_copyable(bscale, mapsteps)
+            m_bscale(bscale), m_mapsteps(mapsteps), m_id(SoftSolenoidData::next_id)
        {
+           // next created soft solenoid has another id for its data
+           SoftSolenoidData::next_id++;
+
+           // validate sin and cos coefficients are the same length
            m_ncoef = cos_coef.size();
-           if (m_ncoef !=  int(sin_coef.size()))
-                throw std::runtime_error("SoftSolenoid: cos and sin coefficients must have same length!");
+           if (m_ncoef != int(sin_coef.size()))
+               throw std::runtime_error("SoftSolenoid: cos and sin coefficients must have same length!");
 
-            m_cos_coef.resize(m_ncoef);
-            m_sin_coef.resize(m_ncoef);
-            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                                  cos_coef.begin(), cos_coef.end(),
-                                  m_cos_coef.begin());
-            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                                  sin_coef.begin(), sin_coef.end(),
-                                  m_sin_coef.begin());
-            amrex::Gpu::synchronize();
+           // host data
+           SoftSolenoidData::h_cos_coef[m_id] = cos_coef;
+           SoftSolenoidData::h_sin_coef[m_id] = sin_coef;
+           m_cos_h_data = SoftSolenoidData::h_cos_coef[m_id].data();
+           m_sin_h_data = SoftSolenoidData::h_sin_coef[m_id].data();
 
-            // low-level objects we can use on device
-            m_cos_data = m_cos_coef.data();
-            m_sin_data = m_sin_coef.data();
+           // device data
+           SoftSolenoidData::d_cos_coef.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
+           SoftSolenoidData::d_sin_coef.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
+           amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
+                                 cos_coef.begin(), cos_coef.end(),
+                                 SoftSolenoidData::d_cos_coef[m_id].begin());
+           amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
+                                 sin_coef.begin(), sin_coef.end(),
+                                 SoftSolenoidData::d_sin_coef[m_id].begin());
+           amrex::Gpu::streamSynchronize();
+
+           // low-level objects we can use on device
+           m_cos_d_data = SoftSolenoidData::d_cos_coef[m_id].data();
+           m_sin_d_data = SoftSolenoidData::d_sin_coef[m_id].data();
         }
-
-        // copy and move constructors
-        SoftSolenoid(SoftSolenoid const & other)
-          : Thick(other.m_ds, other.m_nslice),
-            SoftSolenoid_device_copyable(other.m_bscale, other.m_mapsteps)
-        {
-#if !AMREX_DEVICE_COMPILE
-            // copy the data container if we copy the host element
-            m_cos_coef = other.m_cos_coef;
-            m_sin_coef = other.m_sin_coef;
-            amrex::Gpu::synchronize();
-#endif
-            m_ncoef = m_cos_coef.size();
-            m_cos_data = m_cos_coef.data();
-            m_sin_data = m_sin_coef.data();
-        }
-        SoftSolenoid& operator=(SoftSolenoid const& other)
-        {
-            if (this == &other)
-                return *this;
-
-            Thick::operator=(other);
-            SoftSolenoid_device_copyable::operator=(other);
-#if !AMREX_DEVICE_COMPILE
-            // copy the data container if we copy the host element
-            m_cos_coef = other.m_cos_coef;
-            m_sin_coef = other.m_sin_coef;
-            amrex::Gpu::synchronize();
-#endif
-            m_ncoef = m_cos_coef.size();
-            m_cos_data = m_cos_coef.data();
-            m_sin_data = m_sin_coef.data();
-            return *this;
-        }
-        SoftSolenoid(SoftSolenoid && other) = default;
-        SoftSolenoid& operator=(SoftSolenoid && other) = default;
-
-        AMREX_GPU_HOST
-        ~SoftSolenoid() = default;
 
         /** Push all particles */
         using BeamOptic::operator();
@@ -272,7 +238,7 @@ namespace data
          *
          * @param[in,out] refpart reference particle
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -348,6 +314,16 @@ namespace data
         {
             using namespace amrex::literals; // for _rt and _prt
 
+            // pick the right data depending if we are on the host side
+            // (reference particle push) or device side (particles):
+#if AMREX_DEVICE_COMPILE
+            amrex::ParticleReal* cos_data = m_cos_d_data;
+            amrex::ParticleReal* sin_data = m_sin_d_data;
+#else
+            amrex::ParticleReal* cos_data = m_cos_h_data;
+            amrex::ParticleReal* sin_data = m_sin_h_data;
+#endif
+
             // specify constants
             using ablastr::constant::math::pi;
             amrex::ParticleReal const zlen = m_ds;
@@ -361,16 +337,16 @@ namespace data
 
             if (abs(z)<=zmid)
             {
-               bfield = 0.5_prt*m_cos_data[0];
+               bfield = 0.5_prt*cos_data[0];
                bfieldint = z*bfield;
                for (int j=1; j < m_ncoef; ++j)
                {
-                 bfield = bfield + m_cos_data[j]*cos(j*2*pi*z/zlen) +
-                      m_sin_data[j]*sin(j*2*pi*z/zlen);
-                 bfieldp = bfieldp-j*2*pi*m_cos_data[j]*sin(j*2*pi*z/zlen)/zlen +
-                      j*2*pi*m_sin_data[j]*cos(j*2*pi*z/zlen)/zlen;
-                 bfieldint = bfieldint + zlen*m_cos_data[j]*sin(j*2*pi*z/zlen)/(j*2*pi) -
-                      zlen*m_sin_data[j]*cos(j*2*pi*z/zlen)/(j*2*pi);
+                 bfield = bfield + cos_data[j]*cos(j*2*pi*z/zlen) +
+                     sin_data[j]*sin(j*2*pi*z/zlen);
+                 bfieldp = bfieldp-j*2*pi*cos_data[j]*sin(j*2*pi*z/zlen)/zlen +
+                      j*2*pi*sin_data[j]*cos(j*2*pi*z/zlen)/zlen;
+                 bfieldint = bfieldint + zlen*cos_data[j]*sin(j*2*pi*z/zlen)/(j*2*pi) -
+                      zlen*sin_data[j]*cos(j*2*pi*z/zlen)/(j*2*pi);
                }
             }
             return std::make_tuple(bfield, bfieldp, bfieldint);
@@ -528,10 +504,33 @@ namespace data
 
         }
 
+        /** Close and deallocate all data and handles.
+         */
+        void
+        finalize ()
+        {
+            // remove from unique data map
+            if (SoftSolenoidData::h_cos_coef.count(m_id) != 0u)
+                SoftSolenoidData::h_cos_coef.erase(m_id);
+            if (SoftSolenoidData::h_sin_coef.count(m_id) != 0u)
+                SoftSolenoidData::h_sin_coef.erase(m_id);
+
+            if (SoftSolenoidData::d_cos_coef.count(m_id) != 0u)
+                SoftSolenoidData::d_cos_coef.erase(m_id);
+            if (SoftSolenoidData::d_sin_coef.count(m_id) != 0u)
+                SoftSolenoidData::d_sin_coef.erase(m_id);
+        }
+
     private:
-        // we cannot copy these to device with a memcpy when we copy the element class
-        amrex::Gpu::DeviceVector<amrex::ParticleReal> m_cos_coef; //! cosine coefficients in Fourier expansion of on-axis magnetic field Bz
-        amrex::Gpu::DeviceVector<amrex::ParticleReal> m_sin_coef; //! sine coefficients in Fourier expansion of on-axis magnetic  field Bz
+        amrex::ParticleReal m_bscale; //! scaling factor for solenoid Bz field
+        int m_mapsteps; //! number of map integration steps per slice
+        int m_id; //! unique soft solenoid id used for data lookup map
+
+        int m_ncoef = 0; //! number of Fourier coefficients
+        amrex::ParticleReal* m_cos_h_data = nullptr; //! non-owning pointer to host cosine coefficients
+        amrex::ParticleReal* m_sin_h_data = nullptr; //! non-owning pointer to host sine coefficients
+        amrex::ParticleReal* m_cos_d_data = nullptr; //! non-owning pointer to device cosine coefficients
+        amrex::ParticleReal* m_sin_d_data = nullptr; //! non-owning pointer to device sine coefficients
     };
 
 } // namespace impactx

--- a/src/particles/elements/Sol.H
+++ b/src/particles/elements/Sol.H
@@ -12,7 +12,8 @@
 
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/beamoptic.H"
-#include "mixin/beamoptic.H"
+#include "mixin/thick.H"
+#include "mixin/nofinalize.H"
 
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
@@ -24,7 +25,8 @@ namespace impactx
 {
     struct Sol
     : public elements::BeamOptic<Sol>,
-      public elements::Thick
+      public elements::Thick,
+      public elements::NoFinalize
     {
         static constexpr auto name = "Sol";
         using PType = ImpactXParticleContainer::ParticleType;

--- a/src/particles/elements/mixin/nofinalize.H
+++ b/src/particles/elements/mixin/nofinalize.H
@@ -1,0 +1,34 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_ELEMENTS_MIXIN_NOFINALIZE_H
+#define IMPACTX_ELEMENTS_MIXIN_NOFINALIZE_H
+
+
+namespace impactx::elements
+{
+    /** This is a helper class for lattice elements that need no finalize function.
+     *
+     * Finalize helpers are used to clean up static/shared data, usually dynamic
+     * memory from parameters or state from external libraries.
+     */
+    struct NoFinalize
+    {
+        /** Close and deallocate all data and handles.
+         */
+        void
+        finalize ()
+        {
+            // nothing to do
+        }
+    };
+
+} // namespace impactx::elements
+
+#endif // IMPACTX_ELEMENTS_MIXIN_NOFINALIZE_H

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -26,6 +26,8 @@ def amrex_init():
             "amrex.signal_handling=0",
             # abort GPU runs if out-of-memory instead of swapping to host RAM
             "amrex.abort_on_out_of_gpu_memory=1",
+            # do not rely on implicit host-device memory transfers
+            "amrex.the_arena_is_managed=0",
         ]
     )
     yield

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -26,8 +26,8 @@ def amrex_init():
             "amrex.signal_handling=0",
             # abort GPU runs if out-of-memory instead of swapping to host RAM
             "amrex.abort_on_out_of_gpu_memory=1",
-            # do not rely on implicit host-device memory transfers
-            "amrex.the_arena_is_managed=0",
+            # allow implicit host-device memory transfers
+            "amrex.the_arena_is_managed=1",
         ]
     )
     yield

--- a/tests/python/test_charge_deposition.py
+++ b/tests/python/test_charge_deposition.py
@@ -63,7 +63,7 @@ def test_charge_deposition(save_png=True):
         bx = mfi.validbox()
         rbx = amrex.RealBox(bx, dr, gm.ProbLo())
 
-        arr = rho.array(mfi)
+        arr = rho.array(mfi)  # TODO: explicit device-to-host memory copy
         arr_np = np.array(arr, copy=False)  # indices: comp, z, y, x
 
         # shift box to zero-based local mfi index space


### PR DESCRIPTION
Disable managed memory by default for performance and non-bugness.

Please disable explicitly if needed for some of the current scripting tasks, e.g., in the current Python bindings.

Tests:
- [x] all ctest w/o the pytests of AMReX tests (to fix) and `FODO.programmable.py.run` (no AoS cupy support) ran (CUDA 11.7) and passed as before

Follow-up:
- [x] `test_charge_deposition`: explicit memory copy #340