### PR TITLE
CMake: No Deprecation Warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,14 +16,18 @@ endif()
 
 # CMake policies ##############################################################
 #
+# Setting a cmake_policy to OLD is deprecated by definition and will raise a
+# verbose warning
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
+endif()
+
 # AMReX 21.06+ supports CUDA_ARCHITECTURES with CMake 3.20+
 # CMake 3.18+: CMAKE_CUDA_ARCHITECTURES
 # https://cmake.org/cmake/help/latest/policy/CMP0104.html
-#if(CMAKE_VERSION VERSION_LESS 3.20)
-    if(POLICY CMP0104)
-        cmake_policy(SET CMP0104 OLD)
-    endif()
-#endif()
+if(POLICY CMP0104)
+    cmake_policy(SET CMP0104 OLD)
+endif()
 
 
 # C++ Standard in Superbuilds #################################################


### PR DESCRIPTION
Setting a `cmake_policy` to `OLD` is deprecated by definition and will raise a verbose warning.