### PR TITLE
Re-initialize geometry object(s) in initGrids

### DIFF
--- a/examples/cfchannel/run_cfchannel_10nC.py
+++ b/examples/cfchannel/run_cfchannel_10nC.py
@@ -9,12 +9,10 @@
 import amrex.space3d as amr
 from impactx import ImpactX, RefPart, distribution, elements
 
-pp_amr = amr.ParmParse("amr")
-pp_amr.addarr("n_cell", [48, 48, 40])  # [72, 72, 64] for increased precision
-
 sim = ImpactX()
 
 # set numerical parameters and IO control
+sim.n_cell = [48, 48, 40]  # [72, 72, 64] for increased precision
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = True
 sim.prob_relative = 3.0

--- a/examples/expanding_beam/run_expanding.py
+++ b/examples/expanding_beam/run_expanding.py
@@ -9,12 +9,10 @@
 import amrex.space3d as amr
 from impactx import ImpactX, RefPart, distribution, elements
 
-pp_amr = amr.ParmParse("amr")
-pp_amr.addarr("n_cell", [56, 56, 48])
-
 sim = ImpactX()
 
 # set numerical parameters and IO control
+sim.n_cell = [56, 56, 48]
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = True
 sim.dynamic_size = True

--- a/examples/kurth/run_kurth_10nC_periodic.py
+++ b/examples/kurth/run_kurth_10nC_periodic.py
@@ -9,12 +9,10 @@
 import amrex.space3d as amr
 from impactx import ImpactX, distribution, elements
 
-pp_amr = amr.ParmParse("amr")
-pp_amr.addarr("n_cell", [48, 48, 40])  # use [72, 72, 72] for increased precision
-
 sim = ImpactX()
 
 # set numerical parameters and IO control
+sim.n_cell = [48, 48, 40]  # use [72, 72, 72] for increased precision
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = True
 # sim.diagnostics = False  # benchmarking

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -50,6 +50,28 @@ namespace impactx
     {
         BL_PROFILE("ImpactX::initGrids");
 
+        // n_cells has been set using dummy values earlier. We now know the true value of
+        // n_cells, so we recompute the Geometry objects for each level here *if* the user
+        // has set n_cells in the inputs file
+        {
+            amrex::Vector<int> n_cell(AMREX_SPACEDIM);
+            amrex::ParmParse pp_amr("amr");
+            pp_amr.queryarr("n_cell", n_cell);
+
+            amrex::IntVect lo(amrex::IntVect::TheZeroVector()), hi(n_cell);
+            hi -= amrex::IntVect::TheUnitVector();
+            amrex::Box index_domain(lo,hi);
+            for (int i = 0; i <= max_level; i++)
+            {
+                geom[i].Domain(index_domain);
+                if (i < max_level) {
+                    index_domain.refine(ref_ratio[i]);
+                }
+            }
+        }
+
+        // the particle container has been set to track the same Geometry as ImpactX
+
         // this is the earliest point that we need to know the particle shape,
         // so that we can initialize the guard size of our MultiFabs
         m_particle_container->SetParticleShape();

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -50,7 +50,7 @@ namespace impactx
     {
         BL_PROFILE("ImpactX::initGrids");
 
-        // n_cells has been set using dummy values earlier. We now know the true value of
+        // n_cells has been set using temporary values earlier. We now know the true value of
         // n_cells, so we recompute the Geometry objects for each level here *if* the user
         // has set n_cells in the inputs file
         {

--- a/src/initialization/InitAmrCore.cpp
+++ b/src/initialization/InitAmrCore.cpp
@@ -88,9 +88,8 @@ namespace details
     {
         amrex::ParmParse pp_amr("amr");
 
-        // Domain index space
-        amrex::Vector<int> n_cell;
-        pp_amr.getarr("n_cell", n_cell);
+        // Domain index space - we use dummy values here, then fix later
+        amrex::Vector<int> n_cell = {AMREX_D_DECL(256,256,256)};
         amrex::Box domain(amrex::IntVect(0), amrex::IntVect(n_cell));
 
         // Domain physical size

--- a/src/initialization/InitAmrCore.cpp
+++ b/src/initialization/InitAmrCore.cpp
@@ -88,7 +88,7 @@ namespace details
     {
         amrex::ParmParse pp_amr("amr");
 
-        // Domain index space - we use dummy values here, then fix later
+        // Domain index space - we use temporary values here, then fix later
         amrex::Vector<int> n_cell = {AMREX_D_DECL(256,256,256)};
         amrex::Box domain(amrex::IntVect(0), amrex::IntVect(n_cell));
 

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -83,13 +83,13 @@ void init_ImpactX (py::module& m)
                 pp_amr.getarr("n_cell", n_cell);
                 return n_cell;
             },
-            [](ImpactX & /* ix */, std::array<int, AMREX_SPACEDIM> /* n_cell */) {
-                throw std::runtime_error("setting n_cell is not yet implemented");
-                /*
+            [](ImpactX & /* ix */, std::array<int, AMREX_SPACEDIM> n_cell) {
                 amrex::ParmParse pp_amr("amr");
                 amrex::Vector<int> const n_cell_v(n_cell.begin(), n_cell.end());
                 pp_amr.addarr("n_cell", n_cell_v);
 
+                // note, this must be done *before* initGrids is called
+                /*
                 int const max_level = ix.maxLevel();
                 for (int lev=0; lev<=max_level; lev++) {
                     ix.ClearLevel(lev);

--- a/tests/python/test_charge_deposition.py
+++ b/tests/python/test_charge_deposition.py
@@ -21,24 +21,21 @@ def test_charge_deposition(save_png=True):
     """
     Deposit charge and access/plot it
     """
-    pp_amr = amr.ParmParse("amr")
-    pp_amr.addarr("n_cell", [16, 24, 32])
-
     sim = impactx.ImpactX()
 
-    assert sim.n_cell == [16, 24, 32]
-
+    sim.n_cell = [16, 24, 32]
     sim.load_inputs_file("examples/fodo/input_fodo.in")
     sim.space_charge = True
     sim.slice_step_diagnostics = False
 
     # Future:
-    # sim.ncell = [25, 25, 45]
     # sim.domain = amr.RealBox([1., 2., 3.], [4., 5., 6.])
     print(f"sim.n_cell={sim.n_cell}")
     print(f"sim.domain={sim.domain}")
 
     sim.init_grids()
+    assert sim.n_cell == [16, 24, 32]
+
     sim.init_beam_distribution_from_inputs()
     sim.init_lattice_elements_from_inputs()
 

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -240,15 +240,9 @@ def test_impactx_change_resolution():
     This is currently a work-around because we cannot yet change the cells
     after the simulation object as been created.
     """
-    pp_amr = amr.ParmParse("amr")
-    pp_amr.addarr("n_cell", [16, 24, 32])
-
     sim = ImpactX()
 
-    # Future:
-    # sim.ncell = [16, 24, 32]
-    # sim.domain = amr.RealBox([1., 2., 3.], [4., 5., 6.])
-
+    sim.n_cell = [16, 24, 32]
     sim.particle_shape = 2
     sim.slice_step_diagnostics = False
     sim.diagnostics = False


### PR DESCRIPTION
This will allow us to delay setting the `amr.n_cells` parameter until *after* the ImpactX instance is constructed.