### PR TITLE
Fix macOS CI: DYLD Lib Path

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -82,6 +82,8 @@ jobs:
       run: |
         sudo cmake --build build --target install
 
+        export DYLD_LIBRARY_PATH=/usr/local/lib:${DYLD_LIBRARY_PATH}
+
         impactx.MPI.OMP.DP.OPMD examples/fodo/input_fodo.in algo.particle_shape = 1 || \
         { cat Backtrace.0.0; exit 1; }
         impactx.MPI.OMP.DP.OPMD examples/fodo/input_fodo.in algo.particle_shape = 2 || \


### PR DESCRIPTION
By default, `/usr/local/lib` should be in `DYLD_LIBRARY_PATH`, but somehow we suddenly got errors of the form
```
dyld[18636]: Library not loaded: @rpath/libamrex_3d.dylib
  Referenced from: <03D20F94-E6DD-3FA1-A198-5DDEE51D6D22> /usr/local/bin/impactx.MPI.OMP.DP.OPMD
  Reason: no LC_RPATH's found
/Users/runner/work/_temp/237ddb9c-4150-447e-96f7-89d33bd16a27.sh: line 4: 18636 Abort trap: 6           impactx.MPI.OMP.DP.OPMD examples/fodo/input_fodo.in algo.particle_shape = 1
```

Adding it manually now.