### PR TITLE
Elements: `sincos(...)`

### DIFF
--- a/src/particles/elements/CFbend.H
+++ b/src/particles/elements/CFbend.H
@@ -16,6 +16,7 @@
 #include "mixin/nofinalize.H"
 
 #include <AMReX_Extension.H>
+#include <AMReX_Math.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
@@ -96,8 +97,7 @@ namespace impactx
 
             if(gx > 0.0) {
                 // calculate expensive terms once
-                amrex::ParticleReal const sinx = sin(omegax * slice_ds);
-                amrex::ParticleReal const cosx = cos(omegax * slice_ds);
+                auto const [sinx, cosx] = amrex::Math::sincos(omegax * slice_ds);
                 amrex::ParticleReal const r56 = slice_ds/betgam2
                     + (sinx - omegax*slice_ds)/(gx*omegax*pow(bet,2)*pow(m_rc,2));
 
@@ -130,8 +130,7 @@ namespace impactx
 
             if(gy > 0.0) {
                 // calculate expensive terms once
-                amrex::ParticleReal const siny = sin(omegay * slice_ds);
-                amrex::ParticleReal const cosy = cos(omegay * slice_ds);
+                auto const [siny, cosy] = amrex::Math::sincos(omegay * slice_ds);
 
                 // advance position and momentum (focusing)
                 p.pos(RealAoS::y) = cosy*y + siny/omegay*py;
@@ -181,9 +180,7 @@ namespace impactx
             amrex::ParticleReal const B = sqrt(pow(pt,2)-1.0_prt)/m_rc;
 
             // calculate expensive terms once
-            //   TODO: use sincos function once wrapped in AMReX
-            amrex::ParticleReal const sin_theta = sin(theta);
-            amrex::ParticleReal const cos_theta = cos(theta);
+            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
 
             // advance position and momentum (bend)
             refpart.px = px*cos_theta - pz*sin_theta;

--- a/src/particles/elements/ExactSbend.H
+++ b/src/particles/elements/ExactSbend.H
@@ -16,6 +16,7 @@
 #include "mixin/nofinalize.H"
 
 #include <AMReX_Extension.H>
+#include <AMReX_Math.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Print.H>      // for PrintToFile
 
@@ -100,8 +101,7 @@ namespace impactx
             amrex::ParticleReal const pperp = sqrt(pow(pt,2)-2.0_prt/bet*pt-pow(py,2)+1.0_prt);
             amrex::ParticleReal const pzi = sqrt(pow(pperp,2)-pow(px,2));
             amrex::ParticleReal const rho = rc + x;
-            amrex::ParticleReal const sin_phi = sin(slice_phi);
-            amrex::ParticleReal const cos_phi = cos(slice_phi);
+            auto const [sin_phi, cos_phi] = amrex::Math::sincos(slice_phi);
 
             // update momenta
             pxout = px*cos_phi + (pzi - rho/rc)*sin_phi;
@@ -153,9 +153,7 @@ namespace impactx
             amrex::ParticleReal const B = refpart.beta_gamma() /rc;
 
             // calculate expensive terms once
-            //   TODO: use sincos function once wrapped in AMReX
-            amrex::ParticleReal const sin_theta = sin(theta);
-            amrex::ParticleReal const cos_theta = cos(theta);
+            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
 
             // advance position and momentum (bend)
             refpart.px = px*cos_theta - pz*sin_theta;

--- a/src/particles/elements/PRot.H
+++ b/src/particles/elements/PRot.H
@@ -18,6 +18,7 @@
 #include <ablastr/constant.H>
 
 #include <AMReX_Extension.H>
+#include <AMReX_Math.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
@@ -43,7 +44,10 @@ namespace impactx
          * @param phi_in Initial angle of reference trajectory w/r/t z (degrees)
          * @param phi_out Final angle of reference trajectory w/r/t/ z (degrees)
          */
-        PRot( amrex::ParticleReal const phi_in, amrex::ParticleReal const phi_out )
+        PRot (
+            amrex::ParticleReal phi_in,
+            amrex::ParticleReal phi_out
+        )
         : m_phi_in(phi_in * degree2rad), m_phi_out(phi_out * degree2rad)
         {
         }
@@ -62,12 +66,13 @@ namespace impactx
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                PType& AMREX_RESTRICT p,
-                amrex::ParticleReal & AMREX_RESTRICT px,
-                amrex::ParticleReal & AMREX_RESTRICT py,
-                amrex::ParticleReal & AMREX_RESTRICT pt,
-                RefPart const & refpart) const {
-
+            PType & AMREX_RESTRICT p,
+            amrex::ParticleReal & AMREX_RESTRICT px,
+            amrex::ParticleReal & AMREX_RESTRICT py,
+            amrex::ParticleReal & AMREX_RESTRICT pt,
+            RefPart const & refpart
+        ) const
+        {
             using namespace amrex::literals; // for _rt and _prt
 
             // access AoS data such as positions and cpu/id
@@ -85,26 +90,27 @@ namespace impactx
 
             // store rotation angle and initial, final values of pz
             amrex::ParticleReal const theta = m_phi_out - m_phi_in;
+            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
+            auto const [sin_phi_in, cos_phi_in] = amrex::Math::sincos(m_phi_in);
+
             amrex::ParticleReal const pz = sqrt(1.0_prt - 2.0_prt*pt/beta
-               + pow(pt,2) - pow(py,2) - pow(px + sin(m_phi_in),2));
-            amrex::ParticleReal const pzf = pz*cos(theta) - (px +
-                 sin(m_phi_in))*sin(theta);
+               + pow(pt,2) - pow(py,2) - pow(px + sin_phi_in,2));
+            amrex::ParticleReal const pzf = pz*cos_theta - (px + sin_phi_in)*sin_theta;
 
             // advance position and momentum
             p.pos(RealAoS::x) = x*pz/pzf;
-            pxout = px*cos(theta) + (pz - cos(m_phi_in))*sin(theta);
+            pxout = px*cos_theta + (pz - cos_phi_in)*sin_theta;
 
-            p.pos(RealAoS::y) = y + py*x*sin(theta)/pzf;
+            p.pos(RealAoS::y) = y + py*x*sin_theta/pzf;
             pyout = py;
 
-            p.pos(RealAoS::t) = t - (pt - 1.0_prt/beta)*x*sin(theta)/pzf;
+            p.pos(RealAoS::t) = t - (pt - 1.0_prt/beta)*x*sin_theta/pzf;
             ptout = pt;
 
             // assign updated momenta
             px = pxout;
             py = pyout;
             pt = ptout;
-
         }
 
         /** This pushes the reference particle. */

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -16,6 +16,7 @@
 #include "mixin/nofinalize.H"
 
 #include <AMReX_Extension.H>
+#include <AMReX_Math.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
@@ -83,10 +84,8 @@ namespace impactx
             amrex::ParticleReal const bet = sqrt(betgam2/(1.0_prt + betgam2));
 
             // calculate expensive terms once
-            //   TODO: use sincos function once wrapped in AMReX
             amrex::ParticleReal const theta = slice_ds/m_rc;
-            amrex::ParticleReal const sin_theta = sin(theta);
-            amrex::ParticleReal const cos_theta = cos(theta);
+            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
 
             // advance position and momentum (sector bend)
             p.pos(RealAoS::x) = cos_theta*x + m_rc*sin_theta*px
@@ -138,9 +137,7 @@ namespace impactx
             amrex::ParticleReal const B = sqrt(pow(pt,2)-1.0_prt)/m_rc;
 
             // calculate expensive terms once
-            //   TODO: use sincos function once wrapped in AMReX
-            amrex::ParticleReal const sin_theta = sin(theta);
-            amrex::ParticleReal const cos_theta = cos(theta);
+            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
 
             // advance position and momentum (bend)
             refpart.px = px*cos_theta - pz*sin_theta;

--- a/src/particles/elements/Sol.H
+++ b/src/particles/elements/Sol.H
@@ -16,6 +16,7 @@
 #include "mixin/nofinalize.H"
 
 #include <AMReX_Extension.H>
+#include <AMReX_Math.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
@@ -38,8 +39,11 @@ namespace impactx
          *           = (magnetic field Bz in T) / (rigidity in T-m)
          * @param nslice number of slices used for the application of space charge
          */
-        Sol( amrex::ParticleReal const ds, amrex::ParticleReal const ks,
-              int const nslice )
+        Sol (
+            amrex::ParticleReal ds,
+            amrex::ParticleReal ks,
+            int nslice
+        )
         : Thick(ds, nslice), m_ks(ks)
         {
         }
@@ -57,12 +61,13 @@ namespace impactx
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                PType& AMREX_RESTRICT p,
-                amrex::ParticleReal & AMREX_RESTRICT px,
-                amrex::ParticleReal & AMREX_RESTRICT py,
-                amrex::ParticleReal & AMREX_RESTRICT pt,
-                RefPart const & refpart) const {
-
+            PType & AMREX_RESTRICT p,
+            amrex::ParticleReal & AMREX_RESTRICT px,
+            amrex::ParticleReal & AMREX_RESTRICT py,
+            amrex::ParticleReal & AMREX_RESTRICT pt,
+            RefPart const & refpart
+        ) const
+        {
             using namespace amrex::literals; // for _rt and _prt
 
             // access AoS data such as positions and cpu/id
@@ -91,11 +96,12 @@ namespace impactx
             amrex::ParticleReal ptout = pt;
 
             // advance positions and momenta using map for focusing
-            xout = cos(theta)*x + sin(theta)/alpha*px;
-            pxout = -alpha*sin(theta)*x + cos(theta)*px;
+            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
+            xout = cos_theta*x + sin_theta/alpha*px;
+            pxout = -alpha*sin_theta*x + cos_theta*px;
 
-            yout = cos(theta)*y + sin(theta)/alpha*py;
-            pyout = -alpha*sin(theta)*y + cos(theta)*py;
+            yout = cos_theta*y + sin_theta/alpha*py;
+            pyout = -alpha*sin_theta*y + cos_theta*py;
 
             tout = t + (slice_ds/betgam2)*pt;
             ptout = pt;
@@ -106,11 +112,11 @@ namespace impactx
             pt = ptout;
 
             // advance positions and momenta using map for rotation
-            p.pos(RealAoS::x) = cos(theta)*xout + sin(theta)*yout;
-            pxout = cos(theta)*px + sin(theta)*py;
+            p.pos(RealAoS::x) = cos_theta*xout + sin_theta*yout;
+            pxout = cos_theta*px + sin_theta*py;
 
-            p.pos(RealAoS::y) = -sin(theta)*xout + cos(theta)*yout;
-            pyout = -sin(theta)*px + cos(theta)*py;
+            p.pos(RealAoS::y) = -sin_theta*xout + cos_theta*yout;
+            pyout = -sin_theta*px + cos_theta*py;
 
             p.pos(RealAoS::t) = tout;
             ptout = pt;
@@ -119,7 +125,6 @@ namespace impactx
             px = pxout;
             py = pyout;
             pt = ptout;
-
         }
 
         /** This pushes the reference particle.
@@ -127,8 +132,8 @@ namespace impactx
          * @param[in,out] refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void operator() (RefPart & AMREX_RESTRICT refpart) const {
-
+        void operator() (RefPart & AMREX_RESTRICT refpart) const
+        {
             using namespace amrex::literals; // for _rt and _prt
 
             // assign input reference particle values

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -454,9 +454,9 @@ void init_elements(py::module& m)
     py::class_<Sol, elements::Thick> py_Sol(me, "Sol");
     py_Sol
         .def(py::init<
-                amrex::ParticleReal const,
-                amrex::ParticleReal const,
-                int const>(),
+                amrex::ParticleReal,
+                amrex::ParticleReal,
+                int>(),
              py::arg("ds"), py::arg("ks"), py::arg("nslice") = 1,
              "An ideal hard-edge Solenoid magnet."
         )
@@ -466,8 +466,8 @@ void init_elements(py::module& m)
     py::class_<PRot, elements::Thin> py_PRot(me, "PRot");
     py_PRot
         .def(py::init<
-                amrex::ParticleReal const,
-                amrex::ParticleReal const>(),
+                amrex::ParticleReal,
+                amrex::ParticleReal>(),
              py::arg("phi_in"), py::arg("phi_out"),
              "An exact pole-face rotation in the x-z plane. Both angles are in degrees."
         )


### PR DESCRIPTION
Update a few elements to use the `sincos` function to calculate `sin` and `cos` in one go.

Most compilers identify this as an automatic optimization, but we can also make it explicit to be sure.