### PR TITLE
MAD-X: Add TKICKER, HKICKER and VKICKER to accepted input

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -629,3 +629,13 @@ add_impactx_test(kicker_madx.py
         examples/kicker/analysis_kicker.py
         OFF  # no plot script yet
 )
+# copy MAD-X lattice file
+file(COPY ${ImpactX_SOURCE_DIR}/examples/kicker/hvkicker.madx
+        DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/hvkicker_madx.py)
+add_impactx_test(hvkicker_madx.py
+        examples/kicker/run_hvkicker_madx.py
+        OFF   # ImpactX MPI-parallel
+        ON   # ImpactX Python interface
+        examples/kicker/analysis_kicker.py
+        OFF  # no plot script yet
+)

--- a/examples/kicker/hvkicker.madx
+++ b/examples/kicker/hvkicker.madx
@@ -1,0 +1,8 @@
+beam, particle=electron, energy=2.0;
+
+M1: MONITOR, L=0.0;
+HK1: HKICKER, hkick=2.0e-3;
+VK1: VKICKER, vkick=3.0e-3;
+
+KICKLATTICE: Line=(M1,HK1,VK1,M1);
+USE, SEQUENCE = KICKLATTICE;

--- a/examples/kicker/kicker.madx
+++ b/examples/kicker/kicker.madx
@@ -2,7 +2,8 @@ beam, particle=electron, energy=2.0;
 
 M1: MONITOR, L=0.0;
 HK1: KICKER, hkick=2.0e-3, vkick=0.0;
-VK1: KICKER, hkick=0.0, vkick=3.0e-3;
+! TKICKER and KICKER are currently treated the exact same in ImpactX
+VK1: TKICKER, hkick=0.0, vkick=3.0e-3;
 
 KICKLATTICE: Line=(M1,HK1,VK1,M1);
 USE, SEQUENCE = KICKLATTICE;

--- a/examples/kicker/run_hvkicker_madx.py
+++ b/examples/kicker/run_hvkicker_madx.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Chad Mitchell, Axel Huebl, Marco Garten
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+
+import amrex.space3d as amr
+from impactx import ImpactX, RefPart, distribution, elements
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# load a 2 GeV electron beam with an initial
+# unnormalized rms emittance of  nm
+bunch_charge_C = 1.0e-9  # used without space charge
+npart = 10000  # number of macro particles
+
+#   reference particle
+ref = sim.particle_container().ref_particle().load_file("hvkicker.madx")
+
+#   particle bunch
+distr = distribution.Waterbag(
+    sigmaX=4.0e-3,
+    sigmaY=4.0e-3,
+    sigmaT=1.0e-3,
+    sigmaPx=3.0e-4,
+    sigmaPy=3.0e-4,
+    sigmaPt=2.0e-3,
+)
+sim.add_particles(bunch_charge_C, distr, npart)
+
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+
+# design the accelerator lattice
+sim.lattice.load_file("hvkicker.madx", nslice=1)
+
+# run simulation
+sim.evolve()
+
+# clean shutdown
+del sim
+amr.finalize()

--- a/src/python/impactx/MADXParser.py
+++ b/src/python/impactx/MADXParser.py
@@ -102,6 +102,9 @@ class MADXParser:
         self.__kicker = {"name": "", "hkick": 0.0, "vkick": 0.0, "type": "kicker"}
 
         self.__kicker_pattern = r"(.*):kicker,(.*)=(.*),(.*)=(.*);"
+        # equivalent to kicker
+        # http://mad.web.cern.ch/mad/madx.old/Introduction/tkickers.html
+        self.__tkicker_pattern = r"(.*):tkicker,(.*)=(.*),(.*)=(.*);"
         # horizontal kicker without vkick
         self.__hkicker_pattern = r"(.*):hkicker,(.*)=(.*);"
         # vertical kicker without hkick
@@ -371,6 +374,31 @@ class MADXParser:
                                 + "'"
                                 + " does not exist for vkicker.",
                             )
+
+                    self.__elements.append(self.__kicker.copy())
+
+                # We treat TKICKER elements exactly like KICKER elements for now
+                # http://mad.web.cern.ch/mad/madx.old/Introduction/tkickers.html
+                elif re.search(r':\btkicker\b', line):
+                    obj = re.match(self.__tkicker_pattern, line)
+
+                    # first tag is name
+                    self.__kicker["name"] = obj.group(1)
+
+                    for i in range(2, self.__nKicker + 2, 2):
+                        if obj.group(i) in self.__kicker:
+                            self.__kicker[obj.group(i)] = float(obj.group(i + 1))
+                        else:
+                            raise MADXInputError(
+                                "TKicker",
+                                "Line "
+                                + str(nLine)
+                                + ": Parameter "
+                                + "'"
+                                + obj.group(i)
+                                + "'"
+                                + " does not exist for tkicker.",
+                                )
 
                     self.__elements.append(self.__kicker.copy())
 

--- a/src/python/impactx/MADXParser.py
+++ b/src/python/impactx/MADXParser.py
@@ -303,7 +303,7 @@ class MADXParser:
 
                     self.__elements.append(self.__dipedge.copy())
 
-                elif re.search(r':\bkicker\b', line):
+                elif re.search(r":\bkicker\b", line):
                     obj = re.match(self.__kicker_pattern, line)
 
                     # first tag is name
@@ -326,7 +326,7 @@ class MADXParser:
 
                     self.__elements.append(self.__kicker.copy())
 
-                elif re.search(r':\bhkicker\b', line):
+                elif re.search(r":\bhkicker\b", line):
                     obj = re.match(self.__hkicker_pattern, line)
 
                     # first tag is name
@@ -346,11 +346,11 @@ class MADXParser:
                                 + obj.group(i)
                                 + "'"
                                 + " does not exist for hkicker.",
-                                )
+                            )
 
                     self.__elements.append(self.__kicker.copy())
 
-                elif re.search(r':\bvkicker\b', line):
+                elif re.search(r":\bvkicker\b", line):
                     obj = re.match(self.__vkicker_pattern, line)
 
                     # first tag is name
@@ -370,7 +370,7 @@ class MADXParser:
                                 + obj.group(i)
                                 + "'"
                                 + " does not exist for vkicker.",
-                                )
+                            )
 
                     self.__elements.append(self.__kicker.copy())
 

--- a/src/python/impactx/MADXParser.py
+++ b/src/python/impactx/MADXParser.py
@@ -102,9 +102,15 @@ class MADXParser:
         self.__kicker = {"name": "", "hkick": 0.0, "vkick": 0.0, "type": "kicker"}
 
         self.__kicker_pattern = r"(.*):kicker,(.*)=(.*),(.*)=(.*);"
+        # horizontal kicker without vkick
+        self.__hkicker_pattern = r"(.*):hkicker,(.*)=(.*);"
+        # vertical kicker without hkick
+        self.__vkicker_pattern = r"(.*):vkicker,(.*)=(.*);"
 
         # don't count name and type --> len - 2
         self.__nKicker = 2 * (len(self.__kicker) - 2)
+        self.__nHkicker = self.__nKicker - 2
+        self.__nVkicker = self.__nKicker - 2
 
         self.beam = {
             "energy": 0.0,
@@ -297,7 +303,7 @@ class MADXParser:
 
                     self.__elements.append(self.__dipedge.copy())
 
-                elif "kicker" in line:
+                elif re.search(r':\bkicker\b', line):
                     obj = re.match(self.__kicker_pattern, line)
 
                     # first tag is name
@@ -317,6 +323,54 @@ class MADXParser:
                                 + "'"
                                 + " does not exist for kicker.",
                             )
+
+                    self.__elements.append(self.__kicker.copy())
+
+                elif re.search(r':\bhkicker\b', line):
+                    obj = re.match(self.__hkicker_pattern, line)
+
+                    # first tag is name
+                    self.__kicker["name"] = obj.group(1)
+                    self.__kicker["vkick"] = 0.0
+
+                    for i in range(2, self.__nHkicker + 2, 2):
+                        if obj.group(i) in self.__kicker:
+                            self.__kicker[obj.group(i)] = float(obj.group(i + 1))
+                        else:
+                            raise MADXInputError(
+                                "HKicker",
+                                "Line "
+                                + str(nLine)
+                                + ": Parameter "
+                                + "'"
+                                + obj.group(i)
+                                + "'"
+                                + " does not exist for hkicker.",
+                                )
+
+                    self.__elements.append(self.__kicker.copy())
+
+                elif re.search(r':\bvkicker\b', line):
+                    obj = re.match(self.__vkicker_pattern, line)
+
+                    # first tag is name
+                    self.__kicker["name"] = obj.group(1)
+                    self.__kicker["hkick"] = 0.0
+
+                    for i in range(2, self.__nVkicker + 2, 2):
+                        if obj.group(i) in self.__kicker:
+                            self.__kicker[obj.group(i)] = float(obj.group(i + 1))
+                        else:
+                            raise MADXInputError(
+                                "VKicker",
+                                "Line "
+                                + str(nLine)
+                                + ": Parameter "
+                                + "'"
+                                + obj.group(i)
+                                + "'"
+                                + " does not exist for vkicker.",
+                                )
 
                     self.__elements.append(self.__kicker.copy())
 

--- a/src/python/impactx/MADXParser.py
+++ b/src/python/impactx/MADXParser.py
@@ -379,7 +379,7 @@ class MADXParser:
 
                 # We treat TKICKER elements exactly like KICKER elements for now
                 # http://mad.web.cern.ch/mad/madx.old/Introduction/tkickers.html
-                elif re.search(r':\btkicker\b', line):
+                elif re.search(r":\btkicker\b", line):
                     obj = re.match(self.__tkicker_pattern, line)
 
                     # first tag is name
@@ -398,7 +398,7 @@ class MADXParser:
                                 + obj.group(i)
                                 + "'"
                                 + " does not exist for tkicker.",
-                                )
+                            )
 
                     self.__elements.append(self.__kicker.copy())
 

--- a/src/python/impactx/madx_to_impactx.py
+++ b/src/python/impactx/madx_to_impactx.py
@@ -34,7 +34,7 @@ def lattice(parsed_beamline, nslice=1):
         # Kicker, idealized thin element,
         # MADX also defines length "L" and a roll angle around the longitudinal axis "TILT"
         # https://mad.web.cern.ch/mad/webguide/manual.html#Ch11.S11
-        "KICKER": "Kicker",  # HKICKER and VKICKER become KICKER elements
+        "KICKER": "Kicker",  # TKICKER, HKICKER and VKICKER become KICKER elements
         # note: in MAD-X, this keeps track only of the beam centroid,
         # "In addition it serves to record the beam position for closed orbit correction."
         "MONITOR": "BeamMonitor",  # drift + output diagnostics

--- a/src/python/impactx/madx_to_impactx.py
+++ b/src/python/impactx/madx_to_impactx.py
@@ -34,7 +34,7 @@ def lattice(parsed_beamline, nslice=1):
         # Kicker, idealized thin element,
         # MADX also defines length "L" and a roll angle around the longitudinal axis "TILT"
         # https://mad.web.cern.ch/mad/webguide/manual.html#Ch11.S11
-        "KICKER": "Kicker",
+        "KICKER": "Kicker",  # HKICKER and VKICKER become KICKER elements
         # note: in MAD-X, this keeps track only of the beam centroid,
         # "In addition it serves to record the beam position for closed orbit correction."
         "MONITOR": "BeamMonitor",  # drift + output diagnostics
@@ -72,6 +72,13 @@ def lattice(parsed_beamline, nslice=1):
                         # MAD-X is using half the gap height
                         g=2.0 * d["hgap"],
                         K2=d["fint"],
+                    )
+                )
+            elif d["type"] == "kicker":
+                impactx_beamline.append(
+                    elements.Kicker(
+                        xkick=d["hkick"],
+                        ykick=d["vkick"],
                     )
                 )
             elif d["type"] == "monitor":

--- a/src/python/impactx/madx_to_impactx.py
+++ b/src/python/impactx/madx_to_impactx.py
@@ -74,13 +74,6 @@ def lattice(parsed_beamline, nslice=1):
                         K2=d["fint"],
                     )
                 )
-            elif d["type"] == "kicker":
-                impactx_beamline.append(
-                    elements.Kicker(
-                        xkick=d["hkick"],
-                        ykick=d["vkick"],
-                    )
-                )
             elif d["type"] == "monitor":
                 if d["l"] > 0:
                     impactx_beamline.append(elements.Drift(ds=d["l"], nslice=nslice))


### PR DESCRIPTION
We add HKICKER and VKICKER semantically as available elements of type KICKER.
We also add TKICKER and treat it exactly the same as KICKER.

Depends on #419, merge only after rebase