### PR TITLE
Python: Programmable Element w/ Dynamic

### DIFF
--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -227,7 +227,7 @@ void init_elements(py::module& m)
         )
     ;
 
-    py::class_<Programmable>(me, "Programmable")
+    py::class_<Programmable>(me, "Programmable", py::dynamic_attr())
         .def(py::init<
                  amrex::ParticleReal,
                  int>(),


### PR DESCRIPTION
Enable support for dynamic attributes in the `Programmable` element. This avoids that we need to derive the element to carry around additional Python state.
https://pybind11.readthedocs.io/en/stable/classes.html#dynamic-attributes