### PR TITLE
Add 6D minimum and maximum values to reduced beam characteristics

### DIFF
--- a/docs/source/dataanalysis/dataanalysis.rst
+++ b/docs/source/dataanalysis/dataanalysis.rst
@@ -61,20 +61,20 @@ The code writes out the values in an ASCII file prefixed ``reduced_beam_characte
 * ``step``
     Iteration within the simulation
 * ``s``, ``ref_beta_gamma``
-    Reference particle coordinate ``s`` and relativistic momentum normalized by the particle mass and the speed of light
-* ``x_mean``, ``y_mean``, ``t_mean``
-    Average beam particle position in the dimensions of ``x``, ``y`` (transverse coordinates), and ``t`` (normalized time difference)
+    Reference particle coordinate ``s`` (unit: meter) and relativistic momentum normalized by the particle mass and the speed of light (unit: dimensionless)
+* ``x_mean/min/max``, ``y_mean/min/max``, ``t_mean/min/max``
+    Average / minimum / maximum beam particle position in the dimensions of ``x``, ``y`` (transverse coordinates, unit: meter), and ``t`` (normalized time difference :math:`ct`, unit: meter)
 * ``sig_x``, ``sig_y``, ``sig_t``
-    RMS of the average beam particle positions
-* ``px_mean``, ``py_mean``, ``pt_mean``
-    Average beam momenta
+    RMS of the average beam particle positions (unit: meter)
+* ``px_mean/min/max``, ``py_mean/min/max``, ``pt_mean/min/max``
+    Average / minimum / maximum beam momenta normalized by reference particle momentum (unit: dimensionless, radians for transverse momenta)
 * ``sig_px``, ``sig_py``, ``sig_pt``
-    RMS of the average beam momenta (energy difference for ``pt``)
+    RMS of the average beam momenta (energy difference for ``pt``) (unit: dimensionless)
 * ``emittance_x``, ``emittance_y``, ``emittance_t``
-    Normalized beam emittance
+    Normalized beam emittance (unit: meter)
 * ``alpha_x``, ``alpha_y``, ``alpha_t``
-    Twiss alpha
+    Courant-Snyder (Twiss) alpha (unit: dimensionless)
 * ``beta_x``, ``beta_y``, ``beta_t``
-    Twiss beta
+    Courant-Snyder (Twiss) beta (unit: meter)
 * ``charge``
-    Cumulated beam charge in C
+    Cumulated beam charge (unit: Coulomb)

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -47,9 +47,13 @@ namespace impactx::diagnostics
                 file_handler << "step s x y z t px py pz pt\n";
             } else if (otype == OutputType::PrintReducedBeamCharacteristics) {
                 file_handler << "step" << " " << "s" << " " << "ref_beta_gamma" << " "
-                             << "x_mean" << " " << "y_mean" << " " << "t_mean" << " "
+                             << "x_mean" << " " << "x_min" << " " << "x_max" << " "
+                             << "y_mean" << " " << "y_min" << " " << "y_max" << " "
+                             << "t_mean" << " " << "t_min" << " " << "t_max" << " "
                              << "sig_x" << " " << "sig_y" << " " << "sig_t" << " "
-                             << "px_mean" << " " << "py_mean" << " " << "pt_mean" << " "
+                             << "px_mean" << " " << "px_min" << " " << "px_max" << " "
+                             << "py_mean" << " " << "py_min" << " " << "py_max" << " "
+                             << "pt_mean" << " " << "pt_min" << " " << "pt_max" << " "
                              << "sig_px" << " " << "sig_py" << " " << "sig_pt" << " "
                              << "emittance_x" << " " << "emittance_y" << " " << "emittance_t" << " "
                              << "alpha_x" << " " << "alpha_y" << " " << "alpha_t" << " "
@@ -84,9 +88,13 @@ namespace impactx::diagnostics
                 diagnostics::reduced_beam_characteristics(pc);
 
             file_handler << step << " " << rbc.at("s") << " " << rbc.at("ref_beta_gamma") << " "
-                         << rbc.at("x_mean") << " " << rbc.at("y_mean") << " " << rbc.at("t_mean") << " "
+                         << rbc.at("x_mean") << " " << rbc.at("x_min") << " " << rbc.at("x_max") << " "
+                         << rbc.at("y_mean") << " " << rbc.at("y_min") << " " << rbc.at("y_max") << " "
+                         << rbc.at("t_mean") << " " << rbc.at("t_min") << " " << rbc.at("t_max") << " "
                          << rbc.at("sig_x") << " " << rbc.at("sig_y") << " " << rbc.at("sig_t") << " "
-                         << rbc.at("px_mean") << " " << rbc.at("py_mean") << " " << rbc.at("pt_mean") << " "
+                         << rbc.at("px_mean") << " " << rbc.at("px_min") << " " << rbc.at("px_max") << " "
+                         << rbc.at("py_mean") << " " << rbc.at("py_min") << " " << rbc.at("py_max") << " "
+                         << rbc.at("pt_mean") << " " << rbc.at("pt_min") << " " << rbc.at("pt_max") << " "
                          << rbc.at("sig_px") << " " << rbc.at("sig_py") << " " << rbc.at("sig_pt") << " "
                          << rbc.at("emittance_x") << " " << rbc.at("emittance_y") << " " << rbc.at("emittance_t") << " "
                          << rbc.at("alpha_x") << " " << rbc.at("alpha_y") << " " << rbc.at("alpha_t") << " "
@@ -121,6 +129,7 @@ namespace impactx::diagnostics
                     amrex::ParticleReal const *const AMREX_RESTRICT part_px = soa_real[RealSoA::px].dataPtr();
                     amrex::ParticleReal const *const AMREX_RESTRICT part_py = soa_real[RealSoA::py].dataPtr();
 
+                    // TODO: Refactor since this condition is always true here
                     if (otype == OutputType::PrintNonlinearLensInvariants) {
                         using namespace amrex::literals;
 


### PR DESCRIPTION
This PR adds global minimum and maximum values for all phase space coordinates `x`, `y`, `t`, `px`, `py`, `pt` of the particle beam to the `ReducedBeamCharacteristics` output.

Documentation for quantities is added and unit information for the `reduced_beam_characteristics()` function has been added where it was missing.

See below visualizations of output from the FODO example
|  x  | y | t |
|:---------------------:|:-----------------------:|:--------------------:|
| ![x_min_max](https://github.com/ECP-WarpX/impactx/assets/5416860/32a0f3b6-adfb-4105-8553-c1dd5931d676) | ![y_min_max](https://github.com/ECP-WarpX/impactx/assets/5416860/da758857-2030-448a-9c87-2c392aebf2e3) | ![t_min_max](https://github.com/ECP-WarpX/impactx/assets/5416860/79e1a308-ef0f-4d00-8a0e-594ddb6ea5e4) | 
| px | py | pt |
| ![px_min_max](https://github.com/ECP-WarpX/impactx/assets/5416860/81735e66-e636-4584-92bf-e1bcb581617d) | ![py_min_max](https://github.com/ECP-WarpX/impactx/assets/5416860/2d5e8cb0-b201-42fc-917e-b0aafd5eb522) | ![pt_min_max](https://github.com/ECP-WarpX/impactx/assets/5416860/37327841-5f4f-4915-b5ef-0a8c0417a841) |






