### PR TITLE
ImpactX: Verbosity Control

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -52,6 +52,10 @@ Overall simulation parameters
     It is mainly intended for debug purposes, and is best used with ``impactx.always_warn_immediately=1``.
     For more information on the warning logger, see `this section <https://warpx.readthedocs.io/en/latest/developers/warning_logger.html>`__ of the WarpX documentation.
 
+* ``impactx.verbose`` (int: ``0`` for silent, higher is more verbose; default is ``1``) optional
+    Controls how much information is printed to the terminal, when running ImpactX.
+
+
 .. _running-cpp-parameters-box:
 
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -176,6 +176,11 @@ General
       If set to ``1``, ImpactX immediately prints every warning message as soon as it is generated. (default: ``0`` for false)
       It is mainly intended for debug purposes, in case a simulation crashes before a global warning report can be printed.
 
+   .. py:property:: verbose
+
+      Controls how much information is printed to the terminal, when running ImpactX.
+      ``0`` for silent, higher is more verbose. Default is ``1``.
+
    .. py:method:: evolve()
 
       Run the main simulation loop for a number of steps.

--- a/src/initialization/Warnings.cpp
+++ b/src/initialization/Warnings.cpp
@@ -23,7 +23,11 @@ namespace impactx
 {
 void ImpactX::init_warning_logger ()
 {
-    amrex::ParmParse const pp_impactx("impactx");
+    amrex::ParmParse pp_impactx("impactx");
+
+    // verbosity
+    int verbose = 1;
+    pp_impactx.queryAdd("verbose", verbose);
 
     // Set the flag to control if ImpactX has to emit a warning message
     // as soon as a warning is recorded
@@ -57,12 +61,21 @@ bool ImpactX::early_param_check ()
 {
     BL_PROFILE("ImpactX::early_param_check");
 
-    amrex::Print() << "\n";
+    // verbosity
+    amrex::ParmParse pp_impactx("impactx");
+    int verbose = 1;
+    pp_impactx.queryAdd("verbose", verbose);
+
+    if (verbose > 0) {
+        amrex::Print() << "\n";
+    }
     amrex::ParmParse::QueryUnusedInputs();
 
     // Print the warning list right after the first step.
-    amrex::Print() << ablastr::warn_manager::GetWMInstance()
-        .PrintGlobalWarnings("FIRST STEP");
+    if (verbose > 0) {
+        amrex::Print() << ablastr::warn_manager::GetWMInstance()
+                          .PrintGlobalWarnings("FIRST STEP");
+    }
 
     return true;
 }

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -362,6 +362,18 @@ void init_ImpactX (py::module& m)
             "if there are unused parameters in the input."
         )
 
+        .def_property("verbose",
+            [](ImpactX & /* ix */){
+                return detail::get_or_throw<int>("impactx", "verbose");
+            },
+            [](ImpactX & /* ix */, int const verbose) {
+                amrex::ParmParse pp_impactx("impactx");
+                pp_impactx.add("verbose", verbose);
+            },
+            "Controls how much information is printed to the terminal, when running ImpactX.\n"
+            "``0`` for silent, higher is more verbose. Default is ``1``."
+        )
+
         .def("finalize", &ImpactX::finalize,
              "Deallocate all contexts and data."
         )


### PR DESCRIPTION
Add `impactx.verbose` (AMReX inputs) / `sim.verbose` (Py) to silence all prints to the terminal in automated runs.

Used in #539