### PR TITLE
Profiler: Charge Deposition

### DIFF
--- a/src/particles/ChargeDeposition.cpp
+++ b/src/particles/ChargeDeposition.cpp
@@ -15,6 +15,7 @@
 
 #include <AMReX.H>
 #include <AMReX_AmrParGDB.H>
+#include <AMReX_BLProfiler.H>
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_ParticleTile.H>
 
@@ -28,6 +29,8 @@ namespace impactx
         std::unordered_map<int, amrex::MultiFab> & rho,
         amrex::Vector<amrex::IntVect> const & ref_ratio)
     {
+        BL_PROFILE("ImpactXParticleContainer::DepositCharge");
+
         using namespace amrex::literals; // for _rt and _prt
 
         // reset the values in rho to zero

--- a/src/particles/spacecharge/PoissonSolve.cpp
+++ b/src/particles/spacecharge/PoissonSolve.cpp
@@ -13,8 +13,6 @@
 #include <ablastr/fields/PoissonSolver.H>
 
 #include <AMReX_BLProfiler.H>
-#include <AMReX_Extension.H>  // for AMREX_RESTRICT
-#include <AMReX_LO_BCTYPES.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_REAL.H>       // for ParticleReal
 
@@ -30,6 +28,8 @@ namespace impactx::spacecharge
         amrex::Vector<amrex::IntVect> rel_ref_ratio
     )
     {
+        BL_PROFILE("impactx::spacecharge::PoissonSolve");
+
         using namespace amrex::literals;
 
         // set space charge field to zero

--- a/src/particles/transformation/CoordinateTransformation.cpp
+++ b/src/particles/transformation/CoordinateTransformation.cpp
@@ -25,6 +25,7 @@ namespace impactx::transformation
                                    CoordSystem direction)
     {
         BL_PROFILE("impactx::transformation::CoordinateTransformation");
+
         using namespace amrex::literals; // for _rt and _prt
 
         if (direction == CoordSystem::s) {


### PR DESCRIPTION
Add missing annotations for the tiny profiler sections in space charge kicks: charge deposition was not captured.