### PR TITLE
Ruff: Run on pyi files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,6 @@ repos:
     # Run the linter
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
-      types_or: [python, jupyter]
     # Run the formatter
     - id: ruff-format
 

--- a/src/python/impactx/MADXParser.pyi
+++ b/src/python/impactx/MADXParser.pyi
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os as os
 import re as re
 import warnings as warnings

--- a/src/python/impactx/__init__.pyi
+++ b/src/python/impactx/__init__.pyi
@@ -13,29 +13,30 @@ impactx_pybind
 """
 
 from __future__ import annotations
+
+import os as os
+
 from amrex import space3d as amr
 from impactx.extensions.ImpactXParIter import register_ImpactXParIter_extension
 from impactx.extensions.ImpactXParticleContainer import (
     register_ImpactXParticleContainer_extension,
 )
-from impactx.impactx_pybind import Config
-from impactx.impactx_pybind import CoordSystem
-from impactx.impactx_pybind import ImpactX
-from impactx.impactx_pybind import ImpactXParConstIter
-from impactx.impactx_pybind import ImpactXParIter
-from impactx.impactx_pybind import ImpactXParticleContainer
-from impactx.impactx_pybind import RefPart
-from impactx.impactx_pybind import coordinate_transformation
-from impactx.impactx_pybind import distribution
-from impactx.impactx_pybind import elements
-from impactx.impactx_pybind import push
-from impactx.madx_to_impactx import read_beam
-from impactx.madx_to_impactx import read_lattice
-import os as os
-from . import MADXParser
-from . import extensions
-from . import impactx_pybind
-from . import madx_to_impactx
+from impactx.impactx_pybind import (
+    Config,
+    CoordSystem,
+    ImpactX,
+    ImpactXParConstIter,
+    ImpactXParIter,
+    ImpactXParticleContainer,
+    RefPart,
+    coordinate_transformation,
+    distribution,
+    elements,
+    push,
+)
+from impactx.madx_to_impactx import read_beam, read_lattice
+
+from . import MADXParser, extensions, impactx_pybind, madx_to_impactx
 
 __all__ = [
     "Config",

--- a/src/python/impactx/extensions/__init__.pyi
+++ b/src/python/impactx/extensions/__init__.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from . import ImpactXParIter
-from . import ImpactXParticleContainer
+
+from . import ImpactXParIter, ImpactXParticleContainer
 
 __all__ = ["ImpactXParIter", "ImpactXParticleContainer"]

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -13,12 +13,15 @@ impactx_pybind
 """
 
 from __future__ import annotations
-from amrex import space3d as amr
-import amrex.space3d.amrex_3d_pybind
-import pybind11_stubgen.typing_ext
+
 import typing
-from . import distribution
-from . import elements
+
+import pybind11_stubgen.typing_ext
+
+import amrex.space3d.amrex_3d_pybind
+from amrex import space3d as amr
+
+from . import distribution, elements
 
 __all__ = [
     "Config",

--- a/src/python/impactx/impactx_pybind/elements.pyi
+++ b/src/python/impactx/impactx_pybind/elements.pyi
@@ -3,8 +3,10 @@ Accelerator lattice elements in ImpactX
 """
 
 from __future__ import annotations
-import impactx.impactx_pybind
+
 import typing
+
+import impactx.impactx_pybind
 
 __all__ = [
     "Alignment",

--- a/src/python/impactx/madx_to_impactx.pyi
+++ b/src/python/impactx/madx_to_impactx.pyi
@@ -1,10 +1,11 @@
 from __future__ import annotations
-from impactx.MADXParser import MADXParser
-import impactx.impactx_pybind
-from impactx.impactx_pybind import RefPart
-from impactx.impactx_pybind import elements
+
 import typing
 import warnings as warnings
+
+import impactx.impactx_pybind
+from impactx.impactx_pybind import RefPart, elements
+from impactx.MADXParser import MADXParser
 
 __all__ = [
     "MADXParser",


### PR DESCRIPTION
Ensure ruff is actually run on .pyi files.
They have a separate type pyi but we can just use the defaults, too.

Follow-up to #671 