### PR TITLE
Named: `name` Only Used Once

### DIFF
--- a/src/particles/elements/Aperture.H
+++ b/src/particles/elements/Aperture.H
@@ -79,7 +79,7 @@ namespace impactx
             amrex::ParticleReal rotation_degree = 0,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Alignment(dx, dy, rotation_degree),
           m_shape(shape), m_action(action), m_xmax(xmax), m_ymax(ymax), m_repeat_x(repeat_x), m_repeat_y(repeat_y)
         {

--- a/src/particles/elements/Buncher.H
+++ b/src/particles/elements/Buncher.H
@@ -52,7 +52,7 @@ namespace impactx
             amrex::ParticleReal rotation_degree = 0,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Alignment(dx, dy, rotation_degree),
           m_V(V), m_k(k)
         {

--- a/src/particles/elements/CFbend.H
+++ b/src/particles/elements/CFbend.H
@@ -61,7 +61,7 @@ namespace impactx
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Thick(ds, nslice),
           Alignment(dx, dy, rotation_degree),
           m_rc(rc), m_k(k)

--- a/src/particles/elements/ChrDrift.H
+++ b/src/particles/elements/ChrDrift.H
@@ -55,7 +55,7 @@ namespace impactx
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Thick(ds, nslice),
           Alignment(dx, dy, rotation_degree)
         {

--- a/src/particles/elements/ChrPlasmaLens.H
+++ b/src/particles/elements/ChrPlasmaLens.H
@@ -63,7 +63,7 @@ namespace impactx
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Thick(ds, nslice),
           Alignment(dx, dy, rotation_degree),
           m_k(k), m_unit(unit)

--- a/src/particles/elements/ChrQuad.H
+++ b/src/particles/elements/ChrQuad.H
@@ -66,7 +66,7 @@ namespace impactx
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Thick(ds, nslice),
           Alignment(dx, dy, rotation_degree),
           m_k(k), m_unit(unit)

--- a/src/particles/elements/ChrUniformAcc.H
+++ b/src/particles/elements/ChrUniformAcc.H
@@ -61,7 +61,7 @@ namespace impactx
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Thick(ds, nslice),
           Alignment(dx, dy, rotation_degree),
           m_ez(ez), m_bz(bz)

--- a/src/particles/elements/ConstF.H
+++ b/src/particles/elements/ConstF.H
@@ -58,7 +58,7 @@ namespace impactx
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Thick(ds, nslice),
           Alignment(dx, dy, rotation_degree),
           m_kx(kx), m_ky(ky), m_kt(kt)

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -63,7 +63,7 @@ namespace impactx
             amrex::ParticleReal rotation_degree = 0,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Alignment(dx, dy, rotation_degree),
           m_psi(psi), m_rc(rc), m_g(g), m_K2(K2)
         {

--- a/src/particles/elements/Drift.H
+++ b/src/particles/elements/Drift.H
@@ -21,6 +21,7 @@
 #include <AMReX_REAL.H>
 
 #include <cmath>
+#include <utility>
 
 
 namespace impactx
@@ -52,7 +53,7 @@ namespace impactx
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Thick(ds, nslice),
           Alignment(dx, dy, rotation_degree)
         {

--- a/src/particles/elements/ExactDrift.H
+++ b/src/particles/elements/ExactDrift.H
@@ -52,7 +52,7 @@ namespace impactx
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Thick(ds, nslice),
           Alignment(dx, dy, rotation_degree)
         {

--- a/src/particles/elements/ExactSbend.H
+++ b/src/particles/elements/ExactSbend.H
@@ -69,7 +69,7 @@ namespace impactx
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Thick(ds, nslice),
           Alignment(dx, dy, rotation_degree),
           m_phi(phi * degree2rad), m_B(B)

--- a/src/particles/elements/Kicker.H
+++ b/src/particles/elements/Kicker.H
@@ -61,7 +61,7 @@ namespace impactx
             amrex::ParticleReal rotation_degree = 0,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Alignment(dx, dy, rotation_degree),
           m_xkick(xkick), m_ykick(ykick), m_unit(unit)
         {

--- a/src/particles/elements/Multipole.H
+++ b/src/particles/elements/Multipole.H
@@ -54,7 +54,7 @@ namespace impactx
             amrex::ParticleReal rotation_degree = 0,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Alignment(dx, dy, rotation_degree),
           m_multipole(multipole), m_Kn(K_normal), m_Ks(K_skew)
         {

--- a/src/particles/elements/NonlinearLens.H
+++ b/src/particles/elements/NonlinearLens.H
@@ -57,7 +57,7 @@ namespace impactx
             amrex::ParticleReal rotation_degree = 0,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Alignment(dx, dy, rotation_degree),
           m_knll(knll), m_cnll(cnll)
         {

--- a/src/particles/elements/PRot.H
+++ b/src/particles/elements/PRot.H
@@ -52,7 +52,7 @@ namespace impactx
             amrex::ParticleReal phi_out,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           m_phi_in(phi_in * degree2rad),
           m_phi_out(phi_out * degree2rad)
         {

--- a/src/particles/elements/PlaneXYRot.H
+++ b/src/particles/elements/PlaneXYRot.H
@@ -57,7 +57,7 @@ namespace impactx
             amrex::ParticleReal rotation_degree = 0,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Alignment(dx, dy, rotation_degree),
           m_phi(phi * degree2rad)
         {

--- a/src/particles/elements/Programmable.H
+++ b/src/particles/elements/Programmable.H
@@ -39,7 +39,7 @@ namespace impactx
             int nslice=1,
             std::optional<std::string> name = std::nullopt
         )
-          : Named(name), m_ds(ds), m_nslice(nslice)
+          : Named(std::move(name)), m_ds(ds), m_nslice(nslice)
         {}
 
         /** Push all particles relative to the reference particle

--- a/src/particles/elements/Quad.H
+++ b/src/particles/elements/Quad.H
@@ -57,7 +57,7 @@ namespace impactx
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Thick(ds, nslice),
           Alignment(dx, dy, rotation_degree),
           m_k(k)

--- a/src/particles/elements/RFCavity.H
+++ b/src/particles/elements/RFCavity.H
@@ -141,7 +141,7 @@ namespace RFCavityData
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )
-          : Named(name),
+          : Named(std::move(name)),
             Thick(ds, nslice),
             Alignment(dx, dy, rotation_degree),
             m_escale(escale), m_freq(freq), m_phase(phase), m_mapsteps(mapsteps), m_id(RFCavityData::next_id)

--- a/src/particles/elements/Sbend.H
+++ b/src/particles/elements/Sbend.H
@@ -55,7 +55,7 @@ namespace impactx
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Thick(ds, nslice),
           Alignment(dx, dy, rotation_degree),
           m_rc(rc)

--- a/src/particles/elements/ShortRF.H
+++ b/src/particles/elements/ShortRF.H
@@ -57,7 +57,7 @@ namespace impactx
             amrex::ParticleReal rotation_degree = 0,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Alignment(dx, dy, rotation_degree),
           m_V(V), m_freq(freq), m_phase(phase)
         {

--- a/src/particles/elements/SoftQuad.H
+++ b/src/particles/elements/SoftQuad.H
@@ -146,7 +146,7 @@ namespace SoftQuadrupoleData
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )
-          : Named(name),
+          : Named(std::move(name)),
             Thick(ds, nslice),
             Alignment(dx, dy, rotation_degree),
             m_gscale(gscale), m_mapsteps(mapsteps), m_id(SoftQuadrupoleData::next_id)

--- a/src/particles/elements/SoftSol.H
+++ b/src/particles/elements/SoftSol.H
@@ -157,7 +157,7 @@ namespace SoftSolenoidData
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )
-          : Named(name),
+          : Named(std::move(name)),
             Thick(ds, nslice),
             Alignment(dx, dy, rotation_degree),
             m_bscale(bscale), m_unit(unit), m_mapsteps(mapsteps), m_id(SoftSolenoidData::next_id)

--- a/src/particles/elements/Sol.H
+++ b/src/particles/elements/Sol.H
@@ -56,7 +56,7 @@ namespace impactx
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Thick(ds, nslice),
           Alignment(dx, dy, rotation_degree),
           m_ks(ks)

--- a/src/particles/elements/TaperedPL.H
+++ b/src/particles/elements/TaperedPL.H
@@ -59,7 +59,7 @@ namespace impactx
             amrex::ParticleReal rotation_degree = 0,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Alignment(dx, dy, rotation_degree),
           m_k(k), m_taper(taper), m_unit(unit)
         {

--- a/src/particles/elements/ThinDipole.H
+++ b/src/particles/elements/ThinDipole.H
@@ -57,7 +57,7 @@ namespace impactx
             amrex::ParticleReal rotation_degree = 0,
             std::optional<std::string> name = std::nullopt
         )
-        : Named(name),
+        : Named(std::move(name)),
           Alignment(dx, dy, rotation_degree),
           m_theta(theta * degree2rad),
           m_rc(rc)


### PR DESCRIPTION
... avoid an unnecessary copy. (Found via clang-tidy during #743.)