### PR TITLE
`diags/` Folder: Only w/ Diags

### DIFF
--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -72,7 +72,11 @@ namespace impactx {
         init_warning_logger();
 
         // move old diagnostics out of the way
-        amrex::UtilCreateCleanDirectory("diags", true);
+        bool diag_enable = true;
+        amrex::ParmParse("diag").queryAdd("enable", diag_enable);
+        if (diag_enable) {
+            amrex::UtilCreateCleanDirectory("diags", true);
+        }
 
         // the particle container has been set to track the same Geometry as ImpactX
 


### PR DESCRIPTION
Do not create or move out of the way old diagnostics folders, if diagnostics are disabled. This is useful in optimization runs that solely rely on in situ diagnostics for speed.

Used in #539