### PR TITLE
Particle Enums: Rename Momentum

### DIFF
--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -41,7 +41,7 @@ namespace impactx
         {
             x,  ///< position in x [m] (at fixed s OR fixed t)
             y,  ///< position in y [m] (at fixed s OR fixed t)
-            t,  ///< time-of-flight c*t [m] (at fixed s)
+            t,  ///< c * time-of-flight [m] (at fixed s)
             nattribs ///< the number of attributes above (always last)
         };
 
@@ -65,8 +65,8 @@ namespace impactx
     {
         enum
         {
-            ux,  ///< momentum in x, scaled by the magnitude of the reference momentum [unitless] (at fixed s or t)
-            uy,  ///< momentum in y, scaled by the magnitude of the reference momentum [unitless] (at fixed s or t)
+            px,  ///< momentum in x, scaled by the magnitude of the reference momentum [unitless] (at fixed s or t)
+            py,  ///< momentum in y, scaled by the magnitude of the reference momentum [unitless] (at fixed s or t)
             pt,  ///< energy deviation, scaled by speed of light * the magnitude of the reference momentum [unitless] (at fixed s)
             qm,  ///< charge to mass ratio, in q_e/m_e [q_e/eV]
             w,   ///< particle weight, number of real particles represented by this macroparticle [unitless]

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -134,8 +134,8 @@ namespace impactx
         // write Real attributes (SoA) to particle initialized zero
         DefineAndReturnParticleTile(0, 0, 0);
 
-        pinned_tile.push_back_real(RealSoA::ux, px);
-        pinned_tile.push_back_real(RealSoA::uy, py);
+        pinned_tile.push_back_real(RealSoA::px, px);
+        pinned_tile.push_back_real(RealSoA::py, py);
         pinned_tile.push_back_real(RealSoA::pt, pt);
         pinned_tile.push_back_real(RealSoA::qm, np, qm);
         pinned_tile.push_back_real(RealSoA::w, np, bchchg/ablastr::constant::SI::q_e/np);

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -67,8 +67,8 @@ namespace impactx::diagnostics
 
                 // preparing access to particle data: SoA of Reals
                 auto &soa_real = pti.GetStructOfArrays().GetRealData();
-                amrex::ParticleReal const *const AMREX_RESTRICT part_px = soa_real[RealSoA::ux].dataPtr();
-                amrex::ParticleReal const *const AMREX_RESTRICT part_py = soa_real[RealSoA::uy].dataPtr();
+                amrex::ParticleReal const *const AMREX_RESTRICT part_px = soa_real[RealSoA::px].dataPtr();
+                amrex::ParticleReal const *const AMREX_RESTRICT part_py = soa_real[RealSoA::py].dataPtr();
                 amrex::ParticleReal const *const AMREX_RESTRICT part_pt = soa_real[RealSoA::pt].dataPtr();
 
                 if (otype == OutputType::PrintParticles) {

--- a/src/particles/elements/mixin/beamoptic.H
+++ b/src/particles/elements/mixin/beamoptic.H
@@ -114,8 +114,8 @@ namespace detail
 
         // preparing access to particle data: SoA of Reals
         auto& soa_real = pti.GetStructOfArrays().GetRealData();
-        amrex::ParticleReal* const AMREX_RESTRICT part_px = soa_real[RealSoA::ux].dataPtr();
-        amrex::ParticleReal* const AMREX_RESTRICT part_py = soa_real[RealSoA::uy].dataPtr();
+        amrex::ParticleReal* const AMREX_RESTRICT part_px = soa_real[RealSoA::px].dataPtr();
+        amrex::ParticleReal* const AMREX_RESTRICT part_py = soa_real[RealSoA::py].dataPtr();
         amrex::ParticleReal* const AMREX_RESTRICT part_pt = soa_real[RealSoA::pt].dataPtr();
 
         detail::PushSingleParticle<T_Element> const pushSingleParticle(

--- a/src/particles/spacecharge/GatherAndPush.cpp
+++ b/src/particles/spacecharge/GatherAndPush.cpp
@@ -70,8 +70,8 @@ namespace impactx::spacecharge
 
                 // preparing access to particle data: SoA of Reals
                 auto& soa_real = pti.GetStructOfArrays().GetRealData();
-                amrex::ParticleReal* const AMREX_RESTRICT part_px = soa_real[RealSoA::ux].dataPtr();
-                amrex::ParticleReal* const AMREX_RESTRICT part_py = soa_real[RealSoA::uy].dataPtr();
+                amrex::ParticleReal* const AMREX_RESTRICT part_px = soa_real[RealSoA::px].dataPtr();
+                amrex::ParticleReal* const AMREX_RESTRICT part_py = soa_real[RealSoA::py].dataPtr();
                 amrex::ParticleReal* const AMREX_RESTRICT part_pz = soa_real[RealSoA::pz].dataPtr(); // note: currently for a fixed t
 
                 // group together constants for the momentum push

--- a/src/particles/transformation/CoordinateTransformation.cpp
+++ b/src/particles/transformation/CoordinateTransformation.cpp
@@ -50,8 +50,8 @@ namespace transformation {
 
                 // preparing access to particle data: SoA of Reals
                 auto &soa_real = pti.GetStructOfArrays().GetRealData();
-                amrex::ParticleReal *const AMREX_RESTRICT part_px = soa_real[RealSoA::ux].dataPtr();
-                amrex::ParticleReal *const AMREX_RESTRICT part_py = soa_real[RealSoA::uy].dataPtr();
+                amrex::ParticleReal *const AMREX_RESTRICT part_px = soa_real[RealSoA::px].dataPtr();
+                amrex::ParticleReal *const AMREX_RESTRICT part_py = soa_real[RealSoA::py].dataPtr();
 
                 if( direction == Direction::to_fixed_s) {
                     BL_PROFILE("impactx::transformation::CoordinateTransformation::to_fixed_s");


### PR DESCRIPTION
Rename momentum to start with `p` for all components. Fix a comment for `t`.

Follow-up to #351