### PR TITLE
Fix literal includes of KV test files in DistGen example

### DIFF
--- a/examples/distgen/README.rst
+++ b/examples/distgen/README.rst
@@ -100,13 +100,13 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
 
    .. tab-item:: Python: Script
 
-       .. literalinclude:: run_kvdist_from_twiss.py
+       .. literalinclude:: run_kvdist_twiss.py
           :language: python3
           :caption: You can copy this file from ``examples/distgen/run_kvdist_twiss.py``.
 
    .. tab-item:: Executable: Input File
 
-       .. literalinclude:: input_kvdist_from_twiss.in
+       .. literalinclude:: input_kvdist_twiss.in
           :language: ini
           :caption: You can copy this file from ``examples/distgen/input_kvdist_twiss.in``.
 


### PR DESCRIPTION
Overlooked uncommitted changes in #697.
This fixes the includes in the documentation of the `DistGen` example.