### PR TITLE
CI: Run with 2 Cores

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       CMAKE_GENERATOR: Ninja
       CXXFLAGS: "-Werror"
-      OMP_NUM_THREADS: 4
+      OMP_NUM_THREADS: 2
     steps:
     - uses: actions/checkout@v3
 
@@ -82,7 +82,7 @@ jobs:
     env:
       CMAKE_GENERATOR: Ninja
       CXXFLAGS: "-Werror"
-      OMP_NUM_THREADS: 4
+      OMP_NUM_THREADS: 2
     steps:
     - uses: actions/checkout@v3
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,7 +14,7 @@ if(ImpactX_MPI)
     set(MPI_TEST_EXE
         ${MPIEXEC_EXECUTABLE}
         ${MPI_ALLOW_ROOT}
-        ${MPIEXEC_NUMPROC_FLAG} 3
+        ${MPIEXEC_NUMPROC_FLAG} 2
         ${MPIEXEC_POSTFLAGS}
         ${MPIEXEC_PREFLAGS}
     )
@@ -83,7 +83,7 @@ function(add_impactx_test name input is_mpi is_python analysis_script plot_scrip
     if(is_mpi)
         set_property(TEST ${name}.run APPEND PROPERTY ENVIRONMENT "OMP_NUM_THREADS=1")
     else()
-        set_property(TEST ${name}.run APPEND PROPERTY ENVIRONMENT "OMP_NUM_THREADS=3")
+        set_property(TEST ${name}.run APPEND PROPERTY ENVIRONMENT "OMP_NUM_THREADS=2")
     endif()
 
     # analysis and plots

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -18,7 +18,7 @@ add_test(NAME ${pytest_name}
 )
 
 #   limit threads
-set_property(TEST ${pytest_name} APPEND PROPERTY ENVIRONMENT "OMP_NUM_THREADS=3")
+set_property(TEST ${pytest_name} APPEND PROPERTY ENVIRONMENT "OMP_NUM_THREADS=2")
 
 #   set PYTHONPATH and PATH (for .dll files)
 impactx_test_set_pythonpath(${pytest_name})


### PR DESCRIPTION
Keep runs to two cores. It looks like we actually get 4 vcores (aka 2 physical cores with 2x HT), which we know does usually slow us down in runs.

See https://github.com/ECP-WarpX/impactx/pull/523#issuecomment-1955965479

Building seems to marginally get better with `-j 4` over `-j 2`, so we keep that.