### PR TITLE
Fix: Windows add_dll_directory Expand

### DIFF
--- a/src/python/impactx/__init__.py
+++ b/src/python/impactx/__init__.py
@@ -12,8 +12,9 @@ if os.name == "nt":
     # add anything in PATH
     paths = os.environ.get("PATH", "")
     for p in paths.split(";"):
-        if os.path.exists(p):
-            os.add_dll_directory(p)
+        p_abs = os.path.abspath(os.path.expanduser(os.path.expandvars(p)))
+        if os.path.exists(p_abs):
+            os.add_dll_directory(p_abs)
 
 # import core bindings to C++
 from . import impactx_pybind as cxx


### PR DESCRIPTION
Expand paths in `PATH` environment variable before adding them and make them absolute paths.

Fix #534