### PR TITLE
Store additional beam metadata

### DIFF
--- a/src/particles/elements/diagnostics/openPMD.cpp
+++ b/src/particles/elements/diagnostics/openPMD.cpp
@@ -257,6 +257,11 @@ namespace detail
             }
         }
 
+        // beam mass
+        beam.setAttribute( "mass", ref_part.mass );
+        beam.setAttribute( "beta_ref", ref_part.beta() );
+        beam.setAttribute( "gamma_ref", ref_part.gamma() );
+
         // openPMD coarse position
         {
             beam["positionOffset"]["x"].resetDataset(d_fl);


### PR DESCRIPTION
In offline discussions with @s-sajid-ali, it was proposed to add `particle_mass, beta_ref, gamma_ref` as attributes in the openPMD file, in order to make the ImpactX output readable by Synergia.