### PR TITLE
Documentation corrections

### DIFF
--- a/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
@@ -130,8 +130,4 @@ python3 -m pip install --upgrade yt
 # install or update impactx dependencies such as picmistandard
 python3 -m pip install --upgrade -r $HOME/src/impactx/requirements.txt
 python3 -m pip install cupy-cuda11x  # CUDA 11.7 compatible wheel
-# optional: for libEnsemble
-python3 -m pip install -r $HOME/src/impactx/Tools/LibEnsemble/requirements.txt
-# optional: for optimas (based on libEnsemble & ax->botorch->gpytorch->pytorch)
 python3 -m pip install --upgrade torch  # CUDA 11.7 compatible wheel
-python3 -m pip install -r $HOME/src/impactx/Tools/optimas/requirements.txt

--- a/docs/source/install/hpc/perlmutter.rst
+++ b/docs/source/install/hpc/perlmutter.rst
@@ -153,7 +153,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile the applicat
          cd $HOME/src/impactx
          rm -rf build_pm_gpu
 
-         cmake -S . -B build_pm_gpu -DImpactX_COMPUTE=CUDA -DImpactX_PSATD=ON -DImpactX_QED_TABLE_GEN=ON -DImpactX_DIMS="1;2;RZ;3"
+         cmake -S . -B build_pm_gpu -DImpactX_COMPUTE=CUDA
          cmake --build build_pm_gpu -j 16
 
       The ImpactX application executables are now in ``$HOME/src/impactx/build_pm_gpu/bin/``.
@@ -164,7 +164,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile the applicat
          cd $HOME/src/impactx
          rm -rf build_pm_gpu_py
 
-         cmake -S . -B build_pm_gpu_py -DImpactX_COMPUTE=CUDA -DImpactX_PSATD=ON -DImpactX_QED_TABLE_GEN=ON -DImpactX_APP=OFF -DImpactX_PYTHON=ON -DImpactX_DIMS="1;2;RZ;3"
+         cmake -S . -B build_pm_gpu_py -DImpactX_COMPUTE=CUDA -DImpactX_APP=OFF -DImpactX_PYTHON=ON
          cmake --build build_pm_gpu_py -j 16 --target pip_install
 
    .. tab-item:: CPU Nodes
@@ -174,7 +174,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile the applicat
          cd $HOME/src/impactx
          rm -rf build_pm_cpu
 
-         cmake -S . -B build_pm_cpu -DImpactX_COMPUTE=OMP -DImpactX_PSATD=ON -DImpactX_QED_TABLE_GEN=ON -DImpactX_DIMS="1;2;RZ;3"
+         cmake -S . -B build_pm_cpu -DImpactX_COMPUTE=OMP
          cmake --build build_pm_cpu -j 16
 
       The ImpactX application executables are now in ``$HOME/src/impactx/build_pm_cpu/bin/``.
@@ -184,7 +184,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile the applicat
 
          rm -rf build_pm_cpu_py
 
-         cmake -S . -B build_pm_cpu_py -DImpactX_COMPUTE=OMP -DImpactX_PSATD=ON -DImpactX_QED_TABLE_GEN=ON -DImpactX_APP=OFF -DImpactX_PYTHON=ON -DImpactX_DIMS="1;2;RZ;3"
+         cmake -S . -B build_pm_cpu_py -DImpactX_COMPUTE=OMP -DImpactX_APP=OFF -DImpactX_PYTHON=ON
          cmake --build build_pm_cpu_py -j 16 --target pip_install
 
 Now, you can :ref:`submit Perlmutter compute jobs <running-cpp-perlmutter>` for ImpactX :ref:`Python (PICMI) scripts <usage-picmi>` (:ref:`example scripts <usage-examples>`).

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -393,7 +393,7 @@ This module provides particle beam distributions that can be used to initialize 
 .. py:class:: impactx.distribution.Kurth4D(sigx, sigy, sigt, sigpx, sigpy, sigpt, muxpx=0.0, muypy=0.0, mutpt=0.0)
 
    A 4D Kurth distribution transversely + a uniform distribution
-   it t + a Gaussian distribution in pt.
+   in t + a Gaussian distribution in pt.
 
 .. py:class:: impactx.distribution.Kurth6D(sigx, sigy, sigt, sigpx, sigpy, sigpt, muxpx=0.0, muypy=0.0, mutpt=0.0)
 
@@ -405,7 +405,7 @@ This module provides particle beam distributions that can be used to initialize 
 .. py:class:: impactx.distribution.KVdist(sigx, sigy, sigt, sigpx, sigpy, sigpt, muxpx=0.0, muypy=0.0, mutpt=0.0)
 
    A K-V distribution transversely + a uniform distribution
-   it t + a Gaussian distribution in pt.
+   in t + a Gaussian distribution in pt.
 
 .. py:class:: impactx.distribution.None
 

--- a/src/particles/distribution/KVdist.H
+++ b/src/particles/distribution/KVdist.H
@@ -25,7 +25,7 @@ namespace impactx::distribution
     struct KVdist
     {
         /** A K-V distribution transversely + a uniform distribution
-         *  it t + a Gaussian distribution in pt
+         *  in t + a Gaussian distribution in pt
          *
          * Return sampling from a K-V + uniform distribution.
          *

--- a/src/particles/distribution/Kurth4D.H
+++ b/src/particles/distribution/Kurth4D.H
@@ -25,7 +25,7 @@ namespace impactx::distribution
     struct Kurth4D
     {
         /** A 4D Kurth distribution transversely + a uniform distribution
-         *  it t + a Gaussian distribution in pt
+         *  in t + a Gaussian distribution in pt
          *
          * Return sampling from a 4D Kurth + uniform distribution.
          *

--- a/src/python/distribution.cpp
+++ b/src/python/distribution.cpp
@@ -45,7 +45,7 @@ void init_distribution(py::module& m)
              py::arg("sigmaPx"), py::arg("sigmaPy"), py::arg("sigmaPt"),
              py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0,
              "A 4D Kurth distribution transversely + a uniform distribution\n"
-             "it t + a Gaussian distribution in pt"
+             "in t + a Gaussian distribution in pt"
         );
 
     py::class_<distribution::Kurth6D>(md, "Kurth6D")
@@ -72,7 +72,7 @@ void init_distribution(py::module& m)
              py::arg("sigmaPx"), py::arg("sigmaPy"), py::arg("sigmaPt"),
              py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0,
              "A K-V distribution transversely + a uniform distribution\n"
-             "it t + a Gaussian distribution in pt"
+             "in t + a Gaussian distribution in pt"
         );
 
     py::class_<distribution::None>(md, "None")


### PR DESCRIPTION
This PR adds two small cleanings to the documentation.
1. It removes some unnecessary build instructions that were copied from WarpX.
2. It changes 'it' to 'in' in a few places