### PR TITLE
Python: Expose Properties of `ConstF`

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -465,6 +465,18 @@ This module provides elements for the accelerator lattice.
    :param kt: Focusing strength for t in 1/m.
    :param nslice: number of slices used for the application of space charge
 
+   .. py:property:: kx
+
+      focusing x strength in 1/m
+
+   .. py:property:: ky
+
+      focusing y strength in 1/m
+
+   .. py:property:: kt
+
+      focusing t strength in 1/m
+
 .. py:class:: impactx.elements.DipEdge(psi, rc, g, K2)
 
    Edge focusing associated with bend entry or exit

--- a/src/particles/elements/ConstF.H
+++ b/src/particles/elements/ConstF.H
@@ -138,7 +138,6 @@ namespace impactx
 
         }
 
-    private:
         amrex::ParticleReal m_kx; //! focusing x strength in 1/m
         amrex::ParticleReal m_ky; //! focusing y strength in 1/m
         amrex::ParticleReal m_kt; //! focusing t strength in 1/m

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -141,6 +141,21 @@ void init_elements(py::module& m)
              py::arg("ds"), py::arg("kx"), py::arg("ky"), py::arg("kt"), py::arg("nslice") = 1,
              "A linear Constant Focusing element."
         )
+        .def_property("kx",
+        [](ConstF & cf) { return cf.m_kx; },
+        [](ConstF & cf, amrex::ParticleReal kx) { cf.m_kx = kx; },
+            "focusing x strength in 1/m"
+        )
+        .def_property("ky",
+              [](ConstF & cf) { return cf.m_ky; },
+              [](ConstF & cf, amrex::ParticleReal ky) { cf.m_ky = ky; },
+              "focusing y strength in 1/m"
+        )
+        .def_property("kt",
+              [](ConstF & cf) { return cf.m_kt; },
+              [](ConstF & cf, amrex::ParticleReal kt) { cf.m_kt = kt; },
+              "focusing t strength in 1/m"
+        )
     ;
 
     py::class_<DipEdge, elements::Thin>(me, "DipEdge")


### PR DESCRIPTION
Expose the focusing strength of the constant focusing element to Python for manipulation.