### PR TITLE
[Draft] Unit Test for dashboard

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,11 +38,13 @@ jobs:
     - name: install pip dependencies
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade build packaging setuptools wheel pytest
+        python3 -m pip install --upgrade build packaging setuptools wheel
         python3 -m pip install --upgrade -r requirements_mpi.txt
+        python3 -m pip install --upgrade -r src/python/impactx/dashboard/requirements.txt
         python3 -m pip install --upgrade -r src/python/impactx/dashboard/requirements.txt
         python3 -m pip install --upgrade -r examples/requirements.txt
         python3 -m pip install --upgrade -r tests/python/requirements.txt
+        set -e
         python3 -m pip install --upgrade pipx
         python3 -m pipx install openPMD-validator
     - name: CCache Cache

--- a/.github/workflows/stubs.yml
+++ b/.github/workflows/stubs.yml
@@ -38,11 +38,7 @@ jobs:
     - name: Dependencies
       run: |
         .github/workflows/dependencies/gcc-openmpi.sh
-        python3 -m pip install -U pybind11-stubgen pre-commit
-
-    - name: Dashboard Dependencies
-      run: |
-        python3 -m pip install -U matplotlib plotly trame trame-matplotlib trame-plotly trame-router trame-xterm trame-vuetify
+        python3 -m pip install -U pybind11-stubgen
 
     - name: Set Up Cache
       uses: actions/cache@v4
@@ -86,7 +82,6 @@ jobs:
     - name: Unit tests
       run: |
         mpiexec -np 1 python3 -m pytest tests/python/
-
 
     - uses: stefanzweifel/git-auto-commit-action@v5
       name: Commit Updated Stub Files

--- a/.github/workflows/stubs.yml
+++ b/.github/workflows/stubs.yml
@@ -40,6 +40,10 @@ jobs:
         .github/workflows/dependencies/gcc-openmpi.sh
         python3 -m pip install -U pybind11-stubgen pre-commit
 
+    - name: Dashboard Dependencies
+      run: |
+        python3 -m pip install -U trame trame-matplotlib trame-plotly trame-router trame-xterm trame-vuetify
+
     - name: Set Up Cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/stubs.yml
+++ b/.github/workflows/stubs.yml
@@ -83,6 +83,7 @@ jobs:
       run: |
         mpiexec -np 1 python3 -m pytest tests/python/
 
+
     - uses: stefanzweifel/git-auto-commit-action@v5
       name: Commit Updated Stub Files
       if: github.event_name == 'push' && github.repository == 'ECP-WarpX/impactx' && github.ref == 'refs/heads/development'

--- a/.github/workflows/stubs.yml
+++ b/.github/workflows/stubs.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Dashboard Dependencies
       run: |
-        python3 -m pip install -U trame trame-matplotlib trame-plotly trame-router trame-xterm trame-vuetify
+        python3 -m pip install -U matplotlib plotly trame trame-matplotlib trame-plotly trame-router trame-xterm trame-vuetify
 
     - name: Set Up Cache
       uses: actions/cache@v4

--- a/.github/workflows/stubs.yml
+++ b/.github/workflows/stubs.yml
@@ -39,6 +39,23 @@ jobs:
       run: |
         .github/workflows/dependencies/gcc-openmpi.sh
         python3 -m pip install -U pybind11-stubgen
+        python3 -m pip install seleniumbase pytest
+
+    # Added: Install Firefox and geckodriver
+    - name: Install Browser Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y firefox-esr xvfb
+        wget https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux64.tar.gz
+        tar -xzf geckodriver-v0.33.0-linux64.tar.gz
+        sudo mv geckodriver /usr/local/bin/
+        sudo chmod +x /usr/local/bin/geckodriver
+
+    # Added: Start virtual display
+    - name: Start Virtual Display
+      run: |
+        Xvfb :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+        echo "DISPLAY=:99" >> $GITHUB_ENV
 
     - name: Set Up Cache
       uses: actions/cache@v4
@@ -81,7 +98,8 @@ jobs:
 
     - name: Unit tests
       run: |
-        mpiexec -np 1 python3 -m pytest tests/python/
+        export DISPLAY=:99
+        mpiexec -np 1 python3 -m pytest -v tests/python/
 
     - uses: stefanzweifel/git-auto-commit-action@v5
       name: Commit Updated Stub Files

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -17,6 +17,7 @@ jobs:
     - name: install dependencies
       run: |
         .github/workflows/dependencies/clang-san-openmpi.sh
+        python3 -m pip install --upgrade seleniumbase
 
     - name: CCache Cache
       uses: actions/cache@v4

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -17,7 +17,6 @@ jobs:
     - name: install dependencies
       run: |
         .github/workflows/dependencies/clang-san-openmpi.sh
-        python3 -m pip install --upgrade seleniumbase
 
     - name: CCache Cache
       uses: actions/cache@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,9 +71,11 @@ jobs:
 
         python3 -m pip install -U pip
         python3 -m pip install -U build packaging setuptools wheel
+        python3 -m pip install -U build packaging setuptools wheel
         python3 -m pip install -U -r requirements.txt
         python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt
         python3 -m pip install -U -r examples/requirements.txt
+        python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt
         python3 -m pip install -U -r tests/python/requirements.txt
         python3 -m pip install -U openPMD-validator
     - name: Build
@@ -184,6 +186,7 @@ jobs:
         python3 -m pip install -U -r requirements.txt
         python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt
         python3 -m pip install -U -r examples/requirements.txt
+        python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt
         python3 -m pip install -U -r tests/python/requirements.txt
         python3 -m pip install -U openPMD-validator
     - name: Build

--- a/src/python/impactx/dashboard/Analyze/plotsMain.py
+++ b/src/python/impactx/dashboard/Analyze/plotsMain.py
@@ -152,6 +152,7 @@ def run_simulation_impactX():
             ctrl.terminal_print(line)
         ctrl.terminal_print("Simulation complete.")
 
+
     asyncio.create_task(print_lines())
 
 
@@ -175,6 +176,7 @@ def on_filtered_data_change(**kwargs):
 
 @ctrl.add("run_simulation")
 def run_simulation_and_store():
+    state.simulation_complete = True,
     state.plot_options = available_plot_options(simulationClicked=True)
     run_simulation_impactX()
     update_plot()

--- a/src/python/impactx/dashboard/Analyze/plotsMain.py
+++ b/src/python/impactx/dashboard/Analyze/plotsMain.py
@@ -152,7 +152,6 @@ def run_simulation_impactX():
             ctrl.terminal_print(line)
         ctrl.terminal_print("Simulation complete.")
 
-
     asyncio.create_task(print_lines())
 
 
@@ -176,7 +175,7 @@ def on_filtered_data_change(**kwargs):
 
 @ctrl.add("run_simulation")
 def run_simulation_and_store():
-    state.simulation_complete = True,
+    state.simulation_complete = (True,)
     state.plot_options = available_plot_options(simulationClicked=True)
     run_simulation_impactX()
     update_plot()

--- a/src/python/impactx/dashboard/Analyze/plotsMain.py
+++ b/src/python/impactx/dashboard/Analyze/plotsMain.py
@@ -228,7 +228,7 @@ class AnalyzeSimulation:
                 with vuetify.VCard(style="height: 50vh; width: 150vh;"):
                     with vuetify.VTabs(v_model=("active_tab", 0)):
                         vuetify.VTab("Plot")
-                        vuetify.VTab("Interact")
+                        vuetify.VTab("Interact", id="interact")
                     vuetify.VDivider()
                     with vuetify.VTabsItems(v_model="active_tab"):
                         with vuetify.VTabItem():

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -162,7 +162,6 @@ def on_distribution_type_change(**kwargs):
 
 @ctrl.add("updateDistributionParameters")
 def on_distribution_parameter_change(parameter_name, parameter_value, parameter_type):
-    parameter_value, input_type = generalFunctions.determine_input_type(parameter_value)
     error_message = generalFunctions.validate_against(parameter_value, parameter_type)
 
     update_distribution_parameters(parameter_name, parameter_value, error_message)

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -198,6 +198,7 @@ class DistributionParameters:
                     with vuetify.VCol(cols=6):
                         vuetify.VCombobox(
                             label="Select Distribution",
+                            id="selected_distribution",
                             v_model=("selectedDistribution",),
                             items=("listOfDistributions",),
                             dense=True,
@@ -205,6 +206,7 @@ class DistributionParameters:
                     with vuetify.VCol(cols=6):
                         vuetify.VSelect(
                             v_model=("selectedDistributionType",),
+                            id="selected_distribution_type",
                             label="Type",
                             items=(["Twiss", "Quadratic Form"],),
                             dense=True,
@@ -221,6 +223,7 @@ class DistributionParameters:
                                 ):
                                     vuetify.VTextField(
                                         label=("parameter.parameter_name",),
+                                        id=("parameter.parameter_name",),
                                         v_model=("parameter.parameter_default_value",),
                                         suffix=("parameter.parameter_units",),
                                         change=(

--- a/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
@@ -141,6 +141,7 @@ class InputParameters:
                         vuetify.VTextField(
                             v_model=("npart",),
                             label="Number of Particles",
+                            id="npart",
                             error_messages=("npart_validation",),
                             change=(
                                 ctrl.on_input_change,
@@ -154,6 +155,7 @@ class InputParameters:
                         vuetify.VTextField(
                             v_model=("kin_energy",),
                             label="Kinetic Energy",
+                            id="kin_energy",
                             error_messages=("kin_energy_validation",),
                             change=(
                                 ctrl.on_input_change,
@@ -167,6 +169,7 @@ class InputParameters:
                         vuetify.VSelect(
                             v_model=("kin_energy_unit",),
                             label="Unit",
+                            id="kin_energy_unit",
                             items=(["meV", "eV", "keV", "MeV", "GeV", "TeV"],),
                             change=(ctrl.kin_energy_unit_change, "[$event]"),
                             dense=True,
@@ -175,6 +178,7 @@ class InputParameters:
                     with vuetify.VCol(cols=8, classes="py-0"):
                         vuetify.VTextField(
                             label="Bunch Charge",
+                            id="bunch_charge_C",
                             v_model=("bunch_charge_C",),
                             error_messages=("bunch_charge_C_validation",),
                             change=(

--- a/src/python/impactx/dashboard/Input/latticeConfiguration/latticeMain.py
+++ b/src/python/impactx/dashboard/Input/latticeConfiguration/latticeMain.py
@@ -253,6 +253,7 @@ class LatticeConfiguration:
                     with vuetify.VCol(cols=8):
                         vuetify.VCombobox(
                             label="Select Accelerator Lattice",
+                            id="selected_lattice",
                             v_model=("selectedLattice", None),
                             items=("listOfLatticeElements",),
                             error_messages=("isSelectedLatticeListEmpty",),
@@ -262,6 +263,7 @@ class LatticeConfiguration:
                     with vuetify.VCol(cols="auto"):
                         vuetify.VBtn(
                             "ADD",
+                            id="add_button",
                             color="primary",
                             dense=True,
                             classes="mr-2",
@@ -270,6 +272,7 @@ class LatticeConfiguration:
                     with vuetify.VCol(cols="auto"):
                         vuetify.VBtn(
                             "CLEAR",
+                            id="clear_button",
                             color="secondary",
                             dense=True,
                             classes="mr-2",
@@ -337,6 +340,7 @@ class LatticeConfiguration:
                                     ):
                                         vuetify.VTextField(
                                             label=("parameter.parameter_name",),
+                                            id=("parameter.parameter_name",),
                                             v_model=(
                                                 "parameter.parameter_default_value",
                                             ),

--- a/src/python/impactx/dashboard/Input/latticeConfiguration/latticeMain.py
+++ b/src/python/impactx/dashboard/Input/latticeConfiguration/latticeMain.py
@@ -437,3 +437,13 @@ class LatticeConfiguration:
                                     style="max-width: 75px",
                                     classes="ma-0 pa-0",
                                 )
+            vuetify.VDivider()
+            with vuetify.VCardActions():
+                vuetify.VSpacer()
+                vuetify.VBtn(
+                    "Close",
+                    id="lattice_settings_close",
+                    color="primary",
+                    text=True,
+                    click="showDialog_settings = false",
+                )

--- a/src/python/impactx/dashboard/Input/latticeConfiguration/latticeMain.py
+++ b/src/python/impactx/dashboard/Input/latticeConfiguration/latticeMain.py
@@ -282,6 +282,7 @@ class LatticeConfiguration:
                         vuetify.VIcon(
                             "mdi-cog",
                             click="showDialog_settings = true",
+                            id="lattice_settings_icon",
                         )
                 with vuetify.VRow():
                     with vuetify.VCol():
@@ -340,7 +341,7 @@ class LatticeConfiguration:
                                     ):
                                         vuetify.VTextField(
                                             label=("parameter.parameter_name",),
-                                            id=("parameter.parameter_name",),
+                                            id=("parameter.parameter_name + index",),
                                             v_model=(
                                                 "parameter.parameter_default_value",
                                             ),
@@ -424,6 +425,7 @@ class LatticeConfiguration:
                             with vuetify.VCol(no_gutters=True):
                                 vuetify.VTextField(
                                     v_model=("nsliceDefaultValue",),
+                                    id="nslice_default_value",
                                     change=(
                                         ctrl.nsliceDefaultChange,
                                         "['nslice', $event]",

--- a/src/python/impactx/dashboard/Input/latticeConfiguration/latticeMain.py
+++ b/src/python/impactx/dashboard/Input/latticeConfiguration/latticeMain.py
@@ -165,7 +165,6 @@ def on_add_lattice_element_click():
 def on_lattice_element_parameter_change(
     index, parameter_name, parameter_value, parameter_type
 ):
-    parameter_value, input_type = generalFunctions.determine_input_type(parameter_value)
     error_message = generalFunctions.validate_against(parameter_value, parameter_type)
 
     update_latticeElement_parameters(

--- a/src/python/impactx/dashboard/Input/trameFunctions.py
+++ b/src/python/impactx/dashboard/Input/trameFunctions.py
@@ -40,4 +40,4 @@ class TrameFunctions:
             with vuetify.VListItemIcon():
                 vuetify.VIcon(mdi_icon)
             with vuetify.VListItemContent():
-                vuetify.VListItemTitle(route_title)
+                vuetify.VListItemTitle(route_title, id=f"{route_title}_route")

--- a/src/python/impactx/dashboard/Toolbar/toolbarMain.py
+++ b/src/python/impactx/dashboard/Toolbar/toolbarMain.py
@@ -51,6 +51,7 @@ class ToolbarElements:
             v_model=("active_plot", "1D plots over s"),
             items=("plot_options",),
             label="Select plot to view",
+            id="select_plot",
             hide_details=True,
             dense=True,
             style="max-width: 250px",
@@ -61,6 +62,7 @@ class ToolbarElements:
     def run_simulation_button():
         vuetify.VBtn(
             "Run Simulation",
+            id="run_simulation_button",
             style="background-color: #00313C; color: white; margin: 0 20px;",
             click=ctrl.run_simulation,
             disabled=("disableRunSimulationButton", True),

--- a/src/python/impactx/dashboard/Toolbar/toolbarMain.py
+++ b/src/python/impactx/dashboard/Toolbar/toolbarMain.py
@@ -71,13 +71,13 @@ class ToolbarElements:
     @staticmethod
     def show_simulation_complete():
         vuetify.VAlert(
-                "Simulation Complete",
-                v_model=("simulation_complete", False),
-                id="simulation_complete",
-                type="success",
-                dense=True,
-                classes="mt-4",
-            )
+            "Simulation Complete",
+            v_model=("simulation_complete", False),
+            id="simulation_complete",
+            type="success",
+            dense=True,
+            classes="mt-4",
+        )
 
     @staticmethod
     def dashboard_info():
@@ -119,7 +119,7 @@ class Toolbars:
 
         (ToolbarElements.dashboard_info(),)
         (vuetify.VSpacer(),)
-        ToolbarElements.show_simulation_complete(),
+        (ToolbarElements.show_simulation_complete(),)
         (ToolbarElements.run_simulation_button(),)
 
     @staticmethod

--- a/src/python/impactx/dashboard/Toolbar/toolbarMain.py
+++ b/src/python/impactx/dashboard/Toolbar/toolbarMain.py
@@ -69,6 +69,17 @@ class ToolbarElements:
         )
 
     @staticmethod
+    def show_simulation_complete():
+        vuetify.VAlert(
+                "Simulation Complete",
+                v_model=("simulation_complete", False),
+                id="simulation_complete",
+                type="success",
+                dense=True,
+                classes="mt-4",
+            )
+
+    @staticmethod
     def dashboard_info():
         """
         Creates an alert box with dashboard information.
@@ -108,6 +119,7 @@ class Toolbars:
 
         (ToolbarElements.dashboard_info(),)
         (vuetify.VSpacer(),)
+        ToolbarElements.show_simulation_complete(),
         (ToolbarElements.run_simulation_button(),)
 
     @staticmethod

--- a/src/python/impactx/dashboard/__main__.py
+++ b/src/python/impactx/dashboard/__main__.py
@@ -62,7 +62,7 @@ with RouterViewLayout(server, "/Analyze"):
 # GUI
 # -----------------------------------------------------------------------------
 def init_terminal():
-    with xterm.XTerm(v_if="$route.path == '/Run'") as term:
+    with xterm.XTerm(v_if="$route.path == '/Run'", id="xterm_component") as term:
         ctrl.terminal_print = term.writeln
 
 

--- a/src/python/impactx/dashboard/__main__.py
+++ b/src/python/impactx/dashboard/__main__.py
@@ -62,7 +62,7 @@ with RouterViewLayout(server, "/Analyze"):
 # GUI
 # -----------------------------------------------------------------------------
 def init_terminal():
-    with xterm.XTerm(v_if="$route.path == '/Run'", id="xterm_component") as term:
+    with xterm.XTerm(v_show="$route.path == '/Run'", id="xterm_component") as term:
         ctrl.terminal_print = term.writeln
 
 

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -10,6 +10,9 @@ file(MAKE_DIRECTORY ${pytest_rundir})
 file(COPY ${ImpactX_SOURCE_DIR}/examples
      DESTINATION ${pytest_rundir})
 
+file(COPY ${ImpactX_SOURCE_DIR}/src/python/impactx/dashboard
+DESTINATION ${pytest_rundir})
+
 #   run
 add_test(NAME ${pytest_name}
     COMMAND ${Python_EXECUTABLE} -m pytest -s -vvvv
@@ -22,3 +25,9 @@ set_property(TEST ${pytest_name} APPEND PROPERTY ENVIRONMENT "OMP_NUM_THREADS=2"
 
 #   set PYTHONPATH and PATH (for .dll files)
 impactx_test_set_pythonpath(${pytest_name})
+
+# Add environment variables needed for dashboard tests
+set_property(TEST ${pytest_name} APPEND PROPERTY ENVIRONMENT
+    "DISPLAY=:99"
+    "PYTHONPATH=${pytest_rundir}:$ENV{PYTHONPATH}"
+)

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -73,10 +73,16 @@ def test_simulation():
             sb.click("#Run_route")
             sb.sleep(1)
             sb.click("#run_simulation_button")
-            sb.sleep(25)
+            sb.sleep(7)
 
-            # Check if "Simulation complete" message is printed
-            xterm_content = sb.get_text("#xterm_component")
-            assert "Simulation complete." in xterm_content
+            sb.wait_for_element("#select_plot", timeout=10)
+
+            # Interact with phase space projection plots
+            sb.click("#Analyze_route")
+            sb.sleep(3)
+            sb.click("#select_plot")
+            sb.click("div.v-list-item:nth-of-type(2)")
+            sb.wait_for_element("#interact", timeout=10)
+            sb.click("#interact")
     finally:
         app_process.terminate()

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -1,0 +1,68 @@
+from seleniumbase import SB
+from util import set_input_value, wait_for_ready
+
+
+def test_simulation():
+    """
+    This test runs the FODO example on the dashboard and verifies
+    that the simulation has ran successfully.
+    """
+
+    with SB() as sb:
+        url = "http://localhost:8080/index.html#/Input"
+        sb.open(url)
+
+        wait_for_ready(sb, 60)
+
+        # Adjust beam properties
+        sb.click("#particle_shape")
+        sb.click("div.v-list-item:nth-of-type(2)")
+        set_input_value(sb, "npart", 10000)
+        set_input_value(sb, "kin_energy", 2.0e3)
+        set_input_value(sb, "bunch_charge_C", 1.0e-9)
+
+        # Adjust beam distribution
+        set_input_value(sb, "selected_distribution", "Waterbag")
+        set_input_value(sb, "lambdaX", 3.9984884770e-5)
+        set_input_value(sb, "lambdaY", 3.9984884770e-5)
+        set_input_value(sb, "lambdaT", 1.0e-3)
+        set_input_value(sb, "lambdaPx", 2.6623538760e-5)
+        set_input_value(sb, "lambdaPy", 2.6623538760e-5)
+        set_input_value(sb, "lambdaPt", 2.0e-3)
+        set_input_value(sb, "muxpx", -0.846574929020762)
+        set_input_value(sb, "muypy", 0.846574929020762)
+        set_input_value(sb, "mutpt", 0.0)
+
+        # Adjust lattice configuration
+        sb.click("#lattice_settings_icon")
+        sb.sleep(1)
+        set_input_value(sb, "nslice_default_value", 25)
+        sb.click("#lattice_settings_close")
+        sb.click("#clear_button")
+        set_input_value(sb, "selected_lattice", "Drift")
+        sb.click("#add_button")
+        set_input_value(sb, "ds0", 0.25)
+        set_input_value(sb, "selected_lattice", "Quad")
+        sb.click("#add_button")
+        set_input_value(sb, "ds1", 1.0)
+        set_input_value(sb, "k1", 1.0)
+        set_input_value(sb, "selected_lattice", "Drift")
+        sb.click("#add_button")
+        set_input_value(sb, "ds2", 0.5)
+        set_input_value(sb, "selected_lattice", "Quad")
+        sb.click("#add_button")
+        set_input_value(sb, "ds3", 1.0)
+        set_input_value(sb, "k3", -1.0)
+        set_input_value(sb, "selected_lattice", "Drift")
+        sb.click("#add_button")
+        set_input_value(sb, "ds4", 0.25)
+
+        # Run simulation
+        sb.click("#Run_route")
+        sb.sleep(1)
+        sb.click("#run_simulation_button")
+        sb.sleep(7)
+
+        # Check if "Simulation complete" message is printed
+        xterm_content = sb.get_text("#xterm_component")
+        assert "Simulation complete." in xterm_content

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -20,6 +20,8 @@ def test_dashboard():
     """
     from seleniumbase import SB
 
+    app_process = None
+
     try:
         with SB(headless=True) as sb:
             app_process = start_dashboard()
@@ -87,4 +89,5 @@ def test_dashboard():
             sb.wait_for_element("#interact", timeout=10)
             sb.click("#interact")
     finally:
-        app_process.terminate()
+        if app_process is not None:
+            app_process.terminate()

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -1,7 +1,6 @@
 import importlib
 
-from util import set_input_value, start_dashboard, wait_for_ready
-import time
+from util import set_input_value, start_dashboard, wait_for_dashboard_ready, wait_for_ready
 
 import pytest
 
@@ -17,14 +16,15 @@ def test_simulation():
     from seleniumbase import SB
 
     app_process = start_dashboard()
-    time.sleep(10)
+
+    wait_for_dashboard_ready(app_process, timeout=60)
 
     try:
         with SB() as sb:
             url = "http://localhost:8080/index.html#/Input"
             sb.open(url)
 
-            wait_for_ready(sb, 60)
+            wait_for_ready(sb, ".trame__loader", 60)
 
             # Adjust beam properties
             sb.click("#particle_shape")
@@ -73,9 +73,7 @@ def test_simulation():
             sb.click("#Run_route")
             sb.sleep(1)
             sb.click("#run_simulation_button")
-            sb.sleep(7)
-
-            sb.wait_for_element("#select_plot", timeout=10)
+            sb.sleep(7) # for simulation to finish
 
             # Interact with phase space projection plots
             sb.click("#Analyze_route")

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -81,7 +81,9 @@ def test_dashboard():
             sb.click("#Run_route")
             sb.click("#run_simulation_button")
 
-            assert check_until_visible(sb, "#simulation_complete"), "Simulation did not complete successfully."
+            assert check_until_visible(
+                sb, "#simulation_complete"
+            ), "Simulation did not complete successfully."
 
     finally:
         if app_process is not None:

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -65,11 +65,10 @@ def test_simulation():
             sb.click("#Run_route")
             sb.sleep(1)
             sb.click("#run_simulation_button")
-            sb.sleep(7)
+            sb.sleep(25)
 
             # Check if "Simulation complete" message is printed
             xterm_content = sb.get_text("#xterm_component")
             assert "Simulation complete." in xterm_content
-
     finally:
         app_process.terminate()

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -2,7 +2,7 @@ import importlib
 
 import pytest
 from util import (
-    look_for_text,
+    check_until_visible,
     set_input_value,
     start_dashboard,
     wait_for_dashboard_ready,
@@ -81,9 +81,7 @@ def test_dashboard():
             sb.click("#Run_route")
             sb.click("#run_simulation_button")
 
-            assert look_for_text(
-                sb, "#xterm_component", "Simulation complete.", timeout=TIMEOUT
-            ), "'Simulation compelte.' not found."
+            assert check_until_visible(sb, "#simulation_complete"), "Simulation did not complete successfully."
 
     finally:
         if app_process is not None:

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -8,19 +8,18 @@ import pytest
 @pytest.mark.skipif(
     importlib.util.find_spec("seleniumbase") is None, reason="seleniumbase is not available"
 )
-def test_simulation():
+def test_dashboard():
     """
     This test runs the FODO example on the dashboard and verifies
     that the simulation has ran successfully.
     """
     from seleniumbase import SB
 
-    app_process = start_dashboard()
-
-    wait_for_dashboard_ready(app_process, timeout=60)
-
     try:
         with SB() as sb:
+            app_process = start_dashboard()
+            wait_for_dashboard_ready(app_process, timeout=60)
+
             url = "http://localhost:8080/index.html#/Input"
             sb.open(url)
 

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -1,12 +1,20 @@
-from seleniumbase import SB
+import importlib
+
 from util import set_input_value, start_dashboard, wait_for_ready
 import time
 
+import pytest
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("seleniumbase") is None, reason="seleniumbase is not available"
+)
 def test_simulation():
     """
     This test runs the FODO example on the dashboard and verifies
     that the simulation has ran successfully.
     """
+    from seleniumbase import SB
 
     app_process = start_dashboard()
     time.sleep(10)

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -1,12 +1,17 @@
 import importlib
 
-from util import set_input_value, start_dashboard, wait_for_dashboard_ready, wait_for_ready
-
 import pytest
+from util import (
+    set_input_value,
+    start_dashboard,
+    wait_for_dashboard_ready,
+    wait_for_ready,
+)
 
 
 @pytest.mark.skipif(
-    importlib.util.find_spec("seleniumbase") is None, reason="seleniumbase is not available"
+    importlib.util.find_spec("seleniumbase") is None,
+    reason="seleniumbase is not available",
 )
 def test_dashboard():
     """
@@ -72,7 +77,7 @@ def test_dashboard():
             sb.click("#Run_route")
             sb.sleep(1)
             sb.click("#run_simulation_button")
-            sb.sleep(7) # for simulation to finish
+            sb.sleep(7)  # for simulation to finish
 
             # Interact with phase space projection plots
             sb.click("#Analyze_route")

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -1,6 +1,6 @@
 from seleniumbase import SB
-from util import set_input_value, wait_for_ready
-
+from util import set_input_value, start_dashboard, wait_for_ready
+import time
 
 def test_simulation():
     """
@@ -8,61 +8,68 @@ def test_simulation():
     that the simulation has ran successfully.
     """
 
-    with SB() as sb:
-        url = "http://localhost:8080/index.html#/Input"
-        sb.open(url)
+    app_process = start_dashboard()
+    time.sleep(10)
 
-        wait_for_ready(sb, 60)
+    try:
+        with SB() as sb:
+            url = "http://localhost:8080/index.html#/Input"
+            sb.open(url)
 
-        # Adjust beam properties
-        sb.click("#particle_shape")
-        sb.click("div.v-list-item:nth-of-type(2)")
-        set_input_value(sb, "npart", 10000)
-        set_input_value(sb, "kin_energy", 2.0e3)
-        set_input_value(sb, "bunch_charge_C", 1.0e-9)
+            wait_for_ready(sb, 60)
 
-        # Adjust beam distribution
-        set_input_value(sb, "selected_distribution", "Waterbag")
-        set_input_value(sb, "lambdaX", 3.9984884770e-5)
-        set_input_value(sb, "lambdaY", 3.9984884770e-5)
-        set_input_value(sb, "lambdaT", 1.0e-3)
-        set_input_value(sb, "lambdaPx", 2.6623538760e-5)
-        set_input_value(sb, "lambdaPy", 2.6623538760e-5)
-        set_input_value(sb, "lambdaPt", 2.0e-3)
-        set_input_value(sb, "muxpx", -0.846574929020762)
-        set_input_value(sb, "muypy", 0.846574929020762)
-        set_input_value(sb, "mutpt", 0.0)
+            # Adjust beam properties
+            sb.click("#particle_shape")
+            sb.click("div.v-list-item:nth-of-type(2)")
+            set_input_value(sb, "npart", 10000)
+            set_input_value(sb, "kin_energy", 2.0e3)
+            set_input_value(sb, "bunch_charge_C", 1.0e-9)
 
-        # Adjust lattice configuration
-        sb.click("#lattice_settings_icon")
-        sb.sleep(1)
-        set_input_value(sb, "nslice_default_value", 25)
-        sb.click("#lattice_settings_close")
-        sb.click("#clear_button")
-        set_input_value(sb, "selected_lattice", "Drift")
-        sb.click("#add_button")
-        set_input_value(sb, "ds0", 0.25)
-        set_input_value(sb, "selected_lattice", "Quad")
-        sb.click("#add_button")
-        set_input_value(sb, "ds1", 1.0)
-        set_input_value(sb, "k1", 1.0)
-        set_input_value(sb, "selected_lattice", "Drift")
-        sb.click("#add_button")
-        set_input_value(sb, "ds2", 0.5)
-        set_input_value(sb, "selected_lattice", "Quad")
-        sb.click("#add_button")
-        set_input_value(sb, "ds3", 1.0)
-        set_input_value(sb, "k3", -1.0)
-        set_input_value(sb, "selected_lattice", "Drift")
-        sb.click("#add_button")
-        set_input_value(sb, "ds4", 0.25)
+            # Adjust beam distribution
+            set_input_value(sb, "selected_distribution", "Waterbag")
+            set_input_value(sb, "lambdaX", 3.9984884770e-5)
+            set_input_value(sb, "lambdaY", 3.9984884770e-5)
+            set_input_value(sb, "lambdaT", 1.0e-3)
+            set_input_value(sb, "lambdaPx", 2.6623538760e-5)
+            set_input_value(sb, "lambdaPy", 2.6623538760e-5)
+            set_input_value(sb, "lambdaPt", 2.0e-3)
+            set_input_value(sb, "muxpx", -0.846574929020762)
+            set_input_value(sb, "muypy", 0.846574929020762)
+            set_input_value(sb, "mutpt", 0.0)
 
-        # Run simulation
-        sb.click("#Run_route")
-        sb.sleep(1)
-        sb.click("#run_simulation_button")
-        sb.sleep(7)
+            # Adjust lattice configuration
+            sb.click("#lattice_settings_icon")
+            sb.sleep(1)
+            set_input_value(sb, "nslice_default_value", 25)
+            sb.click("#lattice_settings_close")
+            sb.click("#clear_button")
+            set_input_value(sb, "selected_lattice", "Drift")
+            sb.click("#add_button")
+            set_input_value(sb, "ds0", 0.25)
+            set_input_value(sb, "selected_lattice", "Quad")
+            sb.click("#add_button")
+            set_input_value(sb, "ds1", 1.0)
+            set_input_value(sb, "k1", 1.0)
+            set_input_value(sb, "selected_lattice", "Drift")
+            sb.click("#add_button")
+            set_input_value(sb, "ds2", 0.5)
+            set_input_value(sb, "selected_lattice", "Quad")
+            sb.click("#add_button")
+            set_input_value(sb, "ds3", 1.0)
+            set_input_value(sb, "k3", -1.0)
+            set_input_value(sb, "selected_lattice", "Drift")
+            sb.click("#add_button")
+            set_input_value(sb, "ds4", 0.25)
 
-        # Check if "Simulation complete" message is printed
-        xterm_content = sb.get_text("#xterm_component")
-        assert "Simulation complete." in xterm_content
+            # Run simulation
+            sb.click("#Run_route")
+            sb.sleep(1)
+            sb.click("#run_simulation_button")
+            sb.sleep(7)
+
+            # Check if "Simulation complete" message is printed
+            xterm_content = sb.get_text("#xterm_component")
+            assert "Simulation complete." in xterm_content
+
+    finally:
+        app_process.terminate()

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -11,6 +11,7 @@ from util import (
 
 TIMEOUT = 60
 
+
 @pytest.mark.skipif(
     importlib.util.find_spec("seleniumbase") is None,
     reason="seleniumbase is not available",
@@ -80,7 +81,9 @@ def test_dashboard():
             sb.click("#Run_route")
             sb.click("#run_simulation_button")
 
-            assert look_for_text(sb, "#xterm_component", "Simulation complete.", timeout=TIMEOUT), "'Simulation compelte.' not found."
+            assert look_for_text(
+                sb, "#xterm_component", "Simulation complete.", timeout=TIMEOUT
+            ), "'Simulation compelte.' not found."
 
     finally:
         if app_process is not None:

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -16,7 +16,7 @@ def test_dashboard():
     from seleniumbase import SB
 
     try:
-        with SB() as sb:
+        with SB(headless=True) as sb:
             app_process = start_dashboard()
             wait_for_dashboard_ready(app_process, timeout=60)
 

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -19,7 +19,7 @@ TIMEOUT = 60
 def test_dashboard():
     """
     This test runs the FODO example on the dashboard and verifies
-    that the simulation has ran successfully.
+    that the simulation has run successfully.
     """
     from seleniumbase import SB
 

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -36,11 +36,13 @@ def test_dashboard():
             wait_for_ready(sb, ".trame__loader", TIMEOUT)
 
             # Adjust beam properties
-            sb.click("#particle_shape")
-            sb.click("div.v-list-item:nth-of-type(2)")
             set_input_value(sb, "npart", 10000)
             set_input_value(sb, "kin_energy", 2.0e3)
             set_input_value(sb, "bunch_charge_C", 1.0e-9)
+
+            # Change distribution type to "Quadratic"
+            sb.click("#selected_distribution_type")
+            sb.click("div.v-list-item__title:contains('Quadratic Form')")
 
             # Adjust beam distribution
             set_input_value(sb, "selected_distribution", "Waterbag")

--- a/tests/python/dashboard/util.py
+++ b/tests/python/dashboard/util.py
@@ -71,12 +71,26 @@ def check_until_visible(sb, selector, timeout=10, interval=1):
     return False
 
 
+def find_repo_root():
+    """
+    Finds the root directory of the repository by looking for a .git directory.
+    """
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while True:
+        if os.path.isdir(os.path.join(current_dir, ".git")):
+            return current_dir
+        parent_dir = os.path.dirname(current_dir)
+        if parent_dir == current_dir:
+            raise Exception("Repository root not found.")
+        current_dir = parent_dir
+
+
 def start_dashboard():
     """
     Function which starts up impactx-dashboard server.
     """
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    working_directory = os.path.join(script_dir, "../../../src/python/impactx")
+    repo_root = find_repo_root()
+    working_directory = os.path.join(repo_root, "src", "python", "impactx", "dashboard")
     working_directory = os.path.normpath(working_directory)
 
     return subprocess.Popen(

--- a/tests/python/dashboard/util.py
+++ b/tests/python/dashboard/util.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 
 def wait_for_ready(sb, element_name, timeout):
@@ -53,7 +54,7 @@ def start_dashboard():
     working_directory = os.path.normpath(working_directory)
 
     return subprocess.Popen(
-        ["python", "-m", "dashboard", "--server"],
+        [sys.executable, "-m", "dashboard", "--server"],
         cwd=working_directory,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/tests/python/dashboard/util.py
+++ b/tests/python/dashboard/util.py
@@ -4,6 +4,9 @@ import subprocess
 
 def wait_for_ready(sb, element_name, timeout):
     # Code adapted from https://github.com/Kitware/trame-client/blob/master/trame_client/utils/testing.py
+    """
+    Function waits until element_name is present.
+    """
     for i in range(timeout):
         print(f"wait_for_ready {i}")
         if sb.is_element_present(element_name):

--- a/tests/python/dashboard/util.py
+++ b/tests/python/dashboard/util.py
@@ -58,20 +58,16 @@ def set_input_value(sb, element_id, value, timeout=60):
                 )
 
 
-def look_for_text(sb, element_id, text_to_look_for, timeout):
+def check_until_visible(sb, selector, timeout=10, interval=1):
     """
-    Function which repeatedly checks for specific text every second until it appears or the timeout is reached.
+    Function which retries checking if an element is visible.
     """
 
-    start_time = time.time()
-    while time.time() - start_time < timeout:
-        try:
-            if sb.is_text_visible(text_to_look_for, element_id):
-                return True
-        except Exception as e:
-            print(f"Error checking for text: {e}")
-        time.sleep(1)
-
+    end_time = time.time() + timeout
+    while time.time() < end_time:
+        if sb.is_element_visible(selector):
+            return True
+        time.sleep(interval)
     return False
 
 

--- a/tests/python/dashboard/util.py
+++ b/tests/python/dashboard/util.py
@@ -52,7 +52,7 @@ def start_dashboard():
     working_directory = os.path.normpath(working_directory)
 
     return subprocess.Popen(
-        ["python", "-m", "dashboard"],
+        ["python", "-m", "dashboard", "--server"],
         cwd=working_directory,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/tests/python/dashboard/util.py
+++ b/tests/python/dashboard/util.py
@@ -1,0 +1,22 @@
+def wait_for_ready(sb, timeout=60):
+    for i in range(timeout):
+        print(f"wait_for_ready {i}")
+        if sb.is_element_present(".trame__loader"):
+            sb.sleep(1)
+        else:
+            print("Ready")
+            return
+
+
+def set_input_value(sb, element_id, value):
+    """
+    Function to clear, update, and trigger a change event on an input field by ID.
+    """
+    selector = f"#{element_id}"
+    sb.clear(selector)
+
+    if not isinstance(value, str):
+        value = str(value)
+
+    sb.update_text(selector, value)
+    sb.send_keys(selector, "\n")

--- a/tests/python/dashboard/util.py
+++ b/tests/python/dashboard/util.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 
+
 def wait_for_ready(sb, timeout=60):
     for i in range(timeout):
         print(f"wait_for_ready {i}")
@@ -23,6 +24,7 @@ def set_input_value(sb, element_id, value):
 
     sb.update_text(selector, value)
     sb.send_keys(selector, "\n")
+
 
 def start_dashboard():
     """

--- a/tests/python/dashboard/util.py
+++ b/tests/python/dashboard/util.py
@@ -1,8 +1,13 @@
 import os
 import subprocess
 import sys
-from selenium.common.exceptions import ElementNotInteractableException, JavascriptException
 import time
+
+from selenium.common.exceptions import (
+    ElementNotInteractableException,
+    JavascriptException,
+)
+
 
 def wait_for_ready(sb, element_name, timeout=10):
     """
@@ -48,7 +53,10 @@ def set_input_value(sb, element_id, value, timeout=60):
             break
         except (ElementNotInteractableException, JavascriptException):
             if time.time() > end_time:
-                raise Exception(f"Element {selector} not interactable after {timeout} seconds.")
+                raise Exception(
+                    f"Element {selector} not interactable after {timeout} seconds."
+                )
+
 
 def look_for_text(sb, element_id, text_to_look_for, timeout):
     """
@@ -65,6 +73,7 @@ def look_for_text(sb, element_id, text_to_look_for, timeout):
         time.sleep(1)
 
     return False
+
 
 def start_dashboard():
     """

--- a/tests/python/dashboard/util.py
+++ b/tests/python/dashboard/util.py
@@ -29,6 +29,7 @@ def wait_for_dashboard_ready(process, timeout=60):
                 return
     raise Exception("Dashboard did not start correctly.")
 
+
 def set_input_value(sb, element_id, value):
     """
     Function to clear, update, and trigger a change event on an input field by ID.
@@ -56,5 +57,5 @@ def start_dashboard():
         cwd=working_directory,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        universal_newlines=True
+        universal_newlines=True,
     )

--- a/tests/python/dashboard/util.py
+++ b/tests/python/dashboard/util.py
@@ -2,15 +2,29 @@ import os
 import subprocess
 
 
-def wait_for_ready(sb, timeout=60):
+def wait_for_ready(sb, element_name, timeout):
+    # Code adapted from https://github.com/Kitware/trame-client/blob/master/trame_client/utils/testing.py
     for i in range(timeout):
         print(f"wait_for_ready {i}")
-        if sb.is_element_present(".trame__loader"):
+        if sb.is_element_present(element_name):
             sb.sleep(1)
         else:
             print("Ready")
             return
 
+
+def wait_for_dashboard_ready(process, timeout=60):
+    """
+    Function waits until the dashboard server is ready by checking the process output.
+    """
+    for i in range(timeout):
+        line = process.stdout.readline()
+        if line:
+            print(line, end="")
+            if "App running at:" in line:
+                print("Dashboard is ready!")
+                return
+    raise Exception("Dashboard did not start correctly.")
 
 def set_input_value(sb, element_id, value):
     """
@@ -36,5 +50,8 @@ def start_dashboard():
 
     return subprocess.Popen(
         ["python", "-m", "dashboard"],
-        cwd=working_directory
+        cwd=working_directory,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True
     )

--- a/tests/python/dashboard/util.py
+++ b/tests/python/dashboard/util.py
@@ -1,3 +1,6 @@
+import os
+import subprocess
+
 def wait_for_ready(sb, timeout=60):
     for i in range(timeout):
         print(f"wait_for_ready {i}")
@@ -20,3 +23,16 @@ def set_input_value(sb, element_id, value):
 
     sb.update_text(selector, value)
     sb.send_keys(selector, "\n")
+
+def start_dashboard():
+    """
+    Function which starts up impactx-dashboard server.
+    """
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    working_directory = os.path.join(script_dir, "../../../src/python/impactx")
+    working_directory = os.path.normpath(working_directory)
+
+    return subprocess.Popen(
+        ["python", "-m", "dashboard"],
+        cwd=working_directory
+    )

--- a/tests/python/dashboard/util.py
+++ b/tests/python/dashboard/util.py
@@ -90,7 +90,7 @@ def start_dashboard():
     Function which starts up impactx-dashboard server.
     """
     repo_root = find_repo_root()
-    working_directory = os.path.join(repo_root, "src", "python", "impactx", "dashboard")
+    working_directory = os.path.join(repo_root, "src", "python", "impactx")
     working_directory = os.path.normpath(working_directory)
 
     return subprocess.Popen(

--- a/tests/python/requirements.txt
+++ b/tests/python/requirements.txt
@@ -1,2 +1,3 @@
 -r ../../examples/requirements.txt
 pytest
+seleniumbase


### PR DESCRIPTION
This PR introduces the first unit test for the ImpactX dashboard, leveraging the SeleniumBase library to simulate a simulation run by a user with the GUI.

### Key Features
  - The unit test runs a simulation using the parameters from the FODO cell example on the GUI. (takes ~1 minute)
  - The test is considered successful if the simulation is completed without errors.

### Issues

- ~~**Dependency on Running Dashboard:**~~
  - ~~The current implementation requires the ImpactX dashboard to run in a separate terminal before executing the test via `pytest`.~~
  - ~~Can investigate to potentially have dashboard be launched within the test itself.~~
  - ~~Unit test is flaky with passing/failing, unsure if this is due to code error or error in pytest implementation. Need to investigate. Started occurring after the implementation of subprocess.~~
 - **Adding seleniumbase as a dependency**
   - Unsure where to add. (implemented incorrectly)

### Checklist

- [X] Implement unit test for impactx-dashboard (testing with FODO cell simulation parameters.
- [X] Automate the dashboard launch within the test.
- [X] Fix flaky unit test
- [x] Include seleniumbase dependency in CI test files
- [x] Include trame dependencies in CI test files
- [ ] Fix headless state for ctest

Resolves #667 