### PR TITLE
Rename element `name` to `type`

### DIFF
--- a/docs/source/usage/workflows/add_element.rst
+++ b/docs/source/usage/workflows/add_element.rst
@@ -53,7 +53,7 @@ To simplify the logic, we use so-called `mixin classes <https://en.wikipedia.org
    :language: cpp
    :dedent: 4
    :start-at: struct Drift
-   :end-at: static constexpr auto name = "Drift";
+   :end-at: static constexpr auto type = "Drift";
 
 After this brief boilerplate, our beamline elements implement three simple parts:
 

--- a/src/particles/PushAll.H
+++ b/src/particles/PushAll.H
@@ -37,7 +37,7 @@ namespace impactx
     )
     {
         // performance profiling per element
-        std::string const profile_name = "impactx::Push::" + std::string(T_Element::name);
+        std::string const profile_name = "impactx::Push::" + std::string(T_Element::type);
         BL_PROFILE(profile_name);
 
         // preparing to access reference particle data: RefPart

--- a/src/particles/elements/Aperture.H
+++ b/src/particles/elements/Aperture.H
@@ -30,7 +30,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "Aperture";
+        static constexpr auto type = "Aperture";
         using PType = ImpactXParticleContainer::ParticleType;
 
         enum Shape

--- a/src/particles/elements/Buncher.H
+++ b/src/particles/elements/Buncher.H
@@ -30,7 +30,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "Buncher";
+        static constexpr auto type = "Buncher";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** A short RF cavity element at zero crossing for bunching

--- a/src/particles/elements/CFbend.H
+++ b/src/particles/elements/CFbend.H
@@ -31,7 +31,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "CFbend";
+        static constexpr auto type = "CFbend";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** An combined-function bend, consisting of an ideal sector bend with

--- a/src/particles/elements/ChrDrift.H
+++ b/src/particles/elements/ChrDrift.H
@@ -30,7 +30,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "ChrDrift";
+        static constexpr auto type = "ChrDrift";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** A drift with chromatic effects included

--- a/src/particles/elements/ChrPlasmaLens.H
+++ b/src/particles/elements/ChrPlasmaLens.H
@@ -30,7 +30,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "ChrPlasmaLens";
+        static constexpr auto type = "ChrPlasmaLens";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** An active cylindrically symmetric plasma lens with chromatic focusing

--- a/src/particles/elements/ChrQuad.H
+++ b/src/particles/elements/ChrQuad.H
@@ -31,7 +31,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "ChrQuad";
+        static constexpr auto type = "ChrQuad";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** A Quadrupole magnet with chromatic focusing

--- a/src/particles/elements/ChrUniformAcc.H
+++ b/src/particles/elements/ChrUniformAcc.H
@@ -30,7 +30,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "ChrAcc";
+        static constexpr auto type = "ChrAcc";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** Acceleration in a uniform field Ez, with a uniform solenoidal field Bz.

--- a/src/particles/elements/ConstF.H
+++ b/src/particles/elements/ConstF.H
@@ -30,7 +30,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "ConstF";
+        static constexpr auto type = "ConstF";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** A linear Constant Focusing element

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -30,7 +30,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "DipEdge";
+        static constexpr auto type = "DipEdge";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** Edge focusing associated with bend entry or exit

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -30,7 +30,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "Drift";
+        static constexpr auto type = "Drift";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** A drift

--- a/src/particles/elements/Empty.H
+++ b/src/particles/elements/Empty.H
@@ -24,7 +24,7 @@ namespace impactx
     : public elements::Thin,
       public elements::NoFinalize
     {
-        static constexpr auto name = "None";
+        static constexpr auto type = "None";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** This element does nothing.

--- a/src/particles/elements/ExactDrift.H
+++ b/src/particles/elements/ExactDrift.H
@@ -30,7 +30,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "ExactDrift";
+        static constexpr auto type = "ExactDrift";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** A drift using the exact nonlinear transfer map

--- a/src/particles/elements/ExactSbend.H
+++ b/src/particles/elements/ExactSbend.H
@@ -32,7 +32,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "ExactSbend";
+        static constexpr auto type = "ExactSbend";
         static constexpr amrex::ParticleReal degree2rad = ablastr::constant::math::pi / 180.0;
         using PType = ImpactXParticleContainer::ParticleType;
 

--- a/src/particles/elements/Kicker.H
+++ b/src/particles/elements/Kicker.H
@@ -30,7 +30,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "Kicker";
+        static constexpr auto type = "Kicker";
         using PType = ImpactXParticleContainer::ParticleType;
 
         enum UnitSystem

--- a/src/particles/elements/Multipole.H
+++ b/src/particles/elements/Multipole.H
@@ -30,7 +30,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "Multipole";
+        static constexpr auto type = "Multipole";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** A general thin multipole element

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -30,7 +30,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "NonlinearLens";
+        static constexpr auto type = "NonlinearLens";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** Single short segment of the nonlinear magnetic insert element

--- a/src/particles/elements/PRot.H
+++ b/src/particles/elements/PRot.H
@@ -31,7 +31,7 @@ namespace impactx
       public elements::Thin,
       public elements::NoFinalize
     {
-        static constexpr auto name = "PRot";
+        static constexpr auto type = "PRot";
         using PType = ImpactXParticleContainer::ParticleType;
 
         static constexpr amrex::ParticleReal degree2rad = ablastr::constant::math::pi / 180.0;

--- a/src/particles/elements/Programmable.H
+++ b/src/particles/elements/Programmable.H
@@ -23,7 +23,7 @@ namespace impactx
 {
     struct Programmable
     {
-        static constexpr auto name = "Programmable";
+        static constexpr auto type = "Programmable";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** This element can be programmed

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -30,7 +30,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "Quad";
+        static constexpr auto type = "Quad";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** A Quadrupole magnet

--- a/src/particles/elements/RFCavity.H
+++ b/src/particles/elements/RFCavity.H
@@ -106,7 +106,7 @@ namespace RFCavityData
       public elements::Thick,
       public elements::Alignment
     {
-        static constexpr auto name = "RFCavity";
+        static constexpr auto type = "RFCavity";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** An RF cavity

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -31,7 +31,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "Sbend";
+        static constexpr auto type = "Sbend";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** An ideal sector bend

--- a/src/particles/elements/ShortRF.H
+++ b/src/particles/elements/ShortRF.H
@@ -30,7 +30,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "ShortRF";
+        static constexpr auto type = "ShortRF";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** A short RF cavity element

--- a/src/particles/elements/SoftQuad.H
+++ b/src/particles/elements/SoftQuad.H
@@ -115,7 +115,7 @@ namespace SoftQuadrupoleData
       public elements::Thick,
       public elements::Alignment
     {
-        static constexpr auto name = "SoftQuadrupole";
+        static constexpr auto type = "SoftQuadrupole";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** A soft-edge quadrupole

--- a/src/particles/elements/SoftSol.H
+++ b/src/particles/elements/SoftSol.H
@@ -120,7 +120,7 @@ namespace SoftSolenoidData
       public elements::Thick,
       public elements::Alignment
     {
-        static constexpr auto name = "SoftSolenoid";
+        static constexpr auto type = "SoftSolenoid";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** A soft-edge solenoid

--- a/src/particles/elements/Sol.H
+++ b/src/particles/elements/Sol.H
@@ -31,7 +31,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "Sol";
+        static constexpr auto type = "Sol";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** An ideal hard-edge Solenoid magnet

--- a/src/particles/elements/TaperedPL.H
+++ b/src/particles/elements/TaperedPL.H
@@ -30,7 +30,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "TaperedPL";
+        static constexpr auto type = "TaperedPL";
         using PType = ImpactXParticleContainer::ParticleType;
 
         /** A short segment of a nonlinear plasma lens with a transverse taper.

--- a/src/particles/elements/ThinDipole.H
+++ b/src/particles/elements/ThinDipole.H
@@ -27,7 +27,7 @@ namespace impactx
       public elements::Alignment,
       public elements::NoFinalize
     {
-        static constexpr auto name = "ThinDipole";
+        static constexpr auto type = "ThinDipole";
         using PType = ImpactXParticleContainer::ParticleType;
 
         static constexpr amrex::ParticleReal degree2rad = ablastr::constant::math::pi / 180.0;

--- a/src/particles/elements/diagnostics/AdditionalProperties.cpp
+++ b/src/particles/elements/diagnostics/AdditionalProperties.cpp
@@ -53,7 +53,7 @@ namespace impactx::diagnostics
         NonlinearLensInvariants const nonlinear_lens_invariants(alpha, beta, tn, cn);
 
         // profile time spent here
-        std::string profile_name = "impactx::Push::" + std::string(BeamMonitor::name) + "::add_optional_properties";
+        std::string profile_name = "impactx::Push::" + std::string(BeamMonitor::type) + "::add_optional_properties";
         BL_PROFILE(profile_name);
 
         // add runtime properties for H and I

--- a/src/particles/elements/diagnostics/openPMD.H
+++ b/src/particles/elements/diagnostics/openPMD.H
@@ -65,7 +65,7 @@ namespace detail
     struct BeamMonitor
     : public elements::Thin
     {
-        static constexpr auto name = "BeamMonitor";
+        static constexpr auto type = "BeamMonitor";
         using PType = typename ImpactXParticleContainer::ParticleType;
         using PinnedContainer = typename ImpactXParticleContainer::ContainerLike<amrex::PinnedArenaAllocator>;
 

--- a/src/particles/elements/diagnostics/openPMD.cpp
+++ b/src/particles/elements/diagnostics/openPMD.cpp
@@ -315,7 +315,7 @@ namespace detail
     )
     {
 #ifdef ImpactX_USE_OPENPMD
-        std::string profile_name = "impactx::Push::" + std::string(BeamMonitor::name);
+        std::string profile_name = "impactx::Push::" + std::string(BeamMonitor::type);
         BL_PROFILE(profile_name);
 
         // preparing to access reference particle data: RefPart


### PR DESCRIPTION
This string just names the type of the element. In #705, we will introduce per-element, user-defined names in a separate PR, which we will use the `name` field for.