### PR TITLE
Programmable Element: Profile `pc` Push

### DIFF
--- a/src/particles/elements/Programmable.cpp
+++ b/src/particles/elements/Programmable.cpp
@@ -11,6 +11,8 @@
 #include "Programmable.H"
 #include "particles/PushAll.H"
 
+#include <AMReX_BLProfiler.H>
+
 
 namespace impactx
 {
@@ -25,6 +27,7 @@ namespace impactx
             push_all(pc, *this, step, m_threadsafe);
         }
         else {
+            BL_PROFILE("impactx::Push::Programmable");
             m_push(&pc, step);
         }
     }


### PR DESCRIPTION
If he `m_push` member is overwritten by the user, then we do not call into `push_all` and thus do not add element-wise profiling to the `Programmable` element yet.

This adds profiling for this case, which is then reflected in the tiny profiler as well as NVTX range marks.