### PR TITLE
[WIP] PoissonSolve: Remove ABLASTR Workaround

### DIFF
--- a/src/particles/spacecharge/PoissonSolve.cpp
+++ b/src/particles/spacecharge/PoissonSolve.cpp
@@ -10,11 +10,6 @@
 #include "PoissonSolve.H"
 
 #include <ablastr/constant.H>
-/* work-around for https://github.com/ECP-WarpX/WarpX/pull/4090 in ABLASTR 23.07 */
-namespace PhysConst
-{
-    using namespace ablastr::constant::SI;
-}
 #include <ablastr/fields/PoissonSolver.H>
 
 #include <AMReX_BLProfiler.H>


### PR DESCRIPTION
Remove the workaround for
  https://github.com/ECP-WarpX/WarpX/pull/4090
with was introduced in #399.

- [ ] update ABLASTR