### PR TITLE
AmrCore(Data): Make Member Variable

### DIFF
--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -12,14 +12,13 @@
 
 #include "particles/distribution/All.H"
 #include "particles/elements/All.H"
-#include "particles/ImpactXParticleContainer.H"
 
-#include <AMReX_AmrCore.H>
-#include <AMReX_MultiFab.H>
+#include "initialization/AmrCoreData.H"
+
+#include <AMReX_REAL.H>
 
 #include <list>
 #include <memory>
-#include <unordered_map>
 
 
 namespace impactx
@@ -28,8 +27,7 @@ namespace impactx
      *
      * This is the central ImpactX simulation class
      */
-    class ImpactX final
-        : public amrex::AmrCore
+    class ImpactX
     {
       public:
         /** Construct an ImpactX simulation object
@@ -47,7 +45,7 @@ namespace impactx
          * This must come first, before particle beams and lattice elements are
          * initialized.
          */
-        void initGrids ();
+        void init_grids ();
 
         /** Initialize the particle beam distribution
          *
@@ -100,32 +98,12 @@ namespace impactx
          */
         void init_warning_logger ();
 
-        //! Tag cells for refinement.  TagBoxArray tags is built on level lev grids.
-        void ErrorEst (int lev,
-                       amrex::TagBoxArray& tags,
-                       amrex::Real time,
-                       int ngrow) override;
+        /** The AMReX core object that contains AMR hierarchy, \see amrex::AmrCore
+         *
+         * Inside here, we store our particle containers and space charge fields.
+         */
+        std::unique_ptr<initialization::AmrCoreData> amr_data;
 
-      private:
-        //! Make a new level from scratch using provided BoxArray and DistributionMapping.
-        //! Only used during initialization.
-        void MakeNewLevelFromScratch (int lev, amrex::Real time, const amrex::BoxArray& ba,
-                                              const amrex::DistributionMapping& dm) override;
-
-        //! Make a new level using provided BoxArray and DistributionMapping and fill
-        //  with interpolated coarse level data.
-        void MakeNewLevelFromCoarse (int lev, amrex::Real time, const amrex::BoxArray& ba,
-                                             const amrex::DistributionMapping& dm) override;
-
-        //! Remake an existing level using provided BoxArray and DistributionMapping
-        //  and fill with existing fine and coarse data.
-        void RemakeLevel (int lev, amrex::Real time, const amrex::BoxArray& ba,
-                                  const amrex::DistributionMapping& dm) override;
-
-        //! Delete level data
-        void ClearLevel (int lev) override;
-
-      public:
         /** Resize the mesh, based on the extent of the bunch of particle
          *
          * This only changes the physical extent of the mesh, but not the
@@ -133,21 +111,28 @@ namespace impactx
          */
         void ResizeMesh ();
 
-        /** these are the physical/beam particles of the simulation */
-        std::unique_ptr<ImpactXParticleContainer> m_particle_container;
-
-        /** former beam particles that got lost in apertures, the wall, etc. */
-        std::unique_ptr<ImpactXParticleContainer> m_particles_lost;
-
-        /** charge density per level */
-        std::unordered_map<int, amrex::MultiFab> m_rho;
-        /** scalar potential per level */
-        std::unordered_map<int, amrex::MultiFab> m_phi;
-        /** space charge field (vector) per level */
-        std::unordered_map<int, std::unordered_map<std::string, amrex::MultiFab> > m_space_charge_field;
-
         /** these are elements defining the accelerator lattice */
         std::list<KnownElements> m_lattice;
+
+        /** Was init_grids already called?
+         *
+         * Some operations, like resizing a simulation in terms of cells and changing blocking
+         * factors are not possible after they were initialized in AMReX. This keeps track
+         * of this.
+         */
+        bool initialized ()
+        {
+            return m_grids_initialized;
+        }
+
+      private:
+        /** Keeps track if init_grids was called.
+         *
+         * Some operations, like resizing a simulation in terms of cells and changing blocking
+         * factors are not possible after they were initialized in AMReX. This keeps track
+         * of this.
+         */
+        bool m_grids_initialized = false;
     };
 
 } // namespace impactx

--- a/src/initialization/AmrCoreData.H
+++ b/src/initialization/AmrCoreData.H
@@ -10,13 +10,20 @@
 #ifndef IMPACTX_AMR_CORE_DATA_H
 #define IMPACTX_AMR_CORE_DATA_H
 
+#include "AmrCoreData_fwd.H"
+#include "particles/ImpactXParticleContainer.H"
+
 #include <AMReX_AmrCore.H>
 #include <AMReX_AmrMesh.H>
 #include <AMReX_BoxArray.H>
 #include <AMReX_DistributionMapping.H>
 #include <AMReX_Geometry.H>
+#include <AMReX_MultiFab.H>
 #include <AMReX_REAL.H>
 #include <AMReX_TagBox.H>
+
+#include <string>
+#include <unordered_map>
 
 
 namespace impactx::initialization
@@ -33,7 +40,7 @@ namespace impactx::initialization
     class AmrCoreData final
         : public amrex::AmrCore
     {
-    public:
+      public:
         AmrCoreData (
             amrex::Geometry const& level_0_geom,
             amrex::AmrInfo const& amr_info
@@ -55,7 +62,19 @@ namespace impactx::initialization
 
         ~AmrCoreData() = default;
 
-    private:
+        /** these are the physical/beam particles of the simulation */
+        std::unique_ptr<impactx::ImpactXParticleContainer> m_particle_container;
+
+        /** former beam particles that got lost in apertures, the wall, etc. */
+        std::unique_ptr<impactx::ImpactXParticleContainer> m_particles_lost;
+
+        /** charge density per level */
+        std::unordered_map<int, amrex::MultiFab> m_rho;
+        /** scalar potential per level */
+        std::unordered_map<int, amrex::MultiFab> m_phi;
+        /** space charge field (vector) per level */
+        std::unordered_map<int, std::unordered_map<std::string, amrex::MultiFab> > m_space_charge_field;
+
         void ErrorEst (
             [[maybe_unused]] int lev,
             [[maybe_unused]] amrex::TagBoxArray& tags,

--- a/src/initialization/AmrCoreData.cpp
+++ b/src/initialization/AmrCoreData.cpp
@@ -9,6 +9,8 @@
  */
 #include "AmrCoreData.H"
 
+#include "initialization/InitMeshRefinement.H"
+
 #include <AMReX.H>
 
 
@@ -36,12 +38,74 @@ namespace impactx::initialization
 
     void
     AmrCoreData::ErrorEst (
-        [[maybe_unused]] int lev,
-        [[maybe_unused]] amrex::TagBoxArray& tags,
+        int lev,
+        amrex::TagBoxArray& tags,
         [[maybe_unused]] amrex::Real time,
         [[maybe_unused]] int ngrow)
     {
-        amrex::Abort("Do not use");
+        // level zero is of size in meters (per dimension):
+        //   rb_0 = beam_width * prob_relative[lvl=0]
+        // level zero is of size in cells:
+        //   nx_0 = amr.n_cell
+        // level one is of size in meters:
+        //   rb_1 = beam_width * prob_relative[lvl=1]
+        // level one is of size in cells:
+        //   nx_1 = amr.n_cell * rb_1                 / rb_0                 * amr.ref_ratio[lvl=0]
+        //        = amr.n_cell * prob_relative[lvl=1] / prob_relative[lvl=0] * amr.ref_ratio[lvl=0]
+        // level one lowest/highest cell index to refine:
+        //   ref_1_lo = nx_1 / nx_0 / 2
+        //   ref_1_hi = ref_1_lo + nx_1
+        // ...
+        // level n is of size in cells:
+        //   nx_n = amr.n_cell   * rb_n                 / rb_0                         * amr.ref_ratio[lvl=n-1] * amr.ref_ratio[lvl=n-2] * ... * amr.ref_ratio[lvl=0]
+        //        = amr.n_cell   * prob_relative[lvl=n] / prob_relative[lvl=0] * amr.ref_ratio[lvl=n-1] * amr.ref_ratio[lvl=n-2] * ... * amr.ref_ratio[lvl=0]
+        //        = n_cell_{n-1} * prob_relative[lvl=n] / prob_relative[lvl=0] * amr.ref_ratio[lvl=n-1]
+        // level n+1 is of size in cells:
+        //   nx_nup = n_cell_n * prob_relative[lvl=n+1] / prob_relative[lvl=0] * amr.ref_ratio[lvl=n]
+        // level n and n+1 have the following difference in cells, if coarsened to level n
+        //   nx_n_diff = (nx_n - nx_nup / amr.ref_ratio[lvl=n])
+        // level n lowest/highest cell index to refine:
+        //   ref_n_lo = small_end_n + nx_n_diff / 2
+        //   ref_n_hi = big_end_n   - nx_n_diff / 2
+
+        const auto dom = boxArray(lev).minimalBox();  // covered index space of the current level
+        auto const r_cell_n = amrex::RealVect(dom.size());  // on the current level
+        amrex::RealVect const r_ref_ratio = ref_ratio[lev];
+
+        // level width relative to beam width
+        amrex::Vector<amrex::Real> const prob_relative = read_mr_prob_relative();
+
+        amrex::RealVect const n_cell_nup = amrex::RealVect(r_cell_n) * r_ref_ratio
+                                           * prob_relative[lev+1] / prob_relative[0];
+        amrex::RealVect const n_cell_diff = (r_cell_n - n_cell_nup / r_ref_ratio);
+
+        amrex::RealVect const r_fine_tag_lo = amrex::RealVect(dom.smallEnd()) + n_cell_diff / 2.0;
+        amrex::RealVect const r_fine_tag_hi = amrex::RealVect(dom.bigEnd())   - n_cell_diff / 2.0;
+
+        amrex::IntVect const fine_tag_lo = {
+                AMREX_D_DECL((int)std::ceil(r_fine_tag_lo[0]), (int)std::ceil(r_fine_tag_lo[1]), (int)std::ceil(r_fine_tag_lo[2]))
+        };
+        amrex::IntVect const fine_tag_hi = {
+                AMREX_D_DECL((int)std::ceil(r_fine_tag_hi[0]), (int)std::ceil(r_fine_tag_hi[1]), (int)std::ceil(r_fine_tag_hi[2]))
+        };
+
+        amrex::Box const fine_tag = {fine_tag_lo, fine_tag_hi};
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        for (amrex::MFIter mfi(tags); mfi.isValid(); ++mfi)
+        {
+            const amrex::Box& bx = mfi.fabbox();
+            const auto& fab = tags.array(mfi);
+            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            {
+                amrex::IntVect const idx {AMREX_D_DECL(i, j, k)};
+                if (fine_tag.contains(idx)) {
+                    fab(i,j,k) = amrex::TagBox::SET;
+                }
+            });
+        }
     }
 
     void
@@ -51,7 +115,60 @@ namespace impactx::initialization
         [[maybe_unused]] const amrex::BoxArray& ba,
         [[maybe_unused]] const amrex::DistributionMapping& dm)
     {
-        amrex::Abort("Do not use");
+        amrex::ignore_unused(time);
+
+        // set human-readable tag for each MultiFab
+        auto const tag = [lev]( std::string tagname ) {
+            tagname.append("[l=").append(std::to_string(lev)).append("]");
+            return amrex::MFInfo().SetTag(std::move(tagname));
+        };
+
+        // charge (rho) mesh
+        amrex::BoxArray const& cba = ba;
+        // for MR levels (TODO):
+        //cba.coarsen(refRatio(lev - 1));
+
+        // staggering and number of charge components in the field
+        auto const rho_nodal_flag = amrex::IntVect::TheNodeVector();
+        int const num_components_rho = 1;
+
+        // guard cells for charge deposition
+        int const particle_shape = m_particle_container->GetParticleShape();
+        int num_guards_rho = 0;
+        if (particle_shape % 2 == 0)  // even shape orders
+            num_guards_rho = particle_shape / 2 + 1;
+        else  // odd shape orders
+            num_guards_rho = (particle_shape + 1) / 2;
+
+        m_rho.emplace(
+                lev,
+                amrex::MultiFab{amrex::convert(cba, rho_nodal_flag), dm, num_components_rho, num_guards_rho, tag("rho")});
+
+        // scalar potential
+        auto const phi_nodal_flag = rho_nodal_flag;
+        int const num_components_phi = 1;
+        int const num_guards_phi = num_guards_rho + 1; // todo: I think this just depends on max(MLMG, force calc)
+        m_phi.emplace(
+                lev,
+                amrex::MultiFab{amrex::convert(cba, phi_nodal_flag), dm, num_components_phi, num_guards_phi, tag("phi")});
+
+        // space charge force
+        std::unordered_map<std::string, amrex::MultiFab> f_comp;
+        for (std::string const comp : {"x", "y", "z"})
+        {
+            std::string const str_tag = "space_charge_field_" + comp;
+            f_comp.emplace(
+                    comp,
+                    amrex::MultiFab{
+                            amrex::convert(cba, rho_nodal_flag),
+                            dm,
+                            num_components_rho,
+                            num_guards_rho,
+                            tag(str_tag)
+                    }
+            );
+        }
+        m_space_charge_field.emplace(lev, std::move(f_comp));
     }
 
     void
@@ -61,7 +178,7 @@ namespace impactx::initialization
         [[maybe_unused]] const amrex::BoxArray& ba,
         [[maybe_unused]] const amrex::DistributionMapping& dm)
     {
-        amrex::Abort("Do not use");
+        amrex::Abort("MakeNewLevelFromCoarse: Not Implemented Yet");
     }
 
     void
@@ -71,12 +188,14 @@ namespace impactx::initialization
         [[maybe_unused]] const amrex::BoxArray& ba,
         [[maybe_unused]] const amrex::DistributionMapping& dm)
     {
-        amrex::Abort("Do not use");
+        amrex::Abort("RemakeLevel: Not Implemented Yet");
     }
 
     void
     AmrCoreData::ClearLevel ([[maybe_unused]] int lev)
     {
-        amrex::Abort("Do not use");
+        m_rho.erase(lev);
+        m_phi.erase(lev);
+        m_space_charge_field.erase(lev);
     }
 } // namespace impactx::initialization

--- a/src/initialization/AmrCoreData_fwd.H
+++ b/src/initialization/AmrCoreData_fwd.H
@@ -1,0 +1,29 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_AMR_CORE_DATA_FWD_H
+#define IMPACTX_AMR_CORE_DATA_FWD_H
+
+
+namespace impactx::initialization
+{
+    /** Data in AmrCore
+     *
+     * This wrapper is needed because AmrCore cannot be constructed, due to
+     * pure virtuals in it.
+     *
+     * The primary purpose of this wrapper is to transport simulation_geometry
+     * the geometry (topology) of the simulation and amr_info; contains
+     * information on mesh-refinement and box/grid blocks.
+     */
+    class AmrCoreData;
+
+} // namespace impactx::initialization
+
+#endif // IMPACTX_AMR_CORE_DATA_FWD_H

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -38,7 +38,7 @@ namespace impactx
     {
         BL_PROFILE("ImpactX::add_particles");
 
-        auto const & ref = m_particle_container->GetRefParticle();
+        auto const & ref = amr_data->m_particle_container->GetRefParticle();
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ref.charge_qe() != 0.0,
             "add_particles: Reference particle charge not yet set!");
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ref.mass_MeV() != 0.0,
@@ -102,15 +102,15 @@ namespace impactx
             distribution.finalize();
         }, distr);
 
-        m_particle_container->AddNParticles(x, y, t, px, py, pt,
-                                            ref.qm_qeeV(),
+        amr_data->m_particle_container->AddNParticles(x, y, t, px, py, pt,
+                                                      ref.qm_qeeV(),
                                             bunch_charge * rel_part_this_proc);
 
         // Resize the mesh to fit the spatial extent of the beam and then
         // redistribute particles, so they reside on the MPI rank that is
         // responsible for the respective spatial particle position.
         this->ResizeMesh();
-        m_particle_container->Redistribute();
+        amr_data->m_particle_container->Redistribute();
     }
 
     void ImpactX::initBeamDistributionFromInputs ()
@@ -154,7 +154,7 @@ namespace impactx
         }
 
         // set charge and mass and energy of ref particle
-        m_particle_container->GetRefParticle()
+        amr_data->m_particle_container->GetRefParticle()
                 .set_charge_qe(qe).set_mass_MeV(massE).set_kin_energy_MeV(kin_energy);
 
         int npart = 1;  // Number of simulation particles
@@ -341,6 +341,6 @@ namespace impactx
         }
 
         amrex::Print() << "Initialized beam distribution parameters" << std::endl;
-        amrex::Print() << "# of particles: " << m_particle_container->TotalNumberOfParticles() << std::endl;
+        amrex::Print() << "# of particles: " << amr_data->m_particle_container->TotalNumberOfParticles() << std::endl;
     }
 } // namespace impactx

--- a/src/initialization/InitMeshRefinement.H
+++ b/src/initialization/InitMeshRefinement.H
@@ -1,0 +1,70 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#pragma once
+
+#include <ablastr/warn_manager/WarnManager.H>
+
+#include <AMReX.H>
+#include <AMReX_BLProfiler.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_REAL.H>
+#include <AMReX_Utility.H>
+
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+
+namespace impactx::initialization
+{
+    amrex::Vector<amrex::Real>
+    read_mr_prob_relative ()
+    {
+        amrex::ParmParse pp_amr("amr");
+        amrex::ParmParse pp_geometry("geometry");
+
+        int max_level = 0;
+        pp_amr.query("max_level", max_level);
+
+        // The box is expanded beyond the min and max of the particle beam.
+        amrex::Vector<amrex::Real> prob_relative(max_level + 1, 1.0);
+        prob_relative[0] = 3.0;  // top/bottom pad the beam on the lowest level by default by its width
+        pp_geometry.queryarr("prob_relative", prob_relative);
+
+        if (prob_relative[0] < 3.0)
+            ablastr::warn_manager::WMRecordWarning(
+                    "ImpactX::read_mr_prob_relative",
+                    "Dynamic resizing of the mesh uses a geometry.prob_relative "
+                    "padding of less than 3 for level 0. This might result in boundary "
+                    "artifacts for space charge calculation. "
+                    "There is no minimum good value for this parameter, consider "
+                    "doing a convergence test.",
+                    ablastr::warn_manager::WarnPriority::high
+            );
+
+        if (prob_relative[0] < 1.0)
+            throw std::runtime_error("geometry.prob_relative must be >= 1.0 (the beam size) on the coarsest level");
+
+        // check that prob_relative[0] > prob_relative[1] > prob_relative[2] ...
+        amrex::Real last_lev_rel = std::numeric_limits<amrex::Real>::max();
+        for (int lev = 0; lev <= max_level; ++lev) {
+            amrex::Real const prob_relative_lvl = prob_relative[lev];
+            if (prob_relative_lvl <= 0.0)
+                throw std::runtime_error("geometry.prob_relative must be strictly positive for all levels");
+            if (prob_relative_lvl > last_lev_rel)
+                throw std::runtime_error("geometry.prob_relative must be descending over refinement levels");
+
+            last_lev_rel = prob_relative_lvl;
+        }
+
+        return prob_relative;
+    }
+} // namespace impactx::initialization

--- a/src/initialization/InitMeshRefinement.cpp
+++ b/src/initialization/InitMeshRefinement.cpp
@@ -72,187 +72,13 @@ namespace detail
         return prob_relative;
     }
 }
-    /** Tag cells on level for refinement.
-     *
-     * @param lev the current level to refine
-     * @param tags the TagBoxArray tags are built on level lev grids
-     * @param time current simulation time, unused
-     * @param ngrow unused legacy argument that is always zero
-     */
-    void ImpactX::ErrorEst (
-        int lev,
-        amrex::TagBoxArray& tags,
-        [[maybe_unused]] amrex::Real time,
-        [[maybe_unused]] int ngrow
-    )
-    {
-        // level zero is of size in meters (per dimension):
-        //   rb_0 = beam_width * prob_relative[lvl=0]
-        // level zero is of size in cells:
-        //   nx_0 = amr.n_cell
-        // level one is of size in meters:
-        //   rb_1 = beam_width * prob_relative[lvl=1]
-        // level one is of size in cells:
-        //   nx_1 = amr.n_cell * rb_1                 / rb_0                 * amr.ref_ratio[lvl=0]
-        //        = amr.n_cell * prob_relative[lvl=1] / prob_relative[lvl=0] * amr.ref_ratio[lvl=0]
-        // level one lowest/highest cell index to refine:
-        //   ref_1_lo = nx_1 / nx_0 / 2
-        //   ref_1_hi = ref_1_lo + nx_1
-        // ...
-        // level n is of size in cells:
-        //   nx_n = amr.n_cell   * rb_n                 / rb_0                         * amr.ref_ratio[lvl=n-1] * amr.ref_ratio[lvl=n-2] * ... * amr.ref_ratio[lvl=0]
-        //        = amr.n_cell   * prob_relative[lvl=n] / prob_relative[lvl=0] * amr.ref_ratio[lvl=n-1] * amr.ref_ratio[lvl=n-2] * ... * amr.ref_ratio[lvl=0]
-        //        = n_cell_{n-1} * prob_relative[lvl=n] / prob_relative[lvl=0] * amr.ref_ratio[lvl=n-1]
-        // level n+1 is of size in cells:
-        //   nx_nup = n_cell_n * prob_relative[lvl=n+1] / prob_relative[lvl=0] * amr.ref_ratio[lvl=n]
-        // level n and n+1 have the following difference in cells, if coarsened to level n
-        //   nx_n_diff = (nx_n - nx_nup / amr.ref_ratio[lvl=n])
-        // level n lowest/highest cell index to refine:
-        //   ref_n_lo = small_end_n + nx_n_diff / 2
-        //   ref_n_hi = big_end_n   - nx_n_diff / 2
-
-        const auto dom = boxArray(lev).minimalBox();  // covered index space of the current level
-        auto const r_cell_n = amrex::RealVect(dom.size());  // on the current level
-        amrex::RealVect const r_ref_ratio = ref_ratio[lev];
-
-        // level width relative to beam width
-        amrex::Vector<amrex::Real> const prob_relative = detail::read_mr_prob_relative();
-
-        amrex::RealVect const n_cell_nup = amrex::RealVect(r_cell_n) * r_ref_ratio
-                                           * prob_relative[lev+1] / prob_relative[0];
-        amrex::RealVect const n_cell_diff = (r_cell_n - n_cell_nup / r_ref_ratio);
-
-        amrex::RealVect const r_fine_tag_lo = amrex::RealVect(dom.smallEnd()) + n_cell_diff / 2.0;
-        amrex::RealVect const r_fine_tag_hi = amrex::RealVect(dom.bigEnd())   - n_cell_diff / 2.0;
-
-        amrex::IntVect const fine_tag_lo = {
-            AMREX_D_DECL((int)std::ceil(r_fine_tag_lo[0]), (int)std::ceil(r_fine_tag_lo[1]), (int)std::ceil(r_fine_tag_lo[2]))
-        };
-        amrex::IntVect const fine_tag_hi = {
-            AMREX_D_DECL((int)std::ceil(r_fine_tag_hi[0]), (int)std::ceil(r_fine_tag_hi[1]), (int)std::ceil(r_fine_tag_hi[2]))
-        };
-
-        amrex::Box const fine_tag = {fine_tag_lo, fine_tag_hi};
-
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-        for (amrex::MFIter mfi(tags); mfi.isValid(); ++mfi)
-        {
-            const amrex::Box& bx = mfi.fabbox();
-            const auto& fab = tags.array(mfi);
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-            {
-                amrex::IntVect const idx {AMREX_D_DECL(i, j, k)};
-                if (fine_tag.contains(idx)) {
-                    fab(i,j,k) = amrex::TagBox::SET;
-                }
-            });
-        }
-    }
-
-    /** Make a new level from scratch using provided BoxArray and DistributionMapping.
-     *
-     * Only used during initialization.
-     */
-    void ImpactX::MakeNewLevelFromScratch (int lev, amrex::Real time, const amrex::BoxArray& ba,
-                                           const amrex::DistributionMapping& dm)
-    {
-        amrex::ignore_unused(time);
-
-        // set human-readable tag for each MultiFab
-        auto const tag = [lev]( std::string tagname ) {
-            tagname.append("[l=").append(std::to_string(lev)).append("]");
-            return amrex::MFInfo().SetTag(std::move(tagname));
-        };
-
-        // charge (rho) mesh
-        amrex::BoxArray const& cba = ba;
-        // for MR levels (TODO):
-        //cba.coarsen(refRatio(lev - 1));
-
-        // staggering and number of charge components in the field
-        auto const rho_nodal_flag = amrex::IntVect::TheNodeVector();
-        int const num_components_rho = 1;
-
-        // guard cells for charge deposition
-        int const particle_shape = m_particle_container->GetParticleShape();
-        int num_guards_rho = 0;
-        if (particle_shape % 2 == 0)  // even shape orders
-            num_guards_rho = particle_shape / 2 + 1;
-        else  // odd shape orders
-            num_guards_rho = (particle_shape + 1) / 2;
-
-        m_rho.emplace(
-            lev,
-            amrex::MultiFab{amrex::convert(cba, rho_nodal_flag), dm, num_components_rho, num_guards_rho, tag("rho")});
-
-        // scalar potential
-        auto const phi_nodal_flag = rho_nodal_flag;
-        int const num_components_phi = 1;
-        int const num_guards_phi = num_guards_rho + 1; // todo: I think this just depends on max(MLMG, force calc)
-        m_phi.emplace(
-            lev,
-            amrex::MultiFab{amrex::convert(cba, phi_nodal_flag), dm, num_components_phi, num_guards_phi, tag("phi")});
-
-        // space charge force
-        std::unordered_map<std::string, amrex::MultiFab> f_comp;
-        for (std::string const comp : {"x", "y", "z"})
-        {
-            std::string const str_tag = "space_charge_field_" + comp;
-            f_comp.emplace(
-                comp,
-                amrex::MultiFab{
-                    amrex::convert(cba, rho_nodal_flag),
-                    dm,
-                    num_components_rho,
-                    num_guards_rho,
-                    tag(str_tag)
-                }
-            );
-        }
-        m_space_charge_field.emplace(lev, std::move(f_comp));
-    }
-
-    /** Make a new level using provided BoxArray and DistributionMapping and fill
-     *  with interpolated coarse level data.
-     *
-     * @todo this function is not (yet) implemented.
-     */
-    void ImpactX::MakeNewLevelFromCoarse (int lev, amrex::Real time, const amrex::BoxArray& ba,
-                                         const amrex::DistributionMapping& dm)
-    {
-        // todo
-        amrex::ignore_unused(lev, time, ba, dm);
-    }
-
-    /** Remake an existing level using provided BoxArray and DistributionMapping
-     *  and fill with existing fine and coarse data.
-     *
-     * @todo this function is not (yet) implemented.
-     */
-    void ImpactX::RemakeLevel (int lev, amrex::Real time, const amrex::BoxArray& ba,
-                              const amrex::DistributionMapping& dm)
-    {
-        // todo
-        amrex::ignore_unused(lev, time, ba, dm);
-    }
-
-    /** Delete level data
-     */
-    void ImpactX::ClearLevel (int lev)
-    {
-        m_rho.erase(lev);
-        m_phi.erase(lev);
-        m_space_charge_field.erase(lev);
-    }
 
     void ImpactX::ResizeMesh ()
     {
         BL_PROFILE("ImpactX::ResizeMesh");
 
         // Extract the min and max of the particle positions
-        auto const [x_min, y_min, z_min, x_max, y_max, z_max] = m_particle_container->MinAndMaxPositions();
+        auto const [x_min, y_min, z_min, x_max, y_max, z_max] = amr_data->m_particle_container->MinAndMaxPositions();
 
         // guard for flat beams:
         //   https://github.com/ECP-WarpX/impactx/issues/44
@@ -263,7 +89,7 @@ namespace detail
         bool dynamic_size = true;
         pp_geometry.query("dynamic_size", dynamic_size);
 
-        amrex::Vector<amrex::RealBox> rb(this->finestLevel() + 1);  // extent per level
+        amrex::Vector<amrex::RealBox> rb(amr_data->finestLevel() + 1);  // extent per level
         if (dynamic_size)
         {
             // The coarsest level is expanded (or reduced) relative the min and max of particles.
@@ -279,7 +105,7 @@ namespace detail
 
             // In AMReX, all levels have the same problem domain, that of the
             // coarsest level, even if only partly covered.
-            for (int lev = 0; lev <= this->finestLevel(); ++lev)
+            for (int lev = 0; lev <= amr_data->finestLevel(); ++lev)
             {
                 rb[lev].setLo(beam_min - beam_padding);
                 rb[lev].setHi(beam_max + beam_padding);
@@ -296,7 +122,7 @@ namespace detail
 
             rb[0] = {prob_lo.data(), prob_hi.data()};
 
-            if (this->max_level > 1)
+            if (amr_data->maxLevel() > 1)
                 amrex::Abort("Did not implement ResizeMesh for static domains and >1 MR levels.");
         }
 
@@ -309,13 +135,13 @@ namespace detail
         // Resize the domain size
         amrex::Geometry::ResetDefaultProbDomain(rb[0]);
 
-        for (int lev = 0; lev <= this->finestLevel(); ++lev)
+        for (int lev = 0; lev <= amr_data->finestLevel(); ++lev)
         {
-            amrex::Geometry g = Geom(lev);
+            amrex::Geometry g = amr_data->Geom(lev);
             g.ProbDomain(rb[lev]);
-            SetGeometry(lev, g);
+            amr_data->SetGeometry(lev, g);
 
-            m_particle_container->SetParticleGeometry(lev, g);
+            amr_data->m_particle_container->SetParticleGeometry(lev, g);
         }
     }
 } // namespace impactx

--- a/src/initialization/Validate.cpp
+++ b/src/initialization/Validate.cpp
@@ -23,7 +23,7 @@ namespace impactx
         BL_PROFILE("ImpactX::validate");
 
         // reference particle initialized?
-        auto const & ref = m_particle_container->GetRefParticle();
+        auto const & ref = amr_data->m_particle_container->GetRefParticle();
         if (ref.kin_energy_MeV() == 0.0)
             throw std::runtime_error("The reference particle energy is zero. Not yet initialized?");
 
@@ -31,10 +31,10 @@ namespace impactx
         // count particles - if no particles are found in our particle container, then a lot of
         // AMReX routines over ParIter won't work, and we have nothing to do here anyway
         {
-            int const nLevelPC = finestLevel();
+            int const nLevelPC = amr_data->finestLevel();
             amrex::Long nParticles = 0;
             for (int lev = 0; lev <= nLevelPC; ++lev) {
-                nParticles += m_particle_container->NumberOfParticlesAtLevel(lev);
+                nParticles += amr_data->m_particle_container->NumberOfParticlesAtLevel(lev);
             }
             if (nParticles == 0)
                 throw std::runtime_error("No particles found. Cannot run evolve without a beam.");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* argv[])
     BL_PROFILE_VAR("main()", pmain);
     {
         impactx::ImpactX impactX;
-        impactX.initGrids();
+        impactX.init_grids();
         impactX.initBeamDistributionFromInputs();
         impactX.initLatticeElementsFromInputs();
         impactX.evolve();

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -11,6 +11,7 @@
 #define IMPACTX_PARTICLE_CONTAINER_H
 
 #include "ReferenceParticle.H"
+#include "initialization/AmrCoreData_fwd.H"
 
 #include <AMReX_AmrCoreFwd.H>
 #include <AMReX_BaseFwd.H>
@@ -150,7 +151,7 @@ namespace impactx
         using const_iterator = impactx::ParConstIter;
 
         //! Construct a new particle container
-        ImpactXParticleContainer (amrex::AmrCore* amr_core);
+        ImpactXParticleContainer (initialization::AmrCoreData* amr_core);
 
         //! Destruct a particle container
         virtual ~ImpactXParticleContainer() = default;

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -9,6 +9,8 @@
  */
 #include "ImpactXParticleContainer.H"
 
+#include "initialization/AmrCoreData.H"
+
 #include <ablastr/constant.H>
 #include <ablastr/particles/ParticleMoments.H>
 
@@ -51,7 +53,7 @@ namespace impactx
         : amrex::ParConstIter<0, 0, RealSoA::nattribs, IntSoA::nattribs>(pc, level,
               info.SetDynamic(do_omp_dynamic())) {}
 
-    ImpactXParticleContainer::ImpactXParticleContainer (amrex::AmrCore* amr_core)
+    ImpactXParticleContainer::ImpactXParticleContainer (initialization::AmrCoreData* amr_core)
         : amrex::ParticleContainer<0, 0, RealSoA::nattribs, IntSoA::nattribs>(amr_core->GetParGDB())
     {
         SetParticleSize();

--- a/tests/python/test_charge_deposition.py
+++ b/tests/python/test_charge_deposition.py
@@ -32,10 +32,10 @@ def test_charge_deposition(save_png=True):
     # Future:
     # sim.domain = amr.RealBox([1., 2., 3.], [4., 5., 6.])
     print(f"sim.n_cell={sim.n_cell}")
-    print(f"sim.domain={sim.domain}")
 
     sim.init_grids()
     assert sim.n_cell == [16, 24, 32]
+    print(f"sim.domain={sim.domain}")
 
     sim.init_beam_distribution_from_inputs()
     sim.init_lattice_elements_from_inputs()


### PR DESCRIPTION
Gain more control over initialization and finalization by using `AmrCore` effectively as a member variable of the `ImpactX` class.

Move all particle and mesh data into this new member variable `amr_data`. Move MR init logic into the `AmrCoreData` type, too.

Preparation for a simpler #504 fix.