### PR TITLE
Python Examples: Finalize Sim

### DIFF
--- a/examples/alignment/run_alignment.py
+++ b/examples/alignment/run_alignment.py
@@ -57,3 +57,6 @@ sim.lattice.extend(lattice)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/aperture/run_aperture.py
+++ b/examples/aperture/run_aperture.py
@@ -62,3 +62,6 @@ sim.lattice.extend(
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/apochromatic/run_apochromatic.py
+++ b/examples/apochromatic/run_apochromatic.py
@@ -71,3 +71,6 @@ sim.lattice.extend(lattice_line)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/apochromatic/run_apochromatic_pl.py
+++ b/examples/apochromatic/run_apochromatic_pl.py
@@ -109,3 +109,6 @@ sim.lattice.extend(lattice_line)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/cfbend/run_cfbend.py
+++ b/examples/cfbend/run_cfbend.py
@@ -61,3 +61,6 @@ sim.lattice.extend(bend)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/cfbend/run_cfbend_madx.py
+++ b/examples/cfbend/run_cfbend_madx.py
@@ -48,3 +48,6 @@ sim.lattice.load_file("chicane.madx", nslice=25)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/cfchannel/run_cfchannel.py
+++ b/examples/cfchannel/run_cfchannel.py
@@ -55,3 +55,6 @@ sim.lattice.extend(
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/cfchannel/run_cfchannel_10nC.py
+++ b/examples/cfchannel/run_cfchannel_10nC.py
@@ -60,3 +60,6 @@ sim.lattice.extend(
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/chicane/run_chicane.py
+++ b/examples/chicane/run_chicane.py
@@ -78,3 +78,6 @@ sim.lattice.append(monitor)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/chicane/run_chicane_madx.py
+++ b/examples/chicane/run_chicane_madx.py
@@ -48,3 +48,6 @@ sim.lattice.load_file("chicane.madx", nslice=25)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/compression/run_compression.py
+++ b/examples/compression/run_compression.py
@@ -58,3 +58,6 @@ sim.lattice.append(monitor)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/cyclotron/run_cyclotron.py
+++ b/examples/cyclotron/run_cyclotron.py
@@ -64,3 +64,6 @@ sim.periods = 150
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/epac2004_benchmarks/run_bithermal.py
+++ b/examples/epac2004_benchmarks/run_bithermal.py
@@ -66,3 +66,6 @@ sim.lattice.append(monitor)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/epac2004_benchmarks/run_fodo_rf_SC.py
+++ b/examples/epac2004_benchmarks/run_fodo_rf_SC.py
@@ -197,3 +197,6 @@ sim.lattice.append(monitor)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/epac2004_benchmarks/run_thermal.py
+++ b/examples/epac2004_benchmarks/run_thermal.py
@@ -64,3 +64,6 @@ sim.lattice.append(monitor)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/expanding_beam/run_expanding.py
+++ b/examples/expanding_beam/run_expanding.py
@@ -59,3 +59,6 @@ sim.lattice.extend([monitor, elements.Drift(ds=6.0, nslice=40), monitor])
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/fodo/run_fodo.py
+++ b/examples/fodo/run_fodo.py
@@ -67,3 +67,6 @@ sim.lattice.extend(fodo)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/fodo/run_fodo_madx.py
+++ b/examples/fodo/run_fodo_madx.py
@@ -49,3 +49,6 @@ sim.lattice.load_file("fodo.madx", nslice=25)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/fodo/run_fodo_programmable.py
+++ b/examples/fodo/run_fodo_programmable.py
@@ -172,3 +172,6 @@ sim.lattice.extend(fodo)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/fodo_chromatic/run_fodo_chr.py
+++ b/examples/fodo_chromatic/run_fodo_chr.py
@@ -67,3 +67,6 @@ sim.lattice.extend(fodo)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/fodo_rf/run_fodo_rf.py
+++ b/examples/fodo_rf/run_fodo_rf.py
@@ -66,3 +66,6 @@ sim.lattice.append(monitor)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/iota_lattice/run_iotalattice.py
+++ b/examples/iota_lattice/run_iotalattice.py
@@ -122,3 +122,6 @@ sim.periods = 5
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/iota_lattice/run_iotalattice_sdep.py
+++ b/examples/iota_lattice/run_iotalattice_sdep.py
@@ -218,3 +218,6 @@ sim.periods = 5
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/iota_lens/run_iotalens.py
+++ b/examples/iota_lens/run_iotalens.py
@@ -56,3 +56,6 @@ sim.lattice.extend(nllens_lattice)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/iota_lens/run_iotalens_sdep.py
+++ b/examples/iota_lens/run_iotalens_sdep.py
@@ -92,3 +92,6 @@ sim.periods = 1
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/kicker/run_hvkicker_madx.py
+++ b/examples/kicker/run_hvkicker_madx.py
@@ -48,3 +48,6 @@ sim.lattice.load_file("hvkicker.madx", nslice=1)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/kicker/run_kicker.py
+++ b/examples/kicker/run_kicker.py
@@ -56,3 +56,6 @@ sim.lattice.extend(kicklattice)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/kicker/run_kicker_madx.py
+++ b/examples/kicker/run_kicker_madx.py
@@ -48,3 +48,6 @@ sim.lattice.load_file("kicker.madx", nslice=1)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/kurth/run_kurth_10nC_periodic.py
+++ b/examples/kurth/run_kurth_10nC_periodic.py
@@ -54,3 +54,6 @@ sim.lattice.extend([monitor, drift1, constf1, drift1, monitor])
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/kurth/run_kurth_periodic.py
+++ b/examples/kurth/run_kurth_periodic.py
@@ -52,3 +52,6 @@ sim.lattice.extend([monitor, drift1, constf1, drift1, monitor])
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/multipole/run_multipole.py
+++ b/examples/multipole/run_multipole.py
@@ -57,3 +57,6 @@ sim.lattice.extend(multipole)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/positron_channel/run_positron.py
+++ b/examples/positron_channel/run_positron.py
@@ -69,3 +69,6 @@ sim.periods = 250
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/pytorch_surrogate_model/run_ml_surrogate.py
+++ b/examples/pytorch_surrogate_model/run_ml_surrogate.py
@@ -265,3 +265,6 @@ for i in range(N_stage):
 sim.lattice.extend([monitor])
 
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/quadrupole_softedge/run_quadrupole_softedge.py
+++ b/examples/quadrupole_softedge/run_quadrupole_softedge.py
@@ -76,3 +76,6 @@ sim.lattice.extend([monitor, drift1, quad1, drift2, quad2, drift1, monitor])
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/rfcavity/run_rfcavity.py
+++ b/examples/rfcavity/run_rfcavity.py
@@ -139,3 +139,6 @@ sim.lattice.extend(
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/rotation/run_rotation.py
+++ b/examples/rotation/run_rotation.py
@@ -57,3 +57,6 @@ sim.lattice.extend(rotated_drift)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/solenoid/run_solenoid.py
+++ b/examples/solenoid/run_solenoid.py
@@ -56,3 +56,6 @@ sim.lattice.extend(
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/solenoid/run_solenoid_madx.py
+++ b/examples/solenoid/run_solenoid_madx.py
@@ -45,3 +45,6 @@ sim.lattice.load_file("solenoid.madx", nslice=1)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/solenoid_softedge/run_solenoid_softedge.py
+++ b/examples/solenoid_softedge/run_solenoid_softedge.py
@@ -137,3 +137,6 @@ sim.lattice.extend(
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()

--- a/examples/thin_dipole/run_thin_dipole.py
+++ b/examples/thin_dipole/run_thin_dipole.py
@@ -64,3 +64,6 @@ sim.lattice.append(monitor)
 
 # run simulation
 sim.evolve()
+
+# clean shutdown
+sim.finalize()


### PR DESCRIPTION
As in the Python tests, run explicitly `sim.finalize()` for a controlled and clean shutdown. This also stops and prints the tiny profiler table.

Follow-up to  #510