### PR TITLE
Python: 3.8+

### DIFF
--- a/docs/source/install/dependencies.rst
+++ b/docs/source/install/dependencies.rst
@@ -25,7 +25,7 @@ Optional dependencies include:
   - see `optional I/O backends <https://github.com/openPMD/openPMD-api#dependencies>`__
 - `CCache <https://ccache.dev>`__: to speed up rebuilds (For CUDA support, needs version 3.7.9+ and 4.2+ is recommended)
 - `Ninja <https://ninja-build.org>`__: for faster parallel compiles
-- `Python 3.7+ <https://www.python.org>`__
+- `Python 3.8+ <https://www.python.org>`__
 
   - `mpi4py <https://mpi4py.readthedocs.io>`__
   - `numpy <https://numpy.org>`__

--- a/setup.py
+++ b/setup.py
@@ -269,7 +269,7 @@ setup(
     ext_modules=cxx_modules,
     cmdclass=cmdclass,
     zip_safe=False,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     tests_require=["numpy", "pandas", "pytest", "scipy"],
     install_requires=install_requires,
     # cmdclass={'test': PyTest},
@@ -287,10 +287,10 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Programming Language :: C++",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         (
             "License :: OSI Approved :: " "BSD License"
         ),  # TODO: use real SPDX: BSD-3-Clause-LBNL


### PR DESCRIPTION
Python 3.7 went EOL last month.
Time to bump up our supported versions to 3.8+ as well.