### PR TITLE
Remove distutils

### DIFF
--- a/.github/workflows/dependencies/clang-san-openmpi.sh
+++ b/.github/workflows/dependencies/clang-san-openmpi.sh
@@ -26,7 +26,8 @@ sudo apt-get install -y \
     python3-pip         \
     wget
 
-python3 -m pip install -U pip setuptools wheel
+python3 -m pip install -U pip
+python3 -m pip install -U build packaging setuptools wheel
 python3 -m pip install -U cmake pytest
 python3 -m pip install -U -r requirements_mpi.txt
 python3 -m pip install -U -r examples/requirements.txt

--- a/.github/workflows/dependencies/clang-tidy.sh
+++ b/.github/workflows/dependencies/clang-tidy.sh
@@ -25,7 +25,8 @@ sudo apt-get install -y \
     python3-pip         \
     wget
 
-python3 -m pip install -U pip setuptools wheel
+python3 -m pip install -U pip
+python3 -m pip install -U build packaging setuptools wheel
 python3 -m pip install -U cmake pytest
 python3 -m pip install -U -r requirements_mpi.txt
 python3 -m pip install -U -r examples/requirements.txt

--- a/.github/workflows/dependencies/gcc-openmpi.sh
+++ b/.github/workflows/dependencies/gcc-openmpi.sh
@@ -22,7 +22,8 @@ sudo apt-get install -y \
     python3-pip         \
     wget
 
-python3 -m pip install -U pip setuptools wheel
+python3 -m pip install -U pip
+python3 -m pip install -U build packaging setuptools wheel
 python3 -m pip install -U cmake pytest
 python3 -m pip install -U -r requirements_mpi.txt
 python3 -m pip install -U -r examples/requirements.txt

--- a/.github/workflows/dependencies/gcc.sh
+++ b/.github/workflows/dependencies/gcc.sh
@@ -21,7 +21,8 @@ sudo apt-get install -y \
     python3-pip         \
     wget
 
-python3 -m pip install -U pip setuptools wheel
+python3 -m pip install -U pip
+python3 -m pip install -U build packaging setuptools wheel
 python3 -m pip install -U cmake pytest
 python3 -m pip install -U -r examples/requirements.txt
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -51,7 +51,8 @@ jobs:
         brew install ninja
         brew install open-mpi
         brew install pkg-config
-        python3 -m pip install --upgrade pip setuptools wheel pytest
+        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade build packaging setuptools wheel pytest
         python3 -m pip install --upgrade pytest
         python3 -m pip install --upgrade -r requirements_mpi.txt
         python3 -m pip install --upgrade -r examples/requirements.txt

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,7 +52,8 @@ jobs:
         $env:HDF5_DIR = "C:/Program Files/HDF_Group/HDF5/1.12.2/cmake/"
         $env:HDF5_USE_STATIC_LIBRARIES = "ON"
 
-        python3 -m pip install -U pip setuptools wheel pytest
+        python3 -m pip install -U pip
+        python3 -m pip install -U build packaging setuptools wheel pytest
         python3 -m pip install -U -r requirements.txt
         python3 -m pip install -U -r examples/requirements.txt
         python3 -m pip install -U openPMD-validator
@@ -137,7 +138,8 @@ jobs:
         set "HDF5_DIR=C:/Program Files/HDF_Group/HDF5/1.12.2/cmake/"
         set "HDF5_USE_STATIC_LIBRARIES=ON"
 
-        python3 -m pip install -U pip setuptools wheel pytest
+        python3 -m pip install -U pip
+        python3 -m pip install -U build packaging setuptools wheel pytest
         python3 -m pip install -U -r requirements.txt
         python3 -m pip install -U -r examples/requirements.txt
         python3 -m pip install -U openPMD-validator

--- a/docs/source/developers/testing.rst
+++ b/docs/source/developers/testing.rst
@@ -12,7 +12,8 @@ In order to run our tests, you need to have a few :ref:`Python packages installe
 
 .. code-block:: sh
 
-   python3 -m pip install -U pip setuptools wheel pytest
+   python3 -m pip install -U pip
+   python3 -m pip install -U build packaging setuptools wheel pytest
    python3 -m pip install -r examples/requirements.txt
 
 Run

--- a/docs/source/install/cmake.rst
+++ b/docs/source/install/cmake.rst
@@ -35,7 +35,8 @@ ImpactX depends on popular third party software.
 
    .. code-block:: bash
 
-      python3 -m pip install -U pip setuptools wheel pytest
+      python3 -m pip install -U pip
+      python3 -m pip install -U build packaging setuptools wheel pytest
       python3 -m pip install -U -r examples/requirements.txt
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "cmake>=3.20.0,<4.0.0"
+    "cmake>=3.20.0,<4.0.0",
+    "packaging>=23",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,6 @@
 # Authors: Axel Huebl
 # License: BSD-3-Clause-LBNL
 #
-from distutils.command.build import build
-from distutils.command.clean import clean
-from distutils.version import LooseVersion
 import os
 import platform
 import re
@@ -16,6 +13,7 @@ import subprocess
 import sys
 
 from setuptools import Extension, setup
+from setuptools.command.build import build
 from setuptools.command.build_ext import build_ext
 
 
@@ -33,10 +31,8 @@ class CopyPreBuild(build):
         #   by default, this stays around. we want to make sure generated
         #   files like libwarpx.(2d|3d|rz).(so|pyd) are always only the
         #   ones we want to package and not ones from an earlier wheel's stage
-        c = clean(self.distribution)
-        c.all = True
-        c.finalize_options()
-        c.run()
+        if os.path.exists(self.build_base):
+            shutil.rmtree(self.build_base)
 
         # call superclass
         build.run(self)
@@ -68,6 +64,8 @@ class CMakeExtension(Extension):
 
 class CMakeBuild(build_ext):
     def run(self):
+        from packaging.version import parse
+
         try:
             out = subprocess.check_output(["cmake", "--version"])
         except OSError:
@@ -77,10 +75,8 @@ class CMakeBuild(build_ext):
                 + ", ".join(e.name for e in self.extensions)
             )
 
-        cmake_version = LooseVersion(
-            re.search(r"version\s*([\d.]+)", out.decode()).group(1)
-        )
-        if cmake_version < "3.20.0":
+        cmake_version = parse(re.search(r"version\s*([\d.]+)", out.decode()).group(1))
+        if cmake_version < parse("3.20.0"):
             raise RuntimeError("CMake >= 3.20.0 is required")
 
         for ext in self.extensions:


### PR DESCRIPTION
Distutils is gone in Python 3.12+.

Refs.:
- https://peps.python.org/pep-0632/#migration-advice
- https://github.com/AMReX-Codes/pyamrex/pull/180