### PR TITLE
Dist None: Set to Zero

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -394,7 +394,7 @@ This module provides particle beam distributions that can be used to initialize 
 
 .. py:class:: impactx.distribution.None
 
-   This distribution does nothing.
+   This distribution sets all values to zero.
 
 .. py:class:: impactx.distribution.Semigaussian(sigx, sigy, sigt, sigpx, sigpy, sigpt, muxpx=0.0, muypy=0.0, mutpt=0.0)
 

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -21,6 +21,7 @@
 #include <AMReX_Print.H>
 
 #include <string>
+#include <variant>
 
 
 namespace impactx

--- a/src/particles/distribution/None.H
+++ b/src/particles/distribution/None.H
@@ -18,7 +18,7 @@ namespace impactx::distribution
 {
     struct None
     {
-        /** This distribution does nothing
+        /** This distribution sets all values to zero.
          */
          None()
          {
@@ -26,7 +26,7 @@ namespace impactx::distribution
 
         /** Return 1 6D particle coordinate
          *
-         * Does nothing to the parameters.
+         * Sets all values to zero.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -38,15 +38,22 @@ namespace impactx::distribution
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                [[maybe_unused]] amrex::ParticleReal & x,
-                [[maybe_unused]] amrex::ParticleReal & y,
-                [[maybe_unused]] amrex::ParticleReal & t,
-                [[maybe_unused]] amrex::ParticleReal & px,
-                [[maybe_unused]] amrex::ParticleReal & py,
-                [[maybe_unused]] amrex::ParticleReal & pt,
+                amrex::ParticleReal & x,
+                amrex::ParticleReal & y,
+                amrex::ParticleReal & t,
+                amrex::ParticleReal & px,
+                amrex::ParticleReal & py,
+                amrex::ParticleReal & pt,
                 [[maybe_unused]] amrex::RandomEngine const& engine) const
         {
-            /* nothing to do */
+            using namespace amrex::literals;
+
+            x = 0_prt;
+            y = 0_prt;
+            t = 0_prt;
+            px = 0_prt;
+            py = 0_prt;
+            pt = 0_prt;
         }
     };
 

--- a/src/python/distribution.cpp
+++ b/src/python/distribution.cpp
@@ -77,7 +77,7 @@ void init_distribution(py::module& m)
 
     py::class_<distribution::None>(md, "None")
         .def(py::init<>(),
-             "This distribution does nothing"
+             "Sets all values to zero."
         );
 
     py::class_<distribution::Semigaussian>(md, "Semigaussian")


### PR DESCRIPTION
With GCC 12, compiling the `None` distribution throws warnings in compilation of `add_particles`. Originally, this was added so that the `std::variant` for `impactx::distribution::KnownDistributions` creates a default constructor for the variant.

Adding an assert that the distribution cannot be used in `add_particles` does not silence the warning diagnostics. Thus, we simply make it a distribution that sets the values to zero.