### PR TITLE
Zenodo: Add Ji's ORCiD

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -17,7 +17,8 @@
       },
       {
         "affiliation": "Lawrence Berkeley National Laboratory",
-        "name": "Qiang, Ji"
+        "name": "Qiang, Ji",
+        "orcid": "0000-0002-2537-483X"
       },
       {
         "affiliation": "Lawrence Berkeley National Laboratory",


### PR DESCRIPTION
Adding Ji's ORCiD to the metadata of our Zenodo releases.