### PR TITLE
CMake: Replace `FetchContent_Populate`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.24.0)
 project(ImpactX VERSION 24.08)
 
 include(${ImpactX_SOURCE_DIR}/cmake/ImpactXFunctions.cmake)

--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -100,29 +100,20 @@ macro(find_ablastr)
             #       or AMReX_DIR or AMReX_MODULE_PATH that we could use for the named path instead
             list(APPEND CMAKE_MODULE_PATH "${FETCHCONTENT_BASE_DIR}/fetchedamrex-src/Tools/CMake")
         else()
+            if(ImpactX_COMPUTE STREQUAL CUDA)
+                enable_language(CUDA)
+                # ABLASTR 21.06+ supports CUDA_ARCHITECTURES
+                #if(CMAKE_VERSION VERSION_LESS 3.20)
+                #    include(ABLASTR_SetupCUDA)
+                #endif()
+            endif()
             FetchContent_Declare(fetchedablastr
                 GIT_REPOSITORY ${ImpactX_ablastr_repo}
                 GIT_TAG        ${ImpactX_ablastr_branch}
                 BUILD_IN_SOURCE 0
             )
-            FetchContent_GetProperties(fetchedablastr)
-
-            if(NOT fetchedablastr_POPULATED)
-                FetchContent_Populate(fetchedablastr)
-                #list(APPEND CMAKE_MODULE_PATH "${fetchedamrex_SOURCE_DIR}/Tools/CMake")
-                if(ImpactX_COMPUTE STREQUAL CUDA)
-                    enable_language(CUDA)
-                    # ABLASTR 21.06+ supports CUDA_ARCHITECTURES
-                    #if(CMAKE_VERSION VERSION_LESS 3.20)
-                    #    include(ABLASTR_SetupCUDA)
-                    #endif()
-                endif()
-                add_subdirectory(${fetchedablastr_SOURCE_DIR} ${fetchedablastr_BINARY_DIR})
-                # TODO: this is a bit hacky, check if we find a variable like
-                #       fetchedamrex_SOURCE_DIR or FETCHCONTENT_SOURCE_DIR_FETCHEDAMREX
-                #       or AMReX_DIR or AMReX_MODULE_PATH that we could use for the named path instead
-                list(APPEND CMAKE_MODULE_PATH "${FETCHCONTENT_BASE_DIR}/fetchedamrex-src/Tools/CMake")
-            endif()
+            FetchContent_MakeAvailable(fetchedablastr)
+            list(APPEND CMAKE_MODULE_PATH "${FETCHCONTENT_BASE_DIR}/fetchedamrex-src/Tools/CMake")
 
             # advanced fetch options
             mark_as_advanced(FETCHCONTENT_BASE_DIR)

--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -89,10 +89,6 @@ macro(find_ablastr)
             #list(APPEND CMAKE_MODULE_PATH "${WarpX_amrex_src}/Tools/CMake")
             if(ImpactX_COMPUTE STREQUAL CUDA)
                 enable_language(CUDA)
-                # AMReX 21.06+ supports CUDA_ARCHITECTURES
-                #if(CMAKE_VERSION VERSION_LESS 3.20)
-                #    include(AMReX_SetupCUDA)
-                #endif()
             endif()
             add_subdirectory(${ImpactX_ablastr_src} _deps/localablastr-build/)
             # TODO: this is a bit hacky, check if we find a variable like
@@ -102,10 +98,6 @@ macro(find_ablastr)
         else()
             if(ImpactX_COMPUTE STREQUAL CUDA)
                 enable_language(CUDA)
-                # ABLASTR 21.06+ supports CUDA_ARCHITECTURES
-                #if(CMAKE_VERSION VERSION_LESS 3.20)
-                #    include(ABLASTR_SetupCUDA)
-                #endif()
             endif()
             FetchContent_Declare(fetchedablastr
                 GIT_REPOSITORY ${ImpactX_ablastr_repo}

--- a/cmake/dependencies/pyAMReX.cmake
+++ b/cmake/dependencies/pyAMReX.cmake
@@ -47,12 +47,7 @@ function(find_pyamrex)
                 GIT_TAG        ${ImpactX_pyamrex_branch}
                 BUILD_IN_SOURCE 0
             )
-            FetchContent_GetProperties(fetchedpyamrex)
-
-            if(NOT fetchedpyamrex_POPULATED)
-                FetchContent_Populate(fetchedpyamrex)
-                add_subdirectory(${fetchedpyamrex_SOURCE_DIR} ${fetchedpyamrex_BINARY_DIR})
-            endif()
+            FetchContent_MakeAvailable(fetchedpyamrex)
 
             # advanced fetch options
             mark_as_advanced(FETCHCONTENT_BASE_DIR)

--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -21,12 +21,7 @@ function(find_pybind11)
                 GIT_TAG        ${ImpactX_pybind11_branch}
                 BUILD_IN_SOURCE 0
             )
-            FetchContent_GetProperties(fetchedpybind11)
-
-            if(NOT fetchedpybind11_POPULATED)
-                FetchContent_Populate(fetchedpybind11)
-                add_subdirectory(${fetchedpybind11_SOURCE_DIR} ${fetchedpybind11_BINARY_DIR})
-            endif()
+            FetchContent_MakeAvailable(fetchedpybind11)
 
             # advanced fetch options
             mark_as_advanced(FETCHCONTENT_BASE_DIR)

--- a/docs/source/install/dependencies.rst
+++ b/docs/source/install/dependencies.rst
@@ -7,7 +7,7 @@ ImpactX depends on the following popular third party software.
 Please see installation instructions below.
 
 - a mature `C++17 <https://en.wikipedia.org/wiki/C%2B%2B17>`__ compiler, e.g., GCC 8.4+, Clang 7, NVCC 11.0, MSVC 19.15 or newer
-- `CMake 3.20.0+ <https://cmake.org>`__
+- `CMake 3.24.0+ <https://cmake.org>`__
 - `Git 2.18+ <https://git-scm.com>`__
 - `AMReX <https://amrex-codes.github.io>`__: we automatically download and compile a copy
 - `ABLASTR/WarpX <https://github.com/ECP-WarpX/warpx>`__: we automatically download and compile a copy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "cmake>=3.20.0,<4.0.0",
+    "cmake>=3.24.0,<4.0.0",
     "packaging>=23",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -56,14 +56,14 @@ class CMakeBuild(build_ext):
             out = subprocess.check_output(["cmake", "--version"])
         except OSError:
             raise RuntimeError(
-                "CMake 3.20.0+ must be installed to build the following "
+                "CMake 3.24.0+ must be installed to build the following "
                 + "extensions: "
                 + ", ".join(e.name for e in self.extensions)
             )
 
         cmake_version = parse(re.search(r"version\s*([\d.]+)", out.decode()).group(1))
-        if cmake_version < parse("3.20.0"):
-            raise RuntimeError("CMake >= 3.20.0 is required")
+        if cmake_version < parse("3.24.0"):
+            raise RuntimeError("CMake >= 3.24.0 is required")
 
         for ext in self.extensions:
             self.build_extension(ext)


### PR DESCRIPTION
In CMake superbuilds, `FetchContent_Populate` is now deprecated. Use `FetchContent_MakeAvailable` instead.