### PR TITLE
Introduce `sim.track_particles()`

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -215,7 +215,11 @@ Collective Effects & Overall Simulation Parameters
 
    .. py:method:: evolve()
 
-      Run the main simulation loop for a number of steps.
+      Run the main simulation loop (deprecated, use ``track_particles``)
+
+   .. py:method:: track_particles()
+
+      Run the particle tracking simulation loop.
 
    .. py:method:: resize_mesh()
 

--- a/examples/achromatic_spectrometer/run_spectrometer.py
+++ b/examples/achromatic_spectrometer/run_spectrometer.py
@@ -78,7 +78,7 @@ sim.lattice.append(drift)
 sim.lattice.append(monitor)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/alignment/run_alignment.py
+++ b/examples/alignment/run_alignment.py
@@ -55,7 +55,7 @@ lattice = [
 sim.lattice.extend(lattice)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/aperture/run_aperture.py
+++ b/examples/aperture/run_aperture.py
@@ -63,7 +63,7 @@ sim.lattice.extend(
 )
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/apochromatic/run_apochromatic.py
+++ b/examples/apochromatic/run_apochromatic.py
@@ -69,7 +69,7 @@ lattice_line = [monitor, dr1, q1, q2, q3, dr2, q4, q5, dr2, q6, q7, q8, dr1, mon
 sim.lattice.extend(lattice_line)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/apochromatic/run_apochromatic_pl.py
+++ b/examples/apochromatic/run_apochromatic_pl.py
@@ -108,7 +108,7 @@ lattice_line = [
 sim.lattice.extend(lattice_line)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/cfbend/run_cfbend.py
+++ b/examples/cfbend/run_cfbend.py
@@ -59,7 +59,7 @@ bend = [
 sim.lattice.extend(bend)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/cfbend/run_cfbend_madx.py
+++ b/examples/cfbend/run_cfbend_madx.py
@@ -46,7 +46,7 @@ sim.add_particles(bunch_charge_C, distr, npart)
 sim.lattice.load_file("chicane.madx", nslice=25)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/cfchannel/run_cfchannel.py
+++ b/examples/cfchannel/run_cfchannel.py
@@ -53,7 +53,7 @@ sim.lattice.extend(
 )
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/cfchannel/run_cfchannel_10nC_fft.py
+++ b/examples/cfchannel/run_cfchannel_10nC_fft.py
@@ -59,7 +59,7 @@ sim.lattice.extend(
 )
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/cfchannel/run_cfchannel_10nC_mlmg.py
+++ b/examples/cfchannel/run_cfchannel_10nC_mlmg.py
@@ -58,7 +58,7 @@ sim.lattice.extend(
 )
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/chicane/run_chicane.py
+++ b/examples/chicane/run_chicane.py
@@ -77,7 +77,7 @@ sim.lattice.append(dr3)
 sim.lattice.append(monitor)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/chicane/run_chicane_csr.py
+++ b/examples/chicane/run_chicane_csr.py
@@ -79,7 +79,7 @@ sim.lattice.append(dr3)
 sim.lattice.append(monitor)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/chicane/run_chicane_madx.py
+++ b/examples/chicane/run_chicane_madx.py
@@ -46,7 +46,7 @@ sim.add_particles(bunch_charge_C, distr, npart)
 sim.lattice.load_file("chicane.madx", nslice=25)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/compression/run_compression.py
+++ b/examples/compression/run_compression.py
@@ -56,7 +56,7 @@ sim.lattice.extend([shortrf1, drift1])
 sim.lattice.append(monitor)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/coupled_optics/run_coupled_optics.py
+++ b/examples/coupled_optics/run_coupled_optics.py
@@ -75,7 +75,7 @@ sim.lattice.extend(lattice_coupled)
 sim.lattice.append(monitor)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/cyclotron/run_cyclotron.py
+++ b/examples/cyclotron/run_cyclotron.py
@@ -62,7 +62,7 @@ sim.lattice.extend(period)
 sim.periods = 150
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/distgen/run_gaussian_twiss.py
+++ b/examples/distgen/run_gaussian_twiss.py
@@ -67,7 +67,7 @@ fodo = [
 sim.lattice.extend(fodo)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/distgen/run_kurth4d.py
+++ b/examples/distgen/run_kurth4d.py
@@ -58,7 +58,7 @@ constf = [
 sim.lattice.extend(constf)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/distgen/run_kvdist_twiss.py
+++ b/examples/distgen/run_kvdist_twiss.py
@@ -67,7 +67,7 @@ fodo = [
 sim.lattice.extend(fodo)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/distgen/run_semigaussian.py
+++ b/examples/distgen/run_semigaussian.py
@@ -65,7 +65,7 @@ fodo = [
 sim.lattice.extend(fodo)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/dogleg/run_dogleg.py
+++ b/examples/dogleg/run_dogleg.py
@@ -71,7 +71,7 @@ sim.lattice.extend(lattice_dogleg)
 sim.lattice.append(monitor)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/epac2004_benchmarks/run_bithermal.py
+++ b/examples/epac2004_benchmarks/run_bithermal.py
@@ -65,7 +65,7 @@ sim.lattice.append(constf)
 sim.lattice.append(monitor)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/epac2004_benchmarks/run_fodo_rf_SC.py
+++ b/examples/epac2004_benchmarks/run_fodo_rf_SC.py
@@ -197,7 +197,7 @@ for element in lattice_no_drifts[1:]:
 sim.lattice.append(monitor)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/epac2004_benchmarks/run_thermal.py
+++ b/examples/epac2004_benchmarks/run_thermal.py
@@ -62,7 +62,7 @@ sim.lattice.append(constf)
 sim.lattice.append(monitor)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/expanding_beam/run_expanding_fft.py
+++ b/examples/expanding_beam/run_expanding_fft.py
@@ -58,7 +58,7 @@ monitor = elements.BeamMonitor("monitor", backend="h5")
 sim.lattice.extend([monitor, elements.Drift(name="d1", ds=6.0, nslice=40), monitor])
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/expanding_beam/run_expanding_mlmg.py
+++ b/examples/expanding_beam/run_expanding_mlmg.py
@@ -57,7 +57,7 @@ monitor = elements.BeamMonitor("monitor", backend="h5")
 sim.lattice.extend([monitor, elements.Drift(name="d1", ds=6.0, nslice=40), monitor])
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/fodo/run_fodo.py
+++ b/examples/fodo/run_fodo.py
@@ -65,7 +65,7 @@ fodo = [
 sim.lattice.extend(fodo)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/fodo/run_fodo_madx.py
+++ b/examples/fodo/run_fodo_madx.py
@@ -47,7 +47,7 @@ sim.add_particles(bunch_charge_C, distr, npart)
 sim.lattice.load_file("fodo.madx", nslice=25)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/fodo/run_fodo_twiss.py
+++ b/examples/fodo/run_fodo_twiss.py
@@ -67,7 +67,7 @@ fodo = [
 sim.lattice.extend(fodo)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/fodo_channel/run_fodo.py
+++ b/examples/fodo_channel/run_fodo.py
@@ -65,7 +65,7 @@ sim.lattice.extend(fodo)
 sim.periods = 101
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/fodo_chromatic/run_fodo_chr.py
+++ b/examples/fodo_chromatic/run_fodo_chr.py
@@ -65,7 +65,7 @@ fodo = [
 sim.lattice.extend(fodo)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/fodo_programmable/run_fodo_programmable.py
+++ b/examples/fodo_programmable/run_fodo_programmable.py
@@ -149,7 +149,7 @@ fodo = [
 sim.lattice.extend(fodo)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/fodo_rf/run_fodo_rf.py
+++ b/examples/fodo_rf/run_fodo_rf.py
@@ -64,7 +64,7 @@ for element in lattice_no_drifts[1:]:
 sim.lattice.append(monitor)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/fodo_tune/run_fodo_tune.py
+++ b/examples/fodo_tune/run_fodo_tune.py
@@ -64,7 +64,7 @@ sim.lattice.extend(fodo)
 sim.periods = 100
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 del sim

--- a/examples/initialize_from_array/run_from_array.py
+++ b/examples/initialize_from_array/run_from_array.py
@@ -103,7 +103,7 @@ sim.lattice.extend(
     ]
 )
 
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/iota_lattice/run_iotalattice.py
+++ b/examples/iota_lattice/run_iotalattice.py
@@ -120,7 +120,7 @@ sim.lattice.append(monitor)
 sim.periods = 5
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/iota_lattice/run_iotalattice_sdep.py
+++ b/examples/iota_lattice/run_iotalattice_sdep.py
@@ -216,7 +216,7 @@ sim.lattice.append(monitor)
 sim.periods = 5
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/iota_lens/run_iotalens.py
+++ b/examples/iota_lens/run_iotalens.py
@@ -63,7 +63,7 @@ nllens_lattice = (
 sim.lattice.extend(nllens_lattice)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/iota_lens/run_iotalens_sdep.py
+++ b/examples/iota_lens/run_iotalens_sdep.py
@@ -96,7 +96,7 @@ sim.lattice.append(monitor)
 sim.periods = 1
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/kicker/run_hvkicker_madx.py
+++ b/examples/kicker/run_hvkicker_madx.py
@@ -46,7 +46,7 @@ monitor = elements.BeamMonitor("monitor", backend="h5")
 sim.lattice.load_file("hvkicker.madx", nslice=1)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/kicker/run_kicker.py
+++ b/examples/kicker/run_kicker.py
@@ -54,7 +54,7 @@ kicklattice = [
 sim.lattice.extend(kicklattice)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/kicker/run_kicker_madx.py
+++ b/examples/kicker/run_kicker_madx.py
@@ -46,7 +46,7 @@ monitor = elements.BeamMonitor("monitor", backend="h5")
 sim.lattice.load_file("kicker.madx", nslice=1)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/kurth/run_kurth_10nC_periodic.py
+++ b/examples/kurth/run_kurth_10nC_periodic.py
@@ -52,7 +52,7 @@ drift1 = elements.Drift(name="drift1", ds=1.0, nslice=nslice)
 sim.lattice.extend([monitor, drift1, constf1, drift1, monitor])
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/kurth/run_kurth_periodic.py
+++ b/examples/kurth/run_kurth_periodic.py
@@ -50,7 +50,7 @@ drift1 = elements.Drift(name="drift1", ds=1.0)
 sim.lattice.extend([monitor, drift1, constf1, drift1, monitor])
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/multipole/run_multipole.py
+++ b/examples/multipole/run_multipole.py
@@ -57,7 +57,7 @@ multipole = [
 sim.lattice.extend(multipole)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/optimize_triplet/run_triplet.py
+++ b/examples/optimize_triplet/run_triplet.py
@@ -125,7 +125,7 @@ def run(parameters: tuple, write_particles=False, write_reduced=False) -> dict:
     sim.lattice.extend(build_lattice(parameters, write_particles=write_particles))
 
     # run simulation
-    sim.evolve()
+    sim.track_particles()
 
     # in situ calculate the reduced beam characteristics
     beam = sim.particle_container()

--- a/examples/positron_channel/run_positron.py
+++ b/examples/positron_channel/run_positron.py
@@ -69,7 +69,7 @@ sim.lattice.extend(period)
 sim.periods = 250
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
+++ b/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
@@ -355,6 +355,6 @@ for i in range(N_stage):
         )
 sim.lattice.extend([monitor])
 
-sim.evolve()
+sim.track_particles()
 sim.finalize()
 del sim

--- a/examples/quadrupole_softedge/run_quadrupole_softedge.py
+++ b/examples/quadrupole_softedge/run_quadrupole_softedge.py
@@ -76,7 +76,7 @@ drift2 = elements.Drift(name="drift2", ds=0.5, nslice=ns)
 sim.lattice.extend([monitor, drift1, quad1, drift2, quad2, drift1, monitor])
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/rfcavity/run_rfcavity.py
+++ b/examples/rfcavity/run_rfcavity.py
@@ -138,7 +138,7 @@ sim.lattice.extend(
 )
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/rotation/run_rotation.py
+++ b/examples/rotation/run_rotation.py
@@ -55,7 +55,7 @@ rotated_drift = [
 sim.lattice.extend(rotated_drift)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/solenoid/run_solenoid.py
+++ b/examples/solenoid/run_solenoid.py
@@ -54,7 +54,7 @@ sim.lattice.extend(
 )
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/solenoid/run_solenoid_madx.py
+++ b/examples/solenoid/run_solenoid_madx.py
@@ -43,7 +43,7 @@ sim.add_particles(bunch_charge_C, distr, npart)
 sim.lattice.load_file("solenoid.madx", nslice=1)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/solenoid_softedge/run_solenoid_softedge.py
+++ b/examples/solenoid_softedge/run_solenoid_softedge.py
@@ -136,7 +136,7 @@ sim.lattice.extend(
 )
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/thin_dipole/run_thin_dipole.py
+++ b/examples/thin_dipole/run_thin_dipole.py
@@ -64,7 +64,7 @@ sim.lattice.append(inverse_bend)
 sim.lattice.append(monitor)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -96,9 +96,13 @@ namespace impactx
          */
         bool early_param_check ();
 
-        /** Run the main simulation loop for a number of steps
+        /** Run the main simulation loop
          */
         void evolve ();
+
+        /** Run the particle tracking simulation loop
+         */
+        void track_particles ();
 
         /** Query input for warning logger variables and set up warning logger accordingly
          *

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -128,6 +128,13 @@ namespace impactx {
     {
         BL_PROFILE("ImpactX::evolve");
 
+        track_particles();
+    }
+
+    void ImpactX::track_particles ()
+    {
+        BL_PROFILE("ImpactX::track_particles");
+
         validate();
 
         // verbosity

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -436,9 +436,12 @@ void init_ImpactX (py::module& m)
         )
 
         .def("evolve", &ImpactX::evolve,
-             "Run the main simulation loop for a number of steps."
+             "Run the main simulation loop."
         )
-        // TODO: step
+        .def("track_particles", &ImpactX::track_particles,
+             "Run the particle tracking simulation loop."
+        )
+
         .def("resize_mesh", &ImpactX::ResizeMesh,
              "Resize the mesh :py:attr:`~domain` based on the :py:attr:`~dynamic_size` and related parameters."
         )

--- a/src/python/impactx/dashboard/Toolbar/exportTemplate.py
+++ b/src/python/impactx/dashboard/Toolbar/exportTemplate.py
@@ -83,7 +83,7 @@ sim.add_particles(bunch_charge_C, distr, npart)
 sim.lattice.extend(lattice_configuration)
 
 # Simulate
-sim.evolve()
+sim.track_particles()
 
 sim.finalize()
 """

--- a/src/python/impactx/dashboard/simulation.py
+++ b/src/python/impactx/dashboard/simulation.py
@@ -67,7 +67,7 @@ def run_simulation():
     sim.lattice.extend(lattice_configuration)
 
     # simulate
-    sim.evolve()
+    sim.track_particles()
 
     fig = adjusted_settings_plot(pc)
     fig_original = pc.plot_phasespace()

--- a/tests/python/test_charge_deposition.py
+++ b/tests/python/test_charge_deposition.py
@@ -37,7 +37,7 @@ def test_charge_deposition(save_png=True):
     sim.init_beam_distribution_from_inputs()
     sim.init_lattice_elements_from_inputs()
 
-    sim.evolve()
+    sim.track_particles()
 
     sim.deposit_charge()
 

--- a/tests/python/test_dataframe.py
+++ b/tests/python/test_dataframe.py
@@ -66,7 +66,7 @@ def test_df_pandas(save_png=True):
     sim.lattice.extend(fodo)
 
     # simulate
-    sim.evolve()
+    sim.track_particles()
 
     # check local particles
     df = pc.to_df(local=True)

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -34,7 +34,7 @@ def test_impactx_fodo_file():
     sim.init_beam_distribution_from_inputs()
     sim.init_lattice_elements_from_inputs()
 
-    sim.evolve()
+    sim.track_particles()
 
     # validate the results
     beam = sim.particle_container()
@@ -133,7 +133,7 @@ def test_impactx_nofile():
     print(len(sim.lattice))
     assert len(sim.lattice) > 5
 
-    sim.evolve()
+    sim.track_particles()
 
     # finalize simulation
     sim.finalize()
@@ -163,7 +163,7 @@ def test_impactx_noparticles():
     with pytest.raises(
         RuntimeError, match="No particles found. Cannot run evolve without a beam."
     ):
-        sim.evolve()
+        sim.track_particles()
 
     # finalize simulation
     sim.finalize()
@@ -231,7 +231,7 @@ def test_impactx_resting_refparticle():
         RuntimeError,
         match="The reference particle energy is zero. Not yet initialized?",
     ):
-        sim.evolve()
+        sim.track_particles()
 
     # finalize simulation
     sim.finalize()
@@ -254,7 +254,7 @@ def test_impactx_no_elements():
         RuntimeError,
         match="Beamline lattice has zero elements. Not yet initialized?",
     ):
-        sim.evolve()
+        sim.track_particles()
 
     # finalize simulation
     sim.finalize()

--- a/tests/python/test_particle_tiles.py
+++ b/tests/python/test_particle_tiles.py
@@ -59,7 +59,7 @@ def test_particle_tiles():
     sim.lattice.extend(fodo)
 
     # simulate
-    sim.evolve()
+    sim.track_particles()
 
     # access local particles
     for lvl in range(pc.finest_level + 1):

--- a/tests/python/test_push.py
+++ b/tests/python/test_push.py
@@ -58,7 +58,7 @@ def test_element_push():
     ]
     sim.lattice.extend(fodo)
 
-    sim.evolve()
+    sim.track_particles()
 
     # Push manually through a few (unnamed) elements
     elements.Quad(ds=1.0, k=1.0).push(pc)

--- a/tests/python/test_wake.py
+++ b/tests/python/test_wake.py
@@ -27,7 +27,7 @@ def test_wake(save_png=True):
     sim.init_grids()
     sim.init_beam_distribution_from_inputs()
     sim.init_lattice_elements_from_inputs()
-    sim.evolve()
+    sim.track_particles()
 
     sim.deposit_charge()
 

--- a/tests/python/test_xopt.py
+++ b/tests/python/test_xopt.py
@@ -126,7 +126,7 @@ def run(parameters: dict, write_particles=False, write_reduced=False) -> dict:
     sim.lattice.extend(build_lattice(parameters, write_particles=write_particles))
 
     # run simulation
-    sim.evolve()
+    sim.track_particles()
 
     # in situ calculate the reduced beam characteristics
     beam = sim.particle_container()


### PR DESCRIPTION
We will have multiple ways to evolve the sim soon (particles, only ref particle, only linear push of covariance matrix #714), so it is time to rename our central loop.

For now, `sim.evolve()` just calls the `sim.track_particles()` logic.