### PR TITLE
Python Tests: w/o Managed Memory

### DIFF
--- a/cmake/dependencies/pyAMReX.cmake
+++ b/cmake/dependencies/pyAMReX.cmake
@@ -76,7 +76,7 @@ option(ImpactX_pyamrex_internal "Download & build pyAMReX" ON)
 set(ImpactX_pyamrex_repo "https://github.com/AMReX-Codes/pyamrex.git"
     CACHE STRING
     "Repository URI to pull and build pyamrex from if(ImpactX_pyamrex_internal)")
-set(ImpactX_pyamrex_branch "23.04"
+set(ImpactX_pyamrex_branch "bc24ec54bbb982ce3c388b1caf5b9a0a573ce0a8"
     CACHE STRING
     "Repository branch for ImpactX_pyamrex_repo if(ImpactX_pyamrex_internal)")
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -26,8 +26,8 @@ def amrex_init():
             "amrex.signal_handling=0",
             # abort GPU runs if out-of-memory instead of swapping to host RAM
             "amrex.abort_on_out_of_gpu_memory=1",
-            # allow implicit host-device memory transfers
-            "amrex.the_arena_is_managed=1",
+            # do not rely on implicit host-device memory transfers
+            "amrex.the_arena_is_managed=0",
         ]
     )
     yield

--- a/tests/python/test_charge_deposition.py
+++ b/tests/python/test_charge_deposition.py
@@ -56,14 +56,25 @@ def test_charge_deposition(save_png=True):
 
     half_z = sim.n_cell[2] // 2  # order: x,y,z
 
+    # copy data from device to host
+    rho_host = amrex.MultiFab(
+        rho.box_array(),
+        rho.dm(),
+        rho.n_comp(),
+        rho.n_grow_vect(),
+        amrex.MFInfo().set_arena(amrex.The_Pinned_Arena()),
+    )
+
+    amrex.dtoh_memcpy(rho_host, rho)
+
     f = plt.figure()
     ax = f.gca()
-    ng = rho.nGrowVect
-    for mfi in rho:
+    ng = rho_host.nGrowVect
+    for mfi in rho_host:
         bx = mfi.validbox()
         rbx = amrex.RealBox(bx, dr, gm.ProbLo())
 
-        arr = rho.array(mfi)  # TODO: explicit device-to-host memory copy
+        arr = rho_host.array(mfi)
         arr_np = np.array(arr, copy=False)  # indices: comp, z, y, x
 
         # shift box to zero-based local mfi index space

--- a/tests/python/test_charge_deposition.py
+++ b/tests/python/test_charge_deposition.py
@@ -56,17 +56,20 @@ def test_charge_deposition(save_png=True):
 
     half_z = sim.n_cell[2] // 2  # order: x,y,z
 
-    # copy data from device to host
-    rho_host = amrex.MultiFab(
-        rho.box_array(),
-        rho.dm(),
-        rho.n_comp(),
-        rho.n_grow_vect(),
-        amrex.MFInfo().set_arena(amrex.The_Pinned_Arena()),
-    )
+    # for GPU runs, copy data from device to host for plotting
+    if impactx.Config.have_gpu:
+        rho_host = amrex.MultiFab(
+            rho.box_array(),
+            rho.dm(),
+            rho.n_comp(),
+            rho.n_grow_vect(),
+            amrex.MFInfo().set_arena(amrex.The_Pinned_Arena()),
+        )
+        amrex.dtoh_memcpy(rho_host, rho)
+    else:
+        rho_host = rho
 
-    amrex.dtoh_memcpy(rho_host, rho)
-
+    # plot data slices
     f = plt.figure()
     ax = f.gca()
     ng = rho_host.nGrowVect


### PR DESCRIPTION
Follow-up to #339

- [x] needs https://github.com/AMReX-Codes/pyamrex/pull/123