### PR TITLE
Implement `int` SoA Names

### DIFF
--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -102,6 +102,13 @@ namespace impactx
         {
             nattribs ///< the number of particles above (always last)
         };
+
+        //! named labels for fixed s
+        static constexpr std::initializer_list<char const *> names_s = {};
+        //! named labels for fixed t
+        static constexpr std::initializer_list<char const *> names_t = {};
+        static_assert(names_s.size() == nattribs);
+        static_assert(names_t.size() == nattribs);
     };
 
     /** AMReX iterator for particle boxes
@@ -276,13 +283,17 @@ namespace impactx
         DepositCharge (std::unordered_map<int, amrex::MultiFab> & rho,
                        amrex::Vector<amrex::IntVect> const & ref_ratio);
 
-        /** Get the name of each Real AoS component */
+        /** Get the name of each ParticleReal AoS component */
         std::vector<std::string>
         RealAoS_names () const;
 
-        /** Get the name of each Real SoA component */
+        /** Get the name of each ParticleReal SoA component */
         std::vector<std::string>
         RealSoA_names () const;
+
+        /** Get the name of each int SoA component */
+        std::vector<std::string>
+        intSoA_names () const;
 
         /** Get the current coordinate system of particles in this container */
         CoordSystem
@@ -311,17 +322,25 @@ namespace impactx
 
     }; // ImpactXParticleContainer
 
-    /** Get the name of each Real AoS component */
+    /** Get the name of each ParticleReal AoS component */
     std::vector<std::string>
     get_RealAoS_names ();
 
-    /** Get the name of each Real SoA component
+    /** Get the name of each ParticleReal SoA component
      *
      * @param num_real_comps number of compile-time + runtime arrays
      * @return names
      */
     std::vector<std::string>
     get_RealSoA_names (int num_real_comps);
+
+    /** Get the name of each int SoA component
+     *
+     * @param num_int_comps number of compile-time + runtime arrays
+     * @return names
+     */
+    std::vector<std::string>
+    get_intSoA_names (int num_int_comps);
 
 } // namespace impactx
 

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -252,6 +252,12 @@ namespace impactx
         return get_RealSoA_names(this->NumRealComps());
     }
 
+    std::vector<std::string>
+    ImpactXParticleContainer::intSoA_names () const
+    {
+        return get_intSoA_names(this->NumIntComps());
+    }
+
     CoordSystem
     ImpactXParticleContainer::GetCoordSystem () const
     {
@@ -291,5 +297,23 @@ namespace impactx
         }
 
         return real_soa_names;
+    }
+
+    std::vector<std::string>
+    get_intSoA_names (int num_int_comps)
+    {
+        std::vector<std::string> int_soa_names(num_int_comps);
+
+        // compile-time attributes
+        std::copy(IntSoA::names_s.begin(), IntSoA::names_s.end(), int_soa_names.begin());
+
+        // runtime attributes
+        if (num_int_comps > int(IntSoA::names_s.size()))
+        {
+            // particles lost record their "s" position where they got lost
+            int_soa_names[IntSoA::nattribs] = "s_lost";
+        }
+
+        return int_soa_names;
     }
 } // namespace impactx

--- a/src/python/ImpactXParticleContainer.cpp
+++ b/src/python/ImpactXParticleContainer.cpp
@@ -129,7 +129,9 @@ void init_impactxparticlecontainer(py::module& m)
               "Get the name of each Real AoS component")
 
         .def_property_readonly("RealSoA_names", &ImpactXParticleContainer::RealSoA_names,
-              "Get the name of each Real SoA component")
+              "Get the name of each ParticleReal SoA component")
+        .def_property_readonly("intSoA_names", &ImpactXParticleContainer::intSoA_names,
+               "Get the name of each int SoA component")
     ;
 
     m.def("get_RealAoS_names", &get_RealAoS_names,
@@ -137,5 +139,8 @@ void init_impactxparticlecontainer(py::module& m)
 
     m.def("get_RealSoA_names", &get_RealSoA_names,
           py::arg("num_real_comps"),
-          "Get the name of each Real SoA component\n\nnum_real_comps: pass number of compile-time + runtime arrays");
+          "Get the name of each ParticleReal SoA component\n\nnum_real_comps: pass number of compile-time + runtime arrays");
+    m.def("get_intSoA_names", &get_intSoA_names,
+          py::arg("num_int_comps"),
+          "Get the name of each int SoA component\n\nnum_int_comps: pass number of compile-time + runtime arrays");
 }


### PR DESCRIPTION
Added for symmetry. Integer particle attributes are not used yet in ImpactX.