### PR TITLE
Fix: LUMI-C OpenMP Python

### DIFF
--- a/docs/source/install/hpc/lumi-csc/install_cpu_dependencies.sh
+++ b/docs/source/install/hpc/lumi-csc/install_cpu_dependencies.sh
@@ -122,6 +122,6 @@ python3 -m pip install --upgrade matplotlib
 python3 -m pip install --upgrade yt
 # install or update ImpactX dependencies
 python3 -m pip install --upgrade -r ${SRC_DIR}/impactx/requirements.txt
-# ML & optimization
-python3 -m pip install --upgrade torch --index-url https://download.pytorch.org/whl/cpu
-python3 -m pip install --upgrade optimas[all]
+# ML & optimization (optional)
+#python3 -m pip install --upgrade torch --index-url https://download.pytorch.org/whl/cpu
+#python3 -m pip install --upgrade optimas[all]

--- a/docs/source/install/hpc/lumi-csc/lumi_cpu_impactx.profile.example
+++ b/docs/source/install/hpc/lumi-csc/lumi_cpu_impactx.profile.example
@@ -3,6 +3,7 @@
 
 # required dependencies
 module load LUMI/23.09  partition/C
+module load PrgEnv-aocc
 module load buildtools/23.09
 
 # optional: just an additional text editor


### PR DESCRIPTION
On LUMI-C, our Python modules showed an issue on OpenMP startup when using the default Cray compilers. Switching to the optimized AMD AOCC compiler (using the Cray compiler wrappers) solves the problem.

Also comments out the Python optimization library installs to save hard disk space (can be added when needed via pip at any time).

Follow-up to #626