### PR TITLE
Generate compile_commands.json for clangd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ cmake-build-*/
 .kdev?/
 *.kdev?
 
+# clangd LSP files
+compile_commands.json
+**.cache/clangd
+
 # File-based project format:
 *.iws
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ cmake-build-*/
 *.kdev?
 
 # clangd LSP files
-compile_commands.json
 **.cache/clangd
 
 # File-based project format:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,16 @@ cmake_minimum_required(VERSION 3.20.0)
 project(ImpactX VERSION 23.06)
 
 # generate compile_commands.json
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-    # and place it in the source directory https://stackoverflow.com/a/60910583
-    add_custom_target(
-      copy-compile-commands ALL
-      ${CMAKE_COMMAND} -E copy_if_different
-      ${CMAKE_BINARY_DIR}/compile_commands.json ${PROJECT_SOURCE_DIR})
+if(${CMAKE_GENERATOR} STREQUAL "Unix Makefiles" OR ${CMAKE_GENERATOR} STREQUAL
+                                                   "Ninja")
+  if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+      set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+      # and place it in the source directory https://stackoverflow.com/a/60910583
+      add_custom_target(
+        copy-compile-commands ALL
+        ${CMAKE_COMMAND} -E copy_if_different
+        ${CMAKE_BINARY_DIR}/compile_commands.json ${PROJECT_SOURCE_DIR})
+  endif()
 endif()
 
 include(${ImpactX_SOURCE_DIR}/cmake/ImpactXFunctions.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,14 @@
 cmake_minimum_required(VERSION 3.20.0)
 project(ImpactX VERSION 23.06)
 
+# generate compile_commands.json
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+# and place it in the source directory https://stackoverflow.com/a/60910583
+add_custom_target(
+  copy-compile-commands ALL
+  ${CMAKE_COMMAND} -E copy_if_different
+  ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_CURRENT_LIST_DIR})
+
 include(${ImpactX_SOURCE_DIR}/cmake/ImpactXFunctions.cmake)
 
 # In-source tree builds are messy and can screw up the build system.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,6 @@ if(${CMAKE_GENERATOR} STREQUAL "Unix Makefiles" OR ${CMAKE_GENERATOR} STREQUAL
                                                    "Ninja")
   if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
       set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-      # and place it in the source directory https://stackoverflow.com/a/60910583
-      add_custom_target(
-        copy-compile-commands ALL
-        ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_BINARY_DIR}/compile_commands.json ${PROJECT_SOURCE_DIR})
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,14 @@ cmake_minimum_required(VERSION 3.20.0)
 project(ImpactX VERSION 23.06)
 
 # generate compile_commands.json
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-# and place it in the source directory https://stackoverflow.com/a/60910583
-add_custom_target(
-  copy-compile-commands ALL
-  ${CMAKE_COMMAND} -E copy_if_different
-  ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_CURRENT_LIST_DIR})
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+    # and place it in the source directory https://stackoverflow.com/a/60910583
+    add_custom_target(
+      copy-compile-commands ALL
+      ${CMAKE_COMMAND} -E copy_if_different
+      ${CMAKE_BINARY_DIR}/compile_commands.json ${PROJECT_SOURCE_DIR})
+endif()
 
 include(${ImpactX_SOURCE_DIR}/cmake/ImpactXFunctions.cmake)
 

--- a/src/particles/elements/diagnostics/openPMD.cpp
+++ b/src/particles/elements/diagnostics/openPMD.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "openPMD.H"
+#include "ImpactXVersion.H"
 #include "particles/ImpactXParticleContainer.H"
 
 #include <ablastr/particles/IndexHandling.H>
@@ -198,6 +199,7 @@ namespace detail
 #   endif
                 , "adios2.engine.usesteps = true"
             );
+            series.setSoftware("impactx", IMPACTX_VERSION);
             series.setIterationEncoding( series_encoding );
             m_series = series;
             m_unique_series[m_series_name] = series;


### PR DESCRIPTION
`compile_commands.json` is used by [`clangd` LSP](https://clangd.llvm.org/) to [interpret the source files](https://clangd.llvm.org/design/compile-commands)