### PR TITLE
Diagnostics: NLL Invariants to Monitor

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -539,7 +539,7 @@ Lattice Elements
             * ``<element_name>.nonlinear_lens_invariants`` (``boolean``, default value: ``false``)
 
                 Compute and output the invariants H and I within the nonlinear magnetic insert element (see: ``nonlinear_lens``).
-                Invariants associated with a single short segment of the nonlinear magnetic insert described by V. Danilov and S. Nagaitsev, PRSTAB 13, 084002 (2010), Sect. V.A.
+                Invariants associated with the nonlinear magnetic insert described by V. Danilov and S. Nagaitsev, PRSTAB 13, 084002 (2010), Sect. V.A.
 
                 * ``<element_name>.alpha`` (``float``, unitless) Twiss alpha of the bare linear lattice at the location of output for the nonlinear IOTA invariants H and I.
                   Horizontal and vertical values must be equal.

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -536,6 +536,21 @@ Lattice Elements
                 openPMD `iteration encoding <https://openpmd-api.readthedocs.io/en/0.14.0/usage/concepts.html#iteration-and-series>`__: (v)ariable based, (f)ile based, (g)roup based (default)
                 variable based is an `experimental feature with ADIOS2 <https://openpmd-api.readthedocs.io/en/0.14.0/backends/adios2.html#experimental-new-adios2-schema>`__.
 
+            * ``<element_name>.nonlinear_lens_invariants`` (``boolean``, default value: ``false``)
+
+                Compute and output the invariants H and I within the nonlinear magnetic insert element (see: ``nonlinear_lens``).
+                Invariants associated with a single short segment of the nonlinear magnetic insert described by V. Danilov and S. Nagaitsev, PRSTAB 13, 084002 (2010), Sect. V.A.
+
+                * ``<element_name>.alpha`` (``float``, unitless) Twiss alpha of the bare linear lattice at the location of output for the nonlinear IOTA invariants H and I.
+                  Horizontal and vertical values must be equal.
+
+                * ``<element_name>.beta`` (``float``, meters) Twiss beta of the bare linear lattice at the location of output for the nonlinear IOTA invariants H and I.
+                  Horizontal and vertical values must be equal.
+
+                * ``<element_name>.tn`` (``float``, unitless) dimensionless strength of the IOTA nonlinear magnetic insert element used for computing H and I.
+
+                * ``<element_name>.cn`` (``float``, meters^(1/2)) scale factor of the IOTA nonlinear magnetic insert element used for computing H and I.
+
         * ``line`` a sub-lattice (line) of elements to append to the lattice.
 
             * ``<element_name>.elements`` (``list of strings``) optional (default: no elements)
@@ -693,26 +708,6 @@ Diagnostics and output
 
   Diagnostics for particles lost in apertures, stored as ``diags/openPMD/particles_lost.*`` at the end of the simulation.
   See the ``beam_monitor`` element for backend values.
-
-.. _running-cpp-parameters-diagnostics-reduced:
-
-Reduced Diagnostics
-^^^^^^^^^^^^^^^^^^^
-
-Reduced diagnostics allow the user to compute some reduced quantity (invariants of motion, particle temperature, max of a field, ...) and write a small amount of data to text files.
-Reduced diagnostics are run *in situ* with the simulation.
-
-Diagnostics related to integrable optics in the IOTA nonlinear magnetic insert element:
-
-* ``diag.alpha`` (``float``, unitless) Twiss alpha of the bare linear lattice at the location of output for the nonlinear IOTA invariants H and I.
-  Horizontal and vertical values must be equal.
-
-* ``diag.beta`` (``float``, meters) Twiss beta of the bare linear lattice at the location of output for the nonlinear IOTA invariants H and I.
-  Horizontal and vertical values must be equal.
-
-* ``diag.tn`` (``float``, unitless) dimensionless strength of the IOTA nonlinear magnetic insert element used for computing H and I.
-
-* ``diag.cn`` (``float``, meters^(1/2)) scale factor of the IOTA nonlinear magnetic insert element used for computing H and I.
 
 
 .. _running-cpp-parameters-diagnostics-insitu:

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -116,15 +116,6 @@ General
       The minimum number of digits (default: ``6``) used for the step
       number appended to the diagnostic file names.
 
-   .. py:method:: set_diag_iota_invariants(alpha, beta, tn, cn)
-
-      Set the parameters of the IOTA nonlinear lens invariants diagnostics.
-
-      :param float alpha: Twiss alpha
-      :param float beta: Twiss beta (m)
-      :param float tn: dimensionless strength of the nonlinear insert
-      :param float cn: scale parameter of the nonlinear insert (m^[1/2])
-
    .. py:property:: particle_lost_diagnostics_backend
 
       Diagnostics for particles lost in apertures.
@@ -609,6 +600,32 @@ This module provides elements for the accelerator lattice.
    :param name: name of the series
    :param backend: I/O backend, e.g., ``bp``, ``h5``, ``json``
    :param encoding: openPMD iteration encoding: (v)ariable based, (f)ile based, (g)roup based (default)
+
+   .. py:property:: name
+
+      name of the series
+
+   .. py:property:: nonlinear_lens_invariants
+
+      Compute and output the invariants H and I within the nonlinear magnetic insert element
+
+   .. py:property:: alpha
+
+      Twiss alpha of the bare linear lattice at the location of output for the nonlinear IOTA invariants H and I.
+      Horizontal and vertical values must be equal.
+
+   .. py:property:: beta
+
+      Twiss beta (in meters) of the bare linear lattice at the location of output for the nonlinear IOTA invariants H and I.
+      Horizontal and vertical values must be equal.
+
+   .. py:property:: tn
+
+      Dimensionless strength of the IOTA nonlinear magnetic insert element used for computing H and I.
+
+   .. py:property:: cn
+
+      Scale factor (in meters^(1/2)) of the IOTA nonlinear magnetic insert element used for computing H and I.
 
 .. py:class:: impactx.elements.Programmable
 

--- a/examples/iota_lattice/analysis_iotalattice_sdep.py
+++ b/examples/iota_lattice/analysis_iotalattice_sdep.py
@@ -4,10 +4,8 @@
 # Authors: Axel Huebl, Chad Mitchell
 # License: BSD-3-Clause-LBNL
 #
-import glob
-
 import numpy as np
-import pandas as pd
+import openpmd_api as io
 from scipy.stats import moment
 
 
@@ -25,26 +23,11 @@ def get_moments(beam):
     return (meanH, sigH, meanI, sigI)
 
 
-def read_all_files(file_pattern):
-    """Read in all CSV files from each MPI rank (and potentially OpenMP
-    thread). Concatenate into one Pandas dataframe.
-    Returns
-    -------
-    pandas.DataFrame
-    """
-    return pd.concat(
-        (
-            pd.read_csv(filename, delimiter=r"\s+")
-            for filename in glob.glob(file_pattern)
-        ),
-        axis=0,
-        ignore_index=True,
-    ).set_index("id")
-
-
 # initial/final beam
-initial = read_all_files("diags/nonlinear_lens_invariants_000000.*")
-final = read_all_files("diags/nonlinear_lens_invariants_final.*")
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+last_step = list(series.iterations)[-1]
+initial = series.iterations[1].particles["beam"].to_df()
+final = series.iterations[last_step].particles["beam"].to_df()
 
 # compare number of particles
 num_particles = 10000

--- a/examples/iota_lattice/input_iotalattice.in
+++ b/examples/iota_lattice/input_iotalattice.in
@@ -214,6 +214,7 @@ qe3.k = -6.69148177
 # Beam Monitor: Diagnostics
 monitor.type = beam_monitor
 monitor.backend = h5
+monitor.nonlinear_lens_invariants = true
 
 
 ###############################################################################

--- a/examples/iota_lattice/input_iotalattice_sdep.in
+++ b/examples/iota_lattice/input_iotalattice_sdep.in
@@ -271,6 +271,11 @@ qe3.k = -6.69148177
 # Beam Monitor: Diagnostics
 monitor.type = beam_monitor
 monitor.backend = h5
+monitor.nonlinear_lens_invariants = true
+monitor.alpha = 1.376381920471173
+monitor.beta = 1.892632003628881
+monitor.tn = 0.4
+monitor.cn = 0.01
 
 
 ###############################################################################
@@ -284,8 +289,3 @@ algo.space_charge = false
 # Diagnostics
 ###############################################################################
 diag.slice_step_diagnostics = true
-
-diag.alpha = 1.376381920471173
-diag.beta = 1.892632003628881
-diag.tn = 0.4
-diag.cn = 0.01

--- a/examples/iota_lattice/run_iotalattice_sdep.py
+++ b/examples/iota_lattice/run_iotalattice_sdep.py
@@ -21,11 +21,6 @@ sim.slice_step_diagnostics = True
 # domain decomposition & space charge mesh
 sim.init_grids()
 
-# diagnostics: IOTA nonlinear lens invariants calculation
-sim.set_diag_iota_invariants(
-    alpha=1.376381920471173, beta=1.892632003628881, tn=0.4, cn=0.01
-)
-
 # init particle beam
 energy_MeV = 2.5
 bunch_charge_C = 1.0e-9  # used with space charge
@@ -51,6 +46,11 @@ sim.add_particles(bunch_charge_C, distr, npart)
 
 # add beam diagnostics
 monitor = elements.BeamMonitor("monitor", backend="h5")
+monitor.nonlinear_lens_invariants = True
+monitor.alpha = 1.376381920471173
+monitor.beta = 1.892632003628881
+monitor.tn = 0.4
+monitor.cn = 0.01
 
 # init accelerator lattice
 ns = 10  # number of slices per ds in the element

--- a/examples/iota_lens/analysis_iotalens.py
+++ b/examples/iota_lens/analysis_iotalens.py
@@ -4,10 +4,9 @@
 # Authors: Axel Huebl, Chad Mitchell
 # License: BSD-3-Clause-LBNL
 #
-import glob
 
 import numpy as np
-import pandas as pd
+import openpmd_api as io
 from scipy.stats import moment
 
 
@@ -25,26 +24,11 @@ def get_moments(beam):
     return (meanH, sigH, meanI, sigI)
 
 
-def read_all_files(file_pattern):
-    """Read in all CSV files from each MPI rank (and potentially OpenMP
-    thread). Concatenate into one Pandas dataframe.
-    Returns
-    -------
-    pandas.DataFrame
-    """
-    return pd.concat(
-        (
-            pd.read_csv(filename, delimiter=r"\s+")
-            for filename in glob.glob(file_pattern)
-        ),
-        axis=0,
-        ignore_index=True,
-    ).set_index("id")
-
-
 # initial/final beam
-initial = read_all_files("diags/nonlinear_lens_invariants_000000.*")
-final = read_all_files("diags/nonlinear_lens_invariants_final.*")
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+last_step = list(series.iterations)[-1]
+initial = series.iterations[1].particles["beam"].to_df()
+final = series.iterations[last_step].particles["beam"].to_df()
 
 # compare number of particles
 num_particles = 10000

--- a/examples/iota_lens/analysis_iotalens_sdep.py
+++ b/examples/iota_lens/analysis_iotalens_sdep.py
@@ -4,10 +4,8 @@
 # Authors: Axel Huebl, Chad Mitchell
 # License: BSD-3-Clause-LBNL
 #
-import glob
-
 import numpy as np
-import pandas as pd
+import openpmd_api as io
 from scipy.stats import moment
 
 
@@ -25,26 +23,11 @@ def get_moments(beam):
     return (meanH, sigH, meanI, sigI)
 
 
-def read_all_files(file_pattern):
-    """Read in all CSV files from each MPI rank (and potentially OpenMP
-    thread). Concatenate into one Pandas dataframe.
-    Returns
-    -------
-    pandas.DataFrame
-    """
-    return pd.concat(
-        (
-            pd.read_csv(filename, delimiter=r"\s+")
-            for filename in glob.glob(file_pattern)
-        ),
-        axis=0,
-        ignore_index=True,
-    ).set_index("id")
-
-
 # initial/final beam
-initial = read_all_files("diags/nonlinear_lens_invariants_000000.*")
-final = read_all_files("diags/nonlinear_lens_invariants_final.*")
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+last_step = list(series.iterations)[-1]
+initial = series.iterations[1].particles["beam"].to_df()
+final = series.iterations[last_step].particles["beam"].to_df()
 
 # compare number of particles
 num_particles = 10000

--- a/examples/iota_lens/input_iotalens.in
+++ b/examples/iota_lens/input_iotalens.in
@@ -21,7 +21,7 @@ beam.mutpt = 0.0
 ###############################################################################
 # Beamline: lattice elements and segments
 ###############################################################################
-lattice.elements = const_end nllens foclens const_end
+lattice.elements = monitor const_end nllens foclens const_end monitor
 
 foclens.type = line
 foclens.elements = const nllens
@@ -43,18 +43,17 @@ const.kx = 1.0
 const.ky = 1.0
 const.kt = 1.0e-12
 
+monitor.type = beam_monitor
+monitor.backend = h5
+monitor.nonlinear_lens_invariants = true
+monitor.alpha = 0.0
+monitor.beta = 1.0
+monitor.tn = 0.4
+monitor.cn = 0.01
+
 
 ###############################################################################
 # Algorithms
 ###############################################################################
 algo.particle_shape = 2
 algo.space_charge = false
-
-
-###############################################################################
-# Diagnostics
-###############################################################################
-diag.alpha = 0.0
-diag.beta = 1.0
-diag.tn = 0.4
-diag.cn = 0.01

--- a/examples/iota_lens/input_iotalens_sdep.in
+++ b/examples/iota_lens/input_iotalens_sdep.in
@@ -92,18 +92,15 @@ const.nslice = 1
 # Beam Monitor: Diagnostics
 monitor.type = beam_monitor
 monitor.backend = h5
+monitor.nonlinear_lens_invariants = true
+monitor.alpha = 1.376381920471173
+monitor.beta = 1.892632003628881
+monitor.tn = 0.4
+monitor.cn = 0.01
+
 
 ###############################################################################
 # Algorithms
 ###############################################################################
 algo.particle_shape = 2
 algo.space_charge = false
-
-
-###############################################################################
-# Diagnostics
-###############################################################################
-diag.alpha = 1.376381920471173
-diag.beta = 1.892632003628881
-diag.tn = 0.4
-diag.cn = 0.01

--- a/examples/iota_lens/run_iotalens.py
+++ b/examples/iota_lens/run_iotalens.py
@@ -19,9 +19,6 @@ sim.slice_step_diagnostics = True
 # domain decomposition & space charge mesh
 sim.init_grids()
 
-# diagnostics: IOTA nonlinear lens invariants calculation
-sim.set_diag_iota_invariants(alpha=0.0, beta=1.0, tn=0.4, cn=0.01)
-
 # load a 2.5 MeV proton beam
 kin_energy_MeV = 2.5  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
@@ -42,13 +39,25 @@ distr = distribution.Waterbag(
 )
 sim.add_particles(bunch_charge_C, distr, npart)
 
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+monitor.nonlinear_lens_invariants = True
+monitor.alpha = 0.0
+monitor.beta = 1.0
+monitor.tn = 0.4
+monitor.cn = 0.01
+
 # design the accelerator lattice
 constEnd = elements.ConstF(ds=0.05, kx=1.0, ky=1.0, kt=1.0e-12)
 nllens = elements.NonlinearLens(knll=4.0e-6, cnll=0.01)
 const = elements.ConstF(ds=0.1, kx=1.0, ky=1.0, kt=1.0e-12)
 
 num_lenses = 18
-nllens_lattice = [constEnd] + [nllens, const] * (num_lenses - 1) + [nllens, constEnd]
+nllens_lattice = (
+    [monitor, constEnd]
+    + [nllens, const] * (num_lenses - 1)
+    + [nllens, constEnd, monitor]
+)
 
 # add elements to the lattice segment
 sim.lattice.extend(nllens_lattice)

--- a/examples/iota_lens/run_iotalens_sdep.py
+++ b/examples/iota_lens/run_iotalens_sdep.py
@@ -21,11 +21,6 @@ sim.slice_step_diagnostics = True
 # domain decomposition & space charge mesh
 sim.init_grids()
 
-# diagnostics: IOTA nonlinear lens invariants calculation
-sim.set_diag_iota_invariants(
-    alpha=1.376381920471173, beta=1.892632003628881, tn=0.4, cn=0.01
-)
-
 # load a 2.5 MeV proton beam
 kin_energy_MeV = 2.5  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
@@ -52,6 +47,12 @@ sim.add_particles(bunch_charge_C, distr, npart)
 
 # add beam diagnostics
 monitor = elements.BeamMonitor("monitor", backend="h5")
+monitor.nonlinear_lens_invariants = True
+monitor.alpha = 1.376381920471173
+monitor.beta = 1.892632003628881
+monitor.tn = 0.4
+monitor.cn = 0.01
+
 sim.lattice.append(monitor)
 
 # defining parameters of the nonlinear lens

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -158,12 +158,6 @@ namespace impactx {
                                           "diags/ref_particle",
                                           global_step);
 
-            // print the initial values of the two invariants H and I
-            std::string const diag_name = amrex::Concatenate("diags/nonlinear_lens_invariants_", global_step, file_min_digits);
-            diagnostics::DiagnosticOutput(*amr_data->m_particle_container,
-                                          diagnostics::OutputType::PrintNonlinearLensInvariants,
-                                          diag_name);
-
             // print the initial values of reduced beam characteristics
             diagnostics::DiagnosticOutput(*amr_data->m_particle_container,
                                           diagnostics::OutputType::PrintReducedBeamCharacteristics,
@@ -303,12 +297,6 @@ namespace impactx {
             diagnostics::DiagnosticOutput(*amr_data->m_particle_container,
                                           diagnostics::OutputType::PrintRefParticle,
                                           "diags/ref_particle_final",
-                                          global_step);
-
-            // print the final values of the two invariants H and I
-            diagnostics::DiagnosticOutput(*amr_data->m_particle_container,
-                                          diagnostics::OutputType::PrintNonlinearLensInvariants,
-                                          "diags/nonlinear_lens_invariants_final",
                                           global_step);
 
             // print the final values of the reduced beam characteristics

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -382,6 +382,22 @@ namespace detail
             std::string openpmd_encoding{"g"};
             pp_element.queryAdd("encoding", openpmd_encoding);
 
+            // optional: add and calculate additional particle properties
+            // property: nonlinear lens invariants
+            bool add_nll_invariants = false;
+            pp_element.queryAdd("nonlinear_lens_invariants", add_nll_invariants);
+            if (add_nll_invariants)
+            {
+                amrex::ParticleReal alpha = 0.0;
+                pp_element.queryAdd("alpha", alpha);
+                amrex::ParticleReal beta = 1.0;
+                pp_element.queryAdd("beta", beta);
+                amrex::ParticleReal tn = 0.4;
+                pp_element.queryAdd("tn", tn);
+                amrex::ParticleReal cn = 0.01;
+                pp_element.queryAdd("cn", cn);
+            }
+
             m_lattice.emplace_back(diagnostics::BeamMonitor(openpmd_name, openpmd_backend, openpmd_encoding));
         } else if (element_type == "line")
         {

--- a/src/particles/diagnostics/DiagnosticOutput.cpp
+++ b/src/particles/diagnostics/DiagnosticOutput.cpp
@@ -40,9 +40,7 @@ namespace impactx::diagnostics
 
         // write file header per MPI RANK
         if (!append) {
-            if (otype == OutputType::PrintNonlinearLensInvariants) {
-                file_handler << "id H I\n";
-            } else if (otype == OutputType::PrintRefParticle) {
+            if (otype == OutputType::PrintRefParticle) {
                 file_handler << "step s x y z t px py pz pt\n";
             } else if (otype == OutputType::PrintReducedBeamCharacteristics) {
                 file_handler << "step" << " " << "s" << " " << "ref_beta_gamma" << " "

--- a/src/particles/diagnostics/NonlinearLensInvariants.H
+++ b/src/particles/diagnostics/NonlinearLensInvariants.H
@@ -18,6 +18,7 @@
 
 #include <cmath>
 
+
 namespace impactx::diagnostics
 {
     /** Compute invariants within the nonlinear magnetic insert element
@@ -74,17 +75,16 @@ namespace impactx::diagnostics
             amrex::ParticleReal const py
         ) const
         {
-
             using namespace amrex::literals; // for _rt and _prt
 
             // a complex type with two amrex::ParticleReal
             using Complex = amrex::GpuComplex<amrex::ParticleReal>;
 
             // convert transverse phase space coordinates to normalized units
-            amrex::ParticleReal const xn = x/(m_cn*sqrt(m_beta));
-            amrex::ParticleReal const yn = y/(m_cn*sqrt(m_beta));
-            amrex::ParticleReal const pxn = px*sqrt(m_beta)/m_cn + m_alpha*xn;
-            amrex::ParticleReal const pyn = py*sqrt(m_beta)/m_cn + m_alpha*yn;
+            amrex::ParticleReal const xn = x/(m_cn*std::sqrt(m_beta));
+            amrex::ParticleReal const yn = y/(m_cn*std::sqrt(m_beta));
+            amrex::ParticleReal const pxn = px*std::sqrt(m_beta)/m_cn + m_alpha*xn;
+            amrex::ParticleReal const pyn = py*std::sqrt(m_beta)/m_cn + m_alpha*yn;
 
             // assign complex position zeta = x + iy
             Complex const zeta(xn, yn);
@@ -115,9 +115,9 @@ namespace impactx::diagnostics
 
             // compute invariants H and I
             amrex::ParticleReal const Jz = xn*pyn - yn*pxn;
-            Hinv = (pow(xn,2) + pow(yn,2) + pow(pxn,2) + pow(pyn,2))/2
+            Hinv = (std::pow(xn,2) + std::pow(yn,2) + std::pow(pxn,2) + std::pow(pyn,2))/2
                  + m_tn*Hinv;
-            Iinv = pow(Jz,2) + pow(pxn,2) + pow(xn,2) + m_tn*Iinv;
+            Iinv = std::pow(Jz,2) + std::pow(pxn,2) + std::pow(xn,2) + m_tn*Iinv;
 
             return {Hinv, Iinv};
 
@@ -128,7 +128,6 @@ namespace impactx::diagnostics
         amrex::ParticleReal m_beta; //! Twiss beta (m)
         amrex::ParticleReal m_tn; //! dimensionless strength of the nonlinear insert
         amrex::ParticleReal m_cn; //! scale parameter of the nonlinear insert (m^[1/2])
-
     };
 
 } // namespace impactx

--- a/src/particles/elements/diagnostics/AdditionalProperties.cpp
+++ b/src/particles/elements/diagnostics/AdditionalProperties.cpp
@@ -1,0 +1,126 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "openPMD.H"
+#include "particles/diagnostics/NonlinearLensInvariants.H"
+#include "particles/ImpactXParticleContainer.H"
+
+#include <AMReX.H>
+#include <AMReX_BLProfiler.H>
+#include <AMReX_REAL.H>
+#include <AMReX_RealVect.H>
+#include <AMReX_ParmParse.H>
+
+#include <string>
+#include <utility>
+
+
+namespace impactx::diagnostics
+{
+    void
+    add_optional_properties (
+        std::string const & element_name,
+        ImpactXParticleContainer & pc
+    )
+    {
+        // Parse the diagnostic parameters
+        amrex::ParmParse pp_element(element_name);
+
+        bool enabled = false;
+        pp_element.queryAdd("nonlinear_lens_invariants", enabled);
+        if (!enabled)
+            return;
+
+        amrex::ParticleReal alpha = 0.0;
+        pp_element.queryAdd("alpha", alpha);
+
+        amrex::ParticleReal beta = 1.0;
+        pp_element.queryAdd("beta", beta);
+
+        amrex::ParticleReal tn = 0.4;
+        pp_element.queryAdd("tn", tn);
+
+        amrex::ParticleReal cn = 0.01;
+        pp_element.queryAdd("cn", cn);
+
+        NonlinearLensInvariants const nonlinear_lens_invariants(alpha, beta, tn, cn);
+
+        // profile time spent here
+        std::string profile_name = "impactx::Push::" + std::string(BeamMonitor::name) + "::add_optional_properties";
+        BL_PROFILE(profile_name);
+
+        // add runtime properties for H and I
+        bool comm = false;
+        if (!pc.HasRealComp("H")) {
+            pc.AddRealComp("H", comm);
+        }
+        const int soa_idx_H = pc.GetRealCompIndex("H");
+        if (!pc.HasRealComp("I")) {
+            pc.AddRealComp("I", comm);
+        }
+        const int soa_idx_I = pc.GetRealCompIndex("I");
+
+        // undocumented AMReX stuff that does not belong in user code
+        // can be removed after these are merged
+        //   https://github.com/AMReX-Codes/amrex/pull/3615
+        //   https://github.com/AMReX-Codes/amrex/pull/3861
+        for (int lev = 0; lev <= pc.finestLevel(); ++lev)
+        {
+            for (ImpactXParticleContainer::iterator pti(pc, lev); pti.isValid(); ++pti)
+            {
+                const int grid_id = pti.index();
+                const int tile_id = pti.LocalTileIndex();
+                pc.DefineAndReturnParticleTile(lev, grid_id, tile_id);
+                auto np = pti.numParticles();
+                if (np > 0) {
+                    auto& soa = pti.GetStructOfArrays();
+                    soa.resize(np);
+                }
+            }
+        }
+
+        // loop over refinement levels
+        int const nLevel = pc.finestLevel();
+        for (int lev = 0; lev <= nLevel; ++lev) {
+            // loop over all particle boxes
+            using ParIt = ImpactXParticleContainer::iterator;
+            for (ParIt pti(pc, lev); pti.isValid(); ++pti) {
+                const int np = pti.numParticles();
+
+                // preparing access to particle data: SoA of Reals
+                auto & soa = pti.GetStructOfArrays();
+                auto const * part_x = soa.GetRealData(RealSoA::x).data();
+                auto const * part_y = soa.GetRealData(RealSoA::y).data();
+                auto const * part_px = soa.GetRealData(RealSoA::px).data();
+                auto const * part_py = soa.GetRealData(RealSoA::py).data();
+
+                auto * part_H = soa.GetRealData(soa_idx_H).data();
+                auto * part_I = soa.GetRealData(soa_idx_I).data();
+
+                amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE (long i) {
+                    amrex::ParticleReal const x = part_x[i];
+                    amrex::ParticleReal const y = part_y[i];
+
+                    amrex::ParticleReal const px = part_px[i];
+                    amrex::ParticleReal const py = part_py[i];
+
+                    // calculate invariants of motion
+                    NonlinearLensInvariants::Data const HI_out =
+                        nonlinear_lens_invariants(x, y, px, py);
+
+                    // write particle invariant data
+                    part_H[i] = HI_out.H;
+                    part_I[i] = HI_out.I;
+                });
+            } // end loop over all particle boxes
+        } // end mesh-refinement level loop
+    }
+
+} // namespace impactx::diagnostics

--- a/src/particles/elements/diagnostics/CMakeLists.txt
+++ b/src/particles/elements/diagnostics/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(lib
   PRIVATE
+    AdditionalProperties.cpp
     openPMD.cpp
 )

--- a/src/particles/elements/diagnostics/openPMD.H
+++ b/src/particles/elements/diagnostics/openPMD.H
@@ -148,10 +148,10 @@ namespace detail
         finalize ();
 
     private:
-        std::string m_series_name; //! ...
-        std::string m_OpenPMDFileType; //! ...
-        std::any m_series; //! openPMD::Series; ...
-        int m_step = 0; //! ...
+        std::string m_series_name; //! openPMD filename
+        std::string m_OpenPMDFileType; //! openPMD backend: usually HDF5 (h5) or ADIOS2 (bp/bp4/bp5) or ADIOS2 SST (sst)
+        std::any m_series; //! openPMD::Series that holds potentially multiple outputs
+        int m_step = 0; //! global step for output
 
         int m_file_min_digits = 6; //! minimum number of digits to iteration number in file name
 
@@ -162,6 +162,17 @@ namespace detail
         std::vector<uint64_t> m_offset;
 
     };
+
+    /** Calculate additional particle properties.
+     *
+     * @param[in] element_name name of the element (for input queries)
+     * @param[inout] pc particle container
+     */
+    void
+    add_optional_properties (
+        std::string const & element_name,
+        ImpactXParticleContainer & pc
+    );
 
 } // namespace impactx::diagnostics
 

--- a/src/particles/elements/diagnostics/openPMD.cpp
+++ b/src/particles/elements/diagnostics/openPMD.cpp
@@ -307,12 +307,15 @@ namespace detail
         std::string profile_name = "impactx::Push::" + std::string(BeamMonitor::name);
         BL_PROFILE(profile_name);
 
+        // preparing to access reference particle data: RefPart
+        RefPart & ref_part = pc.GetRefParticle();
+
+        // optional: add and calculate additional particle properties
+        add_optional_properties(m_series_name, pc);
+
         // component names
         std::vector<std::string> real_soa_names = pc.RealSoA_names();
         std::vector<std::string> int_soa_names = pc.intSoA_names();
-
-        // preparing to access reference particle data: RefPart
-        RefPart & ref_part = pc.GetRefParticle();
 
         // pinned memory copy
         PinnedContainer pinned_pc = pc.make_alike<amrex::PinnedArenaAllocator>();

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -297,20 +297,6 @@ void init_ImpactX (py::module& m)
              "The minimum number of digits (default: 6) used for the step\n"
              "number appended to the diagnostic file names."
         )
-        .def("set_diag_iota_invariants",
-              [](ImpactX & /* ix */, amrex::ParticleReal alpha, amrex::ParticleReal beta, amrex::ParticleReal tn, amrex::ParticleReal cn) {
-                  amrex::ParmParse pp_diag("diag");
-
-                  pp_diag.add("alpha", alpha);
-                  pp_diag.add("beta", beta);
-                  pp_diag.add("tn", tn);
-                  pp_diag.add("cn", cn);
-              },
-              py::arg("alpha"), py::arg("beta"), py::arg("tn"), py::arg("cn"),
-              "Set the Twiss alpha, beta (m), dimensionless strength of the nonlinear insert and "
-              "scale parameter of the nonlinear insert (m^[1/2]) of the IOTA nonlinear lens "
-              "invariants diagnostics."
-        )
         .def_property("particle_lost_diagnostics_backend",
                       [](ImpactX & /* ix */) {
                           return detail::get_or_throw<std::string>("diag", "backend");


### PR DESCRIPTION
The calculation of the invariants of motion H and I for the nonlinear lens were still calculated in a slow, inefficient way using per-particle ASCII output.

This moves the calculation and output to the beam monitor, where it can be optionally enabled and has significantly more performant I/O throughput using openPMD.

- [x] update implementation
- [x] update AMReX: https://github.com/AMReX-Codes/amrex/pull/3861
- [x] update docs
- [x] update Python
- [x] update tests