### PR TITLE
CI: Fix Tooling `-Wno-error=pass-failed`

### DIFF
--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -32,7 +32,12 @@ jobs:
           ccache-openmp-clangsan-
 
     - name: build ImpactX
-      env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang, OMPI_CXX: clang++, CXXFLAGS: -Werror}
+      env:
+        CC: mpicc
+        CXX: mpic++
+        OMPI_CC: clang
+        OMPI_CXX: clang++
+        CXXFLAGS: "-Werror -Wno-error=pass-failed"
       run: |
         export LDFLAGS="${LDFLAGS} -fsanitize=address,undefined -shared-libsan"
         export CXXFLAGS="${CXXFLAGS} -fsanitize=address,undefined -shared-libsan"


### PR DESCRIPTION
Tooling update seems to warn on missing vectorization passes now, skip this explicitly in `-Werror`.