### PR TITLE
Refactor Unit Handling for kin_energy

### DIFF
--- a/src/python/impactx/dashboard/Input/defaults.py
+++ b/src/python/impactx/dashboard/Input/defaults.py
@@ -16,7 +16,7 @@ class DashboardDefaults:
         "charge_qe": -1,
         "mass_MeV": 0.51099895,
         "npart": 1000,
-        "kin_energy": 2e3,
+        "kin_energy_on_ui": 2e3,
         "kin_energy_MeV": 2e3,
         "kin_energy_unit": "MeV",
         "bunch_charge_C": 1e-9,
@@ -80,7 +80,7 @@ class DashboardDefaults:
 
     TYPES = {
         "npart": "int",
-        "kin_energy": "float",
+        "kin_energy_on_ui": "float",
         "bunch_charge_C": "float",
         "mass_MeV": "float",
         "charge_qe": "int",

--- a/src/python/impactx/dashboard/Input/inputParameters/inputFunctions.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputFunctions.py
@@ -30,36 +30,11 @@ class InputFunctions:
     """
 
     @staticmethod
-    def value_of_kin_energy_MeV(kineticEnergyOnDisplayValue, OldUnit):
+    def update_kin_energy_sim_value() -> None:
         """
-        Converts the kinetic energy to MeV.
-        :param kineticEnergyOnDisplayValue: The kinetic energy value that is displayed in the UI.
-        :param OldUnit: The previous unit of kin_energy prior to change.
-        :return: The kinetic energy value converted to MeV.
+        Converts UI input to MeV for internal simulation value.
         """
 
         state.kin_energy_MeV = (
-            kineticEnergyOnDisplayValue
-            * CONVERSION_FACTORS[OldUnit]
-            / CONVERSION_FACTORS["MeV"]
+            state.kin_energy_on_ui * CONVERSION_FACTORS[state.kin_energy_unit]
         )
-        return state.kin_energy_MeV
-
-    @staticmethod
-    def update_kin_energy_on_display(old_unit, new_unit, kin_energy_value):
-        """
-        Updates the kinetic energy value in the UI.
-        :param old_unit: The previous unit of kin_energy prior to change.
-        :param new_unit: The new unit of kin_energy changed to by user.
-        :param kin_energy_value: The kinetic energy value in the current unit.
-        :return: The kinetic energy value converted to the new unit.
-        """
-
-        value_in_mev = InputFunctions.value_of_kin_energy_MeV(
-            kin_energy_value, old_unit
-        )
-        kin_energy_value_on_display = (
-            value_in_mev * CONVERSION_FACTORS["MeV"] / CONVERSION_FACTORS[new_unit]
-        )
-
-        return kin_energy_value_on_display

--- a/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
@@ -40,24 +40,14 @@ def validate_and_convert_to_correct_type(state_name):
 
         if getattr(state, state_name) != converted_value:
             setattr(state, state_name, converted_value)
-            if state_name == "kin_energy":
-                state.kin_energy_MeV = InputFunctions.value_of_kin_energy_MeV(
-                    converted_value, state.kin_energy_unit
-                )
+            if state_name == "kin_energy_on_ui":
+                on_kin_energy_unit_change()
 
 
-@ctrl.add("kin_energy_unit_change")
-def on_convert_kin_energy_change(new_unit):
-    old_unit = state.old_kin_energy_unit
-    if old_unit != new_unit and float(state.kin_energy) > 0:
-        state.kin_energy = InputFunctions.update_kin_energy_on_display(
-            old_unit, new_unit, state.kin_energy
-        )
-        state.kin_energy_unit = new_unit
-        state.old_kin_energy_unit = new_unit
-        state.kin_energy_MeV = InputFunctions.value_of_kin_energy_MeV(
-            float(state.kin_energy), new_unit
-        )
+@state.change("kin_energy_unit")
+def on_kin_energy_unit_change(**kwargs) -> None:
+    if state.kin_energy_on_ui != 0:
+        InputFunctions.update_kin_energy_sim_value()
 
 
 # -----------------------------------------------------------------------------
@@ -115,15 +105,14 @@ class InputParameters:
                     with vuetify.VCol(cols=8, classes="py-0"):
                         TrameFunctions.text_field(
                             label="Kinetic Energy",
-                            v_model_name="kin_energy",
-                            input=(ctrl.input_change, "['kin_energy']"),
+                            v_model_name="kin_energy_on_ui",
+                            input=(ctrl.input_change, "['kin_energy_on_ui']"),
                             classes="mr-2",
                         )
                     with vuetify.VCol(cols=4, classes="py-0"):
                         TrameFunctions.select(
                             label="Unit",
                             v_model_name="kin_energy_unit",
-                            input=(ctrl.kin_energy_unit_change, "[$event]"),
                         )
                 with vuetify.VRow(classes="my-2"):
                     with vuetify.VCol(cols=12, classes="py-0"):


### PR DESCRIPTION
This PR refactors the implementation for handling kinetic energy unit changes. While initially intended to address broken functionality introduced in [#780](https://github.com/ECP-WarpX/impactx/pull/780), the scope has evolved to implement a more intuitive approach for unit handling that no longer depends on the previous logic.

Previously, changing units would update both the UI display and backend values to represent the same physical quantity (e.g., 5 MeV changed to GeV would result in 0.005 on both the UI and backend). This behavior has now been redesigned to better align with user expectations. With this update, the backend value (in MeV) is updated to reflect the new unit, while the UI number remains constant (e.g., 5 MeV → 5 GeV).