### PR TITLE
pytest: Temporary Working Directory

### DIFF
--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import os
+
 import pytest
 
 import amrex.space3d as amr
@@ -11,6 +13,9 @@ if impactx.Config.have_mpi:
     print("loaded mpi4py")
 else:
     print("NO mpi4py load")
+
+# base path for input files
+basepath = os.getcwd()
 
 
 @pytest.fixture(autouse=True, scope="function")

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -31,5 +31,5 @@ def amrex_init(tmpdir):
                 "amrex.the_arena_is_managed=0",
             ]
         )
-    yield
-    amr.finalize()
+        yield
+        amr.finalize()

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import time
+
 import pytest
 
 import amrex.space3d as amr
@@ -32,3 +34,8 @@ def amrex_init():
     )
     yield
     amr.finalize()
+
+    # sleep 1s because AMReX diagnostics cleanup can only do one rename
+    # per second
+    # https://github.com/AMReX-Codes/amrex/blob/23.08/Src/Base/AMReX_Utility.cpp#L186-L199
+    time.sleep(1)

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import time
-
 import pytest
 
 import amrex.space3d as amr
@@ -16,26 +14,22 @@ else:
 
 
 @pytest.fixture(autouse=True, scope="function")
-def amrex_init():
-    amr.initialize(
-        [
-            # print AMReX status messages
-            "amrex.verbose=2",
-            # throw exceptions and create core dumps instead of
-            # AMReX backtrace files: allows to attach to
-            # debuggers
-            "amrex.throw_exception=1",
-            "amrex.signal_handling=0",
-            # abort GPU runs if out-of-memory instead of swapping to host RAM
-            "amrex.abort_on_out_of_gpu_memory=1",
-            # do not rely on implicit host-device memory transfers
-            "amrex.the_arena_is_managed=0",
-        ]
-    )
+def amrex_init(tmpdir):
+    with tmpdir.as_cwd():
+        amr.initialize(
+            [
+                # print AMReX status messages
+                "amrex.verbose=2",
+                # throw exceptions and create core dumps instead of
+                # AMReX backtrace files: allows to attach to
+                # debuggers
+                "amrex.throw_exception=1",
+                "amrex.signal_handling=0",
+                # abort GPU runs if out-of-memory instead of swapping to host RAM
+                "amrex.abort_on_out_of_gpu_memory=1",
+                # do not rely on implicit host-device memory transfers
+                "amrex.the_arena_is_managed=0",
+            ]
+        )
     yield
     amr.finalize()
-
-    # sleep 1s because AMReX diagnostics cleanup can only do one rename
-    # per second
-    # https://github.com/AMReX-Codes/amrex/blob/23.08/Src/Base/AMReX_Utility.cpp#L186-L199
-    time.sleep(1)

--- a/tests/python/test_charge_deposition.py
+++ b/tests/python/test_charge_deposition.py
@@ -10,6 +10,7 @@
 
 import math
 
+from conftest import basepath
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -24,7 +25,7 @@ def test_charge_deposition(save_png=True):
     sim = impactx.ImpactX()
 
     sim.n_cell = [16, 24, 32]
-    sim.load_inputs_file("examples/fodo/input_fodo.in")
+    sim.load_inputs_file(basepath + "/examples/fodo/input_fodo.in")
     sim.space_charge = True
     sim.slice_step_diagnostics = False
 

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -7,6 +7,7 @@
 #
 # -*- coding: utf-8 -*-
 
+from conftest import basepath
 import numpy as np
 import pytest
 
@@ -20,7 +21,7 @@ def test_impactx_fodo_file():
     """
     sim = ImpactX()
 
-    sim.load_inputs_file("examples/fodo/input_fodo.in")
+    sim.load_inputs_file(basepath + "/examples/fodo/input_fodo.in")
 
     sim.init_grids()
     sim.init_beam_distribution_from_inputs()
@@ -221,7 +222,7 @@ def test_impactx_no_elements():
     """
     sim = ImpactX()
 
-    sim.load_inputs_file("examples/fodo/input_fodo.in")
+    sim.load_inputs_file(basepath + "/examples/fodo/input_fodo.in")
 
     sim.init_grids()
     sim.init_beam_distribution_from_inputs()


### PR DESCRIPTION
Tests can generate temporary output and directories, which might clash and/or need cleaning between tests.
This changes the current working directory to a unique directory per test.

Seen as:
AMReX counts seconds passed (and factions thereof) since initialization. For subsequent tests, this can collide.
Also, the `UniqueStrings` in AMReX' `UtilCreateCleanDirectory` is pretty coarse in MPI contexts:
https://github.com/AMReX-Codes/amrex/blob/23.08/Src/Base/AMReX_Utility.cpp#L186-L199

If the target exist, the behavior of `std::rename` is implementation dependent. We see crashes of this on macOS.
https://en.cppreference.com/w/cpp/io/c/rename