### PR TITLE
Use new function from Alex for removing invalid particles.

### DIFF
--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -186,7 +186,7 @@ set(ImpactX_ablastr_branch "11aabdca56335c5ae1cbb2257b8abd6c8f04a67c"
 set(ImpactX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(ImpactX_amrex_internal)")
-set(ImpactX_amrex_branch ""
+set(ImpactX_amrex_branch "d8d4828b04df948972613983b18a9dd32c555cfa"
     CACHE STRING
     "Repository branch for ImpactX_amrex_repo if(ImpactX_amrex_internal)")
 

--- a/src/particles/CollectLost.cpp
+++ b/src/particles/CollectLost.cpp
@@ -128,40 +128,7 @@ namespace impactx
                 );
 
                 // remove particles with negative ids in source
-                {
-                    int n_removed = 0;
-                    auto ptile_src_data = ptile_source.getParticleTileData();
-                    auto const ptile_soa = ptile_source.GetStructOfArrays();
-                    auto const ptile_idcpu = ptile_soa.GetIdCPUData().dataPtr();
-                    for (int ip = 0; ip < np; ++ip)
-                    {
-                        if (!amrex::ConstParticleIDWrapper{ptile_idcpu[ip]}.is_valid())
-                            n_removed++;
-                        else
-                        {
-                            if (n_removed > 0)
-                            {
-                                // move down
-                                int const new_index = ip - n_removed;
-
-                                ptile_src_data.m_idcpu[new_index] = ptile_src_data.m_idcpu[ip];
-                                for (int j = 0; j < SrcData::NAR; ++j)
-                                    ptile_src_data.m_rdata[j][new_index] = ptile_src_data.m_rdata[j][ip];
-                                for (int j = 0; j < ptile_src_data.m_num_runtime_real; ++j)
-                                    ptile_src_data.m_runtime_rdata[j][new_index] = ptile_src_data.m_runtime_rdata[j][ip];
-
-                                // unused: integer compile-time or runtime attributes
-                                //for (int j = 0; j < SrcData::NAI; ++j)
-                                //    dst.m_idata[j][new_index] = src.m_idata[j][ip];
-                                //for (int j = 0; j < ptile_src_data.m_num_runtime_int; ++j)
-                                //    dst.m_runtime_idata[j][new_index] = src.m_runtime_idata[j][ip];
-                            }
-                        }
-                    }
-                    AMREX_ALWAYS_ASSERT(np_to_move == n_removed);
-                    ptile_source.resize(np - n_removed);
-                }
-
+                amrex::removeInvalidParticles(ptile_source);
             } // particle tile loop
         } // lev
     }


### PR DESCRIPTION
This uses the new function from @AlexanderSinn to remove invalid particles in CollectLost instead of the current way, which doesn't work in the GPU. 

Fixes #499.