### PR TITLE
Fix main() Profile Region

### DIFF
--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -54,6 +54,9 @@ namespace impactx {
             // this one last
             amr_data.reset();
 
+            if (amrex::Initialized())
+                amrex::Finalize();
+
             // only finalize once
             m_grids_initialized = false;
         }

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -54,9 +54,6 @@ namespace impactx {
             // this one last
             amr_data.reset();
 
-            if (amrex::Initialized())
-                amrex::Finalize();
-
             // only finalize once
             m_grids_initialized = false;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,16 +29,15 @@ int main(int argc, char* argv[])
     impactx::initialization::default_init_AMReX(argc, argv);
 
     {
-        BL_PROFILE("main()");
+        BL_PROFILE_VAR("main()", pmain);
         impactx::ImpactX impactX;
         impactX.init_grids();
         impactX.initBeamDistributionFromInputs();
         impactX.initLatticeElementsFromInputs();
         impactX.evolve();
+        BL_PROFILE_VAR_STOP(pmain);
         impactX.finalize();
     }
-
-    amrex::Finalize();
 
 #if defined(AMREX_USE_MPI)
     AMREX_ALWAYS_ASSERT(MPI_SUCCESS == MPI_Finalize());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,8 +28,8 @@ int main(int argc, char* argv[])
     // it here so users can pass command line arguments
     impactx::initialization::default_init_AMReX(argc, argv);
 
-    BL_PROFILE_VAR("main()", pmain);
     {
+        BL_PROFILE("main()");
         impactx::ImpactX impactX;
         impactX.init_grids();
         impactX.initBeamDistributionFromInputs();
@@ -37,7 +37,8 @@ int main(int argc, char* argv[])
         impactX.evolve();
         impactX.finalize();
     }
-    BL_PROFILE_VAR_STOP(pmain);
+
+    amrex::Finalize();
 
 #if defined(AMREX_USE_MPI)
     AMREX_ALWAYS_ASSERT(MPI_SUCCESS == MPI_Finalize());


### PR DESCRIPTION
Address new errors with AMReX development of the kind:
```
189: 0::Assertion `m_profiler.m_do_profiling == false' failed, file "Src/Base/AMReX_Arena.cpp", line 123 !!!
```
and
```
5: terminate called after throwing an instance of 'std::runtime_error'
5:   what():  Assertion `static_cast<int>(ttstack.size()) == global_depth' failed, file "Src/Base/AMReX_TinyProfiler.cpp", line 174, Msg: "TinyProfiler sections must be nested with respect to each other"
```