### PR TITLE
Python: Add `__repr__` for all Elements

### DIFF
--- a/examples/multipole/run_multipole.py
+++ b/examples/multipole/run_multipole.py
@@ -46,9 +46,9 @@ monitor = elements.BeamMonitor("monitor", backend="h5")
 # design the accelerator lattice
 multipole = [
     monitor,
-    elements.Multipole(multiple=2, K_normal=3.0, K_skew=0.0),
-    elements.Multipole(multiple=3, K_normal=100.0, K_skew=-50.0),
-    elements.Multipole(multiple=4, K_normal=65.0, K_skew=6.0),
+    elements.Multipole(multipole=2, K_normal=3.0, K_skew=0.0),
+    elements.Multipole(multipole=3, K_normal=100.0, K_skew=-50.0),
+    elements.Multipole(multipole=4, K_normal=65.0, K_skew=6.0),
     monitor,
 ]
 # assign a fodo segment

--- a/src/particles/elements/Buncher.H
+++ b/src/particles/elements/Buncher.H
@@ -110,7 +110,6 @@ namespace impactx
         /** This pushes the reference particle. */
         using Thin::operator();
 
-    private:
         amrex::ParticleReal m_V; //! normalized (max) RF voltage drop.
         amrex::ParticleReal m_k; //! RF wavenumber in 1/m.
     };

--- a/src/particles/elements/CFbend.H
+++ b/src/particles/elements/CFbend.H
@@ -221,7 +221,6 @@ namespace impactx
             refpart.s = s + slice_ds;
         }
 
-    private:
         amrex::ParticleReal m_rc; //! bend radius in m
         amrex::ParticleReal m_k;  //! quadrupole strength in m^(-2)
     };

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -116,7 +116,6 @@ namespace impactx
         /** This pushes the reference particle. */
         using Thin::operator();
 
-    private:
         amrex::ParticleReal m_psi; //! pole face angle in rad
         amrex::ParticleReal m_rc; //! bend radius in m
         amrex::ParticleReal m_g; //! gap parameter in m

--- a/src/particles/elements/ExactSbend.H
+++ b/src/particles/elements/ExactSbend.H
@@ -197,7 +197,6 @@ namespace impactx
 
         }
 
-    private:
         amrex::ParticleReal m_phi; //! bend angle in radians
         amrex::ParticleReal m_B;  //! magnetic field in T
     };

--- a/src/particles/elements/Kicker.H
+++ b/src/particles/elements/Kicker.H
@@ -134,7 +134,6 @@ namespace impactx
         /** This pushes the reference particle. */
         using Thin::operator();
 
-    private:
         amrex::ParticleReal m_xkick; //! horizontal kick strength
         amrex::ParticleReal m_ykick; //! vertical kick strength
         UnitSystem m_unit; //! Kicks are for 0 dimensionless, or for 1 in T-m."

--- a/src/particles/elements/Multipole.H
+++ b/src/particles/elements/Multipole.H
@@ -144,7 +144,6 @@ namespace impactx
         /** This pushes the reference particle. */
         using Thin::operator();
 
-    private:
         int m_multipole; //! multipole index
         int m_mfactorial; //! factorial of multipole index
         amrex::ParticleReal m_Kn; //! integrated normal multipole coefficient

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -154,7 +154,6 @@ namespace impactx
         /** This pushes the reference particle. */
         using Thin::operator();
 
-    private:
         amrex::ParticleReal m_knll; //! integrated strength of the nonlinear lens (m)
         amrex::ParticleReal m_cnll; //! distance of singularities from the origin (m)
     };

--- a/src/particles/elements/PRot.H
+++ b/src/particles/elements/PRot.H
@@ -123,7 +123,6 @@ namespace impactx
         /** This pushes the reference particle. */
         using Thin::operator();
 
-    private:
         amrex::ParticleReal m_phi_in; //! normalized (max) RF voltage drop.
         amrex::ParticleReal m_phi_out; //! RF wavenumber in 1/m.
     };

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -178,7 +178,6 @@ namespace impactx
             refpart.s = s + slice_ds;
         }
 
-    private:
         amrex::ParticleReal m_k; //! quadrupole strength in 1/m
     };
 

--- a/src/particles/elements/RFCavity.H
+++ b/src/particles/elements/RFCavity.H
@@ -532,7 +532,6 @@ namespace RFCavityData
                 RFCavityData::d_sin_coef.erase(m_id);
         }
 
-    private:
         amrex::ParticleReal m_escale; //! scaling factor for RF electric field
         amrex::ParticleReal m_freq; //! RF frequency in Hz
         amrex::ParticleReal m_phase; //! RF driven phase in deg

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -183,7 +183,6 @@ namespace impactx
 
         }
 
-    private:
         amrex::ParticleReal m_rc; //! bend radius in m
     };
 

--- a/src/particles/elements/ShortRF.H
+++ b/src/particles/elements/ShortRF.H
@@ -192,8 +192,6 @@ namespace impactx
 
         }
 
-
-    private:
         amrex::ParticleReal m_V; //! normalized (max) RF voltage drop.
         amrex::ParticleReal m_freq; //! RF frequency in Hz.
         amrex::ParticleReal m_phase; //! reference RF phase in degrees.

--- a/src/particles/elements/SoftQuad.H
+++ b/src/particles/elements/SoftQuad.H
@@ -484,7 +484,6 @@ namespace SoftQuadrupoleData
                 SoftQuadrupoleData::d_sin_coef.erase(m_id);
         }
 
-    private:
         amrex::ParticleReal m_gscale; //! scaling factor for quad field gradient
         int m_mapsteps; //! number of map integration steps per slice
         int m_id; //! unique soft quad id used for data lookup map

--- a/src/particles/elements/SoftSol.H
+++ b/src/particles/elements/SoftSol.H
@@ -545,7 +545,6 @@ namespace SoftSolenoidData
                 SoftSolenoidData::d_sin_coef.erase(m_id);
         }
 
-    private:
         amrex::ParticleReal m_bscale; //! scaling factor for solenoid Bz field
         int m_mapsteps; //! number of map integration steps per slice
         int m_id; //! unique soft solenoid id used for data lookup map

--- a/src/particles/elements/Sol.H
+++ b/src/particles/elements/Sol.H
@@ -180,7 +180,6 @@ namespace impactx
             refpart.s = s + slice_ds;
         }
 
-    private:
         amrex::ParticleReal m_ks; //! solenoid strength in 1/m
     };
 

--- a/src/particles/elements/ThinDipole.H
+++ b/src/particles/elements/ThinDipole.H
@@ -152,7 +152,6 @@ namespace impactx
             refpart.pz = pz*cos_theta + px*sin_theta;
         }
 
-    private:
         amrex::ParticleReal m_theta; //! dipole bending angle (rad)
         amrex::ParticleReal m_rc; //! curvature radius (m)
 

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -166,6 +166,11 @@ void init_elements(py::module& m)
 
     py::class_<Aperture, elements::Thin, elements::Alignment> py_Aperture(me, "Aperture");
     py_Aperture
+        .def("__repr__",
+             [](Aperture const & /* ap */) {
+                 return std::string("<impactx.elements.Aperture>");
+             }
+        )
         .def(py::init([](
                  amrex::ParticleReal xmax,
                  amrex::ParticleReal ymax,
@@ -211,6 +216,14 @@ void init_elements(py::module& m)
 
     py::class_<ChrDrift, elements::Thick, elements::Alignment> py_ChrDrift(me, "ChrDrift");
     py_ChrDrift
+        .def("__repr__",
+             [](ChrDrift const & chr_drift) {
+                 std::string r = "<impactx.elements.ChrDrift (ds=";
+                 r.append(std::to_string(chr_drift.ds()))
+                         .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -230,6 +243,16 @@ void init_elements(py::module& m)
 
     py::class_<ChrQuad, elements::Thick, elements::Alignment> py_ChrQuad(me, "ChrQuad");
     py_ChrQuad
+        .def("__repr__",
+             [](ChrQuad const & chr_quad) {
+                 std::string r = "<impactx.elements.ChrQuad (ds=";
+                 r.append(std::to_string(chr_quad.ds()))
+                  .append(", k=")
+                  .append(std::to_string(chr_quad.m_k))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -263,6 +286,16 @@ void init_elements(py::module& m)
 
     py::class_<ChrPlasmaLens, elements::Thick, elements::Alignment> py_ChrPlasmaLens(me, "ChrPlasmaLens");
     py_ChrPlasmaLens
+        .def("__repr__",
+             [](ChrPlasmaLens const & chr_pl_lens) {
+                 std::string r = "<impactx.elements.ChrPlasmaLens (ds=";
+                 r.append(std::to_string(chr_pl_lens.ds()))
+                  .append(", k=")
+                  .append(std::to_string(chr_pl_lens.m_k))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -296,6 +329,18 @@ void init_elements(py::module& m)
 
     py::class_<ChrAcc, elements::Thick, elements::Alignment> py_ChrAcc(me, "ChrAcc");
     py_ChrAcc
+        .def("__repr__",
+             [](ChrAcc const & chr_acc) {
+                 std::string r = "<impactx.elements.ChrAcc (ds=";
+                 r.append(std::to_string(chr_acc.ds()))
+                  .append(", ez=")
+                  .append(std::to_string(chr_acc.m_ez))
+                  .append(", bz=")
+                  .append(std::to_string(chr_acc.m_bz))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -329,6 +374,20 @@ void init_elements(py::module& m)
 
     py::class_<ConstF, elements::Thick, elements::Alignment> py_ConstF(me, "ConstF");
     py_ConstF
+        .def("__repr__",
+             [](ConstF const & constf) {
+                 std::string r = "<impactx.elements.ConstF (ds=";
+                 r.append(std::to_string(constf.ds()))
+                  .append(", kx=")
+                  .append(std::to_string(constf.m_kx))
+                  .append(", ky=")
+                  .append(std::to_string(constf.m_ky))
+                  .append(", kt=")
+                  .append(std::to_string(constf.m_kt))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -369,6 +428,20 @@ void init_elements(py::module& m)
 
     py::class_<DipEdge, elements::Thin, elements::Alignment> py_DipEdge(me, "DipEdge");
     py_DipEdge
+        .def("__repr__",
+             [](DipEdge const & dip_edge) {
+                 std::string r = "<impactx.elements.DipEdge (psi=";
+                 r.append(std::to_string(dip_edge.m_psi))
+                  .append(", rc=")
+                  .append(std::to_string(dip_edge.m_rc))
+                  .append(", g=")
+                  .append(std::to_string(dip_edge.m_g))
+                  .append(", K2=")
+                  .append(std::to_string(dip_edge.m_K2))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -392,6 +465,14 @@ void init_elements(py::module& m)
 
     py::class_<Drift, elements::Thick, elements::Alignment> py_Drift(me, "Drift");
     py_Drift
+        .def("__repr__",
+             [](Drift const & drift) {
+                 std::string r = "<impactx.elements.Drift (ds=";
+                 r.append(std::to_string(drift.ds()))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -411,6 +492,14 @@ void init_elements(py::module& m)
 
     py::class_<ExactDrift, elements::Thick, elements::Alignment> py_ExactDrift(me, "ExactDrift");
     py_ExactDrift
+        .def("__repr__",
+             [](ExactDrift const & exact_drift) {
+                 std::string r = "<impactx.elements.ExactDrift (ds=";
+                 r.append(std::to_string(exact_drift.ds()))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -430,6 +519,18 @@ void init_elements(py::module& m)
 
     py::class_<ExactSbend, elements::Thick, elements::Alignment> py_ExactSbend(me, "ExactSbend");
     py_ExactSbend
+        .def("__repr__",
+             [](ExactSbend const & exact_sbend) {
+                 std::string r = "<impactx.elements.ExactSbend (ds=";
+                 r.append(std::to_string(exact_sbend.ds()))
+                  .append(", phi=")
+                  .append(std::to_string(exact_sbend.m_phi))
+                  .append(", B=")
+                  .append(std::to_string(exact_sbend.m_B))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -453,6 +554,16 @@ void init_elements(py::module& m)
 
     py::class_<Kicker, elements::Thin, elements::Alignment> py_Kicker(me, "Kicker");
     py_Kicker
+        .def("__repr__",
+             [](Kicker const & kicker) {
+                 std::string r = "<impactx.elements.Kicker (xkick=";
+                 r.append(std::to_string(kicker.m_xkick))
+                  .append(", ykick=")
+                  .append(std::to_string(kicker.m_ykick))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init([](
                 amrex::ParticleReal xkick,
                 amrex::ParticleReal ykick,
@@ -483,6 +594,18 @@ void init_elements(py::module& m)
 
     py::class_<Multipole, elements::Thin, elements::Alignment> py_Multipole(me, "Multipole");
     py_Multipole
+        .def("__repr__",
+             [](Multipole const & multipole) {
+                 std::string r = "<impactx.elements.Multipole (multipole=";
+                 r.append(std::to_string(multipole.m_multipole))
+                  .append(", K_normal=")
+                  .append(std::to_string(multipole.m_Kn))
+                  .append(", K_skew=")
+                  .append(std::to_string(multipole.m_Ks))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 int,
                 amrex::ParticleReal,
@@ -491,7 +614,7 @@ void init_elements(py::module& m)
                 amrex::ParticleReal,
                 amrex::ParticleReal
              >(),
-             py::arg("multiple"),
+             py::arg("multipole"),
              py::arg("K_normal"),
              py::arg("K_skew"),
              py::arg("dx") = 0,
@@ -504,6 +627,11 @@ void init_elements(py::module& m)
 
     py::class_<None, elements::Thin> py_None(me, "None");
     py_None
+        .def("__repr__",
+             [](None const & /* none */) {
+                 return std::string("<impactx.elements.None>");
+             }
+        )
         .def(py::init<>(),
              "This element does nothing."
         )
@@ -512,6 +640,16 @@ void init_elements(py::module& m)
 
     py::class_<NonlinearLens, elements::Thin, elements::Alignment> py_NonlinearLens(me, "NonlinearLens");
     py_NonlinearLens
+        .def("__repr__",
+             [](NonlinearLens const & nl) {
+                 std::string r = "<impactx.elements.NonlinearLens (knll=";
+                 r.append(std::to_string(nl.m_knll))
+                  .append(", cnll=")
+                  .append(std::to_string(nl.m_cnll))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -530,6 +668,14 @@ void init_elements(py::module& m)
     register_beamoptics_push(py_NonlinearLens);
 
     py::class_<Programmable>(me, "Programmable", py::dynamic_attr())
+        .def("__repr__",
+             [](Programmable const & prg) {
+                 std::string r = "<impactx.elements.Programmable (ds=";
+                 r.append(std::to_string(prg.ds()))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                  amrex::ParticleReal,
                  int
@@ -575,6 +721,16 @@ void init_elements(py::module& m)
 
     py::class_<Quad, elements::Thick, elements::Alignment> py_Quad(me, "Quad");
     py_Quad
+        .def("__repr__",
+             [](Quad const & quad) {
+                 std::string r = "<impactx.elements.Quad (ds=";
+                 r.append(std::to_string(quad.ds()))
+                  .append(", k=")
+                  .append(std::to_string(quad.m_k))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -596,6 +752,20 @@ void init_elements(py::module& m)
 
     py::class_<RFCavity, elements::Thick, elements::Alignment> py_RFCavity(me, "RFCavity");
     py_RFCavity
+        .def("__repr__",
+             [](RFCavity const & rfc) {
+                 std::string r = "<impactx.elements.RFCavity (ds=";
+                 r.append(std::to_string(rfc.ds()))
+                  .append(", escale=")
+                  .append(std::to_string(rfc.m_escale))
+                  .append(", freq=")
+                  .append(std::to_string(rfc.m_freq))
+                  .append(", phase=")
+                  .append(std::to_string(rfc.m_phase))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -627,6 +797,16 @@ void init_elements(py::module& m)
 
     py::class_<Sbend, elements::Thick, elements::Alignment> py_Sbend(me, "Sbend");
     py_Sbend
+        .def("__repr__",
+             [](Sbend const & sbend) {
+                 std::string r = "<impactx.elements.Sbend (ds=";
+                 r.append(std::to_string(sbend.ds()))
+                  .append(", rc=")
+                  .append(std::to_string(sbend.m_rc))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -648,6 +828,18 @@ void init_elements(py::module& m)
 
     py::class_<CFbend, elements::Thick, elements::Alignment> py_CFbend(me, "CFbend");
     py_CFbend
+        .def("__repr__",
+             [](CFbend const & cfbend) {
+                 std::string r = "<impactx.elements.CFbend (ds=";
+                 r.append(std::to_string(cfbend.ds()))
+                  .append(", rc=")
+                  .append(std::to_string(cfbend.m_rc))
+                  .append(", k=")
+                  .append(std::to_string(cfbend.m_k))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -671,6 +863,16 @@ void init_elements(py::module& m)
 
     py::class_<Buncher, elements::Thin, elements::Alignment> py_Buncher(me, "Buncher");
     py_Buncher
+        .def("__repr__",
+             [](Buncher const & buncher) {
+                 std::string r = "<impactx.elements.Buncher (V=";
+                 r.append(std::to_string(buncher.m_V))
+                  .append(", k=")
+                  .append(std::to_string(buncher.m_k))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -690,6 +892,18 @@ void init_elements(py::module& m)
 
     py::class_<ShortRF, elements::Thin, elements::Alignment> py_ShortRF(me, "ShortRF");
     py_ShortRF
+        .def("__repr__",
+             [](ShortRF const & short_rf) {
+                 std::string r = "<impactx.elements.ShortRF (V=";
+                 r.append(std::to_string(short_rf.m_V))
+                  .append(", freq=")
+                  .append(std::to_string(short_rf.m_freq))
+                  .append(", phase=")
+                  .append(std::to_string(short_rf.m_phase))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -711,6 +925,16 @@ void init_elements(py::module& m)
 
     py::class_<SoftSolenoid, elements::Thick, elements::Alignment> py_SoftSolenoid(me, "SoftSolenoid");
     py_SoftSolenoid
+        .def("__repr__",
+             [](SoftSolenoid const & soft_sol) {
+                 std::string r = "<impactx.elements.SoftSolenoid (ds=";
+                 r.append(std::to_string(soft_sol.ds()))
+                  .append(", bscale=")
+                  .append(std::to_string(soft_sol.m_bscale))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                  amrex::ParticleReal,
                  amrex::ParticleReal,
@@ -738,6 +962,16 @@ void init_elements(py::module& m)
 
     py::class_<Sol, elements::Thick, elements::Alignment> py_Sol(me, "Sol");
     py_Sol
+        .def("__repr__",
+             [](Sol const & soft_sol) {
+                 std::string r = "<impactx.elements.Sol (ds=";
+                 r.append(std::to_string(soft_sol.ds()))
+                  .append(", ks=")
+                  .append(std::to_string(soft_sol.m_ks))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,
@@ -759,6 +993,16 @@ void init_elements(py::module& m)
 
     py::class_<PRot, elements::Thin> py_PRot(me, "PRot");
     py_PRot
+        .def("__repr__",
+             [](PRot const & prot) {
+                 std::string r = "<impactx.elements.PRot (phi_in=";
+                 r.append(std::to_string(prot.m_phi_in))
+                  .append(", phi_out=")
+                  .append(std::to_string(prot.m_phi_out))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal
@@ -772,6 +1016,16 @@ void init_elements(py::module& m)
 
     py::class_<SoftQuadrupole, elements::Thick, elements::Alignment> py_SoftQuadrupole(me, "SoftQuadrupole");
     py_SoftQuadrupole
+        .def("__repr__",
+             [](SoftQuadrupole const & soft_quad) {
+                 std::string r = "<impactx.elements.SoftQuadrupole (ds=";
+                 r.append(std::to_string(soft_quad.ds()))
+                  .append(", gscale=")
+                  .append(std::to_string(soft_quad.m_gscale))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                  amrex::ParticleReal,
                  amrex::ParticleReal,
@@ -799,6 +1053,16 @@ void init_elements(py::module& m)
 
     py::class_<ThinDipole, elements::Thin, elements::Alignment> py_ThinDipole(me, "ThinDipole");
     py_ThinDipole
+        .def("__repr__",
+             [](ThinDipole const & thin_dp) {
+                 std::string r = "<impactx.elements.ThinDipole (theta=";
+                 r.append(std::to_string(thin_dp.m_theta))
+                  .append(", rc=")
+                  .append(std::to_string(thin_dp.m_rc))
+                  .append(")>");
+                 return r;
+             }
+        )
         .def(py::init<
                 amrex::ParticleReal,
                 amrex::ParticleReal,


### PR DESCRIPTION
Implement the standardized `__repr__` method for all ImpactX beamline elements. This shows now central parameters of each element and hides the implementation detail of our facade import module.

```py
import impactx

drift = impactx.elements.Drift(1.0)
```

Before:
```py
print(drift)
<impactx.impactx_pybind.elements.Drift at 0x7f1fbd297b70>

```
After:
```py
print(drift)
<impactx.elements.Drift (ds=1.000000)>
```

Used in #539