### PR TITLE
Distributions: non-private members

### DIFF
--- a/src/particles/distribution/Gaussian.H
+++ b/src/particles/distribution/Gaussian.H
@@ -134,7 +134,6 @@ namespace impactx::distribution
             pt = a2;
         }
 
-    private:
         amrex::ParticleReal m_lambdaX, m_lambdaY, m_lambdaT;  //! related position axis intercepts (length) of the phase space ellipse
         amrex::ParticleReal m_lambdaPx, m_lambdaPy, m_lambdaPt;  //! related momentum axis intercepts of the phase space ellipse
         amrex::ParticleReal m_muxpx, m_muypy, m_mutpt;  //! correlation length-momentum

--- a/src/particles/distribution/KVdist.H
+++ b/src/particles/distribution/KVdist.H
@@ -147,7 +147,6 @@ namespace impactx::distribution
             pt = a2;
         }
 
-    private:
         amrex::ParticleReal m_lambdaX, m_lambdaY, m_lambdaT;  //! related position axis intercepts (length) of the phase space ellipse
         amrex::ParticleReal m_lambdaPx, m_lambdaPy, m_lambdaPt;  //! related momentum axis intercepts of the phase space ellipse
         amrex::ParticleReal m_muxpx, m_muypy, m_mutpt;  //! correlation length-momentum

--- a/src/particles/distribution/Kurth4D.H
+++ b/src/particles/distribution/Kurth4D.H
@@ -157,7 +157,6 @@ namespace impactx::distribution
             pt = a2;
         }
 
-    private:
         amrex::ParticleReal m_lambdaX, m_lambdaY, m_lambdaT;  //! related position axis intercepts (length) of the phase space ellipse
         amrex::ParticleReal m_lambdaPx, m_lambdaPy, m_lambdaPt;  //! related momentum axis intercepts of the phase space ellipse
         amrex::ParticleReal m_muxpx, m_muypy, m_mutpt;  //! correlation length-momentum

--- a/src/particles/distribution/Kurth6D.H
+++ b/src/particles/distribution/Kurth6D.H
@@ -163,7 +163,6 @@ namespace impactx::distribution
             pt = a2;
         }
 
-    private:
         amrex::ParticleReal m_lambdaX, m_lambdaY, m_lambdaT;  //! related position axis intercepts (length) of the phase space ellipse
         amrex::ParticleReal m_lambdaPx, m_lambdaPy, m_lambdaPt;  //! related momentum axis intercepts of the phase space ellipse
         amrex::ParticleReal m_muxpx, m_muypy, m_mutpt;  //! correlation length-momentum

--- a/src/particles/distribution/Semigaussian.H
+++ b/src/particles/distribution/Semigaussian.H
@@ -146,7 +146,6 @@ namespace impactx::distribution
             pt = a2;
         }
 
-    private:
         amrex::ParticleReal m_lambdaX, m_lambdaY, m_lambdaT;  //! related position axis intercepts (length) of the phase space ellipse
         amrex::ParticleReal m_lambdaPx, m_lambdaPy, m_lambdaPt;  //! related momentum axis intercepts of the phase space ellipse
         amrex::ParticleReal m_muxpx, m_muypy, m_mutpt;  //! correlation length-momentum

--- a/src/particles/distribution/Thermal.H
+++ b/src/particles/distribution/Thermal.H
@@ -420,7 +420,6 @@ namespace distribution
             pt = -pz * m_bg;
         }
 
-    private:
         amrex::ParticleReal m_k; //! linear focusing strength (1/meters)
         amrex::ParticleReal m_T1, m_T2; //! temperature of each particle population
         amrex::ParticleReal m_normalize, m_normalize_halo; //! normalization constant of first/second population
@@ -431,6 +430,7 @@ namespace distribution
         amrex::ParticleReal m_bg; ///< reference value of relativistic beta*gamma
         amrex::ParticleReal m_w;  ///< weight of the secondary (halo) population
 
+    private:
         // radial profile data
         amrex::ParticleReal const * m_cdf1 = nullptr; //! non-owning pointer to device core CDF
         amrex::ParticleReal const * m_cdf2 = nullptr; //! non-owning pointer to device halo CDF

--- a/src/particles/distribution/Triangle.H
+++ b/src/particles/distribution/Triangle.H
@@ -153,7 +153,7 @@ namespace impactx::distribution
             t = a1;
             pt = a2;
         }
-    private:
+
         amrex::ParticleReal m_lambdaX, m_lambdaY, m_lambdaT;  //! related position axis intercepts (length) of the phase space ellipse
         amrex::ParticleReal m_lambdaPx, m_lambdaPy, m_lambdaPt;  //! related momentum axis intercepts of the phase space ellipse
         amrex::ParticleReal m_muxpx, m_muypy, m_mutpt; //! correlation length-momentum

--- a/src/particles/distribution/Waterbag.H
+++ b/src/particles/distribution/Waterbag.H
@@ -151,10 +151,9 @@ namespace impactx::distribution
             pt = a2;
         }
 
-    private:
-        amrex::ParticleReal m_lambdaX,m_lambdaY,m_lambdaT;  //! related position axis intercepts (length) of the phase space ellipse
-        amrex::ParticleReal m_lambdaPx,m_lambdaPy,m_lambdaPt;  //! related momentum axis intercepts of the phase space ellipse
-        amrex::ParticleReal m_muxpx,m_muypy,m_mutpt;  //! correlation length-momentum
+        amrex::ParticleReal m_lambdaX, m_lambdaY, m_lambdaT;  //! related position axis intercepts (length) of the phase space ellipse
+        amrex::ParticleReal m_lambdaPx, m_lambdaPy, m_lambdaPt;  //! related momentum axis intercepts of the phase space ellipse
+        amrex::ParticleReal m_muxpx, m_muypy, m_mutpt;  //! correlation length-momentum
     };
 
 } // namespace impactx::distribution


### PR DESCRIPTION
Distributions that are simple struct members, do not hide the properties. This makes access and manipulation from Python bindings easier (todo in a follow-up) and is needed to quickly read the properties for covariance matrix calculations (moved out from #714).