### PR TITLE
Inputs: Rename to Kinetic Beam Energy

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -53,6 +53,9 @@ Overall simulation parameters
 Setting up the field mesh
 -------------------------
 
+ImpactX uses an AMReX grid of boxes to organize and parallelize the simulation domain.
+These boxes also contain a field mesh, if space charge calculations are enabled.
+
 * ``amr.n_cell`` (3 integers) optional (default: 1 `blocking_factor <https://amrex-codes.github.io/amrex/docs_html/GridCreation.html>`__ per MPI process)
     The number of grid points along each direction (on the **coarsest level**)
 
@@ -114,104 +117,119 @@ Domain Boundary Conditions
 Initial Beam Distributions
 --------------------------
 
-* ``<distribution>.type`` (``string``)
+* ``beam.npart`` (``integer``)
+  number of weighted simulation particles
+
+* ``beam.units`` (``string``)
+  currently, only ``static`` is supported.
+
+* ``beam.kin_energy`` (``float``, in MeV)
+  beam kinetic energy
+
+* ``beam.charge`` (``float``, in C)
+  bunch charge
+
+* ``beam.particle`` (``string``)
+  particle type: currently either ``electron``, ``positron`` or ``proton``
+
+* ``beam.distribution`` (``string``)
     Indicates the initial distribution type.
     This should be one of:
 
     * ``waterbag`` for initial Waterbag distribution.
       With additional parameters:
 
-        * ``<distribution>.sigmaX`` (``float``, in meters) rms X
-        * ``<distribution>.sigmaY`` (``float``, in meters) rms Y
-        * ``<distribution>.sigmaT`` (``float``, in radian) rms normalized time difference T
-        * ``<distribution>.sigmaPx`` (``float``, in momentum) rms Px
-        * ``<distribution>.sigmaPy`` (``float``, in momentum) rms Py
-        * ``<distribution>.sigmaPt`` (``float``, in energy deviation) rms Pt
-        * ``<distribution>.muxpx`` (``float``, dimensionless, default: ``0``) correlation X-Px
-        * ``<distribution>.muypy`` (``float``, dimensionless, default: ``0``) correlation Y-Py
-        * ``<distribution>.mutpt`` (``float``, dimensionless, default: ``0``) correlation T-Pt
+        * ``beam.sigmaX`` (``float``, in meters) rms X
+        * ``beam.sigmaY`` (``float``, in meters) rms Y
+        * ``beam.sigmaT`` (``float``, in radian) rms normalized time difference T
+        * ``beam.sigmaPx`` (``float``, in momentum) rms Px
+        * ``beam.sigmaPy`` (``float``, in momentum) rms Py
+        * ``beam.sigmaPt`` (``float``, in energy deviation) rms Pt
+        * ``beam.muxpx`` (``float``, dimensionless, default: ``0``) correlation X-Px
+        * ``beam.muypy`` (``float``, dimensionless, default: ``0``) correlation Y-Py
+        * ``beam.mutpt`` (``float``, dimensionless, default: ``0``) correlation T-Pt
 
     * ``kurth6d`` for initial 6D Kurth distribution.
       With additional parameters:
 
-        * ``<distribution>.sigmaX`` (``float``, in meters) rms X
-        * ``<distribution>.sigmaY`` (``float``, in meters) rms Y
-        * ``<distribution>.sigmaT`` (``float``, in radian) rms normalized time difference T
-        * ``<distribution>.sigmaPx`` (``float``, in momentum) rms Px
-        * ``<distribution>.sigmaPy`` (``float``, in momentum) rms Py
-        * ``<distribution>.sigmaPt`` (``float``, in energy deviation) rms Pt
-        * ``<distribution>.muxpx`` (``float``, dimensionless, default: ``0``) correlation X-Px
-        * ``<distribution>.muypy`` (``float``, dimensionless, default: ``0``) correlation Y-Py
-        * ``<distribution>.mutpt`` (``float``, dimensionless, default: ``0``) correlation T-Pt
+        * ``beam.sigmaX`` (``float``, in meters) rms X
+        * ``beam.sigmaY`` (``float``, in meters) rms Y
+        * ``beam.sigmaT`` (``float``, in radian) rms normalized time difference T
+        * ``beam.sigmaPx`` (``float``, in momentum) rms Px
+        * ``beam.sigmaPy`` (``float``, in momentum) rms Py
+        * ``beam.sigmaPt`` (``float``, in energy deviation) rms Pt
+        * ``beam.muxpx`` (``float``, dimensionless, default: ``0``) correlation X-Px
+        * ``beam.muypy`` (``float``, dimensionless, default: ``0``) correlation Y-Py
+        * ``beam.mutpt`` (``float``, dimensionless, default: ``0``) correlation T-Pt
 
     * ``gaussian`` for initial 6D Gaussian (normal) distribution.
       With additional parameters:
 
-        * ``<distribution>.sigmaX`` (``float``, in meters) rms X
-        * ``<distribution>.sigmaY`` (``float``, in meters) rms Y
-        * ``<distribution>.sigmaT`` (``float``, in radian) rms normalized time difference T
-        * ``<distribution>.sigmaPx`` (``float``, in momentum) rms Px
-        * ``<distribution>.sigmaPy`` (``float``, in momentum) rms Py
-        * ``<distribution>.sigmaPt`` (``float``, in energy deviation) rms Pt
-        * ``<distribution>.muxpx`` (``float``, dimensionless, default: ``0``) correlation X-Px
-        * ``<distribution>.muypy`` (``float``, dimensionless, default: ``0``) correlation Y-Py
-        * ``<distribution>.mutpt`` (``float``, dimensionless, default: ``0``) correlation T-Pt
+        * ``beam.sigmaX`` (``float``, in meters) rms X
+        * ``beam.sigmaY`` (``float``, in meters) rms Y
+        * ``beam.sigmaT`` (``float``, in radian) rms normalized time difference T
+        * ``beam.sigmaPx`` (``float``, in momentum) rms Px
+        * ``beam.sigmaPy`` (``float``, in momentum) rms Py
+        * ``beam.sigmaPt`` (``float``, in energy deviation) rms Pt
+        * ``beam.muxpx`` (``float``, dimensionless, default: ``0``) correlation X-Px
+        * ``beam.muypy`` (``float``, dimensionless, default: ``0``) correlation Y-Py
+        * ``beam.mutpt`` (``float``, dimensionless, default: ``0``) correlation T-Pt
 
     * ``kvdist`` for initial K-V distribution in the transverse plane.
       The distribution is uniform in t and Gaussian in pt.
       With additional parameters:
 
-        * ``<distribution>.sigmaX`` (``float``, in meters) rms X
-        * ``<distribution>.sigmaY`` (``float``, in meters) rms Y
-        * ``<distribution>.sigmaT`` (``float``, in radian) rms normalized time difference T
-        * ``<distribution>.sigmaPx`` (``float``, in momentum) rms Px
-        * ``<distribution>.sigmaPy`` (``float``, in momentum) rms Py
-        * ``<distribution>.sigmaPt`` (``float``, in energy deviation) rms Pt
-        * ``<distribution>.muxpx`` (``float``, dimensionless, default: ``0``) correlation X-Px
-        * ``<distribution>.muypy`` (``float``, dimensionless, default: ``0``) correlation Y-Py
-        * ``<distribution>.mutpt`` (``float``, dimensionless, default: ``0``) correlation T-Pt
+        * ``beam.sigmaX`` (``float``, in meters) rms X
+        * ``beam.sigmaY`` (``float``, in meters) rms Y
+        * ``beam.sigmaT`` (``float``, in radian) rms normalized time difference T
+        * ``beam.sigmaPx`` (``float``, in momentum) rms Px
+        * ``beam.sigmaPy`` (``float``, in momentum) rms Py
+        * ``beam.sigmaPt`` (``float``, in energy deviation) rms Pt
+        * ``beam.muxpx`` (``float``, dimensionless, default: ``0``) correlation X-Px
+        * ``beam.muypy`` (``float``, dimensionless, default: ``0``) correlation Y-Py
+        * ``beam.mutpt`` (``float``, dimensionless, default: ``0``) correlation T-Pt
 
     * ``kurth4d`` for initial 4D Kurth distribution in the transverse plane.
       The distribution is uniform in t and Gaussian in pt.
       With additional parameters:
 
-        * ``<distribution>.sigmaX`` (``float``, in meters) rms X
-        * ``<distribution>.sigmaY`` (``float``, in meters) rms Y
-        * ``<distribution>.sigmaT`` (``float``, in radian) rms normalized time difference T
-        * ``<distribution>.sigmaPx`` (``float``, in momentum) rms Px
-        * ``<distribution>.sigmaPy`` (``float``, in momentum) rms Py
-        * ``<distribution>.sigmaPt`` (``float``, in energy deviation) rms Pt
-        * ``<distribution>.muxpx`` (``float``, dimensionless, default: ``0``) correlation X-Px
-        * ``<distribution>.muypy`` (``float``, dimensionless, default: ``0``) correlation Y-Py
-        * ``<distribution>.mutpt`` (``float``, dimensionless, default: ``0``) correlation T-Pt
+        * ``beam.sigmaX`` (``float``, in meters) rms X
+        * ``beam.sigmaY`` (``float``, in meters) rms Y
+        * ``beam.sigmaT`` (``float``, in radian) rms normalized time difference T
+        * ``beam.sigmaPx`` (``float``, in momentum) rms Px
+        * ``beam.sigmaPy`` (``float``, in momentum) rms Py
+        * ``beam.sigmaPt`` (``float``, in energy deviation) rms Pt
+        * ``beam.muxpx`` (``float``, dimensionless, default: ``0``) correlation X-Px
+        * ``beam.muypy`` (``float``, dimensionless, default: ``0``) correlation Y-Py
+        * ``beam.mutpt`` (``float``, dimensionless, default: ``0``) correlation T-Pt
 
     * ``semigaussian`` for initial Semi-Gaussian distribution.  The distribution is uniform within a cylinder in (x,y,z) and Gaussian in momenta (px,py,pt).
       With additional parameters:
 
-        * ``<distribution>.sigmaX`` (``float``, in meters) rms X
-        * ``<distribution>.sigmaY`` (``float``, in meters) rms Y
-        * ``<distribution>.sigmaT`` (``float``, in radian) rms normalized time difference T
-        * ``<distribution>.sigmaPx`` (``float``, in momentum) rms Px
-        * ``<distribution>.sigmaPy`` (``float``, in momentum) rms Py
-        * ``<distribution>.sigmaPt`` (``float``, in energy deviation) rms Pt
-        * ``<distribution>.muxpx`` (``float``, dimensionless, default: ``0``) correlation X-Px
-        * ``<distribution>.muypy`` (``float``, dimensionless, default: ``0``) correlation Y-Py
-        * ``<distribution>.mutpt`` (``float``, dimensionless, default: ``0``) correlation T-Pt
+        * ``beam.sigmaX`` (``float``, in meters) rms X
+        * ``beam.sigmaY`` (``float``, in meters) rms Y
+        * ``beam.sigmaT`` (``float``, in radian) rms normalized time difference T
+        * ``beam.sigmaPx`` (``float``, in momentum) rms Px
+        * ``beam.sigmaPy`` (``float``, in momentum) rms Py
+        * ``beam.sigmaPt`` (``float``, in energy deviation) rms Pt
+        * ``beam.muxpx`` (``float``, dimensionless, default: ``0``) correlation X-Px
+        * ``beam.muypy`` (``float``, dimensionless, default: ``0``) correlation Y-Py
+        * ``beam.mutpt`` (``float``, dimensionless, default: ``0``) correlation T-Pt
 
     * ``triangle`` a triangle distribution for laser-plasma acceleration related applications.
       A ramped, triangular current profile with a Gaussian energy spread (possibly correlated).
       The transverse distribution is a 4D waterbag.
       With additional parameters:
 
-        * ``<distribution>.sigmaX`` (``float``, in meters) rms X
-        * ``<distribution>.sigmaY`` (``float``, in meters) rms Y
-        * ``<distribution>.sigmaT`` (``float``, in radian) rms normalized time difference T
-        * ``<distribution>.sigmaPx`` (``float``, in momentum) rms Px
-        * ``<distribution>.sigmaPy`` (``float``, in momentum) rms Py
-        * ``<distribution>.sigmaPt`` (``float``, in energy deviation) rms Pt
-        * ``<distribution>.muxpx`` (``float``, dimensionless, default: ``0``) correlation X-Px
-        * ``<distribution>.muypy`` (``float``, dimensionless, default: ``0``) correlation Y-Py
-        * ``<distribution>.mutpt`` (``float``, dimensionless, default: ``0``) correlation T-Pt
+        * ``beam.sigmaX`` (``float``, in meters) rms X
+        * ``beam.sigmaY`` (``float``, in meters) rms Y
+        * ``beam.sigmaT`` (``float``, in radian) rms normalized time difference T
+        * ``beam.sigmaPx`` (``float``, in momentum) rms Px
+        * ``beam.sigmaPy`` (``float``, in momentum) rms Py
+        * ``beam.sigmaPt`` (``float``, in energy deviation) rms Pt
+        * ``beam.muxpx`` (``float``, dimensionless, default: ``0``) correlation X-Px
+        * ``beam.muypy`` (``float``, dimensionless, default: ``0``) correlation Y-Py
+        * ``beam.mutpt`` (``float``, dimensionless, default: ``0``) correlation T-Pt
 
 .. _running-cpp-parameters-lattice:
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -304,31 +304,31 @@ Particles
 
    .. py:property:: px
 
-      momentum in x, normalized to mass*c :math:`p_x = \gamma \beta_x`
+      momentum in x, normalized to mass*c, :math:`p_x = \gamma \beta_x`
 
    .. py:property:: py
 
-      momentum in y, normalized to mass*c :math:`p_x = \gamma \beta_x`
+      momentum in y, normalized to mass*c, :math:`p_x = \gamma \beta_x`
 
    .. py:property:: pz
 
-      momentum in z, normalized to mass*c :math:`p_x = \gamma \beta_x`
+      momentum in z, normalized to mass*c, :math:`p_x = \gamma \beta_x`
 
    .. py:property:: pt
 
-      energy, normalized by rest energy :math:`p_t = -\gamma`
+      energy, normalized by rest energy, :math:`p_t = -\gamma`
 
    .. py:property:: gamma
 
-      Read-only: Get reference particle relativistic gamma :math:`\gamma = 1/\sqrt{1-\beta^2}`
+      Read-only: Get reference particle relativistic gamma, :math:`\gamma = 1/\sqrt{1-\beta^2}`
 
    .. py:property:: beta
 
-      Read-only: Get reference particle relativistic beta :math:`\beta = v/c`
+      Read-only: Get reference particle relativistic beta, :math:`\beta = v/c`
 
    .. py:property:: beta_gamma
 
-      Read-only: Get reference particle beta*gamma
+      Read-only: Get reference particle :math:`\beta \cdot \gamma`
 
    .. py:property:: qm_qeeV
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -304,27 +304,27 @@ Particles
 
    .. py:property:: px
 
-      momentum in x, normalized to proper velocity
+      momentum in x, normalized to mass*c :math:`p_x = \gamma \beta_x`
 
    .. py:property:: py
 
-      momentum in y, normalized to proper velocity
+      momentum in y, normalized to mass*c :math:`p_x = \gamma \beta_x`
 
    .. py:property:: pz
 
-      momentum in z, normalized to proper velocity
+      momentum in z, normalized to mass*c :math:`p_x = \gamma \beta_x`
 
    .. py:property:: pt
 
-      energy deviation, normalized by rest energy
+      energy, normalized by rest energy :math:`p_t = -\gamma`
 
    .. py:property:: gamma
 
-      Read-only: Get reference particle relativistic gamma.
+      Read-only: Get reference particle relativistic gamma :math:`\gamma = 1/\sqrt{1-\beta^2}`
 
    .. py:property:: beta
 
-      Read-only: Get reference particle relativistic beta.
+      Read-only: Get reference particle relativistic beta :math:`\beta = v/c`
 
    .. py:property:: beta_gamma
 
@@ -342,9 +342,9 @@ Particles
 
       Write-only: Set reference particle rest mass (MeV/c^2).
 
-   .. py:method:: set_energy_MeV(energy_MeV)
+   .. py:method:: set_kin_energy_MeV(kin_energy_MeV)
 
-      Write-only: Set reference particle kinetic energy.
+      Write-only: Set reference particle kinetic energy (MeV)
 
    .. py:method:: load_file(madx_file)
 

--- a/examples/cfbend/input_cfbend.in
+++ b/examples/cfbend/input_cfbend.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 2.0e3  #2 GeV
+beam.kin_energy = 2.0e3  #2 GeV
 beam.charge = 1.0e-9
 beam.particle = electron
 beam.distribution = waterbag

--- a/examples/cfbend/run_cfbend.py
+++ b/examples/cfbend/run_cfbend.py
@@ -22,13 +22,13 @@ sim.init_grids()
 
 # load a 5 GeV electron beam with an initial
 # normalized transverse rms emittance of 1 um
-energy_MeV = 2.0e3  # reference energy
+kin_energy_MeV = 2.0e3  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/cfchannel/input_cfchannel.in
+++ b/examples/cfchannel/input_cfchannel.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 2.0e3
+beam.kin_energy = 2.0e3
 beam.charge = 1.0e-9
 beam.particle = proton
 beam.distribution = waterbag

--- a/examples/cfchannel/input_cfchannel_10nC.in
+++ b/examples/cfchannel/input_cfchannel_10nC.in
@@ -4,7 +4,7 @@
 beam.npart = 10000
 #beam.npart = 100000  # optional for increased precision
 beam.units = static
-beam.energy = 2.0e3
+beam.kin_energy = 2.0e3
 beam.charge = 1.0e-8
 beam.particle = proton
 beam.distribution = waterbag

--- a/examples/cfchannel/run_cfchannel.py
+++ b/examples/cfchannel/run_cfchannel.py
@@ -22,13 +22,13 @@ sim.init_grids()
 
 # load a 2 GeV proton beam with an initial
 # normalized transverse rms emittance of 1 um
-energy_MeV = 2.0e3  # reference energy
+kin_energy_MeV = 2.0e3  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/cfchannel/run_cfchannel_10nC.py
+++ b/examples/cfchannel/run_cfchannel_10nC.py
@@ -24,13 +24,13 @@ sim.init_grids()
 
 # load a 2 GeV proton beam with an initial
 # normalized transverse rms emittance of 1 um
-energy_MeV = 2.0e3  # reference energy
+kin_energy_MeV = 2.0e3  # reference energy
 bunch_charge_C = 1.0e-8  # used with space charge
 npart = 10000  # number of macro particles; use 1e5 for increased precision
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/chicane/input_chicane.in
+++ b/examples/chicane/input_chicane.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 5.0e3
+beam.kin_energy = 5.0e3
 beam.charge = 1.0e-9
 beam.particle = electron
 beam.distribution = waterbag

--- a/examples/chicane/run_chicane.py
+++ b/examples/chicane/run_chicane.py
@@ -22,13 +22,13 @@ sim.init_grids()
 
 # load a 5 GeV electron beam with an initial
 # normalized transverse rms emittance of 1 um
-energy_MeV = 5.0e3  # reference energy
+kin_energy_MeV = 5.0e3  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/compression/input_compression.in
+++ b/examples/compression/input_compression.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 20.0
+beam.kin_energy = 20.0
 beam.charge = 1.0e-9
 beam.particle = electron
 beam.distribution = waterbag

--- a/examples/compression/run_compression.py
+++ b/examples/compression/run_compression.py
@@ -23,13 +23,13 @@ sim.init_grids()
 # load a 250 MeV proton beam with an initial
 # unnormalized rms emittance of 1 mm-mrad in all
 # three phase planes
-energy_MeV = 20.0  # reference energy
+kin_energy_MeV = 20.0  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/cyclotron/input_cyclotron.in
+++ b/examples/cyclotron/input_cyclotron.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 4.0e-3
+beam.kin_energy = 4.0e-3
 beam.charge = 1.0e-9
 beam.particle = proton
 beam.distribution = waterbag

--- a/examples/cyclotron/run_cyclotron.py
+++ b/examples/cyclotron/run_cyclotron.py
@@ -21,13 +21,13 @@ sim.slice_step_diagnostics = True
 sim.init_grids()
 
 # load initial beam
-energy_MeV = 4.0e-3  # reference energy
+kin_energy_MeV = 4.0e-3  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/distgen/input_gaussian.in
+++ b/examples/distgen/input_gaussian.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 2.0e3
+beam.kin_energy = 2.0e3
 beam.charge = 1.0e-9
 beam.particle = electron
 beam.distribution = gaussian

--- a/examples/distgen/input_kurth4d.in
+++ b/examples/distgen/input_kurth4d.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 2.0e3
+beam.kin_energy = 2.0e3
 beam.charge = 1.0e-9
 beam.particle = proton
 beam.distribution = kurth4d

--- a/examples/distgen/input_kvdist.in
+++ b/examples/distgen/input_kvdist.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 2.0e3
+beam.kin_energy = 2.0e3
 beam.charge = 1.0e-9
 beam.particle = electron
 beam.distribution = kvdist

--- a/examples/distgen/input_semigaussian.in
+++ b/examples/distgen/input_semigaussian.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 2.0e3
+beam.kin_energy = 2.0e3
 beam.charge = 1.0e-9
 beam.particle = electron
 beam.distribution = gaussian

--- a/examples/expanding_beam/input_expanding.in
+++ b/examples/expanding_beam/input_expanding.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000  # outside tests, use 1e5 or more
 beam.units = static
-beam.energy = 250.0
+beam.kin_energy = 250.0
 beam.charge = 1.0e-9
 beam.particle = electron
 beam.distribution = kurth6d

--- a/examples/expanding_beam/run_expanding.py
+++ b/examples/expanding_beam/run_expanding.py
@@ -27,13 +27,13 @@ sim.init_grids()
 
 # load a 2 GeV electron beam with an initial
 # unnormalized rms emittance of 2 nm
-energy_MeV = 250  # reference energy
+kin_energy_MeV = 250  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles (outside tests, use 1e5 or more)
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Kurth6D(

--- a/examples/fodo/input_fodo.in
+++ b/examples/fodo/input_fodo.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 2.0e3
+beam.kin_energy = 2.0e3
 beam.charge = 1.0e-9
 beam.particle = electron
 beam.distribution = waterbag

--- a/examples/fodo/run_fodo.py
+++ b/examples/fodo/run_fodo.py
@@ -22,13 +22,13 @@ sim.init_grids()
 
 # load a 2 GeV electron beam with an initial
 # unnormalized rms emittance of 2 nm
-energy_MeV = 2.0e3  # reference energy
+kin_energy_MeV = 2.0e3  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/fodo/run_fodo_madx.py
+++ b/examples/fodo/run_fodo_madx.py
@@ -23,7 +23,7 @@ sim.init_grids()
 
 # load a 2 GeV electron beam with an initial
 # unnormalized rms emittance of 2 nm
-energy_MeV = 2.0e3  # reference energy
+kin_energy_MeV = 2.0e3  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 

--- a/examples/fodo/run_fodo_programmable.py
+++ b/examples/fodo/run_fodo_programmable.py
@@ -31,13 +31,13 @@ sim.init_grids()
 
 # load a 2 GeV electron beam with an initial
 # unnormalized rms emittance of 2 nm
-energy_MeV = 2.0e3  # reference energy
+kin_energy_MeV = 2.0e3  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/fodo_chromatic/input_fodo_chr.in
+++ b/examples/fodo_chromatic/input_fodo_chr.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 2.0e3
+beam.kin_energy = 2.0e3
 beam.charge = 1.0e-9
 beam.particle = electron
 beam.distribution = waterbag

--- a/examples/fodo_chromatic/run_fodo_chr.py
+++ b/examples/fodo_chromatic/run_fodo_chr.py
@@ -22,13 +22,13 @@ sim.init_grids()
 
 # load a 2 GeV electron beam with an initial
 # unnormalized rms emittance of 2 nm
-energy_MeV = 2.0e3  # reference energy
+kin_energy_MeV = 2.0e3  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/fodo_rf/input_fodo_rf.in
+++ b/examples/fodo_rf/input_fodo_rf.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 250.0
+beam.kin_energy = 250.0
 beam.charge = 1.0e-9
 beam.particle = proton
 beam.distribution = waterbag

--- a/examples/fodo_rf/run_fodo_rf.py
+++ b/examples/fodo_rf/run_fodo_rf.py
@@ -23,13 +23,13 @@ sim.init_grids()
 # load a 250 MeV proton beam with an initial
 # unnormalized rms emittance of 1 mm-mrad in all
 # three phase planes
-energy_MeV = 250.0  # reference energy
+kin_energy_MeV = 250.0  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/iota_lattice/input_iotalattice.in
+++ b/examples/iota_lattice/input_iotalattice.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 2.5
+beam.kin_energy = 2.5
 beam.charge = 1.0e-9
 beam.particle = proton
 beam.distribution = waterbag

--- a/examples/iota_lattice/run_iotalattice.py
+++ b/examples/iota_lattice/run_iotalattice.py
@@ -21,13 +21,13 @@ sim.slice_step_diagnostics = True
 sim.init_grids()
 
 # init particle beam
-energy_MeV = 2.5
+kin_energy_MeV = 2.5
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/iota_lens/input_iotalens.in
+++ b/examples/iota_lens/input_iotalens.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 2.5
+beam.kin_energy = 2.5
 beam.charge = 1.0e-9
 beam.particle = proton
 beam.distribution = waterbag

--- a/examples/iota_lens/run_iotalens.py
+++ b/examples/iota_lens/run_iotalens.py
@@ -21,13 +21,13 @@ sim.slice_step_diagnostics = True
 sim.init_grids()
 
 # load a 2.5 MeV proton beam
-energy_MeV = 2.5  # reference energy
+kin_energy_MeV = 2.5  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/kicker/input_kicker.in
+++ b/examples/kicker/input_kicker.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 2.0e3
+beam.kin_energy = 2.0e3
 beam.charge = 1.0e-9
 beam.particle = electron
 beam.distribution = waterbag

--- a/examples/kicker/run_kicker.py
+++ b/examples/kicker/run_kicker.py
@@ -22,13 +22,13 @@ sim.init_grids()
 
 # load a 2 GeV electron beam with an initial
 # unnormalized rms emittance of  nm
-energy_MeV = 2.0e3  # reference energy
+kin_energy_MeV = 2.0e3  # reference energy
 bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/kurth/input_kurth_10nC_periodic.in
+++ b/examples/kurth/input_kurth_10nC_periodic.in
@@ -4,7 +4,7 @@
 beam.npart = 10000
 #beam.npart = 100000 #optional for increased precision
 beam.units = static
-beam.energy = 2.0e3
+beam.kin_energy = 2.0e3
 beam.charge = 1.0e-8
 beam.particle = proton
 beam.distribution = kurth6d

--- a/examples/kurth/input_kurth_periodic.in
+++ b/examples/kurth/input_kurth_periodic.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 2.0e3
+beam.kin_energy = 2.0e3
 beam.charge = 1.0e-8
 beam.particle = proton
 beam.distribution = kurth6d

--- a/examples/kurth/run_kurth_10nC_periodic.py
+++ b/examples/kurth/run_kurth_10nC_periodic.py
@@ -24,13 +24,13 @@ sim.init_grids()
 # load a 2 GeV proton beam with an initial
 # unnormalized rms emittance of 1 um in each
 # coordinate plane
-energy_MeV = 2.0e3  # reference energy
+kin_energy_MeV = 2.0e3  # reference energy
 bunch_charge_C = 1.0e-8  # used with space charge
 npart = 10000  # number of macro particles; use 1e5 for increased precision
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Kurth6D(

--- a/examples/kurth/run_kurth_periodic.py
+++ b/examples/kurth/run_kurth_periodic.py
@@ -23,13 +23,13 @@ sim.init_grids()
 # load a 2 GeV proton beam with an initial
 # unnormalized rms emittance of 1 um in each
 # coordinate plane
-energy_MeV = 2.0e3  # reference energy
+kin_energy_MeV = 2.0e3  # reference energy
 bunch_charge_C = 1.0e-8  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Kurth6D(

--- a/examples/multipole/input_multipole.in
+++ b/examples/multipole/input_multipole.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 2.0e3
+beam.kin_energy = 2.0e3
 beam.charge = 1.0e-9
 beam.particle = electron
 beam.distribution = waterbag

--- a/examples/multipole/run_multipole.py
+++ b/examples/multipole/run_multipole.py
@@ -22,13 +22,13 @@ sim.init_grids()
 
 # load a 2 GeV electron beam with an initial
 # unnormalized rms emittance of  nm
-energy_MeV = 2.0e3  # reference energy
+kin_energy_MeV = 2.0e3  # reference energy
 bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/positron_channel/input_positron.in
+++ b/examples/positron_channel/input_positron.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 10.0e3
+beam.kin_energy = 10.0e3
 beam.charge = 190.0e-12
 beam.particle = positron
 beam.distribution = triangle

--- a/examples/positron_channel/run_positron.py
+++ b/examples/positron_channel/run_positron.py
@@ -22,13 +22,13 @@ sim.init_grids()
 
 # load a 10 GeV positron beam with an initial
 # normalized rms emittance of 10 nm
-energy_MeV = 10.0e3  # reference energy
+kin_energy_MeV = 10.0e3  # reference energy
 bunch_charge_C = 190.0e-12  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Triangle(

--- a/examples/quadrupole_softedge/input_quadrupole_softedge.in
+++ b/examples/quadrupole_softedge/input_quadrupole_softedge.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 2.0e3
+beam.kin_energy = 2.0e3
 beam.charge = 1.0e-9
 beam.particle = electron
 beam.distribution = waterbag

--- a/examples/quadrupole_softedge/run_quadrupole_softedge.py
+++ b/examples/quadrupole_softedge/run_quadrupole_softedge.py
@@ -22,13 +22,13 @@ sim.init_grids()
 
 # load a 2 GeV electron beam with an initial
 # unnormalized rms emittance of 2 nm
-energy_MeV = 2.0e3  # reference energy
+kin_energy_MeV = 2.0e3  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/rfcavity/input_rfcavity.in
+++ b/examples/rfcavity/input_rfcavity.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000  # outside tests, use 1e5 or more
 beam.units = static
-beam.energy = 230
+beam.kin_energy = 230
 beam.charge = 1.0e-10
 beam.particle = electron
 beam.distribution = waterbag

--- a/examples/rfcavity/run_rfcavity.py
+++ b/examples/rfcavity/run_rfcavity.py
@@ -23,13 +23,13 @@ sim.init_grids()
 # load a 230 MeV electron beam with an initial
 # unnormalized rms emittance of 1 mm-mrad in all
 # three phase planes
-energy_MeV = 230.0  # reference energy
+kin_energy_MeV = 230.0  # reference energy
 bunch_charge_C = 1.0e-10  # used with space charge
 npart = 10000  # number of macro particles (outside tests, use 1e5 or more)
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/rotation/input_rotation.in
+++ b/examples/rotation/input_rotation.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 2.0e3
+beam.kin_energy = 2.0e3
 beam.charge = 1.0e-9
 beam.particle = electron
 beam.distribution = waterbag

--- a/examples/rotation/run_rotation.py
+++ b/examples/rotation/run_rotation.py
@@ -22,13 +22,13 @@ sim.init_grids()
 
 # load a 2 GeV electron beam with an initial
 # unnormalized rms emittance of  nm
-energy_MeV = 2.0e3  # reference energy
+kin_energy_MeV = 2.0e3  # reference energy
 bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/solenoid/input_solenoid.in
+++ b/examples/solenoid/input_solenoid.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 250.0
+beam.kin_energy = 250.0
 beam.charge = 1.0e-9
 beam.particle = proton
 beam.distribution = waterbag

--- a/examples/solenoid/run_solenoid.py
+++ b/examples/solenoid/run_solenoid.py
@@ -23,13 +23,13 @@ sim.init_grids()
 # load a 250 MeV proton beam with an initial
 # horizontal rms emittance of 1 um and an
 # initial vertical rms emittance of 2 um
-energy_MeV = 250.0  # reference energy
+kin_energy_MeV = 250.0  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/solenoid/solenoid.madx
+++ b/examples/solenoid/solenoid.madx
@@ -1,4 +1,4 @@
-beam, particle=proton, energy=0.250;
+beam, particle=proton, energy=1.188272;
 
 M1: MONITOR,L=0.0;
 SOL1: solenoid, L=3.820395, KS=0.8223219329893234;

--- a/examples/solenoid_softedge/input_solenoid_softedge.in
+++ b/examples/solenoid_softedge/input_solenoid_softedge.in
@@ -3,7 +3,7 @@
 ###############################################################################
 beam.npart = 10000
 beam.units = static
-beam.energy = 250.0
+beam.kin_energy = 250.0
 beam.charge = 1.0e-9
 beam.particle = proton
 beam.distribution = waterbag

--- a/examples/solenoid_softedge/run_solenoid_softedge.py
+++ b/examples/solenoid_softedge/run_solenoid_softedge.py
@@ -23,13 +23,13 @@ sim.init_grids()
 # load a 250 MeV proton beam with an initial
 # horizontal rms emittance of 1 um and an
 # initial vertical rms emittance of 2 um
-energy_MeV = 250.0  # reference energy
+kin_energy_MeV = 250.0  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
-ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_energy_MeV(energy_MeV)
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -39,7 +39,7 @@ namespace impactx
             "add_particles: Reference particle charge not yet set!");
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ref.mass_MeV() != 0.0,
             "add_particles: Reference particle mass not yet set!");
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ref.energy_MeV() != 0.0,
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ref.kin_energy_MeV() != 0.0,
             "add_particles: Reference particle energy not yet set!");
 
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(bunch_charge >= 0.0,
@@ -112,8 +112,8 @@ namespace impactx
         // Parse the beam distribution parameters
         amrex::ParmParse const pp_dist("beam");
 
-        amrex::ParticleReal energy = 0.0;  // Beam kinetic energy (MeV)
-        pp_dist.get("energy", energy);
+        amrex::ParticleReal kin_energy = 0.0;  // Beam kinetic energy (MeV)
+        pp_dist.get("kin_energy", kin_energy);
 
         amrex::ParticleReal bunch_charge = 0.0;  // Bunch charge (C)
         pp_dist.get("charge", bunch_charge);
@@ -145,7 +145,7 @@ namespace impactx
 
         // set charge and mass and energy of ref particle
         m_particle_container->GetRefParticle()
-            .set_charge_qe(qe).set_mass_MeV(massE).set_energy_MeV(energy);
+                .set_charge_qe(qe).set_mass_MeV(massE).set_kin_energy_MeV(kin_energy);
 
         int npart = 1;  // Number of simulation particles
         pp_dist.get("npart", npart);
@@ -300,7 +300,7 @@ namespace impactx
         }
 
         // print information on the initialized beam
-        amrex::Print() << "Beam kinetic energy (MeV): " << energy << std::endl;
+        amrex::Print() << "Beam kinetic energy (MeV): " << kin_energy << std::endl;
         amrex::Print() << "Bunch charge (C): " << bunch_charge << std::endl;
         amrex::Print() << "Particle type: " << particle_type << std::endl;
         amrex::Print() << "Number of particles: " << npart << std::endl;

--- a/src/initialization/Validate.cpp
+++ b/src/initialization/Validate.cpp
@@ -24,7 +24,7 @@ namespace impactx
 
         // reference particle initialized?
         auto const & ref = m_particle_container->GetRefParticle();
-        if (ref.energy_MeV() == 0.0)
+        if (ref.kin_energy_MeV() == 0.0)
             throw std::runtime_error("The reference particle energy is zero. Not yet initialized?");
 
         // particles in the beam bunch

--- a/src/particles/ReferenceParticle.H
+++ b/src/particles/ReferenceParticle.H
@@ -117,7 +117,7 @@ namespace impactx
             // re-scale pt and pz
             if (pt != 0.0_prt)
             {
-                pt = -energy_MeV() / massE - 1.0_prt;
+                pt = -kin_energy_MeV() / massE - 1.0_prt;
                 pz = sqrt(pow(pt, 2) - 1.0_prt);
             }
 
@@ -130,31 +130,31 @@ namespace impactx
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         amrex::ParticleReal
-        energy_MeV () const
+        kin_energy_MeV () const
         {
             using namespace amrex::literals;
 
             amrex::ParticleReal const ref_gamma = -pt;
-            amrex::ParticleReal const ref_energy = mass_MeV() * (ref_gamma - 1.0_prt);
-            return ref_energy;
+            amrex::ParticleReal const ref_kin_energy = mass_MeV() * (ref_gamma - 1.0_prt);
+            return ref_kin_energy;
         }
 
         /** Set reference particle kinetic energy
          *
-         * @param energy initial kinetic energy (MeV)
+         * @param kin_energy initial kinetic energy (MeV)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         RefPart &
-        set_energy_MeV (amrex::ParticleReal const energy)
+        set_kin_energy_MeV (amrex::ParticleReal const kin_energy)
         {
             using namespace amrex::literals;
 
             AMREX_ASSERT_WITH_MESSAGE(mass != 0.0_prt,
-                                      "set_energy_MeV: Set mass first!");
+                                      "set_kin_energy_MeV: Set mass first!");
 
             px = 0.0;
             py = 0.0;
-            pt = -energy / mass_MeV() - 1.0_prt;
+            pt = -kin_energy / mass_MeV() - 1.0_prt;
             pz = sqrt(pow(pt, 2) - 1.0_prt);
 
             return *this;

--- a/src/python/ReferenceParticle.cpp
+++ b/src/python/ReferenceParticle.cpp
@@ -36,7 +36,7 @@ void init_refparticle(py::module& m)
         .def_property_readonly("beta", &RefPart::beta, "Get reference particle relativistic beta")
         .def_property_readonly("beta_gamma", &RefPart::beta_gamma, "Get reference particle beta*gamma")
         .def_property_readonly("mass_MeV", &RefPart::mass_MeV, "Get reference particle rest mass (MeV/c^2)")
-        .def_property_readonly("energy_MeV", &RefPart::energy_MeV, "Get reference particle energy (MeV)")
+        .def_property_readonly("kin_energy_MeV", &RefPart::kin_energy_MeV, "Get reference particle energy (MeV)")
         .def_property_readonly("rigidity_Tm", &RefPart::rigidity_Tm, "Get reference particle magnetic rigidity Brho (T*m)")
         .def_property_readonly("qm_qeeV", &RefPart::qm_qeeV, "Get reference particle charge to mass ratio (charge/eV)")
 
@@ -46,8 +46,8 @@ void init_refparticle(py::module& m)
         .def("set_mass_MeV", &RefPart::set_mass_MeV,
              py::return_value_policy::reference_internal,
              "Set reference particle rest mass (MeV/c^2)", py::arg("mass_MeV"))
-        .def("set_energy_MeV", &RefPart::set_energy_MeV,
+        .def("set_kin_energy_MeV", &RefPart::set_kin_energy_MeV,
              py::return_value_policy::reference_internal,
-             "Set reference particle kinetic energy (MeV)", py::arg("energy_MeV"))
+             "Set reference particle kinetic energy (MeV)", py::arg("kin_energy_MeV"))
     ;
 }

--- a/src/python/impactx/madx_to_impactx.py
+++ b/src/python/impactx/madx_to_impactx.py
@@ -122,7 +122,7 @@ def beam(particle, charge=None, mass=None, energy=None):
     :param str particle: reference particle name
     :param float charge: particle charge (proton charge units)
     :param float mass: particle mass (electron masses)
-    :param float energy: particle energy (GeV)
+    :param float energy: total particle energy (GeV)
         - MAD-X default: 1 GeV
     :return dict: dictionary containing particle and beam attributes in ImpactX units
     """
@@ -131,7 +131,7 @@ def beam(particle, charge=None, mass=None, energy=None):
     kg2MeV = sc.c**2 / sc.electron_volt * 1.0e-6
     muon_mass = sc.physical_constants["electron-muon mass ratio"][0] / sc.m_e
     if energy is None:
-        energy_MeV = 1.0e3  # MAD-X default is 1 GeV particle energy
+        energy_MeV = 1.0e3  # MAD-X default is 1 GeV total particle energy
     else:
         energy_MeV = energy * GeV2MeV
 
@@ -192,6 +192,6 @@ def read_beam(ref: RefPart, madx_file):
 
     ref.set_charge_qe(ref_particle_dict["charge"])
     ref.set_mass_MeV(ref_particle_dict["mass"])
-    ref.set_energy_MeV(ref_particle_dict["energy"])
+    ref.set_kin_energy_MeV(ref_particle_dict["energy"] - ref_particle_dict["mass"])
 
     return ref

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -76,13 +76,13 @@ def test_impactx_nofile():
     sim.init_grids()
 
     # init particle beam
-    energy_MeV = 2.0e3
+    kin_energy_MeV = 2.0e3
     bunch_charge_C = 1.0e-9
     npart = 10000
 
     #   reference particle
     ref = sim.particle_container().ref_particle()
-    ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+    ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch
     distr = distribution.Waterbag(
@@ -137,11 +137,11 @@ def test_impactx_noparticles():
     sim.init_grids()
 
     # init particle beam
-    energy_MeV = 2.0e3
+    kin_energy_MeV = 2.0e3
 
     #   reference particle
     ref = sim.particle_container().ref_particle()
-    ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+    ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
     #   particle bunch: init intentionally missing
 
     # init accelerator lattice

--- a/tests/python/test_transformation.py
+++ b/tests/python/test_transformation.py
@@ -38,15 +38,15 @@ def test_transformation():
 
     # load a 1 GeV electron beam with an initial
     # unnormalized rms emittance of 2 nm
-    energy_MeV = 1e3  # reference energy
-    energy_gamma = energy_MeV / 0.510998950
+    kin_energy_MeV = 1e3  # reference energy
+    energy_gamma = kin_energy_MeV / 0.510998950 + 1.0
     bunch_charge_C = 1.0e-9  # used with space charge
     npart = 10000  # number of macro particles
 
     #   reference particle
     pc = sim.particle_container()
     ref = pc.ref_particle()
-    ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_energy_MeV(energy_MeV)
+    ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch
     distr = distribution.Gaussian(


### PR DESCRIPTION
Rename the inputs:
- AMReX inputs file: `beam.energy` -> `beam.kin_energy`
- Python: `set_kin_energy_MeV` -> `set_kin_energy_MeV`

for clarity.

Spotted and fixed an issue in our MAD-X reader, which forgot to add the rest mass. Fixes a few examples.

Follow-up to #444

Close #435