### PR TITLE
Python: Uniform Naming for units->unit Arguments

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -290,14 +290,14 @@ Lattice Elements
 
             * ``<element_name>.ds`` (``float``, in meters) the segment length
             * ``<element_name>.k`` (``float``, in inverse meters squared OR in T/m) the quadrupole strength
-                = (magnetic field gradient in T/m) / (magnetic rigidity in T-m) - if units = 0
+                = (magnetic field gradient in T/m) / (magnetic rigidity in T-m) - if unit = 0
 
-             OR = magnetic field gradient in T/m - if units = 1
+             OR = magnetic field gradient in T/m - if unit = 1
 
               * k > 0 horizontal focusing
               * k < 0 horizontal defocusing
 
-            * ``<element_name>.units`` (``integer``) specification of units (default: ``0``)
+            * ``<element_name>.unit`` (``integer``) specification of units (default: ``0``)
             * ``<element_name>.dx`` (``float``, in meters) horizontal translation error
             * ``<element_name>.dy`` (``float``, in meters) vertical translation error
             * ``<element_name>.rotation`` (``float``, in degrees) rotation error in the transverse plane
@@ -324,11 +324,11 @@ Lattice Elements
 
             * ``<element_name>.ds`` (``float``, in meters) the segment length
             * ``<element_name>.k`` (``float``, in inverse meters squared OR in T/m) the plasma lens focusing strength
-                = (azimuthal magnetic field gradient in T/m) / (magnetic rigidity in T-m) - if units = 0
+                = (azimuthal magnetic field gradient in T/m) / (magnetic rigidity in T-m) - if unit = 0
 
-             OR = azimuthal magnetic field gradient in T/m - if units = 1
+             OR = azimuthal magnetic field gradient in T/m - if unit = 1
 
-            * ``<element_name>.units`` (``integer``) specification of units (default: ``0``)
+            * ``<element_name>.unit`` (``integer``) specification of units (default: ``0``)
             * ``<element_name>.dx`` (``float``, in meters) horizontal translation error
             * ``<element_name>.dy`` (``float``, in meters) vertical translation error
             * ``<element_name>.rotation`` (``float``, in degrees) rotation error in the transverse plane
@@ -370,15 +370,15 @@ Lattice Elements
 
             * ``<element_name>.ds`` (``float``, in meters) the segment length
             * ``<element_name>.bscale`` (``float``, in inverse meters) Scaling factor for on-axis longitudinal magnetic field
-                = (magnetic field Bz in T) / (magnetic rigidity in T-m) - if units = 0
+                = (magnetic field Bz in T) / (magnetic rigidity in T-m) - if unit = 0
 
-             OR = magnetic field Bz in T - if units = 1
+             OR = magnetic field Bz in T - if unit = 1
 
             * ``<element_name>.cos_coefficients`` (array of ``float``) cos coefficients in Fourier expansion of the on-axis magnetic field Bz
               (optional); default is a thin-shell model from `DOI:10.1016/J.NIMA.2022.166706 <https://doi.org/10.1016/j.nima.2022.166706>`__
             * ``<element_name>.sin_coefficients`` (array of ``float``) sin coefficients in Fourier expansion of the on-axis magnetic field Bz
               (optional); default is a thin-shell model from `DOI:10.1016/J.NIMA.2022.166706 <https://doi.org/10.1016/j.nima.2022.166706>`__
-            * ``<element_name>.units`` (``integer``) specification of units (default: ``0``)
+            * ``<element_name>.unit`` (``integer``) specification of units (default: ``0``)
             * ``<element_name>.dx`` (``float``, in meters) horizontal translation error
             * ``<element_name>.dy`` (``float``, in meters) vertical translation error
             * ``<element_name>.rotation`` (``float``, in degrees) rotation error in the transverse plane
@@ -497,7 +497,7 @@ Lattice Elements
 
             * ``<element_name>.xkick`` (``float``, dimensionless OR in T-m) the horizontal kick strength
             * ``<element_name>.ykick`` (``float``, dimensionless OR in T-m) the vertical kick strength
-            * ``<element_name>.units`` (``string``) specification of units: ``dimensionless`` (default, in units of the magnetic rigidity of the reference particle) or ``T-m``
+            * ``<element_name>.unit`` (``string``) specification of units: ``dimensionless`` (default, in units of the magnetic rigidity of the reference particle) or ``T-m``
             * ``<element_name>.dx`` (``float``, in meters) horizontal translation error
             * ``<element_name>.dy`` (``float``, in meters) vertical translation error
             * ``<element_name>.rotation`` (``float``, in degrees) rotation error in the transverse plane
@@ -532,11 +532,11 @@ Lattice Elements
           This requires these additional parameters:
 
             * ``<element_name>.k`` (``float``, in inverse meters OR in T) the integrated plasma lens focusing strength
-                = (length in m) * (magnetic field gradient :math:`g` in T/m) / (magnetic rigidity in T-m) - if units = 0
+                = (length in m) * (magnetic field gradient :math:`g` in T/m) / (magnetic rigidity in T-m) - if unit = 0
 
-             OR = (length in m) * (magnetic field gradient :math:`g` in T/m) - if units = 1
+             OR = (length in m) * (magnetic field gradient :math:`g` in T/m) - if unit = 1
 
-            * ``<element_name>.units`` (``integer``) specification of units (default: ``0``)
+            * ``<element_name>.unit`` (``integer``) specification of units (default: ``0``)
             * ``<element_name>.taper`` (``float``, in 1/meters) horizontal taper parameter
                 = 1 / (target horizontal dispersion :math:`D_x` in m)
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -539,13 +539,13 @@ This module provides elements for the accelerator lattice.
    :param rotation: rotation error in the transverse plane [degrees]
    :param nslice: number of slices used for the application of space charge
 
-.. py:class:: impactx.elements.Kicker(xkick, ykick, units="dimensionless", dx=0, dy=0, rotation=0)
+.. py:class:: impactx.elements.Kicker(xkick, ykick, unit="dimensionless", dx=0, dy=0, rotation=0)
 
    A thin transverse kicker.
 
    :param xkick: horizontal kick strength (dimensionless OR T-m)
    :param ykick: vertical kick strength (dimensionless OR T-m)
-   :param units: specification of units (``"dimensionless"`` in units of the magnetic rigidity of the reference particle or ``"T-m"``)
+   :param unit: specification of units (``"dimensionless"`` in units of the magnetic rigidity of the reference particle or ``"T-m"``)
 
 .. py:class:: impactx.elements.Multipole(multipole, K_normal, K_skew, dx=0, dy=0, rotation=0)
 
@@ -675,19 +675,19 @@ This module provides elements for the accelerator lattice.
    :param rotation: rotation error in the transverse plane [degrees]
    :param nslice: number of slices used for the application of space charge
 
-.. py:class:: impactx.elements.ChrQuad(ds, k, units=0, dx=0, dy=0, rotation=0, nslice=1)
+.. py:class:: impactx.elements.ChrQuad(ds, k, unit=0, dx=0, dy=0, rotation=0, nslice=1)
 
    A Quadrupole magnet, with chromatic effects included.  The Hamiltonian is expanded
    through second order in the transverse variables (x,px,y,py), with the exact pt
    dependence retained.
 
    :param ds: Segment length in m.
-   :param k:  Quadrupole strength in m^(-2) (MADX convention, if units = 0)
+   :param k:  Quadrupole strength in m^(-2) (MADX convention, if unit = 0)
               = (gradient in T/m) / (rigidity in T-m)
-          OR  Quadrupole strength in T/m (MaryLie convention, if units = 1)
+          OR  Quadrupole strength in T/m (MaryLie convention, if unit = 1)
               k > 0 horizontal focusing
               k < 0 horizontal defocusing
-   :param units: specification of units for quadrupole field strength
+   :param unit: specification of units for quadrupole field strength
    :param dx: horizontal translation error in m
    :param dy: vertical translation error in m
    :param rotation: rotation error in the transverse plane [degrees]
@@ -697,21 +697,21 @@ This module provides elements for the accelerator lattice.
 
       quadrupole strength in 1/m^2 (or T/m)
 
-   .. py:property:: units
+   .. py:property:: unit
 
       unit specification for quad strength
 
-.. py:class:: impactx.elements.ChrPlasmaLens(ds, k, units=0, dx=0, dy=0, rotation=0, nslice=1)
+.. py:class:: impactx.elements.ChrPlasmaLens(ds, k, unit=0, dx=0, dy=0, rotation=0, nslice=1)
 
    An active cylindrically symmetric plasma lens, with chromatic effects included.
    The Hamiltonian is expanded through second order in the transverse variables
    (x,px,y,py), with the exact pt dependence retained.
 
    :param ds: Segment length in m.
-   :param k:  focusing strength in m^(-2) (if units = 0)
+   :param k:  focusing strength in m^(-2) (if unit = 0)
               = (azimuthal magnetic field gradient in T/m) / (rigidity in T-m)
-          OR  azimuthal magnetic field gradient in T/m (if units = 1)
-   :param units: specification of units for plasma lens focusing strength
+          OR  azimuthal magnetic field gradient in T/m (if unit = 1)
+   :param unit: specification of units for plasma lens focusing strength
    :param dx: horizontal translation error in m
    :param dy: vertical translation error in m
    :param rotation: rotation error in the transverse plane [degrees]
@@ -721,7 +721,7 @@ This module provides elements for the accelerator lattice.
 
       plasma lens focusing strength in 1/m^2 (or T/m)
 
-   .. py:property:: units
+   .. py:property:: unit
 
       unit specification for plasma lens focusing strength
 
@@ -908,7 +908,7 @@ This module provides elements for the accelerator lattice.
 
    * G. Ripken and F. Schmidt, Thin-Lens Formalism for Tracking, CERN/SL/95-12 (AP), 1995.
 
-.. py:class:: impactx.elements.TaperedPL(k, taper, units=0, dx=0, dy=0, rotation=0)
+.. py:class:: impactx.elements.TaperedPL(k, taper, unit=0, dx=0, dy=0, rotation=0)
 
    A thin nonlinear plasma lens with transverse (horizontal) taper
 
@@ -918,13 +918,13 @@ This module provides elements for the accelerator lattice.
 
    where :math:`g` is the (linear) field gradient in T/m and :math:`D_x` is the targeted horizontal dispersion in m.
 
-   :param k:  integrated focusing strength in m^(-1) (if units = 0)
+   :param k:  integrated focusing strength in m^(-1) (if unit = 0)
               = (length in m) * (magnetic field gradient :math:`g` in T/m) / (magnetic rigidity in T-m)
-          OR  integrated focusing strength in T (if units = 1)
+          OR  integrated focusing strength in T (if unit = 1)
               = (length in m) * (magnetic field gradient :math:`g` in T/m)
    :param taper: horizontal taper parameter in m^(-1)
               = 1 / (target horizontal dispersion :math:`D_x` in m)
-   :param units: specification of units for plasma lens focusing strength
+   :param unit: specification of units for plasma lens focusing strength
    :param dx: horizontal translation error in m
    :param dy: vertical translation error in m
    :param rotation: rotation error in the transverse plane [degrees]
@@ -937,7 +937,7 @@ This module provides elements for the accelerator lattice.
 
       horizontal taper parameter in 1/m
 
-   .. py:property:: units
+   .. py:property:: unit
 
       unit specification for plasma lens focusing strength
 

--- a/examples/achromatic_spectrometer/run_spectrometer.py
+++ b/examples/achromatic_spectrometer/run_spectrometer.py
@@ -63,7 +63,7 @@ dr = elements.Drift(ds=ds_half, nslice=ns)
 # define the lens segments
 thick_lens = []
 for _ in range(0, num_lenses):
-    pl = elements.TaperedPL(k=dk, taper=dtaper, units=0)
+    pl = elements.TaperedPL(k=dk, taper=dtaper, unit=0)
     segment = [dr, pl, dr]
     thick_lens.extend(segment)
 

--- a/examples/apochromatic/run_apochromatic_pl.py
+++ b/examples/apochromatic/run_apochromatic_pl.py
@@ -55,34 +55,34 @@ dr2 = elements.ChrDrift(ds=2.0, nslice=ns)
 
 # Plasma lens elements
 q1 = elements.ChrPlasmaLens(
-    ds=0.331817852986604588, k=996.147787384348956, units=1, nslice=ns
+    ds=0.331817852986604588, k=996.147787384348956, unit=1, nslice=ns
 )
 q2 = elements.ChrPlasmaLens(
-    ds=0.176038957633108457, k=528.485181135649785, units=1, nslice=ns
+    ds=0.176038957633108457, k=528.485181135649785, unit=1, nslice=ns
 )
 q3 = elements.ChrPlasmaLens(
-    ds=1.041842576046930486, k=3127.707468391874166, units=1, nslice=ns
+    ds=1.041842576046930486, k=3127.707468391874166, unit=1, nslice=ns
 )
 q4 = elements.ChrPlasmaLens(
-    ds=0.334367090894399520, k=501.900417308233112, units=1, nslice=ns
+    ds=0.334367090894399520, k=501.900417308233112, unit=1, nslice=ns
 )
 q5 = elements.ChrPlasmaLens(
-    ds=1.041842576046930486, k=3127.707468391874166, units=1, nslice=ns
+    ds=1.041842576046930486, k=3127.707468391874166, unit=1, nslice=ns
 )
 q6 = elements.ChrPlasmaLens(
-    ds=0.176038957633108457, k=528.485181135649785, units=1, nslice=ns
+    ds=0.176038957633108457, k=528.485181135649785, unit=1, nslice=ns
 )
 q7 = elements.ChrPlasmaLens(
-    ds=0.331817852986604588, k=996.147787384348956, units=1, nslice=ns
+    ds=0.331817852986604588, k=996.147787384348956, unit=1, nslice=ns
 )
 
-# q1 = elements.ChrPlasmaLens(ds=0.331817852986604588, k=2.98636067687944129, units=0, nslice=ns)
-# q2 = elements.ChrPlasmaLens(ds=0.176038957633108457, k=1.584350618697976110, units=0, nslice=ns)
-# q3 = elements.ChrPlasmaLens(ds=1.041842576046930486, k=9.37658318442237437, units=0, nslice=ns)
-# q4 = elements.ChrPlasmaLens(ds=0.334367090894399520, k=1.50465190902479784, units=0, nslice=ns)
-# q5 = elements.ChrPlasmaLens(ds=1.041842576046930486, k=9.37658318442237437, units=0, nslice=ns)
-# q6 = elements.ChrPlasmaLens(ds=0.176038957633108457, k=1.584350618697976110, units=0, nslice=ns)
-# q7 = elements.ChrPlasmaLens(ds=0.331817852986604588, k=2.98636067687944129, units=0, nslice=ns)
+# q1 = elements.ChrPlasmaLens(ds=0.331817852986604588, k=2.98636067687944129, unit=0, nslice=ns)
+# q2 = elements.ChrPlasmaLens(ds=0.176038957633108457, k=1.584350618697976110, unit=0, nslice=ns)
+# q3 = elements.ChrPlasmaLens(ds=1.041842576046930486, k=9.37658318442237437, unit=0, nslice=ns)
+# q4 = elements.ChrPlasmaLens(ds=0.334367090894399520, k=1.50465190902479784, unit=0, nslice=ns)
+# q5 = elements.ChrPlasmaLens(ds=1.041842576046930486, k=9.37658318442237437, unit=0, nslice=ns)
+# q6 = elements.ChrPlasmaLens(ds=0.176038957633108457, k=1.584350618697976110, unit=0, nslice=ns)
+# q7 = elements.ChrPlasmaLens(ds=0.331817852986604588, k=2.98636067687944129, unit=0, nslice=ns)
 
 lattice_line = [
     monitor,

--- a/examples/kicker/run_kicker.py
+++ b/examples/kicker/run_kicker.py
@@ -46,8 +46,8 @@ monitor = elements.BeamMonitor("monitor", backend="h5")
 # design the accelerator lattice
 kicklattice = [
     monitor,
-    elements.Kicker(xkick=2.0e-3, ykick=0.0, units="dimensionless"),
-    elements.Kicker(xkick=0.0, ykick=3.0e-3, units="dimensionless"),
+    elements.Kicker(xkick=2.0e-3, ykick=0.0, unit="dimensionless"),
+    elements.Kicker(xkick=0.0, ykick=3.0e-3, unit="dimensionless"),
     monitor,
 ]
 # assign a lattice

--- a/examples/positron_channel/run_positron.py
+++ b/examples/positron_channel/run_positron.py
@@ -50,11 +50,11 @@ monitor = elements.BeamMonitor("monitor", backend="h5")
 ns = 1  # number of slices per ds in the element
 period = [
     monitor,
-    elements.ChrQuad(ds=0.1, k=-6.674941, units=1, nslice=ns),
+    elements.ChrQuad(ds=0.1, k=-6.674941, unit=1, nslice=ns),
     elements.ChrDrift(ds=0.3, nslice=ns),
-    elements.ChrQuad(ds=0.2, k=6.674941, units=1, nslice=ns),
+    elements.ChrQuad(ds=0.2, k=6.674941, unit=1, nslice=ns),
     elements.ChrDrift(ds=0.3, nslice=ns),
-    elements.ChrQuad(ds=0.1, k=-6.674941, units=1, nslice=ns),
+    elements.ChrQuad(ds=0.1, k=-6.674941, unit=1, nslice=ns),
     elements.ChrDrift(ds=0.1, nslice=ns),
     elements.ChrAcc(ds=1.8, ez=10871.950994502130424, bz=1.0e-12, nslice=ns),
     elements.ChrDrift(ds=0.1, nslice=ns),

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -313,7 +313,7 @@ void init_elements(py::module& m)
              >(),
              py::arg("ds"),
              py::arg("k"),
-             py::arg("units") = 0,
+             py::arg("unit") = 0,
              py::arg("dx") = 0,
              py::arg("dy") = 0,
              py::arg("rotation") = 0,
@@ -325,7 +325,7 @@ void init_elements(py::module& m)
             [](ChrQuad & cq, amrex::ParticleReal k) { cq.m_k = k; },
             "quadrupole strength in 1/m^2 (or T/m)"
         )
-        .def_property("units",
+        .def_property("unit",
             [](ChrQuad & cq) { return cq.m_unit; },
             [](ChrQuad & cq, int unit) { cq.m_unit = unit; },
             "unit specification for quad strength"
@@ -356,7 +356,7 @@ void init_elements(py::module& m)
              >(),
              py::arg("ds"),
              py::arg("k"),
-             py::arg("units") = 0,
+             py::arg("unit") = 0,
              py::arg("dx") = 0,
              py::arg("dy") = 0,
              py::arg("rotation") = 0,
@@ -368,7 +368,7 @@ void init_elements(py::module& m)
             [](ChrQuad & cq, amrex::ParticleReal k) { cq.m_k = k; },
             "focusing strength in 1/m^2 (or T/m)"
         )
-        .def_property("units",
+        .def_property("unit",
             [](ChrQuad & cq) { return cq.m_unit; },
             [](ChrQuad & cq, int unit) { cq.m_unit = unit; },
             "unit specification for focusing strength"
@@ -646,27 +646,27 @@ void init_elements(py::module& m)
         .def(py::init([](
                 amrex::ParticleReal xkick,
                 amrex::ParticleReal ykick,
-                std::string const & units,
+                std::string const & unit,
                 amrex::ParticleReal dx,
                 amrex::ParticleReal dy,
                 amrex::ParticleReal rotation_degree
              )
              {
-                 if (units != "dimensionless" && units != "T-m")
-                     throw std::runtime_error(R"(units must be "dimensionless" or "T-m")");
+                 if (unit != "dimensionless" && unit != "T-m")
+                     throw std::runtime_error(R"(unit must be "dimensionless" or "T-m")");
 
-                 Kicker::UnitSystem const u = units == "dimensionless" ?
+                 Kicker::UnitSystem const u = unit == "dimensionless" ?
                                             Kicker::UnitSystem::dimensionless :
                                             Kicker::UnitSystem::Tm;
                  return new Kicker(xkick, ykick, u, dx, dy, rotation_degree);
              }),
              py::arg("xkick"),
              py::arg("ykick"),
-             py::arg("units") = "dimensionless",
+             py::arg("unit") = "dimensionless",
              py::arg("dx") = 0,
              py::arg("dy") = 0,
              py::arg("rotation") = 0,
-             R"(A thin transverse kicker element. Kicks are for units "dimensionless" or in "T-m".)"
+             R"(A thin transverse kicker element. Kicks are for unit "dimensionless" or in "T-m".)"
         )
         .def_property("xkick",
             [](Kicker & kicker) { return kicker.m_xkick; },
@@ -678,7 +678,7 @@ void init_elements(py::module& m)
             [](Kicker & kicker, amrex::ParticleReal ykick) { kicker.m_ykick = ykick; },
             "vertical kick strength (dimensionless OR T-m)"
         )
-        // TODO units
+        // TODO unit
     ;
     register_beamoptics_push(py_Kicker);
 
@@ -1341,7 +1341,7 @@ void init_elements(py::module& m)
              >(),
              py::arg("k"),
              py::arg("taper"),
-             py::arg("units") = 0,
+             py::arg("unit") = 0,
              py::arg("dx") = 0,
              py::arg("dy") = 0,
              py::arg("rotation") = 0,
@@ -1357,14 +1357,14 @@ void init_elements(py::module& m)
         .def_property("k",
             [](TaperedPL & taperedpl) { return taperedpl.m_k; },
             [](TaperedPL & taperedpl, amrex::ParticleReal k) { taperedpl.m_k = k; },
-            "integrated focusing strength in m^(-1) (if units = 0) or integrated focusing strength in T (if units = 1)"
+            "integrated focusing strength in m^(-1) (if unit = 0) or integrated focusing strength in T (if unit = 1)"
         )
         .def_property("taper",
             [](TaperedPL & taperedpl) { return taperedpl.m_taper; },
             [](TaperedPL & taperedpl, amrex::ParticleReal taper) { taperedpl.m_taper = taper; },
             "horizontal taper parameter in m^(-1) = 1 / (target horizontal dispersion in m)"
         )
-        .def_property("units",
+        .def_property("unit",
             [](TaperedPL & taperedpl) { return taperedpl.m_unit; },
             [](TaperedPL & taperedpl, int unit) { taperedpl.m_unit = unit; },
             "specification of units for plasma lens focusing strength"


### PR DESCRIPTION
Uniform naming convention for units variables, as suggested in #647.