### PR TITLE
Python: Expose Manual Push

### DIFF
--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -11,7 +11,6 @@
 
 #include <AMReX_BLProfiler.H>
 
-#include <string>
 #include <variant>
 
 
@@ -24,12 +23,7 @@ namespace impactx
         // here we just access the element by its respective type
         std::visit([&pc, step](auto&& element)
         {
-            // performance profiling per element
-            std::string element_name;
-            element_name = element.name;
-            std::string const profile_name = "impactx::Push::" + element_name;
             BL_PROFILE("impactx::Push");
-            BL_PROFILE(profile_name);
 
             // push reference particle & all particles
             element(pc, step);

--- a/src/particles/PushAll.H
+++ b/src/particles/PushAll.H
@@ -36,6 +36,10 @@ namespace impactx
             [[maybe_unused]] bool omp_parallel = true
     )
     {
+        // performance profiling per element
+        std::string const profile_name = "impactx::Push::" + std::string(T_Element::name);
+        BL_PROFILE(profile_name);
+
         // preparing to access reference particle data: RefPart
         RefPart & ref_part = pc.GetRefParticle();
 

--- a/src/particles/elements/diagnostics/openPMD.cpp
+++ b/src/particles/elements/diagnostics/openPMD.cpp
@@ -15,6 +15,7 @@
 #include <ablastr/particles/IndexHandling.H>
 
 #include <AMReX.H>
+#include <AMReX_BLProfiler.H>
 #include <AMReX_REAL.H>
 #include <AMReX_ParmParse.H>
 
@@ -23,6 +24,7 @@
 namespace io = openPMD;
 #endif
 
+#include <string>
 #include <utility>
 
 
@@ -310,6 +312,9 @@ namespace detail
         int step
     )
     {
+        std::string profile_name = "impactx::Push::" + std::string(BeamMonitor::name);
+        BL_PROFILE(profile_name);
+
         // preparing to access reference particle data: RefPart
         RefPart & ref_part = pc.GetRefParticle();
 

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -27,7 +27,9 @@ namespace
         using Element = typename T_PyClass::type;  // py::class<T, options...>
 
         cl.def("push",
-            py::overload_cast<ImpactXParticleContainer &, int>(&Element::operator()),
+            [](Element & el, ImpactXParticleContainer & pc, int step) {
+                el(pc, step);
+            },
             py::arg("pc"), py::arg("step")=0,
             "Push first the reference particle, then all other particles."
         );

--- a/tests/python/test_push.py
+++ b/tests/python/test_push.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 The ImpactX Community
+#
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+from impactx import ImpactX, distribution, elements, push
+
+
+def test_element_push():
+    """
+    This tests using ImpactX without a lattice.
+    """
+    sim = ImpactX()
+
+    sim.particle_shape = 2
+    sim.slice_step_diagnostics = True
+    sim.init_grids()
+
+    # init particle beam
+    kin_energy_MeV = 2.0e3
+    bunch_charge_C = 1.0e-9
+    npart = 10000
+
+    #   reference particle
+    ref = sim.particle_container().ref_particle()
+    ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
+
+    #   particle bunch
+    distr = distribution.Waterbag(
+        sigmaX=3.9984884770e-5,
+        sigmaY=3.9984884770e-5,
+        sigmaT=1.0e-3,
+        sigmaPx=2.6623538760e-5,
+        sigmaPy=2.6623538760e-5,
+        sigmaPt=2.0e-3,
+        muxpx=-0.846574929020762,
+        muypy=0.846574929020762,
+        mutpt=0.0,
+    )
+    sim.add_particles(bunch_charge_C, distr, npart)
+
+    pc = sim.particle_container()
+    assert pc.TotalNumberOfParticles() == npart
+
+    # init accelerator lattice
+    fodo = [
+        elements.Drift(0.25),
+    ]
+    sim.lattice.extend(fodo)
+
+    sim.evolve()
+
+    # Push manually through a few elements
+    elements.Quad(1.0, 1.0).push(pc)
+    elements.Drift(0.5).push(pc)
+    elements.Quad(1.0, -1.0).push(pc)
+
+    # alternative formulation
+    push(pc, elements.Drift(0.25))


### PR DESCRIPTION
Enable to push a particle container through an element class without being in the simulation's evolve loop.