### PR TITLE
Amend Notices for Non-Endorsement

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,19 @@
+This Software was developed under funding from the U.S. Department
+of Energy and the U.S. Government consequently retains certain rights. As
+such, the U.S. Government has been granted for itself and others acting on
+its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the
+Software to reproduce, distribute copies to the public, prepare derivative
+works, and perform publicly and display publicly, and to permit other to do
+so.
+
+Reference herein to any specific commercial product, process, or service
+by trade name, trademark, manufacturer, or otherwise does not necessarily
+constitute or imply its endorsement, recommendation, or favoring by the
+United States Government, The Regents of the University of California, or
+Lawrence Berkeley National Laboratory.
+
+The views and opinions of authors expressed herein do not necessarily
+state or reflect those of the United States Government,
+The Regents of the University of California, or
+Lawrence Berkeley National Laboratory, and shall not be used for advertising
+or product endorsement purposes.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,6 @@ All rights reserved.
 
 If you have questions about your rights to use or distribute this software, please contact Berkeley Lab's Intellectual Property Office at IPO@lbl.gov.
 
-NOTICE. This Software was developed under funding from the U.S. Department of Energy and the U.S. Government consequently retains certain rights. As such, the U.S. Government has been granted for itself and others acting on its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software to reproduce, distribute copies to the public, prepare derivative works, and perform publicly and display publicly, and to permit others to do so.
-
-Please see the full license agreement in [LICENSE.txt](LICENSE.txt). The SPDX license identifier is `BSD-3-Clause-LBNL`.
+Please see the full license agreement in [LICENSE.txt](LICENSE.txt).  
+Please see the notices in [NOTICE.txt](NOTICE.txt).  
+The SPDX license identifier is `BSD-3-Clause-LBNL`.


### PR DESCRIPTION
Amend and move NOTICES to NOTICE.txt.

Appended Text:

Reference herein to any specific commercial product, process, or service by trade name, trademark, manufacturer, or otherwise does not necessarily constitute or imply its endorsement, recommendation, or favoring by the United States Government, The Regents of the University of California, or Lawrence Berkeley National Laboratory.

The views and opinions of authors expressed herein do not necessarily state or reflect those of the United States Government, The Regents of the University of California, or
Lawrence Berkeley National Laboratory, and shall not be used for advertising or product endorsement purposes.

See https://github.com/ECP-WarpX/WarpX/pull/4924