### PR TITLE
pyAMReX: Latest Commit

### DIFF
--- a/cmake/dependencies/pyAMReX.cmake
+++ b/cmake/dependencies/pyAMReX.cmake
@@ -79,7 +79,7 @@ option(ImpactX_pyamrex_internal "Download & build pyAMReX" ON)
 set(ImpactX_pyamrex_repo "https://github.com/AMReX-Codes/pyamrex.git"
     CACHE STRING
     "Repository URI to pull and build pyamrex from if(ImpactX_pyamrex_internal)")
-set(ImpactX_pyamrex_branch "23.09"
+set(ImpactX_pyamrex_branch "56d5c98f45cd170dca9cea4be5cee118c0fb8b8f"
     CACHE STRING
     "Repository branch for ImpactX_pyamrex_repo if(ImpactX_pyamrex_internal)")
 


### PR DESCRIPTION
Update to the latest pyAMReX commit.

Mainly, to make available the new `.to_numpy()`/`.to_cupy()` helper functions.