### PR TITLE
Add aperture element

### DIFF
--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -29,6 +29,7 @@ This section allows you to **download input files** that correspond to different
    examples/compression/README.rst
    examples/kicker/README.rst
    examples/thin_dipole/README.rst
+   examples/aperture/README.rst
 
 
 Unit tests

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -520,13 +520,13 @@ Lattice Elements
         * ``aperture`` for a thin collimator element applying a transverse aperture boundary.
           This requires these additional parameters:
 
-            * ``<element_name>.shape`` (``integer``, dimensionless) shape of the aperture boundary
-
-                (m = 0) rectangular, (m = 1) elliptical
-
             * ``<element_name>.xmax`` (``float``, in meters) maximum value of the horizontal coordinate
 
             * ``<element_name>.ymax`` (``float``, in meters) maximum value of the vertical coordinate
+
+            * ``<element_name>.shape`` (``integer``, dimensionless) shape of the aperture boundary
+
+                (m = 0) rectangular, (m = 1) elliptical
 
         * ``beam_monitor`` a beam monitor, writing all beam particles at fixed ``s`` to openPMD files.
           If the same element name is used multiple times, then an output series is created with multiple outputs.

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -524,9 +524,7 @@ Lattice Elements
 
             * ``<element_name>.ymax`` (``float``, in meters) maximum value of the vertical coordinate
 
-            * ``<element_name>.shape`` (``integer``, dimensionless) shape of the aperture boundary
-
-                (m = 0) rectangular, (m = 1) elliptical
+            * ``<element_name>.shape`` (``string``) shape of the aperture boundary: ``rectangular`` (default) or ``elliptical``
 
         * ``beam_monitor`` a beam monitor, writing all beam particles at fixed ``s`` to openPMD files.
           If the same element name is used multiple times, then an output series is created with multiple outputs.

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -509,7 +509,6 @@ Lattice Elements
 
             * ``<element_name>.units`` (``string``) specification of units: ``dimensionless`` (default, in units of the magnetic rigidity of the reference particle) or ``T-m``
 
-
         * ``thin_dipole`` for a thin dipole element.
           This requires these additional parameters:
 

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -509,12 +509,24 @@ Lattice Elements
 
             * ``<element_name>.units`` (``string``) specification of units: ``dimensionless`` (default, in units of the magnetic rigidity of the reference particle) or ``T-m``
 
+
         * ``thin_dipole`` for a thin dipole element.
           This requires these additional parameters:
 
             * ``<element_name>.theta`` (``float``, in degrees) dipole bend angle
 
             * ``<element_name>.rc`` (``float``, in meters) effective radius of curvature
+
+        * ``aperture`` for a thin collimator element applying a transverse aperture boundary.
+          This requires these additional parameters:
+
+            * ``<element_name>.shape`` (``integer``, dimensionless) shape of the aperture boundary
+
+                (m = 0) rectangular, (m = 1) elliptical
+
+            * ``<element_name>.xmax`` (``float``, in meters) maximum value of the horizontal coordinate
+
+            * ``<element_name>.ymax`` (``float``, in meters) maximum value of the vertical coordinate
 
         * ``beam_monitor`` a beam monitor, writing all beam particles at fixed ``s`` to openPMD files.
           If the same element name is used multiple times, then an output series is created with multiple outputs.

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -701,6 +701,11 @@ Diagnostics and output
 * ``diag.file_min_digits`` (``integer``, optional, default: ``6``)
     The minimum number of digits used for the step number appended to the diagnostic file names.
 
+* ``diag.backend`` (``string``, default value: ``default``)
+
+  Diagnostics for particles lost in apertures, stored as ``diags/openPMD/particles_lost.*`` at the end of the simulation.
+  See the ``beam_monitor`` element for backend values.
+
 .. _running-cpp-parameters-diagnostics-reduced:
 
 Reduced Diagnostics

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -116,6 +116,11 @@ General
       The minimum number of digits (default: ``6``) used for the step
       number appended to the diagnostic file names.
 
+   .. py:property:: particle_lost_diagnostics_backend
+
+      Diagnostics for particles lost in apertures.
+      See the ``BeamMonitor`` element for backend values.
+
    .. py:method:: init_grids()
 
       Initialize AMReX blocks/grids for domain decomposition & space charge mesh.

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -712,13 +712,13 @@ References:
    :param phi_in: angle of the reference particle with respect to the longitudinal (z) axis in the original frame in degrees
    :param phi_out: angle of the reference particle with respect to the longitudinal (z) axis in the rotated frame in degrees
 
-.. py:class:: impactx.elements.Aperture(xmax, ymax, shape=0)
+.. py:class:: impactx.elements.Aperture(xmax, ymax, shape="rectangular")
 
    A thin collimator element, applying a transverse aperture boundary.
 
    :param xmax: maximum allowed value of the horizontal coordinate (meter)
    :param ymax: maximum allowed value of the vertical coordinate (meter)
-   :param shape: aperture boundary shape (0 rectangular, 1 elliptical)
+   :param shape: aperture boundary shape: ``"rectangular"`` (default) or ``"elliptical"``
 
 .. py:class:: impactx.elements.SoftQuadrupole(ds, gscale, cos_coefficients, sin_coefficients, nslice=1)
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -712,6 +712,14 @@ References:
    :param phi_in: angle of the reference particle with respect to the longitudinal (z) axis in the original frame in degrees
    :param phi_out: angle of the reference particle with respect to the longitudinal (z) axis in the rotated frame in degrees
 
+.. py:class:: impactx.elements.Aperture(shape=0, xmax, ymax)
+
+   A thin collimator element, applying a transverse aperture boundary.
+
+   :param shape: aperture boundary shape (0 rectangular, 1 elliptical)
+   :param xmax: maximum value of the horizontal coordinate (meter)
+   :param ymax: maximum value of the vertical coordinate (meter)
+
 .. py:class:: impactx.elements.SoftQuadrupole(ds, gscale, cos_coefficients, sin_coefficients, nslice=1)
 
    A soft-edge quadrupole.

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -712,13 +712,13 @@ References:
    :param phi_in: angle of the reference particle with respect to the longitudinal (z) axis in the original frame in degrees
    :param phi_out: angle of the reference particle with respect to the longitudinal (z) axis in the rotated frame in degrees
 
-.. py:class:: impactx.elements.Aperture(shape=0, xmax, ymax)
+.. py:class:: impactx.elements.Aperture(xmax, ymax, shape=0)
 
    A thin collimator element, applying a transverse aperture boundary.
 
+   :param xmax: maximum allowed value of the horizontal coordinate (meter)
+   :param ymax: maximum allowed value of the vertical coordinate (meter)
    :param shape: aperture boundary shape (0 rectangular, 1 elliptical)
-   :param xmax: maximum value of the horizontal coordinate (meter)
-   :param ymax: maximum value of the vertical coordinate (meter)
 
 .. py:class:: impactx.elements.SoftQuadrupole(ds, gscale, cos_coefficients, sin_coefficients, nslice=1)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -619,7 +619,6 @@ add_impactx_test(kicker.py
     examples/kicker/analysis_kicker.py
     OFF  # no plot script yet
 )
-
 # copy MAD-X lattice file
 file(COPY ${ImpactX_SOURCE_DIR}/examples/kicker/kicker.madx
         DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/kicker_madx.py)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -619,6 +619,7 @@ add_impactx_test(kicker.py
     examples/kicker/analysis_kicker.py
     OFF  # no plot script yet
 )
+
 # copy MAD-X lattice file
 file(COPY ${ImpactX_SOURCE_DIR}/examples/kicker/kicker.madx
         DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/kicker_madx.py)
@@ -655,5 +656,23 @@ add_impactx_test(thin_dipole.py
       OFF  # ImpactX MPI-parallel
       ON   # ImpactX Python interface
     examples/thin_dipole/analysis_thin_dipole.py
+    OFF  # no plot script yet
+)
+
+# Aperture collimation ############################################################
+#
+# w/o space charge
+add_impactx_test(aperture
+    examples/aperture/input_aperture.in
+      ON  # ImpactX MPI-parallel
+      OFF  # ImpactX Python interface
+    examples/aperture/analysis_aperture.py
+    OFF  # no plot script yet
+)
+add_impactx_test(aperture.py
+    examples/aperture/run_aperture.py
+      OFF  # ImpactX MPI-parallel
+      ON  # ImpactX Python interface
+    examples/aperture/analysis_aperture.py
     OFF  # no plot script yet
 )

--- a/examples/aperture/README.rst
+++ b/examples/aperture/README.rst
@@ -1,7 +1,7 @@
 .. _examples-aperture:
 
-Aperture collimation
-=====================
+Aperture Collimation
+====================
 
 Proton beam undergoing collimation by a rectangular boundary aperture.
 

--- a/examples/aperture/README.rst
+++ b/examples/aperture/README.rst
@@ -1,0 +1,47 @@
+.. _examples-aperture:
+
+Aperture collimation
+=====================
+
+Proton beam undergoing collimation by a rectangular boundary aperture.
+
+
+We use a 250 MeV proton beam with a horizontal rms beam size of 1.56 mm and a vertical rms beam size of 2.21 mm.
+
+The beam is scraped by a 1 mm x 1.5 mm rectangular aperture.
+
+In this test, the initial values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+The test fails if any of the final coordinates for the valid (not lost) particles lie outside the aperture boundary.
+
+
+Run
+---
+
+This example can be run as a Python script (``python3 run_aperture.py``) or with an app with an input file (``impactx input_aperture.in``).
+Each can also be prefixed with an `MPI executor <https://www.mpi-forum.org>`__, such as ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+
+.. tab-set::
+
+   .. tab-item:: Python Script
+
+       .. literalinclude:: run_aperture.py
+          :language: python3
+          :caption: You can copy this file from ``examples/aperture/run_aperture.py``.
+
+   .. tab-item:: App Input File
+
+       .. literalinclude:: input_aperture.in
+          :language: ini
+          :caption: You can copy this file from ``examples/aperture/input_aperture.in``.
+
+
+Analyze
+-------
+
+We run the following script to analyze correctness:
+
+.. dropdown:: Script ``analysis_aperture.py``
+
+   .. literalinclude:: analysis_aperture.py
+      :language: python3
+      :caption: You can copy this file from ``examples/aperture/analysis_aperture.py``.

--- a/examples/aperture/README.rst
+++ b/examples/aperture/README.rst
@@ -8,10 +8,15 @@ Proton beam undergoing collimation by a rectangular boundary aperture.
 
 We use a 250 MeV proton beam with a horizontal rms beam size of 1.56 mm and a vertical rms beam size of 2.21 mm.
 
-The beam is scraped by a 1 mm x 1.5 mm rectangular aperture.
+After a short drift of 0.123, the beam is scraped by a 1 mm x 1.5 mm rectangular aperture.
 
 In this test, the initial values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
-The test fails if any of the final coordinates for the valid (not lost) particles lie outside the aperture boundary.
+The test fails if:
+
+* any of the final coordinates for the valid (not lost) particles lie outside the aperture boundary or
+* any of the lost particles are inside the aperture boundary or
+* if the sum of lost and kept particles is not equal to the initial particles or
+* if the recorded position :math:`s` for the lost particles does not coincide with the drift distance.
 
 
 Run

--- a/examples/aperture/analysis_aperture.py
+++ b/examples/aperture/analysis_aperture.py
@@ -53,8 +53,6 @@ num_particles = 10000
 assert num_particles == len(initial)
 # we lost particles in apertures
 assert num_particles > len(final)
-print(len(final))
-print(len(particles_lost))
 assert num_particles == len(particles_lost) + len(final)
 
 print("Initial Beam:")
@@ -111,3 +109,8 @@ assert np.greater_equal(dx.max(), 0.0)
 print(f"  y_max={particles_lost['position_y'].max()}")
 print(f"  y_min={particles_lost['position_y'].min()}")
 assert np.greater_equal(dy.max(), 0.0)
+
+# check that s is set correctly
+lost_at_s = particles_lost["s_lost"]
+drift_s = np.ones_like(lost_at_s) * 0.123
+assert np.allclose(lost_at_s, drift_s)

--- a/examples/aperture/analysis_aperture.py
+++ b/examples/aperture/analysis_aperture.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+import numpy as np
+import openpmd_api as io
+from scipy.stats import moment
+
+
+def get_moments(beam):
+    """Calculate standard deviations of beam position & momenta
+    and emittance values
+
+    Returns
+    -------
+    sigx, sigy, sigt, emittance_x, emittance_y, emittance_t
+    """
+    sigx = moment(beam["position_x"], moment=2) ** 0.5  # variance -> std dev.
+    sigpx = moment(beam["momentum_x"], moment=2) ** 0.5
+    sigy = moment(beam["position_y"], moment=2) ** 0.5
+    sigpy = moment(beam["momentum_y"], moment=2) ** 0.5
+    sigt = moment(beam["position_t"], moment=2) ** 0.5
+    sigpt = moment(beam["momentum_t"], moment=2) ** 0.5
+
+    epstrms = beam.cov(ddof=0)
+    emittance_x = (
+        sigx**2 * sigpx**2 - epstrms["position_x"]["momentum_x"] ** 2
+    ) ** 0.5
+    emittance_y = (
+        sigy**2 * sigpy**2 - epstrms["position_y"]["momentum_y"] ** 2
+    ) ** 0.5
+    emittance_t = (
+        sigt**2 * sigpt**2 - epstrms["position_t"]["momentum_t"] ** 2
+    ) ** 0.5
+
+    return (sigx, sigy, sigt, emittance_x, emittance_y, emittance_t)
+
+
+# initial/final beam
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+last_step = list(series.iterations)[-1]
+initial = series.iterations[1].particles["beam"].to_df()
+final = series.iterations[last_step].particles["beam"].to_df()
+
+# compare number of particles
+num_particles = 10000
+assert num_particles == len(initial)
+assert num_particles == len(final)
+
+print("Initial Beam:")
+sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(initial)
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
+print(
+    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
+)
+
+atol = 0.0  # ignored
+rtol = 1.8 * num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
+    [
+        1.559531175539e-3,
+        2.205510139392e-3,
+        1.0e-3,
+        1.0e-6,
+        2.0e-6,
+        1.0e-6,
+    ],
+    rtol=rtol,
+    atol=atol,
+)
+
+# particle-wise comparison against the rectangular aperture boundary
+xmax = 1.0e-3
+ymax = 1.5e-3
+
+dx = abs(final["position_x"]) - xmax
+dy = abs(final["position_y"]) - ymax
+
+print()
+print(f"  x_max={final['position_x'].max()}")
+print(f"  x_min={final['position_x'].min()}")
+assert np.less_equal(dx.max(), 0.0)
+
+print(f"  y_max={final['position_y'].max()}")
+print(f"  y_min={final['position_y'].min()}")
+assert np.less_equal(dy.max(), 0.0)

--- a/examples/aperture/input_aperture.in
+++ b/examples/aperture/input_aperture.in
@@ -1,0 +1,46 @@
+###############################################################################
+# Particle Beam(s)
+###############################################################################
+beam.npart = 10000
+beam.units = static
+beam.energy = 250.0
+beam.charge = 1.0e-9
+beam.particle = proton
+beam.distribution = waterbag
+beam.sigmaX = 1.559531175539e-3
+beam.sigmaY = 2.205510139392e-3
+beam.sigmaT = 1.0e-3
+beam.sigmaPx = 6.41218345413e-4
+beam.sigmaPy = 9.06819680526e-4
+beam.sigmaPt = 1.0e-3
+beam.muxpx = 0.0
+beam.muypy = 0.0
+beam.mutpt = 0.0
+
+
+###############################################################################
+# Beamline: lattice elements and segments
+###############################################################################
+lattice.elements = monitor collimator monitor
+lattice.nslice = 1
+
+monitor.type = beam_monitor
+monitor.backend = h5
+
+collimator.type = aperture
+collimator.shape = 0
+collimator.xmax = 1.0e-3
+collimator.ymax = 1.5e-3
+
+
+###############################################################################
+# Algorithms
+###############################################################################
+algo.particle_shape = 2
+algo.space_charge = false
+
+
+###############################################################################
+# Diagnostics
+###############################################################################
+diag.slice_step_diagnostics = true

--- a/examples/aperture/input_aperture.in
+++ b/examples/aperture/input_aperture.in
@@ -44,3 +44,4 @@ algo.space_charge = false
 # Diagnostics
 ###############################################################################
 diag.slice_step_diagnostics = true
+diag.backend = h5

--- a/examples/aperture/input_aperture.in
+++ b/examples/aperture/input_aperture.in
@@ -28,7 +28,7 @@ monitor.type = beam_monitor
 monitor.backend = h5
 
 collimator.type = aperture
-collimator.shape = 0
+collimator.shape = rectangular
 collimator.xmax = 1.0e-3
 collimator.ymax = 1.5e-3
 

--- a/examples/aperture/input_aperture.in
+++ b/examples/aperture/input_aperture.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 250.0
+beam.kin_energy = 250.0
 beam.charge = 1.0e-9
 beam.particle = proton
 beam.distribution = waterbag

--- a/examples/aperture/input_aperture.in
+++ b/examples/aperture/input_aperture.in
@@ -21,11 +21,14 @@ beam.mutpt = 0.0
 ###############################################################################
 # Beamline: lattice elements and segments
 ###############################################################################
-lattice.elements = monitor collimator monitor
+lattice.elements = monitor drift collimator monitor
 lattice.nslice = 1
 
 monitor.type = beam_monitor
 monitor.backend = h5
+
+drift.type = drift
+drift.ds = 0.123
 
 collimator.type = aperture
 collimator.shape = rectangular

--- a/examples/aperture/run_aperture.py
+++ b/examples/aperture/run_aperture.py
@@ -49,7 +49,7 @@ monitor = elements.BeamMonitor("monitor", backend="h5")
 sim.lattice.extend(
     [
         monitor,
-        elements.Aperture(shape=0, xmax=1.0e-3, ymax=1.5e-3),
+        elements.Aperture(xmax=1.0e-3, ymax=1.5e-3, shape=0),
         monitor,
     ]
 )

--- a/examples/aperture/run_aperture.py
+++ b/examples/aperture/run_aperture.py
@@ -50,6 +50,7 @@ monitor = elements.BeamMonitor("monitor", backend="h5")
 sim.lattice.extend(
     [
         monitor,
+        elements.Drift(0.123),
         elements.Aperture(xmax=1.0e-3, ymax=1.5e-3, shape="rectangular"),
         monitor,
     ]

--- a/examples/aperture/run_aperture.py
+++ b/examples/aperture/run_aperture.py
@@ -16,6 +16,7 @@ sim.particle_shape = 2  # B-spline order
 sim.space_charge = False
 # sim.diagnostics = False  # benchmarking
 sim.slice_step_diagnostics = True
+sim.particle_lost_diagnostics_backend = "h5"
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/examples/aperture/run_aperture.py
+++ b/examples/aperture/run_aperture.py
@@ -49,7 +49,7 @@ monitor = elements.BeamMonitor("monitor", backend="h5")
 sim.lattice.extend(
     [
         monitor,
-        elements.Aperture(xmax=1.0e-3, ymax=1.5e-3, shape=0),
+        elements.Aperture(xmax=1.0e-3, ymax=1.5e-3, shape="rectangular"),
         monitor,
     ]
 )

--- a/examples/aperture/run_aperture.py
+++ b/examples/aperture/run_aperture.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Marco Garten, Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+import amrex.space3d as amr
+from impactx import ImpactX, RefPart, distribution, elements
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# load a 250 MeV proton beam with an initial
+# horizontal rms emittance of 1 um and an
+# initial vertical rms emittance of 2 um
+energy_MeV = 250.0  # reference energy
+bunch_charge_C = 1.0e-9  # used with space charge
+npart = 10000  # number of macro particles
+
+#   reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_energy_MeV(energy_MeV)
+
+#   particle bunch
+distr = distribution.Waterbag(
+    sigmaX=1.559531175539e-3,
+    sigmaY=2.205510139392e-3,
+    sigmaT=1.0e-3,
+    sigmaPx=6.41218345413e-4,
+    sigmaPy=9.06819680526e-4,
+    sigmaPt=1.0e-3,
+)
+sim.add_particles(bunch_charge_C, distr, npart)
+
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+
+# design the accelerator lattice
+sim.lattice.extend(
+    [
+        monitor,
+        elements.Aperture(shape=0, xmax=1.0e-3, ymax=1.5e-3),
+        monitor,
+    ]
+)
+
+# run simulation
+sim.evolve()
+
+# clean shutdown
+del sim
+amr.finalize()

--- a/examples/aperture/run_aperture.py
+++ b/examples/aperture/run_aperture.py
@@ -23,13 +23,13 @@ sim.init_grids()
 # load a 250 MeV proton beam with an initial
 # horizontal rms emittance of 1 um and an
 # initial vertical rms emittance of 2 um
-energy_MeV = 250.0  # reference energy
+kin_energy_MeV = 250.0  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/aperture/run_aperture.py
+++ b/examples/aperture/run_aperture.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright 2022-2023 ImpactX contributors
-# Authors: Marco Garten, Axel Huebl, Chad Mitchell
+# Authors: Axel Huebl, Chad Mitchell
 # License: BSD-3-Clause-LBNL
 #
 # -*- coding: utf-8 -*-

--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -134,6 +134,9 @@ namespace impactx
         /** these are the physical/beam particles of the simulation */
         std::unique_ptr<ImpactXParticleContainer> m_particle_container;
 
+        /** former beam particles that got lost in apertures, the wall, etc. */
+        std::unique_ptr<ImpactXParticleContainer> m_particles_lost;
+
         /** charge density per level */
         std::unordered_map<int, amrex::MultiFab> m_rho;
         /** scalar potential per level */

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -34,7 +34,8 @@ namespace impactx
 {
     ImpactX::ImpactX ()
         : AmrCore(initialization::init_amr_core()),
-          m_particle_container(std::make_unique<ImpactXParticleContainer>(this))
+          m_particle_container(std::make_unique<ImpactXParticleContainer>(this)),
+          m_particles_lost(std::make_unique<ImpactXParticleContainer>(this))
     {
         // todo: if amr.n_cells is provided, overwrite/redefine AmrCore object
 
@@ -82,6 +83,18 @@ namespace impactx
         // init blocks / grids & MultiFabs
         AmrCore::InitFromScratch(0.0);
         amrex::Print() << "boxArray(0) " << boxArray(0) << std::endl;
+
+        // alloc particle containers
+        //   the lost particles have an extra runtime attribute: s when it was lost
+        bool comm = true;
+        m_particles_lost->AddRealComp(comm);
+
+        //   have to resize here, not in the constructor because grids have not
+        //   been built when constructor was called.
+        m_particle_container->reserveData();
+        m_particle_container->resizeData();
+        m_particles_lost->reserveData();
+        m_particles_lost->resizeData();
     }
 
     void ImpactX::evolve ()

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -9,6 +9,7 @@
  */
 #include "ImpactX.H"
 #include "initialization/InitAmrCore.H"
+#include "particles/CollectLost.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/Push.H"
 #include "particles/diagnostics/DiagnosticOutput.H"
@@ -209,6 +210,9 @@ namespace impactx
 
                     // push all particles with external maps
                     Push(*m_particle_container, element_variant, global_step);
+
+                    // move "lost" particles to another particle container
+                    collect_lost_particles(*m_particle_container, *m_particles_lost);
 
                     // just prints an empty newline at the end of the slice_step
                     amrex::Print() << "\n";

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -281,6 +281,16 @@ namespace impactx
                                           diagnostics::OutputType::PrintReducedBeamCharacteristics,
                                           "diags/reduced_beam_characteristics_final",
                                           global_step);
+
+            // output particles lost in apertures
+            {
+                std::string openpmd_backend = "default";
+                pp_diag.queryAdd("backend", openpmd_backend);
+
+                diagnostics::BeamMonitor output_lost("particles_lost", openpmd_backend, "g");
+                output_lost(*m_particles_lost, 0);
+                output_lost.finalize();
+            }
         }
 
         // loop over all beamline elements & finalize them

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -95,6 +95,9 @@ namespace impactx
         m_particle_container->resizeData();
         m_particles_lost->reserveData();
         m_particles_lost->resizeData();
+
+        // register shortcut
+        m_particle_container->SetLostParticleContainer(m_particles_lost.get());
     }
 
     void ImpactX::evolve ()
@@ -225,7 +228,7 @@ namespace impactx
                     Push(*m_particle_container, element_variant, global_step);
 
                     // move "lost" particles to another particle container
-                    collect_lost_particles(*m_particle_container, *m_particles_lost);
+                    collect_lost_particles(*m_particle_container);
 
                     // just prints an empty newline at the end of the slice_step
                     amrex::Print() << "\n";

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -283,6 +283,7 @@ namespace impactx
                                           global_step);
 
             // output particles lost in apertures
+            if (m_particles_lost->TotalNumberOfParticles() > 0)
             {
                 std::string openpmd_backend = "default";
                 pp_diag.queryAdd("backend", openpmd_backend);

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -248,6 +248,13 @@ namespace detail
                 Kicker::UnitSystem::dimensionless :
                 Kicker::UnitSystem::Tm;
             m_lattice.emplace_back( Kicker(xkick, ykick, units) );
+        } else if (element_type == "aperture") {
+            amrex::Real xmax, ymax;
+            int shape = 0;
+            pp_element.get("xmax", xmax);
+	        pp_element.get("ymax", ymax);
+            pp_element.queryAdd("shape", shape);
+            m_lattice.emplace_back( Aperture(shape, xmax, ymax) );
         } else if (element_type == "beam_monitor") {
             std::string openpmd_name = element_name;
             pp_element.queryAdd("name", openpmd_name);

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -252,9 +252,9 @@ namespace detail
             amrex::Real xmax, ymax;
             int shape = 0;
             pp_element.get("xmax", xmax);
-	        pp_element.get("ymax", ymax);
+            pp_element.get("ymax", ymax);
             pp_element.queryAdd("shape", shape);
-            m_lattice.emplace_back( Aperture(shape, xmax, ymax) );
+            m_lattice.emplace_back( Aperture(xmax, ymax, shape) );
         } else if (element_type == "beam_monitor") {
             std::string openpmd_name = element_name;
             pp_element.queryAdd("name", openpmd_name);

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -250,10 +250,15 @@ namespace detail
             m_lattice.emplace_back( Kicker(xkick, ykick, units) );
         } else if (element_type == "aperture") {
             amrex::Real xmax, ymax;
-            int shape = 0;
+            std::string shape_str = "rectangular";
             pp_element.get("xmax", xmax);
             pp_element.get("ymax", ymax);
-            pp_element.queryAdd("shape", shape);
+            pp_element.queryAdd("shape", shape_str);
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(shape_str == "rectangular" || shape_str == "elliptical",
+                                             element_name + ".shape must be \"rectangular\" or \"elliptical\"");
+            Aperture::Shape shape = shape_str == "rectangular" ?
+                                        Aperture::Shape::rectangular :
+                                        Aperture::Shape::elliptical;
             m_lattice.emplace_back( Aperture(xmax, ymax, shape) );
         } else if (element_type == "beam_monitor") {
             std::string openpmd_name = element_name;

--- a/src/particles/CMakeLists.txt
+++ b/src/particles/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(lib
   PRIVATE
     ChargeDeposition.cpp
+    CollectLost.cpp
     ImpactXParticleContainer.cpp
     Push.cpp
 )

--- a/src/particles/CollectLost.H
+++ b/src/particles/CollectLost.H
@@ -1,0 +1,29 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl, Chad Mitchell
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_COLLECT_LOST_H
+#define IMPACTX_COLLECT_LOST_H
+
+#include "particles/ImpactXParticleContainer.H"
+
+
+namespace impactx
+{
+    /** ...
+     *
+     * ...
+     *
+     * @param source
+     * @param dest
+     */
+    void collect_lost_particles (ImpactXParticleContainer& source, ImpactXParticleContainer& dest);
+
+} // namespace impactx
+
+#endif // IMPACTX_COLLECT_LOST_H

--- a/src/particles/CollectLost.H
+++ b/src/particles/CollectLost.H
@@ -15,14 +15,15 @@
 
 namespace impactx
 {
-    /** ...
+    /** Move lost particles into a separate container
      *
-     * ...
+     * If particles are marked as lost, by setting their id to negative, we
+     * will move them to another particle container, store their position when
+     * lost and stop pushing them in the beamline.
      *
-     * @param source
-     * @param dest
+     * @param source the beam particle container that might loose particles
      */
-    void collect_lost_particles (ImpactXParticleContainer& source, ImpactXParticleContainer& dest);
+    void collect_lost_particles (ImpactXParticleContainer& source);
 
 } // namespace impactx
 

--- a/src/particles/CollectLost.cpp
+++ b/src/particles/CollectLost.cpp
@@ -11,48 +11,144 @@
 
 #include <AMReX_GpuLaunch.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_Math.H>
+#include <AMReX_ParticleTransformation.H>
+#include <AMReX_RandomEngine.H>
 
 
 namespace impactx
 {
     void collect_lost_particles (ImpactXParticleContainer& source, ImpactXParticleContainer& dest)
     {
+        BL_PROFILE("impactX::collect_lost_particles");
+
         using SrcData = ImpactXParticleContainer::ParticleTileType::ConstParticleTileDataType;
+        using DstData = ImpactXParticleContainer::ParticleTileType::ParticleTileDataType;
+
+        RefPart const ref_part = source.GetRefParticle();
+        auto const s_lost = ref_part.s;
+
+        // have to resize here, not in the constructor because grids have not
+        // been built when constructor was called.
+        dest.reserveData();
+        dest.resizeData();
 
         // copy all particles marked with a negative ID from source to destination
-        bool const local = true;
-        dest.copyParticles(
-                source,
-                [=] AMREX_GPU_HOST_DEVICE(const SrcData &src, int ip) {
-                    return src.id(ip) < 0;
-                },
-                local
-        );
-
-        // flip IDs back to positive in destination
-        int const nLevel = dest.finestLevel();
+        int const nLevel = source.finestLevel();
         for (int lev = 0; lev <= nLevel; ++lev) {
             // loop over all particle boxes
             using ParIt = ImpactXParticleContainer::iterator;
+            auto& plevel = source.GetParticles(lev);
 
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            for (ParIt pti(dest, lev); pti.isValid(); ++pti) {
-                const int np = pti.numParticles();
+            // TODO: is it safe to add OpenMP parallelism here?
+            for (ParIt pti(source, lev); pti.isValid(); ++pti) {
+                auto index = std::make_pair(pti.index(), pti.LocalTileIndex());
+                if (plevel.find(index) == plevel.end()) continue;
 
-                // preparing access to particle data: AoS
-                using PType = ImpactXParticleContainer::ParticleType;
-                auto &aos = pti.GetArrayOfStructs();
-                PType *AMREX_RESTRICT aos_ptr = aos().dataPtr();
+                auto& ptile_source = plevel.at(index);
+                auto const np = ptile_source.numParticles();
+                if (np == 0) continue;  // no particles in source tile
 
-                amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE(long i) {
-                    PType &p = aos_ptr[i];
-                    p.id() = -p.id();
-                });
-            }
-        }
+                // we will copy particles that were marked as lost, with a negative id
+                auto predicate = [] AMREX_GPU_HOST_DEVICE (const SrcData& src, int ip, const amrex::RandomEngine& /*engine*/) noexcept
+                {
+                    return src.id(ip) < 0;
+                };
 
-        // TODO remove particles with negative ids in source
+                auto& ptile_dest = dest.DefineAndReturnParticleTile(
+                        lev, pti.index(), pti.LocalTileIndex());
+
+                // count how many particles we will copy
+                amrex::ReduceOps<amrex::ReduceOpSum> reduce_op;
+                amrex::ReduceData<int> reduce_data(reduce_op);
+                {
+                    const auto src_data = ptile_source.getConstParticleTileData();
+
+                    const amrex::RandomEngine rng{};  // unused
+                    reduce_op.eval(np, reduce_data, [=] AMREX_GPU_HOST_DEVICE (int ip) {
+                        return predicate(src_data, ip, rng) ? 1 : 0;
+                    });
+                }
+                int const np_to_move = amrex::get<0>(reduce_data.value());
+                if (np_to_move == 0) continue;  // no particles to move from source tile
+
+                // allocate memory in destination
+                int const dst_index = ptile_dest.numParticles();
+                ptile_dest.resize(dst_index + np_to_move);
+
+                // copy particles
+                //   skipped in loop below: integer compile-time or runtime attributes
+                AMREX_ALWAYS_ASSERT(SrcData::NAI == 0);
+                AMREX_ALWAYS_ASSERT(ptile_source.NumRuntimeIntComps() == 0);
+
+                //   first runtime attribute in destination is s position when particle got lost
+                int const s_index = dest.NumRuntimeRealComps() - 1;
+                auto copy_and_mark_negative = [&s_index, &s_lost](DstData& dst, const SrcData& src, int src_ip, int dst_ip) noexcept
+                {
+                    dst.m_aos[dst_ip] = src.m_aos[src_ip];
+
+                    for (int j = 0; j < SrcData::NAR; ++j)
+                        dst.m_rdata[j][dst_ip] = src.m_rdata[j][src_ip];
+                    for (int j = 0; j < src.m_num_runtime_real; ++j)
+                        dst.m_runtime_rdata[j][dst_ip] = src.m_runtime_rdata[j][src_ip];
+
+                    // unused: integer compile-time or runtime attributes
+                    //for (int j = 0; j < SrcData::NAI; ++j)
+                    //    dst.m_idata[j][dst_ip] = src.m_idata[j][src_ip];
+                    //for (int j = 0; j < src.m_num_runtime_int; ++j)
+                    //    dst.m_runtime_idata[j][dst_ip] = src.m_runtime_idata[j][src_ip];
+
+                    // flip id to positive in destination
+                    dst.id(dst_ip) = amrex::Math::abs(dst.id(dst_ip));
+
+                    // remember the current s of the ref particle when lost
+                    dst.m_runtime_rdata[s_index][dst_ip] = s_lost;
+                };
+
+                amrex::filterAndTransformParticles(
+                    ptile_dest,
+                    ptile_source,
+                    predicate,
+                    copy_and_mark_negative,
+                    0,
+                    dst_index
+                );
+
+                // remove particles with negative ids in source
+                {
+                    int n_removed = 0;
+                    auto ptile_src_data = ptile_source.getParticleTileData();
+                    for (int ip = 0; ip < np; ++ip)
+                    {
+                        if (ptile_source.id(ip) < 0)
+                            n_removed++;
+                        else
+                        {
+                            if (n_removed > 0)
+                            {
+                                // move down
+                                int const new_index = ip - n_removed;
+
+                                ptile_src_data.m_aos[new_index] = ptile_src_data.m_aos[ip];
+
+                                for (int j = 0; j < SrcData::NAR; ++j)
+                                    ptile_src_data.m_rdata[j][new_index] = ptile_src_data.m_rdata[j][ip];
+                                for (int j = 0; j < ptile_src_data.m_num_runtime_real; ++j)
+                                    ptile_src_data.m_runtime_rdata[j][new_index] = ptile_src_data.m_runtime_rdata[j][ip];
+
+                                // unused: integer compile-time or runtime attributes
+                                //for (int j = 0; j < SrcData::NAI; ++j)
+                                //    dst.m_idata[j][new_index] = src.m_idata[j][ip];
+                                //for (int j = 0; j < ptile_src_data.m_num_runtime_int; ++j)
+                                //    dst.m_runtime_idata[j][new_index] = src.m_runtime_idata[j][ip];
+                            }
+                        }
+                    }
+                    AMREX_ALWAYS_ASSERT(np_to_move == n_removed);
+                    ptile_source.resize(np - n_removed);
+                }
+
+            } // particle tile loop
+        } // lev
     }
 } // namespace impactx

--- a/src/particles/CollectLost.cpp
+++ b/src/particles/CollectLost.cpp
@@ -1,0 +1,58 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl, Chad Mitchell
+ * License: BSD-3-Clause-LBNL
+ */
+#include "CollectLost.H"
+
+#include <AMReX_GpuLaunch.H>
+#include <AMReX_GpuQualifiers.H>
+
+
+namespace impactx
+{
+    void collect_lost_particles (ImpactXParticleContainer& source, ImpactXParticleContainer& dest)
+    {
+        using SrcData = ImpactXParticleContainer::ParticleTileType::ConstParticleTileDataType;
+
+        // copy all particles marked with a negative ID from source to destination
+        bool const local = true;
+        dest.copyParticles(
+                source,
+                [=] AMREX_GPU_HOST_DEVICE(const SrcData &src, int ip) {
+                    return src.id(ip) < 0;
+                },
+                local
+        );
+
+        // flip IDs back to positive in destination
+        int const nLevel = dest.finestLevel();
+        for (int lev = 0; lev <= nLevel; ++lev) {
+            // loop over all particle boxes
+            using ParIt = ImpactXParticleContainer::iterator;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            for (ParIt pti(dest, lev); pti.isValid(); ++pti) {
+                const int np = pti.numParticles();
+
+                // preparing access to particle data: AoS
+                using PType = ImpactXParticleContainer::ParticleType;
+                auto &aos = pti.GetArrayOfStructs();
+                PType *AMREX_RESTRICT aos_ptr = aos().dataPtr();
+
+                amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE(long i) {
+                    PType &p = aos_ptr[i];
+                    p.id() = -p.id();
+                });
+            }
+        }
+
+        // TODO remove particles with negative ids in source
+    }
+} // namespace impactx

--- a/src/particles/CollectLost.cpp
+++ b/src/particles/CollectLost.cpp
@@ -18,12 +18,42 @@
 
 namespace impactx
 {
+    struct CopyAndMarkNegative
+    {
+        static constexpr int s_index = 0; //!< index of runtime attribute in destination for position s where particle got lost
+        amrex::ParticleReal s_lost; //!< position s in meters where particle got lost
+
+        using SrcData = ImpactXParticleContainer::ParticleTileType::ConstParticleTileDataType;
+        using DstData = ImpactXParticleContainer::ParticleTileType::ParticleTileDataType;
+
+        AMREX_GPU_HOST_DEVICE
+        void operator() (DstData const &dst, SrcData const &src, int src_ip, int dst_ip) const noexcept {
+            dst.m_aos[dst_ip] = src.m_aos[src_ip];
+
+            for (int j = 0; j < SrcData::NAR; ++j)
+                dst.m_rdata[j][dst_ip] = src.m_rdata[j][src_ip];
+            for (int j = 0; j < src.m_num_runtime_real; ++j)
+                dst.m_runtime_rdata[j][dst_ip] = src.m_runtime_rdata[j][src_ip];
+
+            // unused: integer compile-time or runtime attributes
+            //for (int j = 0; j < SrcData::NAI; ++j)
+            //    dst.m_idata[j][dst_ip] = src.m_idata[j][src_ip];
+            //for (int j = 0; j < src.m_num_runtime_int; ++j)
+            //    dst.m_runtime_idata[j][dst_ip] = src.m_runtime_idata[j][src_ip];
+
+            // flip id to positive in destination
+            dst.id(dst_ip) = amrex::Math::abs(dst.id(dst_ip));
+
+            // remember the current s of the ref particle when lost
+            dst.m_runtime_rdata[s_index][dst_ip] = s_lost;
+        }
+    };
+
     void collect_lost_particles (ImpactXParticleContainer& source)
     {
         BL_PROFILE("impactX::collect_lost_particles");
 
         using SrcData = ImpactXParticleContainer::ParticleTileType::ConstParticleTileDataType;
-        using DstData = ImpactXParticleContainer::ParticleTileType::ParticleTileDataType;
 
         ImpactXParticleContainer& dest = *source.GetLostParticleContainer();
 
@@ -52,7 +82,8 @@ namespace impactx
                 if (np == 0) continue;  // no particles in source tile
 
                 // we will copy particles that were marked as lost, with a negative id
-                auto predicate = [] AMREX_GPU_HOST_DEVICE (const SrcData& src, int ip, const amrex::RandomEngine& /*engine*/) noexcept
+                auto const predicate = [] AMREX_GPU_HOST_DEVICE (const SrcData& src, int ip)
+                /* NVCC 11.3.109 chokes in C++17 on this: noexcept */
                 {
                     return src.id(ip) < 0;
                 };
@@ -64,11 +95,11 @@ namespace impactx
                 amrex::ReduceOps<amrex::ReduceOpSum> reduce_op;
                 amrex::ReduceData<int> reduce_data(reduce_op);
                 {
-                    const auto src_data = ptile_source.getConstParticleTileData();
+                    auto const src_data = ptile_source.getConstParticleTileData();
 
-                    const amrex::RandomEngine rng{};  // unused
-                    reduce_op.eval(np, reduce_data, [=] AMREX_GPU_HOST_DEVICE (int ip) {
-                        return predicate(src_data, ip, rng) ? 1 : 0;
+                    reduce_op.eval(np, reduce_data, [=] AMREX_GPU_HOST_DEVICE (int ip)
+                    {
+                        return predicate(src_data, ip);
                     });
                 }
                 int const np_to_move = amrex::get<0>(reduce_data.value());
@@ -83,35 +114,14 @@ namespace impactx
                 AMREX_ALWAYS_ASSERT(SrcData::NAI == 0);
                 AMREX_ALWAYS_ASSERT(ptile_source.NumRuntimeIntComps() == 0);
 
-                //   first runtime attribute in destination is s position when particle got lost
-                int const s_index = dest.NumRuntimeRealComps() - 1;
-                auto copy_and_mark_negative = [&s_index, &s_lost](DstData& dst, const SrcData& src, int src_ip, int dst_ip) noexcept
-                {
-                    dst.m_aos[dst_ip] = src.m_aos[src_ip];
-
-                    for (int j = 0; j < SrcData::NAR; ++j)
-                        dst.m_rdata[j][dst_ip] = src.m_rdata[j][src_ip];
-                    for (int j = 0; j < src.m_num_runtime_real; ++j)
-                        dst.m_runtime_rdata[j][dst_ip] = src.m_runtime_rdata[j][src_ip];
-
-                    // unused: integer compile-time or runtime attributes
-                    //for (int j = 0; j < SrcData::NAI; ++j)
-                    //    dst.m_idata[j][dst_ip] = src.m_idata[j][src_ip];
-                    //for (int j = 0; j < src.m_num_runtime_int; ++j)
-                    //    dst.m_runtime_idata[j][dst_ip] = src.m_runtime_idata[j][src_ip];
-
-                    // flip id to positive in destination
-                    dst.id(dst_ip) = amrex::Math::abs(dst.id(dst_ip));
-
-                    // remember the current s of the ref particle when lost
-                    dst.m_runtime_rdata[s_index][dst_ip] = s_lost;
-                };
+                //   first runtime attribute in destination is s position where particle got lost
+                AMREX_ALWAYS_ASSERT(dest.NumRuntimeRealComps() > 0);
 
                 amrex::filterAndTransformParticles(
                     ptile_dest,
                     ptile_source,
                     predicate,
-                    copy_and_mark_negative,
+                    CopyAndMarkNegative{s_lost},
                     0,
                     dst_index
                 );

--- a/src/particles/CollectLost.cpp
+++ b/src/particles/CollectLost.cpp
@@ -18,12 +18,14 @@
 
 namespace impactx
 {
-    void collect_lost_particles (ImpactXParticleContainer& source, ImpactXParticleContainer& dest)
+    void collect_lost_particles (ImpactXParticleContainer& source)
     {
         BL_PROFILE("impactX::collect_lost_particles");
 
         using SrcData = ImpactXParticleContainer::ParticleTileType::ConstParticleTileDataType;
         using DstData = ImpactXParticleContainer::ParticleTileType::ParticleTileDataType;
+
+        ImpactXParticleContainer& dest = *source.GetLostParticleContainer();
 
         RefPart const ref_part = source.GetRefParticle();
         auto const s_lost = ref_part.s;

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -269,6 +269,14 @@ namespace impactx
         DepositCharge (std::unordered_map<int, amrex::MultiFab> & rho,
                        amrex::Vector<amrex::IntVect> const & ref_ratio);
 
+        /** Get the name of each Real AoS component */
+        std::vector<std::string>
+        RealAoS_names () const;
+
+        /** Get the name of each Real SoA component */
+        std::vector<std::string>
+        RealSoA_names () const;
+
       private:
 
         //! the reference particle for the beam in the particle container
@@ -281,6 +289,18 @@ namespace impactx
         ImpactXParticleContainer* m_particles_lost = nullptr;
 
     }; // ImpactXParticleContainer
+
+    /** Get the name of each Real AoS component */
+    std::vector<std::string>
+    get_RealAoS_names ();
+
+    /** Get the name of each Real SoA component
+     *
+     * @param num_real_comps number of compile-time + runtime arrays
+     * @return names
+     */
+    std::vector<std::string>
+    get_RealSoA_names (int num_real_comps);
 
 } // namespace impactx
 

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -177,6 +177,16 @@ namespace impactx
                        amrex::ParticleReal const & qm,
                        amrex::ParticleReal const & bchchg);
 
+        /** Register storage for lost particles
+         *
+         * @param lost_pc particle container for lost particles
+         */
+        void
+        SetLostParticleContainer (ImpactXParticleContainer * lost_pc);
+
+        ImpactXParticleContainer *
+        GetLostParticleContainer ();
+
         /** Set reference particle attributes
          *
          * @param refpart reference particle
@@ -266,6 +276,9 @@ namespace impactx
 
         //! the particle shape
         std::optional<int> m_particle_shape;
+
+        //! a non-owning reference to lost particles, i.e., due to apertures
+        ImpactXParticleContainer* m_particles_lost = nullptr;
 
     }; // ImpactXParticleContainer
 

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -212,4 +212,45 @@ namespace impactx
             ImpactXParticleContainer, RealSoA::w
         >(*this);
     }
+
+    std::vector<std::string>
+    ImpactXParticleContainer::RealAoS_names () const
+    {
+        return get_RealAoS_names();
+    }
+
+    std::vector<std::string>
+    ImpactXParticleContainer::RealSoA_names () const
+    {
+        return get_RealSoA_names(this->NumRealComps());
+    }
+
+    std::vector<std::string>
+    get_RealAoS_names ()
+    {
+        std::vector<std::string> real_aos_names(RealAoS::names_s.size());
+
+        // compile-time attributes
+        std::copy(RealAoS::names_s.begin(), RealAoS::names_s.end(), real_aos_names.begin());
+
+        return real_aos_names;
+    }
+
+    std::vector<std::string>
+    get_RealSoA_names (int num_real_comps)
+    {
+        std::vector<std::string> real_soa_names(num_real_comps);
+
+        // compile-time attributes
+        std::copy(RealSoA::names_s.begin(), RealSoA::names_s.end(), real_soa_names.begin());
+
+        // runtime attributes
+        if (num_real_comps > int(RealSoA::names_s.size()))
+        {
+            // particles lost record their "s" position where they got lost
+            real_soa_names[RealSoA::nattribs] = "s_lost";
+        }
+
+        return real_soa_names;
+    }
 } // namespace impactx

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -104,11 +104,6 @@ namespace impactx
         // number of particles to add
         int const np = x.size();
 
-        // have to resize here, not in the constructor because grids have not
-        // been built when constructor was called.
-        reserveData();
-        resizeData();
-
         auto& particle_tile = DefineAndReturnParticleTile(0, 0, 0);
 
         /* Create a temporary tile to obtain data from simulation. This data

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -57,6 +57,24 @@ namespace impactx
         SetParticleSize();
     }
 
+    void
+    ImpactXParticleContainer::SetLostParticleContainer (ImpactXParticleContainer * lost_pc)
+    {
+        m_particles_lost = lost_pc;
+    }
+
+    ImpactXParticleContainer *
+    ImpactXParticleContainer::GetLostParticleContainer ()
+    {
+        if (m_particles_lost == nullptr)
+        {
+            throw std::logic_error(
+                    "ImpactXParticleContainer::GetLostParticleContainer No lost particle container registered yet.");
+        } else {
+            return m_particles_lost;
+        }
+    }
+
     void ImpactXParticleContainer::SetParticleShape (int order) {
         if (m_particle_shape.has_value())
         {

--- a/src/particles/elements/All.H
+++ b/src/particles/elements/All.H
@@ -10,6 +10,7 @@
 #ifndef IMPACTX_ELEMENTS_ALL_H
 #define IMPACTX_ELEMENTS_ALL_H
 
+#include "Aperture.H"
 #include "Buncher.H"
 #include "CFbend.H"
 #include "ChrDrift.H"
@@ -43,6 +44,7 @@ namespace impactx
 {
     using KnownElements = std::variant<
         None, /* must be first, so KnownElements creates a default constructor */
+        Aperture,
         Buncher,
         CFbend,
         ChrAcc,

--- a/src/particles/elements/Aperture.H
+++ b/src/particles/elements/Aperture.H
@@ -71,7 +71,7 @@ namespace impactx
             // access AoS data such as positions and cpu/id
             amrex::ParticleReal const x = p.pos(RealAoS::x);
             amrex::ParticleReal const y = p.pos(RealAoS::y);
-            uint64_t const global_id = ablastr::particles::localIDtoGlobal(p.id(), p.cpu());
+            //uint64_t const global_id = ablastr::particles::localIDtoGlobal(p.id(), p.cpu());
 
             // scale horizontal and vertical coordinates
             amrex::ParticleReal const u = x/m_xmax;

--- a/src/particles/elements/Aperture.H
+++ b/src/particles/elements/Aperture.H
@@ -1,0 +1,114 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Chad Mitchell, Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_APERTURE_H
+#define IMPACTX_APERTURE_H
+
+
+#include "particles/ImpactXParticleContainer.H"
+#include "mixin/beamoptic.H"
+#include "mixin/thin.H"
+#include "mixin/nofinalize.H"
+
+#include <ablastr/particles/IndexHandling.H>
+#include <AMReX_Extension.H>
+#include <AMReX_REAL.H>
+
+#include <cmath>
+
+namespace impactx
+{
+    struct Aperture
+    : public elements::BeamOptic<Aperture>,
+      public elements::Thin,
+      public elements::NoFinalize
+    {
+        static constexpr auto name = "Aperture";
+        using PType = ImpactXParticleContainer::ParticleType;
+
+        /** A thin collimator element that applies a transverse aperture boundary.
+         *  Particles outside the boundary are considered lost.
+         *
+         * @param type aperture type (0 rectangular, 1 elliptical)
+         * @param xmax maximum value of horizontal coordinate (m)
+         * @param ymax maximum value of vertical coordinate (m)
+         */
+        Aperture( int const shape,
+                   amrex::ParticleReal const xmax,
+                   amrex::ParticleReal const ymax )
+        : m_shape(shape), m_xmax(xmax), m_ymax(ymax)
+        {
+        }
+
+        /** Push all particles */
+        using BeamOptic::operator();
+
+        /** This is an aperture functor, so that a variable of this type can be used like an
+         *  aperture function.
+         *
+         * @param p Particle AoS data for positions and cpu/id
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param refpart reference particle (unused)
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void operator() (
+                PType& AMREX_RESTRICT p,
+        amrex::ParticleReal & AMREX_RESTRICT px,
+                amrex::ParticleReal & AMREX_RESTRICT py,
+                amrex::ParticleReal & AMREX_RESTRICT pt,
+                [[maybe_unused]] RefPart const & refpart) const {
+
+            using namespace amrex::literals; // for _rt and _prt
+
+            // access AoS data such as positions and cpu/id
+            amrex::ParticleReal const x = p.pos(RealAoS::x);
+            amrex::ParticleReal const y = p.pos(RealAoS::y);
+            uint64_t const global_id = ablastr::particles::localIDtoGlobal(p.id(), p.cpu());
+
+            // scale horizontal and vertical coordinates
+            amrex::ParticleReal const u = x/m_xmax;
+            amrex::ParticleReal const v = y/m_ymax;
+
+            // compare against the aperture boundary
+
+            switch(m_shape) {
+
+           // rectangular aperture (default)
+               case(0) :
+                  if (pow(u,2)>1 || pow(v,2)>1){
+                     p.pos(RealAoS::x) = 0.0_prt; //replace with id change of sign
+             p.pos(RealAoS::y) = 0.0_prt; //replace with id change of sign
+                  }
+
+           // elliptical aperture
+               case(1) :
+                  if (pow(u,2)+pow(v,2)>1){
+                     p.pos(RealAoS::x) = 0.0_prt; //replace with id change of sign
+                     p.pos(RealAoS::y) = 0.0_prt; //replace with id change of sign
+                  }
+
+            }
+
+        }
+
+        /** This pushes the reference particle. */
+        using Thin::operator();
+
+    private:
+        int m_shape; //! aperture type (1 rectangular, 2 elliptical)
+        amrex::ParticleReal m_xmax; //! maximum horizontal coordinate
+        amrex::ParticleReal m_ymax; //! maximum vertical coordinate
+
+    };
+
+} // namespace impactx
+
+#endif // IMPACTX_APERTURE_H

--- a/src/particles/elements/Aperture.H
+++ b/src/particles/elements/Aperture.H
@@ -82,18 +82,20 @@ namespace impactx
             switch(m_shape) {
 
            // rectangular aperture (default)
-               case(0) :
+               case 0 :
                   if (pow(u,2)>1 || pow(v,2)>1){
                      p.pos(RealAoS::x) = 0.0_prt; //replace with id change of sign
                      p.pos(RealAoS::y) = 0.0_prt; //replace with id change of sign
                   }
+                  break;
 
            // elliptical aperture
-               case(1) :
+               case 1 :
                   if (pow(u,2)+pow(v,2)>1){
                      p.pos(RealAoS::x) = 0.0_prt; //replace with id change of sign
                      p.pos(RealAoS::y) = 0.0_prt; //replace with id change of sign
                   }
+                  break;
 
             }
 

--- a/src/particles/elements/Aperture.H
+++ b/src/particles/elements/Aperture.H
@@ -32,16 +32,22 @@ namespace impactx
         static constexpr auto name = "Aperture";
         using PType = ImpactXParticleContainer::ParticleType;
 
+        enum Shape
+        {
+            rectangular,
+            elliptical
+        };
+
         /** A thin collimator element that applies a transverse aperture boundary.
          *  Particles outside the boundary are considered lost.
          *
-         * @param shape aperture shape (0 rectangular, 1 elliptical)
+         * @param shape aperture shape
          * @param xmax maximum value of horizontal coordinate (m)
          * @param ymax maximum value of vertical coordinate (m)
          */
-        Aperture(  amrex::ParticleReal const xmax,
-                   amrex::ParticleReal const ymax,
-                   int const shape)
+        Aperture (amrex::ParticleReal xmax,
+                  amrex::ParticleReal ymax,
+                  Shape shape)
         : m_shape(shape), m_xmax(xmax), m_ymax(ymax)
         {
         }
@@ -60,55 +66,49 @@ namespace impactx
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                PType& AMREX_RESTRICT p,
-                [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT px,
-                [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT py,
-                [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT pt,
-                [[maybe_unused]] RefPart const & refpart) const {
-
+            PType& AMREX_RESTRICT p,
+            [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT px,
+            [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT py,
+            [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT pt,
+            [[maybe_unused]] RefPart const & refpart) const
+        {
             using namespace amrex::literals; // for _rt and _prt
 
             // access AoS data such as positions and cpu/id
             amrex::ParticleReal const x = p.pos(RealAoS::x);
             amrex::ParticleReal const y = p.pos(RealAoS::y);
-            int const id = p.id();
-            //uint64_t const global_id = ablastr::particles::localIDtoGlobal(p.id(), p.cpu());
+            auto const id = p.id();
 
             // scale horizontal and vertical coordinates
-            amrex::ParticleReal const u = x/m_xmax;
-            amrex::ParticleReal const v = y/m_ymax;
+            amrex::ParticleReal const u = x / m_xmax;
+            amrex::ParticleReal const v = y / m_ymax;
 
             // compare against the aperture boundary
-
-            switch(m_shape) {
-
-           // rectangular aperture (default)
-               case 0 :
-                  if (pow(u,2)>1 || pow(v,2)>1){
-                     p.pos(RealAoS::x) = 0.0_prt; //replace with id change of sign
-                     p.pos(RealAoS::y) = 0.0_prt; //replace with id change of sign
+            switch (m_shape)
+            {
+                case Shape::rectangular :  // default
+                  if (pow(u,2)>1 || pow(v,2) > 1_prt) {
+                     p.pos(RealAoS::x) = 0.0_prt; // replace with id change of sign
+                     p.pos(RealAoS::y) = 0.0_prt; // replace with id change of sign
                      p.id() = -id;
                   }
                   break;
 
-           // elliptical aperture
-               case 1 :
-                  if (pow(u,2)+pow(v,2)>1){
-                     p.pos(RealAoS::x) = 0.0_prt; //replace with id change of sign
-                     p.pos(RealAoS::y) = 0.0_prt; //replace with id change of sign
+               case Shape::elliptical :
+                  if (pow(u,2)+pow(v,2) > 1_prt) {
+                     p.pos(RealAoS::x) = 0.0_prt; // replace with id change of sign
+                     p.pos(RealAoS::y) = 0.0_prt; // replace with id change of sign
                      p.id() = -id;
                   }
                   break;
-
             }
-
         }
 
         /** This pushes the reference particle. */
         using Thin::operator();
 
     private:
-        int m_shape; //! aperture type (1 rectangular, 2 elliptical)
+        Shape m_shape; //! aperture type (rectangular, elliptical)
         amrex::ParticleReal m_xmax; //! maximum horizontal coordinate
         amrex::ParticleReal m_ymax; //! maximum vertical coordinate
 

--- a/src/particles/elements/Aperture.H
+++ b/src/particles/elements/Aperture.H
@@ -35,7 +35,7 @@ namespace impactx
         /** A thin collimator element that applies a transverse aperture boundary.
          *  Particles outside the boundary are considered lost.
          *
-         * @param type aperture type (0 rectangular, 1 elliptical)
+         * @param shape aperture shape (0 rectangular, 1 elliptical)
          * @param xmax maximum value of horizontal coordinate (m)
          * @param ymax maximum value of vertical coordinate (m)
          */
@@ -61,9 +61,9 @@ namespace impactx
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
                 PType& AMREX_RESTRICT p,
-        amrex::ParticleReal & AMREX_RESTRICT px,
-                amrex::ParticleReal & AMREX_RESTRICT py,
-                amrex::ParticleReal & AMREX_RESTRICT pt,
+                [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT px,
+                [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT py,
+                [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT pt,
                 [[maybe_unused]] RefPart const & refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
@@ -85,7 +85,7 @@ namespace impactx
                case(0) :
                   if (pow(u,2)>1 || pow(v,2)>1){
                      p.pos(RealAoS::x) = 0.0_prt; //replace with id change of sign
-             p.pos(RealAoS::y) = 0.0_prt; //replace with id change of sign
+                     p.pos(RealAoS::y) = 0.0_prt; //replace with id change of sign
                   }
 
            // elliptical aperture

--- a/src/particles/elements/Aperture.H
+++ b/src/particles/elements/Aperture.H
@@ -39,9 +39,9 @@ namespace impactx
          * @param xmax maximum value of horizontal coordinate (m)
          * @param ymax maximum value of vertical coordinate (m)
          */
-        Aperture( int const shape,
-                   amrex::ParticleReal const xmax,
-                   amrex::ParticleReal const ymax )
+        Aperture(  amrex::ParticleReal const xmax,
+                   amrex::ParticleReal const ymax,
+                   int const shape)
         : m_shape(shape), m_xmax(xmax), m_ymax(ymax)
         {
         }

--- a/src/particles/elements/Aperture.H
+++ b/src/particles/elements/Aperture.H
@@ -71,6 +71,7 @@ namespace impactx
             // access AoS data such as positions and cpu/id
             amrex::ParticleReal const x = p.pos(RealAoS::x);
             amrex::ParticleReal const y = p.pos(RealAoS::y);
+            int const id = p.id();
             //uint64_t const global_id = ablastr::particles::localIDtoGlobal(p.id(), p.cpu());
 
             // scale horizontal and vertical coordinates
@@ -86,6 +87,7 @@ namespace impactx
                   if (pow(u,2)>1 || pow(v,2)>1){
                      p.pos(RealAoS::x) = 0.0_prt; //replace with id change of sign
                      p.pos(RealAoS::y) = 0.0_prt; //replace with id change of sign
+                     p.id() = -id;
                   }
                   break;
 
@@ -94,6 +96,7 @@ namespace impactx
                   if (pow(u,2)+pow(v,2)>1){
                      p.pos(RealAoS::x) = 0.0_prt; //replace with id change of sign
                      p.pos(RealAoS::y) = 0.0_prt; //replace with id change of sign
+                     p.id() = -id;
                   }
                   break;
 

--- a/src/particles/elements/Aperture.H
+++ b/src/particles/elements/Aperture.H
@@ -88,16 +88,12 @@ namespace impactx
             {
                 case Shape::rectangular :  // default
                   if (pow(u,2)>1 || pow(v,2) > 1_prt) {
-                     p.pos(RealAoS::x) = 0.0_prt; // replace with id change of sign
-                     p.pos(RealAoS::y) = 0.0_prt; // replace with id change of sign
                      p.id() = -id;
                   }
                   break;
 
                case Shape::elliptical :
                   if (pow(u,2)+pow(v,2) > 1_prt) {
-                     p.pos(RealAoS::x) = 0.0_prt; // replace with id change of sign
-                     p.pos(RealAoS::y) = 0.0_prt; // replace with id change of sign
                      p.id() = -id;
                   }
                   break;

--- a/src/particles/elements/diagnostics/openPMD.cpp
+++ b/src/particles/elements/diagnostics/openPMD.cpp
@@ -255,8 +255,7 @@ namespace detail
 
         // AoS: Real
         {
-            std::vector<std::string> real_aos_names(RealAoS::names_s.size());
-            std::copy(RealAoS::names_s.begin(), RealAoS::names_s.end(), real_aos_names.begin());
+            std::vector<std::string> real_aos_names = get_RealAoS_names();
             for (auto real_idx=0; real_idx < RealAoS::nattribs; real_idx++) {
                 auto const component_name = real_aos_names.at(real_idx);
                 getComponentRecord(component_name).resetDataset(d_fl);
@@ -293,9 +292,8 @@ namespace detail
 
         // SoA: Real
         {
-            std::vector<std::string> real_soa_names(RealSoA::names_s.size());
-            std::copy(RealSoA::names_s.begin(), RealSoA::names_s.end(), real_soa_names.begin());
-            for (auto real_idx = 0; real_idx < RealSoA::nattribs; real_idx++) {
+            std::vector<std::string> real_soa_names = get_RealSoA_names(pc.NumRealComps());
+            for (auto real_idx = 0; real_idx < pc.NumRealComps(); real_idx++) {
                 auto const component_name = real_soa_names.at(real_idx);
                 getComponentRecord(component_name).resetDataset(d_fl);
             }
@@ -426,10 +424,8 @@ namespace detail
         auto const& soa = pti.GetStructOfArrays();
         //   SoA floating point (ParticleReal) properties
         {
-            std::vector<std::string> real_soa_names(RealSoA::names_s.size());
-            std::copy(RealSoA::names_s.begin(), RealSoA::names_s.end(), real_soa_names.begin());
-
-            for (auto real_idx=0; real_idx < RealSoA::nattribs; real_idx++) {
+            std::vector<std::string> real_soa_names = get_RealSoA_names(soa.NumRealComps());
+            for (auto real_idx=0; real_idx < soa.NumRealComps(); real_idx++) {
                 auto const component_name = real_soa_names.at(real_idx);
                 getComponentRecord(component_name).storeChunkRaw(
                 soa.GetRealData(real_idx).data(), {offset}, {numParticleOnTile64});

--- a/src/particles/elements/diagnostics/openPMD.cpp
+++ b/src/particles/elements/diagnostics/openPMD.cpp
@@ -230,7 +230,6 @@ namespace detail
         io::WriteIterations iterations = series.writeIterations();
         io::Iteration iteration = iterations[m_step];
         io::ParticleSpecies beam = iteration.particles["beam"];
-        io::ParticleSpecies lost = iteration.particles["lost"];
 
         // calculate & update particle offset in MPI-global particle array, per level
         auto const num_levels = pc.finestLevel() + 1;

--- a/src/particles/elements/diagnostics/openPMD.cpp
+++ b/src/particles/elements/diagnostics/openPMD.cpp
@@ -230,6 +230,7 @@ namespace detail
         io::WriteIterations iterations = series.writeIterations();
         io::Iteration iteration = iterations[m_step];
         io::ParticleSpecies beam = iteration.particles["beam"];
+        io::ParticleSpecies lost = iteration.particles["lost"];
 
         // calculate & update particle offset in MPI-global particle array, per level
         auto const num_levels = pc.finestLevel() + 1;

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -260,7 +260,7 @@ void init_ImpactX (py::module& m)
              "Enable or disable diagnostics every slice step in elements (default: disabled).\n\n"
              "By default, diagnostics is performed at the beginning and end of the simulation.\n"
              "Enabling this flag will write diagnostics every step and slice step."
-         )
+        )
         .def_property("diag_file_min_digits",
              [](ImpactX & /* ix */) {
                  return detail::get_or_throw<int>("diag", "file_min_digits");
@@ -271,7 +271,18 @@ void init_ImpactX (py::module& m)
              },
              "The minimum number of digits (default: 6) used for the step\n"
              "number appended to the diagnostic file names."
-         )
+        )
+        .def_property("particle_lost_diagnostics_backend",
+                      [](ImpactX & /* ix */) {
+                          return detail::get_or_throw<std::string>("diag", "backend");
+                      },
+                      [](ImpactX & /* ix */, std::string const backend) {
+                          amrex::ParmParse pp_diag("diag");
+                          pp_diag.add("backend", backend);
+                      },
+                      "Diagnostics for particles lost in apertures.\n\n"
+                      "See the ``BeamMonitor`` element for backend values."
+        )
         .def_property("abort_on_warning_threshold",
              [](ImpactX & /* ix */){
                  return detail::get_or_throw<std::string>("impactx", "abort_on_warning_threshold");

--- a/src/python/ImpactXParticleContainer.cpp
+++ b/src/python/ImpactXParticleContainer.cpp
@@ -22,40 +22,6 @@ using namespace impactx;
 
 void init_impactxparticlecontainer(py::module& m)
 {
-    py::class_<RealAoS>(m, "RealAoS")
-        .def_property_readonly_static("names_s",
-            [](py::object) {
-                std::vector<std::string> real_aos_names(RealAoS::names_s.size());
-                std::copy(RealAoS::names_s.begin(), RealAoS::names_s.end(), real_aos_names.begin());
-                return real_aos_names;
-            },
-            "named labels for fixed s")
-        .def_property_readonly_static("names_t",
-            [](py::object) {
-                std::vector<std::string> real_aos_names(RealAoS::names_t.size());
-                std::copy(RealAoS::names_t.begin(), RealAoS::names_t.end(), real_aos_names.begin());
-                return real_aos_names;
-            },
-            "named labels for fixed t")
-    ;
-
-    py::class_<RealSoA>(m, "RealSoA")
-        .def_property_readonly_static("names_s",
-        [](py::object) {
-                std::vector<std::string> real_soa_names(RealSoA::names_s.size());
-                std::copy(RealSoA::names_s.begin(), RealSoA::names_s.end(), real_soa_names.begin());
-                return real_soa_names;
-        },
-        "named labels for fixed s")
-        .def_property_readonly_static("names_t",
-    [](py::object) {
-            std::vector<std::string> real_soa_names(RealSoA::names_t.size());
-            std::copy(RealSoA::names_t.begin(), RealSoA::names_t.end(), real_soa_names.begin());
-            return real_soa_names;
-        },
-        "named labels for fixed t")
-    ;
-
     py::class_<
         ParIter,
         amrex::ParIter<0, 0, RealSoA::nattribs, IntSoA::nattribs>
@@ -150,5 +116,18 @@ void init_impactxparticlecontainer(py::module& m)
              "Charge deposition"
         )
         */
+
+        .def_property_readonly("RealAoS_names", &ImpactXParticleContainer::RealAoS_names,
+              "Get the name of each Real AoS component")
+
+        .def_property_readonly("RealSoA_names", &ImpactXParticleContainer::RealSoA_names,
+              "Get the name of each Real SoA component")
     ;
+
+    m.def("get_RealAoS_names", &get_RealAoS_names,
+          "Get the name of each Real AoS component");
+
+    m.def("get_RealSoA_names", &get_RealSoA_names,
+          py::arg("num_real_comps"),
+          "Get the name of each Real SoA component\n\nnum_real_comps: pass number of compile-time + runtime arrays");
 }

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -125,12 +125,20 @@ void init_elements(py::module& m)
 
     py::class_<Aperture, elements::Thin> py_Aperture(me, "Aperture");
     py_Aperture
-        .def(py::init<
-        int,
-                amrex::ParticleReal const,
-                amrex::ParticleReal const,
-                int>(),
-             py::arg("xmax"), py::arg("ymax"), py::arg("shape") = 0,
+        .def(py::init([](
+                 amrex::ParticleReal xmax,
+                 amrex::ParticleReal ymax,
+                 std::string shape)
+             {
+                 if (shape != "rectangular" && shape != "elliptical")
+                     throw std::runtime_error("shape must be \"rectangular\" or \"elliptical\"");
+
+                 Aperture::Shape s = shape == "rectangular" ?
+                     Aperture::Shape::rectangular :
+                     Aperture::Shape::elliptical;
+                 return new Aperture(xmax, ymax, s);
+             }),
+             py::arg("xmax"), py::arg("ymax"), py::arg("shape") = "rectangular",
              "A short collimator element applying a transverse aperture boundary."
         )
     ;

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -123,6 +123,18 @@ void init_elements(py::module& m)
 
     // beam optics
 
+    py::class_<Aperture, elements::Thin> py_Aperture(me, "Aperture");
+    py_Aperture
+        .def(py::init<
+        int,
+                amrex::ParticleReal const,
+                amrex::ParticleReal const>(),
+             py::arg("shape") = 0, py::arg("xmax"), py::arg("ymax"),
+             "A short collimator element applying a transverse aperture boundary."
+        )
+    ;
+    register_beamoptics_push(py_Aperture);
+
     py::class_<ChrDrift, elements::Thick> py_ChrDrift(me, "ChrDrift");
     py_ChrDrift
         .def(py::init<

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -130,7 +130,7 @@ void init_elements(py::module& m)
                 amrex::ParticleReal const,
                 amrex::ParticleReal const,
                 int>(),
-             py::arg("xmax"), py::arg("ymax"), py::arg("shape") = 0
+             py::arg("xmax"), py::arg("ymax"), py::arg("shape") = 0,
              "A short collimator element applying a transverse aperture boundary."
         )
     ;

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -128,8 +128,9 @@ void init_elements(py::module& m)
         .def(py::init<
         int,
                 amrex::ParticleReal const,
-                amrex::ParticleReal const>(),
-             py::arg("shape") = 0, py::arg("xmax"), py::arg("ymax"),
+                amrex::ParticleReal const,
+                int>(),
+             py::arg("xmax"), py::arg("ymax"), py::arg("shape") = 0
              "A short collimator element applying a transverse aperture boundary."
         )
     ;

--- a/src/python/impactx/ImpactXParticleContainer.py
+++ b/src/python/impactx/ImpactXParticleContainer.py
@@ -13,8 +13,8 @@ def ix_pc_to_df(self, local=True, comm=None, root_rank=0):
 
     Parameters
     ----------
-    self : amrex.ParticleContainer_*
-        A ParticleContainer class in pyAMReX
+    self : ImpactXParticleContainer_*
+        The particle container class in ImpactX
     local : bool
         MPI-local particles
     comm : MPI Communicator
@@ -36,16 +36,13 @@ def ix_pc_to_df(self, local=True, comm=None, root_rank=0):
         # todo: check if currently in fixed s or fixed t and pick name accordingly
 
         names = []
-        for n in self.RealAoS.names_s:
+        for n in self.RealAoS_names:
             names.append(n)
         names.append("cpuid")
-        for n in self.RealSoA.names_s:
+        for n in self.RealSoA_names:
             names.append(n)
 
         df.columns.values[0 : len(names)] = names
-
-        # todo: also rename runtime attributes (e.g., "s_lost")
-        # https://github.com/ECP-WarpX/impactx/pull/398
 
     return df
 


### PR DESCRIPTION
Added a first draft of collimator/aperture element.  For now, this element simply compares each particle against an aperture boundary (rectangular or elliptical), and records whether the particle has been lost.

For this initial draft, coordinates of lost particles are updated to x = y = 0 (so that all particles lie within the aperture).  This will be changed to modify the sign of the particle index.

- [x] Add new element type (inputs, etc.)
- [x] Update documentation
- [x] Modify particle index handling
- [x] Add benchmark example
- [x] Verify correct index handling
- [x] move particles to a separate particle container and enable output for them #394
  - [x] finalize move (see todos)
  - [x] add `s` of reference particle at point of particle loss to "lost" particle container/species
  - [x] output

*To be followed-up with additional bookkeeping of lost particles.
Metadata to add:
- `s`
- turn number
