### PR TITLE
pytest: support non-top level dirs

### DIFF
--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import os
+from pathlib import Path
 
 import pytest
 
@@ -15,7 +15,7 @@ else:
     print("NO mpi4py load")
 
 # base path for input files
-basepath = os.getcwd()
+basepath = Path(__file__).parent.parent
 
 
 @pytest.fixture(autouse=True, scope="function")


### PR DESCRIPTION
Generalize `basepath` to support running from any directory.

Follow-up to #424

X-ref https://github.com/ECP-WarpX/impactx/commit/476baddf2bc3b1f5e3ad7489de39ffa83c979fbc#r125869050