### PR TITLE
CUDA: Drop <11.3

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -12,7 +12,7 @@ jobs:
 #   https://github.com/ComputationalRadiationPhysics/picongpu/blob/0.5.0/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
 #   https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/
   build_nvcc:
-    name: NVCC 11.0.2 SP
+    name: NVCC 11.3.1 SP
     runs-on: ubuntu-20.04
     if: github.event.pull_request.draft == false
     env:

--- a/.github/workflows/dependencies/nvcc11-openmpi.sh
+++ b/.github/workflows/dependencies/nvcc11-openmpi.sh
@@ -28,15 +28,15 @@ echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x8
 
 sudo apt-get update
 sudo apt-get install -y          \
-    cuda-command-line-tools-11-0 \
-    cuda-compiler-11-0           \
-    cuda-cupti-dev-11-0          \
-    cuda-minimal-build-11-0      \
-    cuda-nvml-dev-11-0           \
-    cuda-nvtx-11-0               \
-    libcufft-dev-11-0            \
-    libcurand-dev-11-0
-sudo ln -s cuda-11.0 /usr/local/cuda
+    cuda-command-line-tools-11-3 \
+    cuda-compiler-11-3           \
+    cuda-cupti-dev-11-3          \
+    cuda-minimal-build-11-3      \
+    cuda-nvml-dev-11-3           \
+    cuda-nvtx-11-3               \
+    libcufft-dev-11-3            \
+    libcurand-dev-11-3
+sudo ln -s cuda-11.3 /usr/local/cuda
 
 # cmake-easyinstall
 #

--- a/docs/source/install/dependencies.rst
+++ b/docs/source/install/dependencies.rst
@@ -15,7 +15,7 @@ Please see installation instructions below.
 Optional dependencies include:
 
 - `MPI 3.0+ <https://www.mpi-forum.org/docs/>`__: for multi-node and/or multi-GPU execution
-- `CUDA Toolkit 11.0+ <https://developer.nvidia.com/cuda-downloads>`__: for Nvidia GPU support (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`_)
+- `CUDA Toolkit 11.3+ <https://developer.nvidia.com/cuda-downloads>`__: for Nvidia GPU support (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`_)
 - `OpenMP 3.1+ <https://www.openmp.org>`__: for threaded CPU execution
 - `FFTW3 <http://www.fftw.org>`_: for spectral solver support
 - `openPMD-api 0.15.1+ <https://github.com/openPMD/openPMD-api>`__: we automatically download and compile a copy of openPMD-api for openPMD I/O support


### PR DESCRIPTION
Drop support for older CUDA releases. The CUDA Toolkit 11.0 added C++17 support but had a few severe issues with it, which are better in 11.3+. These releases are now widely available, so we can drop older releases.

Related to #336