### PR TITLE
CI: Ruff replaced Tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,35 +63,6 @@ repos:
 # C++ formatting
 # clang-format
 
-# Autoremoves unused Python imports
-- repo: https://github.com/hadialqattan/pycln
-  rev: v2.4.0
-  hooks:
-  - id: pycln
-    name: pycln (python)
-
-# Sorts Python imports according to PEP8
-# https://www.python.org/dev/peps/pep-0008/#imports
-- repo: https://github.com/pycqa/isort
-  rev: 5.13.2
-  hooks:
-  - id: isort
-    name: isort (python)
-    args: ["--profile", "black", "--filter-files"]
-
-# Python Formatting
-- repo: https://github.com/psf/black
-  rev: 24.8.0 # Keep in sync with blacken-docs
-  hooks:
-  - id: black
-- repo: https://github.com/asottile/blacken-docs
-  rev: 1.18.0
-  hooks:
-  - id: blacken-docs
-    additional_dependencies:
-    - black==24.8.0 # keep in sync with black hook
-  # TODO: black-jupyter
-
 # Python: Ruff linter
 #   https://docs.astral.sh/ruff/
 - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -100,17 +71,6 @@ repos:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
       types_or: [python, jupyter]
-
-# Python: Flake8 (checks only, does this support auto-fixes?)
-#- repo: https://github.com/PyCQA/flake8
-#  rev: 4.0.1
-#  hooks:
-#  - id: flake8
-#    additional_dependencies: &flake8_dependencies
-#      - flake8-bugbear
-#      - pep8-naming
-#    exclude: ^(docs/.*|tools/.*)$
-# Alternatively: use autopep8?
 
 # Jupyter Notebooks: clean up all cell outputs
 - repo: https://github.com/roy-ht/pre-commit-jupyter


### PR DESCRIPTION
https://docs.astral.sh/ruff/ replaces a lot of linter and formatter tools, remove duplication for stability and less noise.