### PR TITLE
Fix openPMD Meta-Data

### DIFF
--- a/.github/workflows/dependencies/gcc-openmpi.sh
+++ b/.github/workflows/dependencies/gcc-openmpi.sh
@@ -26,3 +26,5 @@ python3 -m pip install -U pip setuptools wheel
 python3 -m pip install -U cmake pytest
 python3 -m pip install -r requirements_mpi.txt
 python3 -m pip install -r examples/requirements.txt
+
+python3 -m pip install -U openPMD-validator

--- a/.github/workflows/dependencies/gcc.sh
+++ b/.github/workflows/dependencies/gcc.sh
@@ -24,3 +24,5 @@ sudo apt-get install -y \
 python3 -m pip install -U pip setuptools wheel
 python3 -m pip install -U cmake pytest
 python3 -m pip install -r examples/requirements.txt
+
+python3 -m pip install -U openPMD-validator

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -54,6 +54,7 @@ jobs:
         python3 -m pip install --upgrade pytest
         python3 -m pip install -r requirements_mpi.txt
         python3 -m pip install -r examples/requirements.txt
+        python3 -m pip install --upgrade openPMD-validator
         set -e
     - name: CCache Cache
       uses: actions/cache@v3
@@ -93,3 +94,6 @@ jobs:
         { cat Backtrace.0.0; exit 1; }
         impactx.MPI.OMP.DP.OPMD examples/fodo/input_fodo.in algo.particle_shape = 3 || \
         { cat Backtrace.0.0; exit 1; }
+
+    - name: validate created openPMD files
+      run: find build -name *.h5 | xargs -n1 -I{} openPMD_check_h5 -i {}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -66,6 +66,9 @@ jobs:
 
         python3 examples/fodo/run_fodo.py
 
+    - name: validate created openPMD files
+      run: find build -name *.h5 | xargs -n1 -I{} openPMD_check_h5 -i {}
+
   build_gcc_python:
     name: GCC w/o MPI w/ Python
     runs-on: ubuntu-20.04
@@ -125,3 +128,6 @@ jobs:
         cmake --build build --target pip_install
 
         python3 examples/fodo/run_fodo.py
+
+    - name: validate created openPMD files
+      run: find build -name *.h5 | xargs -n1 -I{} openPMD_check_h5 -i {}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,6 +55,7 @@ jobs:
         python3 -m pip install -U pip setuptools wheel pytest
         python3 -m pip install -r requirements.txt
         python3 -m pip install -r examples/requirements.txt
+        python3 -m pip install -U openPMD-validator
     - name: Build
       run: |
         $env:HDF5_DIR = "C:/Program Files/HDF_Group/HDF5/1.12.2/cmake/"
@@ -137,6 +138,7 @@ jobs:
         python3 -m pip install -U pip setuptools wheel pytest
         python3 -m pip install -r requirements.txt
         python3 -m pip install -r examples/requirements.txt
+        python3 -m pip install -U openPMD-validator
     - name: Build
       shell: cmd
       run: |
@@ -175,3 +177,6 @@ jobs:
 #        if errorlevel 1 exit 1
 #        cmake --build build --target pip_install
 #        if errorlevel 1 exit 1
+
+    - name: validate created openPMD files
+      run: find build -name *.h5 | xargs -n1 -I{} openPMD_check_h5 -i {}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,6 +82,8 @@ jobs:
         if(!$?) { Exit $LASTEXITCODE }
         cmake --build build --config RelWithDebInfo --target pip_install
         if(!$?) { Exit $LASTEXITCODE }
+    - name: validate created openPMD files
+      run: Get-ChildItem -Path build -Recurse -Filter *.h5 | %{openPMD_check_h5 -i $_}
 
   build_win_clang:
     name: Clang w/ OMP w/o MPI
@@ -179,4 +181,4 @@ jobs:
 #        if errorlevel 1 exit 1
 
     - name: validate created openPMD files
-      run: find build -name *.h5 | xargs -n1 -I{} openPMD_check_h5 -i {}
+      run: Get-ChildItem -Path build -Recurse -Filter *.h5 | %{openPMD_check_h5 -i $_}

--- a/src/particles/elements/diagnostics/openPMD.H
+++ b/src/particles/elements/diagnostics/openPMD.H
@@ -83,11 +83,13 @@ namespace detail
 
         /** Prepare entering the element before starting push logic.
          *
-         * @param[in] pc particle container.
+         * @param[in] pc particle container
+         * @param[in] ref_part reference particle
          * @param[in] step global step for diagnostics
          */
         void prepare (
             PinnedContainer & pc,
+            RefPart const & ref_part,
             int step
         );
 

--- a/src/particles/elements/diagnostics/openPMD.cpp
+++ b/src/particles/elements/diagnostics/openPMD.cpp
@@ -253,6 +253,19 @@ namespace detail
                 getComponentRecord(component_name).resetDataset(d_fl);
             }
         }
+
+        // openPMD coarse position
+        {
+            using vs = std::vector<std::string>;
+            vs const positionComponents{"x", "y", "ct"}; // TODO: generalize
+            for (auto currDim = 0; currDim < AMREX_SPACEDIM; currDim++) {
+                using namespace amrex::literals;
+                std::string const positionComponent = positionComponents[currDim];
+                beam["positionOffset"][positionComponent].resetDataset(d_fl);
+                beam["positionOffset"][positionComponent].makeConstant(0_prt); // TODO: make this the reference particle position?
+            }
+        }
+
         // AoS: Int
         beam["id"][scalar].resetDataset(d_ui);
 
@@ -320,6 +333,8 @@ namespace detail
         auto series = std::any_cast<io::Series>(m_series);
         io::WriteIterations iterations = series.writeIterations();
         io::Iteration iteration = iterations[m_step];
+
+        // close iteration
         iteration.close();
     }
 

--- a/src/particles/elements/diagnostics/openPMD.cpp
+++ b/src/particles/elements/diagnostics/openPMD.cpp
@@ -211,6 +211,7 @@ namespace detail
 
     void BeamMonitor::prepare (
         PinnedContainer & pc,
+        RefPart const & ref_part,
         int step
     ) {
 #ifdef ImpactX_USE_OPENPMD
@@ -256,14 +257,12 @@ namespace detail
 
         // openPMD coarse position
         {
-            using vs = std::vector<std::string>;
-            vs const positionComponents{"x", "y", "ct"}; // TODO: generalize
-            for (auto currDim = 0; currDim < AMREX_SPACEDIM; currDim++) {
-                using namespace amrex::literals;
-                std::string const positionComponent = positionComponents[currDim];
-                beam["positionOffset"][positionComponent].resetDataset(d_fl);
-                beam["positionOffset"][positionComponent].makeConstant(0_prt); // TODO: make this the reference particle position?
-            }
+            beam["positionOffset"]["x"].resetDataset(d_fl);
+            beam["positionOffset"]["x"].makeConstant(ref_part.x);
+            beam["positionOffset"]["y"].resetDataset(d_fl);
+            beam["positionOffset"]["y"].makeConstant(ref_part.y);
+            beam["positionOffset"]["ct"].resetDataset(d_fl);
+            beam["positionOffset"]["ct"].makeConstant(ref_part.t);
         }
 
         // AoS: Int
@@ -311,7 +310,7 @@ namespace detail
         */
 
         // prepare element access
-        this->prepare(pinned_pc, step);
+        this->prepare(pinned_pc, ref_part, step);
 
         // loop over refinement levels
         int const nLevel = pinned_pc.finestLevel();


### PR DESCRIPTION
## Tests

Check created files with `openPMD-validator` to conform with the `openPMD-standard`.

## Fixes

Add the `positionOffset` record of openPMD, which can be used for coarse particle positions or general offsets of a particle species.
This refers now to the offset added by the reference particle.

Follow-up to #299