### PR TITLE
`setup.py`: More Unique `build_base`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class CopyPreBuild(build):
         # clashes with directories many developers have in their source trees;
         # this can create confusing results with "pip install .", which clones
         # the whole source tree by default
-        self.build_base = "_tmppythonbuild"
+        self.build_base = os.path.join("_tmppythonbuild", "impactx")
 
     def run(self):
         # remove existing build directory


### PR DESCRIPTION
This likely can race in superbuilds of dependent projects.

X-ref https://github.com/AMReX-Codes/pyamrex/pull/355