### PR TITLE
CI: Fix macOS Brew CMake

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,7 +43,7 @@ jobs:
         brew install --overwrite python
         brew install adios2
         brew install ccache
-        brew install cmake
+        brew install --cask cmake
         brew install hdf5-mpi
         brew install libomp
         brew link --force libomp


### PR DESCRIPTION
```
Warning: Treating cmake as a formula. For the cask, use homebrew/cask/cmake
Warning: cmake 3.26.4 is already installed and up-to-date.
To reinstall 3.26.4, run:
  brew reinstall cmake
```
```
/Users/runner/work/_temp/92017562-3156-4be4-9360-ab3ff5e42767.sh: line 1: cmake: command not found
```