### PR TITLE
Remove Managed Memory Workarounds

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -813,7 +813,7 @@ Overall simulation parameters
 * ``amrex.the_arena_is_managed``  (``0`` or ``1``; default is ``0`` for false)
     When running on GPUs, device memory that is accessed from the host will automatically be transferred with managed memory.
     This is useful for convenience during development, but has sometimes severe performance and memory footprint implications if relied on (and sometimes vendor bugs).
-    For all regular ImpactX operations, we therefore do explicit memory transfers without the need for managed memory and thus changed the AMReX default to false.
+    For all regular ImpactX operations, we therefore do explicit memory transfers without the need for managed memory.
     `Please also see the documentation in AMReX <https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters>`__.
 
 * ``amrex.omp_threads``  (``system``, ``nosmt`` or positive integer; default is ``nosmt``)

--- a/examples/aperture/input_aperture.in
+++ b/examples/aperture/input_aperture.in
@@ -35,9 +35,6 @@ collimator.shape = rectangular
 collimator.xmax = 1.0e-3
 collimator.ymax = 1.5e-3
 
-# work-around for https://github.com/ECP-WarpX/impactx/issues/499
-amrex.the_arena_is_managed = 1
-
 
 ###############################################################################
 # Algorithms

--- a/examples/aperture/run_absorber.py
+++ b/examples/aperture/run_absorber.py
@@ -6,12 +6,7 @@
 #
 # -*- coding: utf-8 -*-
 
-import amrex.space3d as amr
 from impactx import ImpactX, distribution, elements
-
-# work-around for https://github.com/ECP-WarpX/impactx/issues/499
-pp_amrex = amr.ParmParse("amrex")
-pp_amrex.add("the_arena_is_managed", 1)
 
 sim = ImpactX()
 

--- a/examples/aperture/run_aperture.py
+++ b/examples/aperture/run_aperture.py
@@ -6,12 +6,7 @@
 #
 # -*- coding: utf-8 -*-
 
-import amrex.space3d as amr
 from impactx import ImpactX, distribution, elements
-
-# work-around for https://github.com/ECP-WarpX/impactx/issues/499
-pp_amrex = amr.ParmParse("amrex")
-pp_amrex.add("the_arena_is_managed", 1)
 
 sim = ImpactX()
 

--- a/examples/aperture/run_aperture_periodic.py
+++ b/examples/aperture/run_aperture_periodic.py
@@ -6,12 +6,7 @@
 #
 # -*- coding: utf-8 -*-
 
-import amrex.space3d as amr
 from impactx import ImpactX, distribution, elements
-
-# work-around for https://github.com/ECP-WarpX/impactx/issues/499
-pp_amrex = amr.ParmParse("amrex")
-pp_amrex.add("the_arena_is_managed", 1)
 
 sim = ImpactX()
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -32,8 +32,6 @@ def amrex_init(tmpdir):
                 "amrex.signal_handling=0",
                 # abort GPU runs if out-of-memory instead of swapping to host RAM
                 "amrex.abort_on_out_of_gpu_memory=1",
-                # do not rely on implicit host-device memory transfers
-                "amrex.the_arena_is_managed=0",
             ]
         )
         yield


### PR DESCRIPTION
Two changes:
- the AMReX default for `the_arena_is_managed` is false for a while, so we do not need to "overwrite" it anymore https://github.com/AMReX-Codes/amrex/pull/3438
- our initial implementation of particle loss in apertures was reworked for a while and does not require managed GPU memory anymore: remove work-arounds in inputs #531