### PR TITLE
CI: Pipx for openPMD-validator

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,9 +42,9 @@ jobs:
         python3 -m pip install --upgrade pytest
         python3 -m pip install --upgrade -r requirements_mpi.txt
         python3 -m pip install --upgrade -r examples/requirements.txt
-        python3 -m pip install --upgrade pipx
-        python3 -m pipx install --upgrade openPMD-validator
         set -e
+        python3 -m pip install --upgrade pipx
+        python3 -m pipx install openPMD-validator
     - name: CCache Cache
       uses: actions/cache@v3
       # - once stored under a key, they become immutable (even if local cache path content changes)

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,7 +42,8 @@ jobs:
         python3 -m pip install --upgrade pytest
         python3 -m pip install --upgrade -r requirements_mpi.txt
         python3 -m pip install --upgrade -r examples/requirements.txt
-        python3 -m pip install --upgrade openPMD-validator
+        python3 -m pip install --upgrade pipx
+        python3 -m pipx install --upgrade openPMD-validator
         set -e
     - name: CCache Cache
       uses: actions/cache@v3


### PR DESCRIPTION
Replace `pip` with `pipx` for proper entry points.