### PR TITLE
Update UI interactions

### DIFF
--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -12,7 +12,7 @@ from distribution_input_helpers import twiss
 
 from impactx import distribution
 
-from .. import TrameFunctions, generalFunctions, setup_server, vuetify
+from .. import DashboardDefaults, TrameFunctions, generalFunctions, setup_server, vuetify
 from .distributionFunctions import DistributionFunctions
 
 server, state, ctrl = setup_server()
@@ -117,13 +117,18 @@ def distribution_parameters():
 
 @state.change("distribution")
 def on_distribution_name_change(distribution, **kwargs):
-    if distribution == "Thermal":
-        state.distribution_type = "Quadratic Form"
-        state.distribution_type_disable = True
+    if distribution == "Thermal" or distribution == "Empty":
+        state.distribution_type = ""
+        state.distributionTypeDisabled = True
         state.dirty("distribution_type")
     else:
-        state.distribution_type_disable = False
-    populate_distribution_parameters()
+        type_list_default = DashboardDefaults.LISTS["distribution_type_list"]
+        type_default = DashboardDefaults.DISTRIBUTION_PARAMETERS["distribution_type"]
+
+        if state.distribution_type not in type_list_default:
+            state.distribution_type = type_default
+
+        state.distributionTypeDisabled = False
 
 
 @state.change("distribution_type")

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -12,7 +12,13 @@ from distribution_input_helpers import twiss
 
 from impactx import distribution
 
-from .. import DashboardDefaults, TrameFunctions, generalFunctions, setup_server, vuetify
+from .. import (
+    DashboardDefaults,
+    TrameFunctions,
+    generalFunctions,
+    setup_server,
+    vuetify,
+)
 from .distributionFunctions import DistributionFunctions
 
 server, state, ctrl = setup_server()
@@ -119,7 +125,7 @@ def distribution_parameters():
 def on_distribution_name_change(distribution, **kwargs):
     if distribution == "Thermal" or distribution == "Empty":
         state.distribution_type = ""
-        state.distributionTypeDisabled = True
+        state.distribution_type_disable = True
         state.dirty("distribution_type")
     else:
         type_list_default = DashboardDefaults.LISTS["distribution_type_list"]
@@ -128,7 +134,7 @@ def on_distribution_name_change(distribution, **kwargs):
         if state.distribution_type not in type_list_default:
             state.distribution_type = type_default
 
-        state.distributionTypeDisabled = False
+        state.distribution_type_disable = False
 
 
 @state.change("distribution_type")

--- a/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeFunctions.py
+++ b/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeFunctions.py
@@ -26,7 +26,7 @@ class SpaceChargeFunctions:
 
             if index == 0:
                 if poisson_solver == "multigrid":
-                    if prob_relative_value < 3:
+                    if prob_relative_value <= 3:
                         error_message = "Must be greater than 3."
                 elif poisson_solver == "fft":
                     if prob_relative_value <= 1:

--- a/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeMain.py
+++ b/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeMain.py
@@ -31,9 +31,18 @@ def populate_prob_relative_fields():
     elif state.poisson_solver == "multigrid":
         first_field_value = multigrid_first_field_value
 
-    state.prob_relative = [first_field_value] + [0.0] * (
-        tot_num_prob_relative_fields - 1
-    )
+    if state.prob_relative:
+        size = len(state.prob_relative)
+        num_of_extra_fields = tot_num_prob_relative_fields - size
+
+        if size < tot_num_prob_relative_fields:
+            state.prob_relative.extend([0.0] * (num_of_extra_fields))
+        elif size > tot_num_prob_relative_fields:
+            state.prob_relative = state.prob_relative[:tot_num_prob_relative_fields]
+    else:
+        state.prob_relative = [first_field_value] + [0.0] * (
+            tot_num_prob_relative_fields - 1
+        )
 
     state.prob_relative_fields = [
         {

--- a/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeMain.py
+++ b/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeMain.py
@@ -25,7 +25,7 @@ def populate_prob_relative_fields():
     multigrid_first_field_value = generalFunctions.get_default(
         "prob_relative_first_value_multigrid", "default_values"
     )
-
+    first_field_value = 0
     if state.poisson_solver == "fft":
         first_field_value = fft_first_field_value
     elif state.poisson_solver == "multigrid":

--- a/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeMain.py
+++ b/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeMain.py
@@ -17,8 +17,8 @@ state.n_cell = []
 # -----------------------------------------------------------------------------
 
 
-def populate_prob_relative_fields(max_level):
-    num_prob_relative_fields = int(max_level) + 1
+def populate_prob_relative_fields():
+    tot_num_prob_relative_fields = int(state.max_level) + 1
     fft_first_field_value = generalFunctions.get_default(
         "prob_relative_first_value_fft", "default_values"
     )
@@ -27,15 +27,13 @@ def populate_prob_relative_fields(max_level):
     )
 
     if state.poisson_solver == "fft":
-        state.prob_relative = [fft_first_field_value] + [0.0] * (
-            num_prob_relative_fields - 1
-        )
+        first_field_value = fft_first_field_value
     elif state.poisson_solver == "multigrid":
-        state.prob_relative = [multigrid_first_field_value] + [0.0] * (
-            num_prob_relative_fields - 1
-        )
-    else:
-        state.prob_relative = [0.0] * num_prob_relative_fields
+        first_field_value = multigrid_first_field_value
+
+    state.prob_relative = [first_field_value] + [0.0] * (
+        tot_num_prob_relative_fields - 1
+    )
 
     state.prob_relative_fields = [
         {
@@ -45,7 +43,7 @@ def populate_prob_relative_fields(max_level):
             ),
             "step": generalFunctions.get_default("prob_relative", "steps"),
         }
-        for i in range(num_prob_relative_fields)
+        for i in range(tot_num_prob_relative_fields)
     ]
 
 
@@ -83,7 +81,7 @@ def update_blocking_factor_and_n_cell(category, kwargs):
 # -----------------------------------------------------------------------------
 @state.change("poisson_solver")
 def on_poisson_solver_change(poisson_solver, **kwargs):
-    populate_prob_relative_fields(state.max_level)
+    populate_prob_relative_fields()
     state.dirty("prob_relative_fields")
     generalFunctions.update_simulation_validation_status()
 
@@ -96,7 +94,7 @@ def on_space_charge_change(space_charge, **kwargs):
 
 @state.change("max_level")
 def on_max_level_change(max_level, **kwargs):
-    populate_prob_relative_fields(max_level)
+    populate_prob_relative_fields()
     generalFunctions.update_simulation_validation_status()
 
 

--- a/src/python/impactx/dashboard/Toolbar/exportTemplate.py
+++ b/src/python/impactx/dashboard/Toolbar/exportTemplate.py
@@ -14,15 +14,15 @@ def build_distribution_list():
     Generates an instance of distribution inputs
     as a string for exporting purposes.
     """
-    distribution_name = state.selected_distribution
+    distribution_name = state.distribution
     parameters = DistributionFunctions.convert_distribution_parameters_to_valid_type()
 
-    indentation = " " * (8 if state.selected_distribution_type == "Twiss" else 4)
+    indentation = " " * (8 if state.distribution_type == "Twiss" else 4)
     distribution_parameters = ",\n".join(
         f"{indentation}{key}={value}" for key, value in parameters.items()
     )
 
-    if state.selected_distribution_type == "Twiss":
+    if state.distribution_type == "Twiss":
         return (
             f"distr = distribution.{distribution_name}(\n"
             f"    **twiss(\n"


### PR DESCRIPTION
- [X] Fix distribution interactions
       - Distribution parameters are preserved when only the distribution name is changed. Currently, distribution parameters are reset to the default every time the distribution name is changed, regardless of name. 
       - Additionally, made modification to ensure no parameters are shown when the distribution is set to `Empty`. Currently, it is set to "Twiss"
- [x] Fix prob_relative interactions
      - Similarly with distribution interactions, currently the UI will reset any user inputs for `prob_relative ` whenever the `poisson_solver` or `max_level` fields are changed. This is now solved, where the `prob_relative` fields will have it's values preserved.