### PR TITLE
Doc: IPAC23 Paper

### DIFF
--- a/docs/source/acknowledge_us.rst
+++ b/docs/source/acknowledge_us.rst
@@ -28,7 +28,7 @@ Please add the following sentence to your publications, it helps contributors ke
   This research used the open-source particle-in-cell code ImpactX \url{https://github.com/ECP-WarpX/impactx}.
   We acknowledge all ImpactX contributors.
 
-Main ImpactX reference
+Main ImpactX Reference
 **********************
 
 If your project leads to a scientific publication, please consider citing the paper below.
@@ -38,3 +38,17 @@ If your project leads to a scientific publication, please consider citing the pa
   2022 North American Particle Accelerator Conference (NAPAC'22), TUYE2, pp. 302-306, 2022.
   `arXiv:2208.02382 <https://arxiv.org/abs/2208.02382>`__,
   `DOI:10.18429/JACoW-NAPAC2022-TUYE2 <https://doi.org/10.18429/JACoW-NAPAC2022-TUYE2>`__
+
+Further ImpactX References
+**************************
+
+- Sandberg R T, Lehe R, Mitchell C E, Garten M, Qiang J, Vay J-L and Huebl A.
+  **Hybrid Beamline Element ML-Training for Surrogates in the ImpactX Beam-Dynamics Code**.
+  14th International Particle Accelerator Conference (IPAC'23), WEPA101, *in print*, 2023.
+  `preprint <https://www.ipac23.org/preproc/pdf/WEPA101.pdf>`__,
+  `DOI:10.18429/JACoW-IPAC-23-WEPA101 <https://doi.org/10.18429/JACoW-IPAC-23-WEPA101>`__
+
+- Huebl A, Lehe R, Zoni E, Shapoval O, Sandberg R T, Garten M, Formenti A, Jambunathan R, Kumar P, Gott K, Myers A, Zhang W, Almgren A, Mitchell C E, Qiang J, Sinn A, Diederichs S, Thevenet M, Grote D, Fedeli L, Clark T, Zaim N, Vincenti H, Vay JL.
+  **From Compact Plasma Particle Sources to Advanced Accelerators with Modeling at Exascale**.
+  Proceedings of the 20th Advanced Accelerator Concepts Workshop (AAC'22), *in print*, 2023.
+  `arXiv:2303.12873 <https://arxiv.org/abs/2303.12873>`__


### PR DESCRIPTION
Document the IPAC23 paper, which uses WarpX to train an ML model for ImpactX.