### PR TITLE
Fix Python Init Order

### DIFF
--- a/cmake/dependencies/pyAMReX.cmake
+++ b/cmake/dependencies/pyAMReX.cmake
@@ -79,7 +79,7 @@ option(ImpactX_pyamrex_internal "Download & build pyAMReX" ON)
 set(ImpactX_pyamrex_repo "https://github.com/AMReX-Codes/pyamrex.git"
     CACHE STRING
     "Repository URI to pull and build pyamrex from if(ImpactX_pyamrex_internal)")
-set(ImpactX_pyamrex_branch "24.04"
+set(ImpactX_pyamrex_branch "00ffe7c0e2c37bd538e215b16e50396e58bd261c"
     CACHE STRING
     "Repository branch for ImpactX_pyamrex_repo if(ImpactX_pyamrex_internal)")
 

--- a/src/python/ImpactXParticleContainer.cpp
+++ b/src/python/ImpactXParticleContainer.cpp
@@ -55,11 +55,6 @@ void init_impactxparticlecontainer(py::module& m)
     >(m, "ImpactXParticleContainer")
         //.def(py::init<>())
 
-        .def_property_readonly_static("RealSoA",
-            [](py::object /* pc */){ return py::type::of<RealSoA>(); },
-            "RealSoA attribute name labels"
-        )
-
         .def_property_readonly("coord_system",
             &ImpactXParticleContainer::GetCoordSystem,
             "Get the current coordinate system of particles in this container"

--- a/src/python/pyImpactX.cpp
+++ b/src/python/pyImpactX.cpp
@@ -45,9 +45,9 @@ PYBIND11_MODULE(impactx_pybind, m) {
 
     // note: order from parent to child classes
     init_distribution(m);
-    init_elements(m);
     init_refparticle(m);
     init_impactxparticlecontainer(m);
+    init_elements(m);
     init_transformation(m);
     init_ImpactX(m);
 


### PR DESCRIPTION
Fixing exposed classes to Python: make sure everything returned is registered as a Python type (and in the right order). CI for this coming in the next PR: #578.