### PR TITLE
set num threads to avoid hanging

### DIFF
--- a/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
+++ b/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
@@ -94,10 +94,18 @@ def download_and_unzip(url, data_dir):
 data_url = "https://zenodo.org/records/10810754/files/models.zip?download=1"
 download_and_unzip(data_url, "models.zip")
 
+# it was found that the PyTorch multithreaded defaults interfere with MPI-enabled AMReX
+# when initializing the models
+# so we manually set the number of threads
+if Config.have_mpi:
+    n_threads = torch.get_num_threads()
+    torch.set_num_threads(1)
 model_list = [
     surrogate_model(f"models/beam_stage_{stage_i}_model.pt", device=device)
     for stage_i in range(N_stage)
 ]
+if Config.have_mpi:
+    torch.set_num_threads(n_threads)
 
 pp_amrex = amr.ParmParse("amrex")
 pp_amrex.add("the_arena_init_size", 0)

--- a/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
+++ b/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
@@ -94,9 +94,9 @@ def download_and_unzip(url, data_dir):
 data_url = "https://zenodo.org/records/10810754/files/models.zip?download=1"
 download_and_unzip(data_url, "models.zip")
 
-# it was found that the PyTorch multithreaded defaults interfere with MPI-enabled AMReX
-# when initializing the models
-# so we manually set the number of threads
+# It was found that the PyTorch multithreaded defaults interfere with MPI-enabled AMReX
+# when initializing the models: https://github.com/AMReX-Codes/pyamrex/issues/322
+# So we manually set the number of threads to serial (1).
 if Config.have_mpi:
     n_threads = torch.get_num_threads()
     torch.set_num_threads(1)


### PR DESCRIPTION
As documented in PyAMReX [issue 322](https://github.com/AMReX-Codes/pyamrex/issues/322), the multithreaded PyTorch defaults interfere with MPI-enabled AMReX and these sometimes result in programs that hang.  This PR updates the 15-LPA-stage surrogate model example to avoid this hanging.