### PR TITLE
Python: Fix Unnecessary Lambda

### DIFF
--- a/src/python/impactx/__init__.py
+++ b/src/python/impactx/__init__.py
@@ -34,4 +34,4 @@ elements.KnownElementsList.load_file = lambda self, madx_file, nslice=1: self.ex
 )  # noqa
 
 # MAD-X file reader for reference particle
-RefPart.load_file = lambda self, madx_file: read_beam(self, madx_file)  # noqa
+RefPart.load_file = read_beam  # noqa


### PR DESCRIPTION
From CodeQL:
> This 'lambda' is just a simple wrapper around a callable object. Use that object directly.
>
> A lambda that calls a function without modifying any of its parameters is unnecessary. Python functions are first class objects and can be passed around in the same way as the resulting lambda.