### PR TITLE
AMReX: `development`

### DIFF
--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -169,7 +169,7 @@ set(ImpactX_ablastr_branch "24.10"
 set(ImpactX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(ImpactX_amrex_internal)")
-set(ImpactX_amrex_branch ""
+set(ImpactX_amrex_branch "fcc5bd2927e9dd380aa8dd918c6656050b74dd8f"
     CACHE STRING
     "Repository branch for ImpactX_amrex_repo if(ImpactX_amrex_internal)")
 

--- a/cmake/dependencies/pyAMReX.cmake
+++ b/cmake/dependencies/pyAMReX.cmake
@@ -74,7 +74,7 @@ option(ImpactX_pyamrex_internal "Download & build pyAMReX" ON)
 set(ImpactX_pyamrex_repo "https://github.com/AMReX-Codes/pyamrex.git"
     CACHE STRING
     "Repository URI to pull and build pyamrex from if(ImpactX_pyamrex_internal)")
-set(ImpactX_pyamrex_branch "24.10"
+set(ImpactX_pyamrex_branch "8742a79c29b7db30c7287c8e33109c0d8be1277a"
     CACHE STRING
     "Repository branch for ImpactX_pyamrex_repo if(ImpactX_pyamrex_internal)")
 


### PR DESCRIPTION
Update AMReX to the latest [development](https://github.com/AMReX-Codes/amrex/commits/development/) commit, so we can start using the `SmallMatrix` math from https://github.com/AMReX-Codes/amrex/pull/4176

Use latest pyAMReX commit in [development](https://github.com/AMReX-Codes/pyamrex/commits/development/) for breaking AMReX changes (https://github.com/AMReX-Codes/pyamrex/pull/379).