### PR TITLE
CMake: `ImpactX_PYTHON_IPO`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,10 @@ set_default_build_type("Release")
 # Option to enable interprocedural optimization
 # (also know as "link-time optimization" or "whole program optimization")
 option(ImpactX_IPO "Compile ImpactX with interprocedural optimization (will take more time)" OFF)
+option(ImpactX_PYTHON_IPO
+    "Compile Python bindings with interprocedural optimization (IPO) / link-time optimization (LTO)"
+    ON
+)
 
 # this defined the variable BUILD_TESTING which is ON by default
 include(CTest)
@@ -229,7 +233,10 @@ endif()
 # link dependencies
 target_link_libraries(lib PUBLIC ImpactX::thirdparty::ablastr_3d)
 if(ImpactX_PYTHON)
-    target_link_libraries(pyImpactX PRIVATE pybind11::module pybind11::lto pybind11::windows_extras)
+    target_link_libraries(pyImpactX PRIVATE pybind11::module pybind11::windows_extras)
+    if(ImpactX_PYTHON_IPO)
+        target_link_libraries(pyImpactX PRIVATE pybind11::lto)
+    endif()
 endif()
 
 if(ImpactX_OPENPMD)

--- a/docs/source/install/cmake.rst
+++ b/docs/source/install/cmake.rst
@@ -139,6 +139,11 @@ CMake Option                  Default & Values                               Des
 ``ImpactX_pyamrex_repo``      ``https://github.com/AMReX-Codes/pyamrex.git`` Repository URI to pull and build pyAMReX from
 ``ImpactX_pyamrex_branch``    *we set and maintain a compatible commit*      Repository branch for ``ImpactX_pyamrex_repo``
 ``ImpactX_pyamrex_internal``  **ON**/OFF                                     Needs a pre-installed pyAMReX module if set to ``OFF``
+``ImpactX_PYTHON_IPO``        **ON**/OFF                                     Build Python w/ interprocedural/link optimization (IPO/LTO)
+``ImpactX_pybind11_src``      *None*                                         Path to pybind11 source directory (preferred if set)
+``ImpactX_pybind11_repo``     ``https://github.com/pybind/pybind11.git``     Repository URI to pull and build pybind11 from
+``ImpactX_pybind11_branch``   *we set and maintain a compatible commit*      Repository branch for ``ImpactX_pybind11_repo``
+``ImpactX_pybind11_internal`` **ON**/OFF                                     Needs a pre-installed pybind11 library if set to ``OFF``
 ============================= ============================================== ===========================================================
 
 For example, one can also build against a local AMReX copy.


### PR DESCRIPTION
As in WarpX, add a flag to disable link-time-optimization (LTO) aka interprocedular optimization (IPO) for Python bindings.

This makes the pybind11 Python bindings much slower, but is sometimes fun to disable for rapid development cycles.

See also: https://github.com/ECP-WarpX/WarpX/pull/4603