### PR TITLE
Modify qm_qeeV name and docs.

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -354,9 +354,9 @@ Particles
 
       Read-only: Get reference particle :math:`\beta \cdot \gamma`
 
-   .. py:property:: qm_qeeV
+   .. py:property:: qm_ratio_SI
 
-      Read-only: Get reference particle charge to mass ratio (elementary charge/eV)
+      Read-only: Get reference particle charge to mass ratio (C/kg)
 
    .. py:method:: set_charge_qe(charge_qe)
 

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -106,7 +106,7 @@ namespace impactx
         }, distr);
 
         amr_data->m_particle_container->AddNParticles(x, y, t, px, py, pt,
-                                                      ref.qm_qeeV(),
+                                                      ref.qm_ratio_SI(),
                                             bunch_charge * rel_part_this_proc);
 
         bool space_charge = false;

--- a/src/particles/ReferenceParticle.H
+++ b/src/particles/ReferenceParticle.H
@@ -208,11 +208,11 @@ namespace impactx
 
         /** Get reference particle charge to mass ratio
          *
-         * @returns charge to mass ratio (elementary charge/eV)
+         * @returns charge to mass ratio (in SI units of C/kg)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         amrex::ParticleReal
-        qm_qeeV () const
+        qm_ratio_SI () const
         {
             return charge / mass;
         }

--- a/src/python/ReferenceParticle.cpp
+++ b/src/python/ReferenceParticle.cpp
@@ -38,7 +38,7 @@ void init_refparticle(py::module& m)
         .def_property_readonly("mass_MeV", &RefPart::mass_MeV, "Get reference particle rest mass (MeV/c^2)")
         .def_property_readonly("kin_energy_MeV", &RefPart::kin_energy_MeV, "Get reference particle energy (MeV)")
         .def_property_readonly("rigidity_Tm", &RefPart::rigidity_Tm, "Get reference particle magnetic rigidity Brho (T*m)")
-        .def_property_readonly("qm_qeeV", &RefPart::qm_qeeV, "Get reference particle charge to mass ratio (charge/eV)")
+        .def_property_readonly("qm_ratio_SI", &RefPart::qm_ratio_SI, "Get reference particle charge to mass ratio (C/kg)")
 
         .def("set_charge_qe", &RefPart::set_charge_qe,
              py::return_value_policy::reference_internal,

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -599,9 +599,9 @@ class RefPart:
     @pz.setter
     def pz(self, arg0: float) -> None: ...
     @property
-    def qm_qeeV(self) -> float:
+    def qm_ratio_SI(self) -> float:
         """
-        Get reference particle charge to mass ratio (charge/eV)
+        Get reference particle charge to mass ratio (C/kg)
         """
     @property
     def rigidity_Tm(self) -> float:


### PR DESCRIPTION
Modified all occurrences of the charge-to-mass ratio name `qm_qeeV` to the name `qm_ratio_SI` to correctly reflect content.  Documentation in docs/source/usage/python.rst is also updated. 

Close #656.

Follow-up:  verify documentation of particle parameter qm units in  `add_n_particles(x, y, t, px, py, pt, qm, bchchg)`
in docs/source/usage/python.rst.