### PR TITLE
Sphinx: Make `.pyi` files available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ docs/impactx-doxygen-web.tag.xml
 docs/openpmd-api-doxygen-web.tag.xml
 docs/doxyhtml/
 docs/doxyxml/
+docs/source/amrex.zip
 docs/source/_static/
 
 ####################

--- a/docs/conda.yml
+++ b/docs/conda.yml
@@ -7,6 +7,7 @@ channels:
 dependencies:
   - python
   - doxygen
+  - numpy
   - pip
   - pip:
     - -r requirements.txt

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -264,7 +264,8 @@ sys.path.insert(0, os.path.join(dst_path, ".."))
 shutil.make_archive(dst_path, "zip", dst_path)
 
 # Download pyAMReX stub files
-url = "https://pyamrex.readthedocs.io/en/latest/_static/pyapi/amrex.zip"
-amr_path = os.path.join(api_path, "amrex.zip")
-urllib.request.urlretrieve(url, amr_path)
-shutil.unpack_archive(amr_path, os.path.join(api_path, "amrex"))
+download_with_headers(
+    url="https://pyamrex.readthedocs.io/en/latest/_static/pyapi/amrex.zip",
+    filename="amrex.zip",
+)
+shutil.unpack_archive("amrex.zip", os.path.join(api_path, "amrex"))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,6 +26,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import shutil
 import subprocess
 import sys
 import urllib.request
@@ -236,3 +237,26 @@ subprocess.call(
     "cp impactx-doxygen-web.tag.xml source/_static/doxyhtml/",
     shell=True,
 )
+
+# Copy .pyi interface files and make them available as .py files
+# path to .pyi files w/o having them installed
+src_path = "../../src/python/impactx"
+dst_path = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "_static/pyapi/impactx"
+)
+if os.path.exists(dst_path) and os.path.isdir(dst_path):
+    shutil.rmtree(dst_path)
+shutil.copytree(src_path, dst_path)
+
+for subdir, _dirs, files in os.walk(dst_path):
+    for f in files:
+        if f.find(".pyi") > 0:
+            dir_path = os.path.relpath(subdir, dst_path)
+            old_path = os.path.join(dir_path, f)
+            new_path = old_path.replace(".pyi", ".py")
+            os.replace(
+                os.path.join(dst_path, old_path), os.path.join(dst_path, new_path)
+            )
+
+# insert into PYTHONPATH
+sys.path.insert(0, os.path.join(dst_path, ".."))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -241,9 +241,8 @@ subprocess.call(
 # Copy .pyi interface files and make them available as .py files
 # path to .pyi files w/o having them installed
 src_path = "../../src/python/impactx"
-dst_path = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "_static/pyapi/impactx"
-)
+api_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_static/pyapi")
+dst_path = os.path.join(api_path, "impactx")
 if os.path.exists(dst_path) and os.path.isdir(dst_path):
     shutil.rmtree(dst_path)
 shutil.copytree(src_path, dst_path)
@@ -260,3 +259,12 @@ for subdir, _dirs, files in os.walk(dst_path):
 
 # insert into PYTHONPATH
 sys.path.insert(0, os.path.join(dst_path, ".."))
+
+# make archive for download of dependent Sphinx projects
+shutil.make_archive(dst_path, "zip", dst_path)
+
+# Download pyAMReX stub files
+url = "https://pyamrex.readthedocs.io/en/latest/_static/pyapi/amrex.zip"
+amr_path = os.path.join(api_path, "amrex.zip")
+urllib.request.urlretrieve(url, amr_path)
+shutil.unpack_archive(amr_path, os.path.join(api_path, "amrex"))

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -76,7 +76,7 @@ Collective Effects & Overall Simulation Parameters
 
         When running in envelope mode (when ``algo.track = "envelope"``), this model currently assumes that ``<xy> = <yt> = <tx> = 0``.
 
-      * ``"Gauss3D"`: Calculate 3D space charge forces as if the beam was a Gaussian distribution.
+      * ``"Gauss3D"``: Calculate 3D space charge forces as if the beam was a Gaussian distribution.
 
         This model is supported only in particle tracking mode (when ``algo.track = "particles"``).
         Ref.: J. Qiang et al., "Two-and-a-half dimensional symplectic space-charge solver", LBNL Report Number: LBNL-2001674 (2025).

--- a/src/python/impactx/MADXParser.py
+++ b/src/python/impactx/MADXParser.py
@@ -14,11 +14,7 @@ import re
 import warnings
 
 
-class MADXParserError(Exception):
-    pass
-
-
-class MADXInputError(MADXParserError):
+class MADXInputError(Exception):
     def __init__(self, args, with_traceback):
         self.args = args
         self.with_traceback = with_traceback


### PR DESCRIPTION
Same config [as in pyAMReX](https://github.com/AMReX-Codes/pyamrex/blob/c356855ac49090a18dbe807cfaf7a53ab2ce26b3/docs/source/conf.py#L235-L254) to use `.pyi` interface files in Sphinx docs.

- [ ] ensure `autoclass` and `autofunction` work
- [ ] need fix or work-around for https://github.com/sizmailov/pybind11-stubgen/issues/231 (patch: https://github.com/sizmailov/pybind11-stubgen/pull/275 )

Follow-up to https://github.com/ECP-WarpX/impactx/pull/697#issuecomment-2334980602