### PR TITLE
Perlmutter (NERSC): January 2024 Update

### DIFF
--- a/docs/source/install/hpc/perlmutter-nersc/install_cpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_cpu_dependencies.sh
@@ -43,6 +43,9 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 # General extra dependencies ##################################################
 #
 
+# tmpfs build directory: avoids issues often seen with $HOME and is faster
+build_dir=$(mktemp -d)
+
 # c-blosc (I/O compression)
 if [ -d $HOME/src/c-blosc ]
 then
@@ -53,10 +56,9 @@ then
 else
   git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git $HOME/src/c-blosc
 fi
-rm -rf $HOME/src/c-blosc-pm-cpu-build
-cmake -S $HOME/src/c-blosc -B $HOME/src/c-blosc-pm-cpu-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
-cmake --build $HOME/src/c-blosc-pm-cpu-build --target install --parallel 16
-rm -rf $HOME/src/c-blosc-pm-cpu-build
+cmake -S $HOME/src/c-blosc -B ${build_dir}/c-blosc-pm-cpu-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
+cmake --build ${build_dir}/c-blosc-pm-cpu-build --target install --parallel 16
+rm -rf ${build_dir}/c-blosc-pm-cpu-build
 
 # ADIOS2
 if [ -d $HOME/src/adios2 ]
@@ -68,10 +70,9 @@ then
 else
   git clone -b v2.8.3 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
 fi
-rm -rf $HOME/src/adios2-pm-cpu-build
-cmake -S $HOME/src/adios2 -B $HOME/src/adios2-pm-cpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_CUDA=OFF -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.8.3
-cmake --build $HOME/src/adios2-pm-cpu-build --target install -j 16
-rm -rf $HOME/src/adios2-pm-cpu-build
+cmake -S $HOME/src/adios2 -B ${build_dir}/adios2-pm-cpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_CUDA=OFF -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.8.3
+cmake --build ${build_dir}/adios2-pm-cpu-build --target install -j 16
+rm -rf ${build_dir}/adios2-pm-cpu-build
 
 # BLAS++ (for PSATD+RZ)
 if [ -d $HOME/src/blaspp ]
@@ -84,10 +85,9 @@ then
 else
   git clone https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
 fi
-rm -rf $HOME/src/blaspp-pm-cpu-build
-CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-pm-cpu-build -Duse_openmp=ON -Dgpu_backend=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-master
-cmake --build $HOME/src/blaspp-pm-cpu-build --target install --parallel 16
-rm -rf $HOME/src/blaspp-pm-cpu-build
+CXX=$(which CC) cmake -S $HOME/src/blaspp -B ${build_dir}/blaspp-pm-cpu-build -Duse_openmp=ON -Dgpu_backend=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-master
+cmake --build ${build_dir}/blaspp-pm-cpu-build --target install --parallel 16
+rm -rf ${build_dir}/blaspp-pm-cpu-build
 
 # LAPACK++ (for PSATD+RZ)
 if [ -d $HOME/src/lapackpp ]
@@ -100,10 +100,9 @@ then
 else
   git clone https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
-rm -rf $HOME/src/lapackpp-pm-cpu-build
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-pm-cpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-master
-cmake --build $HOME/src/lapackpp-pm-cpu-build --target install --parallel 16
-rm -rf $HOME/src/lapackpp-pm-cpu-build
+CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B ${build_dir}/lapackpp-pm-cpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-master
+cmake --build ${build_dir}/lapackpp-pm-cpu-build --target install --parallel 16
+rm -rf ${build_dir}/lapackpp-pm-cpu-build
 
 
 # Python ######################################################################
@@ -127,7 +126,10 @@ MPICC="cc -shared" python3 -m pip install --upgrade mpi4py --no-cache-dir --no-b
 python3 -m pip install --upgrade openpmd-api
 python3 -m pip install --upgrade matplotlib
 python3 -m pip install --upgrade yt
-# install or update impactx dependencies such as picmistandard
+# install or update impactx dependencies
 python3 -m pip install --upgrade -r $HOME/src/impactx/requirements.txt
-# optional: for libEnsemble
-python3 -m pip install -r $HOME/src/impactx/Tools/LibEnsemble/requirements.txt
+python3 -m pip install --upgrade torch --index-url https://download.pytorch.org/whl/cpu
+
+
+# remove build temporary directory
+rm -rf ${build_dir}

--- a/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
@@ -43,6 +43,9 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 # General extra dependencies ##################################################
 #
 
+# tmpfs build directory: avoids issues often seen with $HOME and is faster
+build_dir=$(mktemp -d)
+
 # c-blosc (I/O compression)
 if [ -d $HOME/src/c-blosc ]
 then
@@ -53,10 +56,9 @@ then
 else
   git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git $HOME/src/c-blosc
 fi
-rm -rf $HOME/src/c-blosc-pm-gpu-build
-cmake -S $HOME/src/c-blosc -B $HOME/src/c-blosc-pm-gpu-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
-cmake --build $HOME/src/c-blosc-pm-gpu-build --target install --parallel 16
-rm -rf $HOME/src/c-blosc-pm-gpu-build
+cmake -S $HOME/src/c-blosc -B ${build_dir}/c-blosc-pm-gpu-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
+cmake --build ${build_dir}/c-blosc-pm-gpu-build --target install --parallel 16
+rm -rf ${build_dir}/c-blosc-pm-gpu-build
 
 # ADIOS2
 if [ -d $HOME/src/adios2 ]
@@ -68,10 +70,9 @@ then
 else
   git clone -b v2.8.3 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
 fi
-rm -rf $HOME/src/adios2-pm-gpu-build
-cmake -S $HOME/src/adios2 -B $HOME/src/adios2-pm-gpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.8.3
-cmake --build $HOME/src/adios2-pm-gpu-build --target install -j 16
-rm -rf $HOME/src/adios2-pm-gpu-build
+cmake -S $HOME/src/adios2 -B ${build_dir}/adios2-pm-gpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.8.3
+cmake --build ${build_dir}/adios2-pm-gpu-build --target install -j 16
+rm -rf ${build_dir}/adios2-pm-gpu-build
 
 # BLAS++ (for PSATD+RZ)
 if [ -d $HOME/src/blaspp ]
@@ -84,10 +85,9 @@ then
 else
   git clone https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
 fi
-rm -rf $HOME/src/blaspp-pm-gpu-build
-CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-pm-gpu-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-master
-cmake --build $HOME/src/blaspp-pm-gpu-build --target install --parallel 16
-rm -rf $HOME/src/blaspp-pm-gpu-build
+CXX=$(which CC) cmake -S $HOME/src/blaspp -B ${build_dir}/blaspp-pm-gpu-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-master
+cmake --build ${build_dir}/blaspp-pm-gpu-build --target install --parallel 16
+rm -rf ${build_dir}/blaspp-pm-gpu-build
 
 # LAPACK++ (for PSATD+RZ)
 if [ -d $HOME/src/lapackpp ]
@@ -100,10 +100,9 @@ then
 else
   git clone https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
-rm -rf $HOME/src/lapackpp-pm-gpu-build
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-pm-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-master
-cmake --build $HOME/src/lapackpp-pm-gpu-build --target install --parallel 16
-rm -rf $HOME/src/lapackpp-pm-gpu-build
+CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B ${build_dir}/lapackpp-pm-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-master
+cmake --build ${build_dir}/lapackpp-pm-gpu-build --target install --parallel 16
+rm -rf ${build_dir}/lapackpp-pm-gpu-build
 
 
 # Python ######################################################################
@@ -127,7 +126,11 @@ MPICC="cc -target-accel=nvidia80 -shared" python3 -m pip install --upgrade mpi4p
 python3 -m pip install --upgrade openpmd-api
 python3 -m pip install --upgrade matplotlib
 python3 -m pip install --upgrade yt
-# install or update impactx dependencies such as picmistandard
+# install or update impactx dependencies
 python3 -m pip install --upgrade -r $HOME/src/impactx/requirements.txt
-python3 -m pip install cupy-cuda12x  # CUDA 12 compatible wheel
+python3 -m pip install --upgrade cupy-cuda12x  # CUDA 12 compatible wheel
 python3 -m pip install --upgrade torch  # CUDA 12 compatible wheel
+
+
+# remove build temporary directory
+rm -rf ${build_dir}

--- a/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
@@ -129,5 +129,5 @@ python3 -m pip install --upgrade matplotlib
 python3 -m pip install --upgrade yt
 # install or update impactx dependencies such as picmistandard
 python3 -m pip install --upgrade -r $HOME/src/impactx/requirements.txt
-python3 -m pip install cupy-cuda11x  # CUDA 11.7 compatible wheel
-python3 -m pip install --upgrade torch  # CUDA 11.7 compatible wheel
+python3 -m pip install cupy-cuda12x  # CUDA 12 compatible wheel
+python3 -m pip install --upgrade torch  # CUDA 12 compatible wheel

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_cpu_impactx.profile.example
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_cpu_impactx.profile.example
@@ -7,14 +7,14 @@ if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in yo
 
 # required dependencies
 module load cpu
-module load cmake/3.22.0
-module load cray-fftw/3.3.10.3
+module load cmake/3.24.3
+module load cray-fftw/3.3.10.6
 
 # optional: for QED support with detailed tables
 export BOOST_ROOT=/global/common/software/spackecp/perlmutter/e4s-23.05/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/boost-1.82.0-ow5r5qrgslcwu33grygouajmuluzuzv3
 
 # optional: for openPMD and PSATD+RZ support
-module load cray-hdf5-parallel/1.12.2.7
+module load cray-hdf5-parallel/1.12.2.9
 export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.8.3:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/blaspp-master:$CMAKE_PREFIX_PATH
@@ -28,10 +28,10 @@ export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/lapackpp-master/
 export PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.8.3/bin:${PATH}
 
 # optional: CCache
-export PATH=/global/common/software/spackecp/perlmutter/e4s-23.05/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/ccache-4.8-eqk2d3bipbpkgwxq7ujlp6mckwal4dwz/bin:$PATH
+export PATH=/global/common/software/spackecp/perlmutter/e4s-23.08/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/ccache-4.8.2-cvooxdw5wgvv2g3vjxjkrpv6dopginv6/bin:$PATH
 
 # optional: for Python bindings or libEnsemble
-module load cray-python/3.9.13.1
+module load cray-python/3.11.5
 
 if [ -d "${CFS}/${proj}/${USER}/sw/perlmutter/cpu/venvs/impactx" ]
 then

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
@@ -6,13 +6,13 @@ export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE
 if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your $MY_PROFILE file! Please edit its line 2 to continue!"; return; fi
 
 # required dependencies
-module load cmake/3.22.0
+module load cmake/3.24.3
 
 # optional: for QED support with detailed tables
 export BOOST_ROOT=/global/common/software/spackecp/perlmutter/e4s-23.05/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/boost-1.82.0-ow5r5qrgslcwu33grygouajmuluzuzv3
 
 # optional: for openPMD and PSATD+RZ support
-module load cray-hdf5-parallel/1.12.2.7
+module load cray-hdf5-parallel/1.12.2.9
 export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.8.3:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/blaspp-master:$CMAKE_PREFIX_PATH
@@ -26,10 +26,10 @@ export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/lapackpp-mast
 export PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.8.3/bin:${PATH}
 
 # optional: CCache
-export PATH=/global/common/software/spackecp/perlmutter/e4s-23.05/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/ccache-4.8-eqk2d3bipbpkgwxq7ujlp6mckwal4dwz/bin:$PATH
+export PATH=/global/common/software/spackecp/perlmutter/e4s-23.08/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/ccache-4.8.2-cvooxdw5wgvv2g3vjxjkrpv6dopginv6/bin:$PATH
 
 # optional: for Python bindings or libEnsemble
-module load cray-python/3.9.13.1
+module load cray-python/3.11.5
 
 if [ -d "${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/impactx" ]
 then


### PR DESCRIPTION
Update modules of Perlmutter after the system upgrade.

Since the default compilers changed, please run the install of dependencies scripts again and rebuild your WarpX executables, too. Essentially, the order documented here from the top: https://impactx.readthedocs.io/en/latest/install/hpc/perlmutter.html

GPU update example:
```bash
source $HOME/perlmutter_gpu_impactx.profile  # updates in this PR!!

bash $HOME/src/impactx/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
source ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/impactx/bin/activate

cd ~/src/impactx
rm -rf build
...
```

X-ref: https://github.com/ECP-WarpX/WarpX/pull/4620