### PR TITLE
Change distribution default parameters to Twiss in dashboard

### DIFF
--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionFunctions.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionFunctions.py
@@ -9,14 +9,15 @@ server, state, ctrl = setup_server()
 
 class DistributionFunctions:
     """
-    Helper functions for the
-    User-Input section for beam properties.
+    Helper functions for the distribution parameters.
     """
 
     @staticmethod
     def convert_distribution_parameters_to_valid_type():
         """
-        Helper function to check if user input is valid.
+        Helper function to convert user-inputted distribution parameters
+        from string type to float type.
+
         :return: A dictionary with parameter names as keys and their validated values.
         """
 

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionFunctions.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionFunctions.py
@@ -1,0 +1,31 @@
+from ...trame_setup import setup_server
+
+server, state, ctrl = setup_server()
+
+# -----------------------------------------------------------------------------
+# Functions
+# -----------------------------------------------------------------------------
+
+
+class DistributionFunctions:
+    """
+    Helper functions for the
+    User-Input section for beam properties.
+    """
+
+    @staticmethod
+    def convert_distribution_parameters_to_valid_type():
+        """
+        Helper function to check if user input is valid.
+        :return: A dictionary with parameter names as keys and their validated values.
+        """
+
+        parameter_input = {
+            param["parameter_name"]: float(param["parameter_default_value"])
+            if param_is_valid
+            else 0.0
+            for param in state.selectedDistributionParameters
+            if (param_is_valid := param["parameter_error_message"] == [])
+        }
+
+        return parameter_input

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -31,7 +31,7 @@ state.listOfDistributionsAndParametersAndDefault = (
 # -----------------------------------------------------------------------------
 
 state.selectedDistribution = "Waterbag"
-state.selectedDistributionType = "Native"
+state.selectedDistributionType = "Twiss"
 state.selectedDistributionParameters = []
 
 # -----------------------------------------------------------------------------
@@ -172,21 +172,19 @@ class DistributionParameters:
             vuetify.VDivider()
             with vuetify.VCardText():
                 with vuetify.VRow():
-                    with vuetify.VCol(cols=8):
+                    with vuetify.VCol(cols=6):
                         vuetify.VCombobox(
                             label="Select Distribution",
                             v_model=("selectedDistribution",),
                             items=("listOfDistributions",),
                             dense=True,
                         )
-                    with vuetify.VCol(cols=4):
+                    with vuetify.VCol(cols=6):
                         vuetify.VSelect(
                             v_model=("selectedDistributionType",),
                             label="Type",
-                            items=(["Native", "Twiss"],),
-                            # change=(ctrl.kin_energy_unit_change, "[$event]"),
+                            items=(["Twiss", "Quadratic Form"],),
                             dense=True,
-                            disabled=True,
                         )
                 with vuetify.VRow(classes="my-2"):
                     for i in range(3):

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -28,7 +28,7 @@ state.listOfDistributionsAndParametersAndDefault = (
 )
 
 # -----------------------------------------------------------------------------
-# Default
+# Defaults
 # -----------------------------------------------------------------------------
 
 state.selectedDistribution = "Waterbag"
@@ -94,8 +94,8 @@ def update_distribution_parameters(
 
 def distribution_parameters():
     """
-    Writes user input for distribution parameters in suitable format for simulation code.
-    :return: An instance of the selected distribution class, initialized with user-provided parameters.
+    :return: An instance of the selected distribution class,
+     initialized with the appropriate parameters provided by the user.
     """
 
     distribution_name = state.selectedDistribution

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -37,6 +37,7 @@ state.listOfDistributionsAndParametersAndDefault = (
 state.selectedDistribution = "Waterbag"
 state.selectedDistributionType = "Twiss"
 state.selectedDistributionParameters = []
+state.distributionTypeDisabled = False
 
 # -----------------------------------------------------------------------------
 # Main Functions
@@ -47,7 +48,7 @@ def populate_distribution_parameters(selectedDistribution):
     """
     Populates distribution parameters based on the selected distribution.
     :param selectedDistribution (str): The name of the selected distribution
-        whos parameters need to be populated.
+    whose parameters need to be populated.
     """
 
     if state.selectedDistributionType == "Twiss":
@@ -58,7 +59,7 @@ def populate_distribution_parameters(selectedDistribution):
                 "parameter_default_value": param.default
                 if param.default != param.empty
                 else None,
-                "parameter_type": "float",  # Harcoding Twiss to 'float' type.
+                "parameter_type": "float",  # Hardcoding Twiss to 'float' type.
                 "parameter_error_message": generalFunctions.validate_against(
                     param.default if param.default != param.empty else None, "float"
                 ),
@@ -139,6 +140,12 @@ def distribution_parameters():
 
 @state.change("selectedDistribution")
 def on_distribution_name_change(selectedDistribution, **kwargs):
+    if selectedDistribution == "Thermal":
+        state.selectedDistributionType = "Quadratic Form"
+        state.distributionTypeDisabled = True
+        state.dirty("selectedDistributionType")
+    else:
+        state.distributionTypeDisabled = False
     populate_distribution_parameters(selectedDistribution)
 
 
@@ -195,6 +202,7 @@ class DistributionParameters:
                             label="Type",
                             items=(["Twiss", "Quadratic Form"],),
                             dense=True,
+                            disabled=("distributionTypeDisabled",),
                         )
                 with vuetify.VRow(classes="my-2"):
                     for i in range(3):

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -12,6 +12,7 @@ from impactx import distribution
 
 from ...trame_setup import setup_server
 from ..generalFunctions import generalFunctions
+from .distributionFunctions import DistributionFunctions
 
 server, state, ctrl = setup_server()
 
@@ -91,24 +92,6 @@ def update_distribution_parameters(
 # -----------------------------------------------------------------------------
 
 
-def parameter_input_checker():
-    """
-    Helper function to check if user input is valid.
-    :return: A dictionary with parameter names as keys and their validated values.
-    """
-
-    parameter_input = {}
-    for param in state.selectedDistributionParameters:
-        if param["parameter_error_message"] == []:
-            parameter_input[param["parameter_name"]] = float(
-                param["parameter_default_value"]
-            )
-        else:
-            parameter_input[param["parameter_name"]] = 0.0
-
-    return parameter_input
-
-
 def distribution_parameters():
     """
     Writes user input for distribution parameters in suitable format for simulation code.
@@ -116,7 +99,7 @@ def distribution_parameters():
     """
 
     distribution_name = state.selectedDistribution
-    parameters = parameter_input_checker()
+    parameters = DistributionFunctions.convert_distribution_parameters_to_valid_type()
 
     distr = getattr(distribution, distribution_name)(**parameters)
     return distr

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -63,6 +63,9 @@ def populate_distribution_parameters(selectedDistribution):
                 "parameter_error_message": generalFunctions.validate_against(
                     param.default if param.default != param.empty else None, "float"
                 ),
+                "parameter_units": "m"
+                if "beta" in param.name or "emitt" in param.name
+                else "",
             }
             for param in sig.parameters.values()
         ]
@@ -82,6 +85,9 @@ def populate_distribution_parameters(selectedDistribution):
                 "parameter_error_message": generalFunctions.validate_against(
                     parameter[1], parameter[2]
                 ),
+                "parameter_units": "m"
+                if "beta" in parameter[0] or "emitt" in parameter[0]
+                else "",
             }
             for parameter in selectedDistributionParameters
         ]
@@ -216,6 +222,7 @@ class DistributionParameters:
                                     vuetify.VTextField(
                                         label=("parameter.parameter_name",),
                                         v_model=("parameter.parameter_default_value",),
+                                        suffix=("parameter.parameter_units",),
                                         change=(
                                             ctrl.updateDistributionParameters,
                                             "[parameter.parameter_name, $event, parameter.parameter_type]",

--- a/src/python/impactx/dashboard/Input/inputParameters/inputFunctions.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputFunctions.py
@@ -26,8 +26,7 @@ CONVERSION_FACTORS = {
 
 class InputFunctions:
     """
-    Helper functions for the
-    User-Input section for beam properties.
+    Helper functions for the beam properties.
     """
 
     @staticmethod

--- a/src/python/impactx/dashboard/Toolbar/exportTemplate.py
+++ b/src/python/impactx/dashboard/Toolbar/exportTemplate.py
@@ -17,13 +17,25 @@ def build_distribution_list():
     distribution_name = state.selectedDistribution
     parameters = DistributionFunctions.convert_distribution_parameters_to_valid_type()
 
-    distribution_parameters = ",\n    ".join(
-        f"{key}={value}" for key, value in parameters.items()
+    indentation = " " * (8 if state.selectedDistributionType == "Twiss" else 4)
+    distribution_parameters = ",\n".join(
+        f"{indentation}{key}={value}" for key, value in parameters.items()
     )
 
-    return (
-        f"distr = distribution.{distribution_name}(\n    {distribution_parameters},\n)"
-    )
+    if state.selectedDistributionType == "Twiss":
+        return (
+            f"distr = distribution.{distribution_name}(\n"
+            f"    **twiss(\n"
+            f"{distribution_parameters},\n"
+            f"    )\n"
+            f")"
+        )
+    else:
+        return (
+            f"distr = distribution.{distribution_name}(\n"
+            f"{distribution_parameters},\n"
+            f")"
+        )
 
 
 def build_lattice_list():
@@ -56,7 +68,7 @@ def input_file():
     dashboard user inputs into a python script.
     """
     script = f"""
-from impactx import ImpactX, distribution, elements
+from impactx import ImpactX, distribution, elements, twiss
 
 sim = ImpactX()
 

--- a/src/python/impactx/dashboard/Toolbar/exportTemplate.py
+++ b/src/python/impactx/dashboard/Toolbar/exportTemplate.py
@@ -1,4 +1,4 @@
-from ..Input.distributionParameters.distributionMain import parameter_input_checker
+from ..Input.distributionParameters.distributionFunctions import DistributionFunctions
 from ..Input.latticeConfiguration.latticeMain import parameter_input_checker_for_lattice
 from ..trame_setup import setup_server
 
@@ -15,7 +15,7 @@ def build_distribution_list():
     as a string for exporting purposes.
     """
     distribution_name = state.selectedDistribution
-    parameters = parameter_input_checker()
+    parameters = DistributionFunctions.convert_distribution_parameters_to_valid_type()
 
     distribution_parameters = ",\n    ".join(
         f"{key}={value}" for key, value in parameters.items()


### PR DESCRIPTION
This PR updates the primary option for beam distribution configurations to "Twiss". The previously primary set, "Native," has been renamed to "Quadratic Form" and is now available as an alternative parameterization for users.

In addition, this PR makes minor adjustments to the code structure and docstrings within the beam distribution section. These changes do not affect functionality.

Tested with [this example](https://impactx.readthedocs.io/en/latest/usage/examples/distgen/README.html#a-6d-gaussian-distribution-from-twiss-functions) to ensure correct functionality.

Checklist

- [X]  Set "Twiss" as the default, with "Quadratic Form" as the alternative option.
- [X]  Update dashboard functionality to correctly display twiss and to read through simulation
- [X]  Update export templates to correctly handle the "Twiss" parameterization.
- [X]  Ensure the "Thermal" distribution uses only a single set of parameters.

I noticed that all beta/emitt parameters must have non-zero values, but this validation is missing in the current PR. PR #690 includes a modified helper function with built-in validation capabilities for non-zero values. Better to either include beta/emitt validation in that PR or in a new one once #690 is merged.

Resolves #724