### PR TITLE
Line Element: Repeat Option

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -460,6 +460,10 @@ Lattice Elements
             * ``<element_name>.reverse`` (``boolean``) optional (default: ``false``)
               Reverse the list of elements in the line before appending to the lattice.
 
+            * ``<element_name>.repeat`` (``integer``) optional (default: ``1``)
+              Repeat the line multiple times before appending to the lattice.
+              Note: ``reverse`` is applied before ``repeat``.
+
 
 .. _running-cpp-parameters-parallelization:
 

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -462,7 +462,7 @@ Lattice Elements
 
             * ``<element_name>.repeat`` (``integer``) optional (default: ``1``)
               Repeat the line multiple times before appending to the lattice.
-              Note: ``reverse`` is applied before ``repeat``.
+              Note: If ``reverse`` and ``repeat`` both appear, then ``reverse`` is applied before ``repeat``.
 
 
 .. _running-cpp-parameters-parallelization:

--- a/examples/iota_lens/input_iotalens.in
+++ b/examples/iota_lens/input_iotalens.in
@@ -21,10 +21,11 @@ beam.mutpt = 0.0
 ###############################################################################
 # Beamline: lattice elements and segments
 ###############################################################################
-lattice.elements = const_end nllens const nllens const nllens const nllens const
-                   nllens const nllens const nllens const nllens const nllens
-                   const nllens const nllens const nllens const nllens const nllens
-                   const nllens const nllens const nllens const nllens const_end
+lattice.elements = const_end nllens foclens const_end
+
+foclens.type = line
+foclens.elements = const nllens
+foclens.repeat = 17
 
 nllens.type = nonlinear_lens
 nllens.knll = 4.0e-6

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -224,6 +224,8 @@ namespace detail
             pp_sub_lattice.queryAdd("reverse", reverse);
             int repeat = 1;
             pp_sub_lattice.queryAdd("repeat", repeat);
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(repeat >= 1,
+                                             element_name + ".repeat must be >= 1");
 
             if (reverse)
                 std::reverse(sub_lattice_elements.begin(), sub_lattice_elements.end());

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -222,12 +222,16 @@ namespace detail
             pp_sub_lattice.queryarr("elements", sub_lattice_elements);
             bool reverse = false;
             pp_sub_lattice.queryAdd("reverse", reverse);
+            int repeat = 1;
+            pp_sub_lattice.queryAdd("repeat", repeat);
 
             if (reverse)
                 std::reverse(sub_lattice_elements.begin(), sub_lattice_elements.end());
 
-            for (std::string const & sub_element_name : sub_lattice_elements) {
-                read_element(sub_element_name, m_lattice, nslice_default, mapsteps_default);
+            for (int n=0; n<repeat; ++n) {
+                for (std::string const &sub_element_name: sub_lattice_elements) {
+                    read_element(sub_element_name, m_lattice, nslice_default, mapsteps_default);
+                }
             }
         } else {
             amrex::Abort("Unknown type for lattice element " + element_name + ": " + element_type);


### PR DESCRIPTION
Adds an option to the `"line"` element to be repeated multiple times (default: 1). This is the same as our Python input to do `N * [elementA, elementB, elementC]`.

Close #365