### PR TITLE
Improve Doc Strings: Ref Kin Energy

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -311,7 +311,7 @@ Particles
 
    .. py:method:: set_energy_MeV(energy_MeV)
 
-      Write-only: Set reference particle energy.
+      Write-only: Set reference particle kinetic energy.
 
    .. py:method:: load_file(madx_file)
 

--- a/src/particles/ReferenceParticle.H
+++ b/src/particles/ReferenceParticle.H
@@ -139,7 +139,7 @@ namespace impactx
             return ref_energy;
         }
 
-        /** Set reference particle energy
+        /** Set reference particle kinetic energy
          *
          * @param energy initial kinetic energy (MeV)
          */

--- a/src/python/ReferenceParticle.cpp
+++ b/src/python/ReferenceParticle.cpp
@@ -48,6 +48,6 @@ void init_refparticle(py::module& m)
              "Set reference particle rest mass (MeV/c^2)", py::arg("mass_MeV"))
         .def("set_energy_MeV", &RefPart::set_energy_MeV,
              py::return_value_policy::reference_internal,
-             "Set reference particle energy (MeV)", py::arg("energy_MeV"))
+             "Set reference particle kinetic energy (MeV)", py::arg("energy_MeV"))
     ;
 }


### PR DESCRIPTION
Clarify that the reference particle energy is in kinetic energy in all doc strings.