### PR TITLE
Change Dynamic Resizing

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -84,10 +84,12 @@ Setting up the field mesh
 * ``geometry.dynamic_size`` (``boolean``) optional (default: ``true`` for dynamic)
     Use dynamic (``true``) resizing of the field mesh, via ``geometry.prob_relative``, or static sizing (``false``), via ``geometry.prob_lo``/``geometry.prob_hi``.
 
-* ``geometry.prob_relative`` (positive ``float``, unitless) optional (default: ``1.0``)
+* ``geometry.prob_relative`` (positive ``float``, unitless) optional (default: ``3.0``)
     By default, we dynamically extract the minimum and maximum of the particle positions in the beam.
-    The field mesh is expanded, per direction, beyond the physical extent of particles by this factor.
-    For instance, ``0.1`` means 10% more cells above and below the beam for vacuum; ``1.0`` means twice as many cells as covered by the beam are used, per direction, for vacuum padding.
+    The field mesh spans, per direction, multiple times the maximum physical extent of beam particles, as given by this factor.
+    The beam minimum and maximum extent are symmetrically padded by the mesh.
+    For instance, ``1.2`` means the mesh will span 10% above and 10% below the beam;
+    ``1.0`` means the beam is exactly covered with the mesh.
 
 * ``geometry.prob_lo`` and ``geometry.prob_hi`` (3 floats, in meters) optional (required if ``geometry.dynamic_size`` is ``false``)
     The extent of the full simulation domain relative to the reference particle position.

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -36,7 +36,13 @@ General
 
    .. py:property:: prob_relative
 
-      The field mesh is expanded beyond the physical extent of particles by this factor.
+      By default, we dynamically extract the minimum and maximum of the particle positions in the beam.
+      The field mesh spans, per direction, multiple times the maximum physical extent of beam particles, as given by this factor.
+      The beam minimum and maximum extent are symmetrically padded by the mesh.
+      For instance, ``1.2`` means the mesh will span 10% above and 10% below the beam;
+      ``1.0`` means the beam is exactly covered with the mesh.
+
+      Default: ``3.0``.
       When set, turns ``dynamic_size`` to ``True``.
 
    .. py:property:: dynamic_size

--- a/examples/cfchannel/input_cfchannel_10nC.in
+++ b/examples/cfchannel/input_cfchannel_10nC.in
@@ -40,5 +40,5 @@ algo.particle_shape = 2
 algo.space_charge = true
 
 amr.n_cell = 48 48 40
-#amr.n_cell = 72 72 64 #optional for increased precision
-geometry.prob_relative = 1.0
+#amr.n_cell = 72 72 64  # optional for increased precision
+geometry.prob_relative = 3.0

--- a/examples/cfchannel/run_cfchannel_10nC.py
+++ b/examples/cfchannel/run_cfchannel_10nC.py
@@ -17,7 +17,7 @@ sim = ImpactX()
 # set numerical parameters and IO control
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = True
-sim.prob_relative = 1.0
+sim.prob_relative = 3.0
 # sim.diagnostics = False  # benchmarking
 sim.slice_step_diagnostics = True
 

--- a/examples/expanding_beam/input_expanding.in
+++ b/examples/expanding_beam/input_expanding.in
@@ -35,4 +35,4 @@ algo.particle_shape = 2
 algo.space_charge = true
 
 amr.n_cell = 56 56 48
-geometry.prob_relative = 1.0
+geometry.prob_relative = 3.0

--- a/examples/expanding_beam/run_expanding.py
+++ b/examples/expanding_beam/run_expanding.py
@@ -18,7 +18,7 @@ sim = ImpactX()
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = True
 sim.dynamic_size = True
-sim.prob_relative = 1.0
+sim.prob_relative = 3.0
 
 # beam diagnostics
 # sim.diagnostics = False  # benchmarking

--- a/examples/kurth/input_kurth_10nC_periodic.in
+++ b/examples/kurth/input_kurth_10nC_periodic.in
@@ -43,5 +43,5 @@ algo.particle_shape = 2
 algo.space_charge = true
 
 amr.n_cell = 48 48 40
-#amr.n_cell = 72 72 72 #optional for increased precision
-geometry.prob_relative = 1.0
+#amr.n_cell = 72 72 72  # optional for increased precision
+geometry.prob_relative = 3.0

--- a/examples/kurth/input_kurth_periodic.in
+++ b/examples/kurth/input_kurth_periodic.in
@@ -40,4 +40,4 @@ algo.particle_shape = 2
 algo.space_charge = false
 
 amr.n_cell = 40 40 32
-geometry.prob_relative = 1.0
+geometry.prob_relative = 3.0

--- a/src/initialization/InitMeshRefinement.cpp
+++ b/src/initialization/InitMeshRefinement.cpp
@@ -160,7 +160,7 @@ namespace impactx
                 ablastr::warn_manager::WMRecordWarning(
                     "ImpactX::ResizeMesh",
                     "Dynamic resizing of the mesh uses a geometry.prob_relative "
-                    "with less than 3 the beam size. This might result in boundary "
+                    "with less than 3x the beam size. This might result in boundary "
                     "artifacts for space charge calculation. "
                     "There is no minimum good value for this parameter, consider "
                     "doing a convergence test.",

--- a/src/initialization/InitMeshRefinement.cpp
+++ b/src/initialization/InitMeshRefinement.cpp
@@ -153,29 +153,31 @@ namespace impactx
         {
             // The box is expanded beyond the min and max of particles.
             // This controlled by the variable `frac` below.
-            amrex::Real frac = 1.0;
+            amrex::Real frac = 3.0;
             pp_geometry.query("prob_relative", frac);
 
-            if (frac < 1.0)
+            if (frac < 3.0)
                 ablastr::warn_manager::WMRecordWarning(
                     "ImpactX::ResizeMesh",
                     "Dynamic resizing of the mesh uses a geometry.prob_relative "
-                    "padding of less than 1. This might result in boundary "
+                    "with less than 3 the beam size. This might result in boundary "
                     "artifacts for space charge calculation. "
                     "There is no minimum good value for this parameter, consider "
                     "doing a convergence test.",
                     ablastr::warn_manager::WarnPriority::high
                 );
 
-            if (frac < 0.0)
-                throw std::runtime_error("geometry.prob_relative must be positive");
+            if (frac < 1.0)
+                throw std::runtime_error("geometry.prob_relative must be >= 1.0 (the beam size) on the coarsest level");
 
-            rb = {
-                {x_min - frac * (x_max - x_min), y_min - frac * (y_max - y_min),
-                 z_min - frac * (z_max - z_min)}, // Low bound
-                {x_max + frac * (x_max - x_min), y_max + frac * (y_max - y_min),
-                 z_max + frac * (z_max - z_min)}  // High bound
-            };
+            amrex::RealVect const beam_min(x_min, y_min, z_min);
+            amrex::RealVect const beam_max(x_max, y_max, z_max);
+            amrex::RealVect const beam_width(beam_max - beam_min);
+
+            amrex::RealVect const beam_padding = beam_width * (frac - 1.0) / 2.0;
+            //                           added to the beam extent --^         ^-- box half above/below the beam
+            rb.setLo(beam_min - beam_padding);
+            rb.setHi(beam_max + beam_padding);
         }
         else
         {

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -142,7 +142,7 @@ void init_ImpactX (py::module& m)
                   amrex::ParmParse pp_geometry("geometry");
                   pp_geometry.add("prob_relative", frac);
               },
-              "The field mesh is expanded beyond the physical extent of particles by this factor."
+              "The field mesh spans, per direction, multiple times the maximum physical extent of beam particles, as given by this factor."
         )
 
         .def_property("dynamic_size",


### PR DESCRIPTION
Change `geometry.prob_relative` to include the beam extent itself in the definition.

Now, `1.0` is exactly the beam, `3.0` is a simulation box with a size 3x than the beam size (as measured by min/max of the most outermost particles per direction).

Preparation for #261, where we want to define higher MR levels to be potentially cutting into the beam distribution.

- [x] depends on https://github.com/AMReX-Codes/amrex/pull/3328 / #371