### PR TITLE
openPMD Beam Input via `Source` Element

### DIFF
--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -83,7 +83,7 @@ Channels & Rings
    :maxdepth: 1
 
    examples/fodo_channel/README.rst
-   examples/fodo_channel_restart/README.rst
+   examples/solenoid_restart/README.rst
 
 
 Lattice Design & Optimization

--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -83,6 +83,7 @@ Channels & Rings
    :maxdepth: 1
 
    examples/fodo_channel/README.rst
+   examples/fodo_channel_restart/README.rst
 
 
 Lattice Design & Optimization

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -627,6 +627,20 @@ This requires these additional parameters:
 * ``<element_name>.nslice`` (``integer``) number of slices used for the application of space charge (default: ``1``)
 
 
+``source``
+^^^^^^^^^^^
+
+``source`` for a particle source.
+Typically at the beginning of a beam line.
+
+Currently, this only supports openPMD files from our ``beam_monitor``.
+
+* ``<element_name>.distribution`` (``string``)
+  Distribution type of particles in the source. currently, only ``"openPMD"`` is supported
+* ``<element_name>.openpmd_path`` (``string``)
+  path to the openPMD series
+
+
 ``tapered_pl``
 ^^^^^^^^^^^^^^
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -738,6 +738,15 @@ This module provides elements for the accelerator lattice.
 
       Scale factor (in meters^(1/2)) of the IOTA nonlinear magnetic insert element used for computing H and I.
 
+.. py:class:: impactx.elements.Source(distribution, openpmd_path, name)
+
+   A particle source.
+   Currently, this only supports openPMD files from our :py:class:`impactx.elements.BeamMonitor`
+
+   :param distribution: Distribution type of particles in the source. currently, only ``"openPMD"`` is supported
+   :param openpmd_path: path to the openPMD series
+   :param name: an optional name for the element
+
 .. py:class:: impactx.elements.Programmable(ds=0.0, nslice=1, name=None)
 
    A programmable beam optics element.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -624,6 +624,28 @@ add_impactx_test(solenoid.MADX.py
 )
 
 
+# Ideal, Hard-Edge Solenoid (Restart + 270 degrees) ###########################
+#
+# w/o space charge
+add_impactx_test(solenoid.restart
+    examples/solenoid_restart/input_solenoid.in
+    OFF  # ImpactX MPI-parallel
+    examples/solenoid_restart/analysis_solenoid.py
+    OFF  # no plot script yet
+)
+set_property(TEST solenoid.restart.run APPEND PROPERTY DEPENDS "solenoid.run")
+
+add_impactx_test(solenoid.restart.py
+    examples/solenoid_restart/run_solenoid.py
+    OFF  # ImpactX MPI-parallel
+    examples/solenoid_restart/analysis_solenoid.py
+    OFF  # no plot script yet
+)
+if(ImpactX_PYTHON)
+    set_property(TEST solenoid.restart.py.run APPEND PROPERTY DEPENDS "solenoid.py.run")
+endif()
+
+
 # Pole-face rotation ##########################################################
 #
 # w/o space charge

--- a/examples/solenoid_restart/README.rst
+++ b/examples/solenoid_restart/README.rst
@@ -7,8 +7,8 @@ This is the same example as the :ref:`proton beam undergoing 90 deg X-Y rotation
 
 The solenoid magnetic field corresponds to B = 2 T.
 
-The second moments of the particle distribution after the solenoid channel are rotated by 90 (start) + 270 = 360 degrees:  the final horizontal moments should coincide with the
-initial vertical moments, and vice-versa, to within the level expected due to noise due to statistical sampling.
+The second moments of the transverse particle distribution after the solenoid channel are rotated by 90 (start) + 270 = 360 degrees:  the final transverse moments should coincide with the
+initial transverse moments to within the level expected due to noise due to statistical sampling.
 
 In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 

--- a/examples/solenoid_restart/README.rst
+++ b/examples/solenoid_restart/README.rst
@@ -1,0 +1,50 @@
+.. _examples-solenoid-restart:
+
+Solenoid channel (Restart)
+==========================
+
+This is the same example as the :ref:`proton beam undergoing 90 deg X-Y rotation in an ideal solenoid channel <examples-solenoid>`, but it restarts the resulting beam and rotates it another 3 channel periods to the initial X-Y conditions.
+
+The solenoid magnetic field corresponds to B = 2 T.
+
+The second moments of the particle distribution after the solenoid channel are rotated by 90 (start) + 270 = 360 degrees:  the final horizontal moments should coincide with the
+initial vertical moments, and vice-versa, to within the level expected due to noise due to statistical sampling.
+
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+
+
+Run
+---
+
+This example can be run **either** as:
+
+* **Python** script: ``python3 run_solenoid.py`` or
+* ImpactX **executable** using an input file: ``impactx input_solenoid.in``
+
+For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+
+.. tab-set::
+
+   .. tab-item:: Python: Script
+
+       .. literalinclude:: run_solenoid.py
+          :language: python3
+          :caption: You can copy this file from ``examples/solenoid_restart/run_solenoid.py``.
+
+   .. tab-item:: Executable: Input File
+
+       .. literalinclude:: input_solenoid.in
+          :language: ini
+          :caption: You can copy this file from ``examples/solenoid_restart/input_solenoid.in``.
+
+
+Analyze
+-------
+
+We run the following script to analyze correctness:
+
+.. dropdown:: Script ``analysis_solenoid.py``
+
+   .. literalinclude:: analysis_solenoid.py
+      :language: python3
+      :caption: You can copy this file from ``examples/solenoid_restart/analysis_solenoid.py``.

--- a/examples/solenoid_restart/analysis_solenoid.py
+++ b/examples/solenoid_restart/analysis_solenoid.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+import numpy as np
+import openpmd_api as io
+from scipy.stats import moment
+
+
+def get_moments(beam):
+    """Calculate standard deviations of beam position & momenta
+    and emittance values
+
+    Returns
+    -------
+    sigx, sigy, sigt, emittance_x, emittance_y, emittance_t
+    """
+    sigx = moment(beam["position_x"], moment=2) ** 0.5  # variance -> std dev.
+    sigpx = moment(beam["momentum_x"], moment=2) ** 0.5
+    sigy = moment(beam["position_y"], moment=2) ** 0.5
+    sigpy = moment(beam["momentum_y"], moment=2) ** 0.5
+    sigt = moment(beam["position_t"], moment=2) ** 0.5
+    sigpt = moment(beam["momentum_t"], moment=2) ** 0.5
+
+    epstrms = beam.cov(ddof=0)
+    emittance_x = (sigx**2 * sigpx**2 - epstrms["position_x"]["momentum_x"] ** 2) ** 0.5
+    emittance_y = (sigy**2 * sigpy**2 - epstrms["position_y"]["momentum_y"] ** 2) ** 0.5
+    emittance_t = (sigt**2 * sigpt**2 - epstrms["position_t"]["momentum_t"] ** 2) ** 0.5
+
+    return (sigx, sigy, sigt, emittance_x, emittance_y, emittance_t)
+
+
+# initial/final beam
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+first_step = list(series.iterations)[0]
+last_step = list(series.iterations)[-1]
+initial = series.iterations[first_step].particles["beam"].to_df()
+final = series.iterations[last_step].particles["beam"].to_df()
+
+# compare number of particles
+num_particles = 10000
+assert num_particles == len(initial)
+assert num_particles == len(final)
+
+print("Initial Beam:")
+sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(initial)
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
+print(
+    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
+)
+
+atol = 0.0  # ignored
+rtol = 1.3 * num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
+    [
+        2.205510139392e-3,
+        1.559531175539e-3,
+        6.404930308742e-3,
+        2.0e-6,
+        1.0e-6,
+        1.0e-6,
+    ],
+    rtol=rtol,
+    atol=atol,
+)
+
+print("")
+print("Final Beam:")
+sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(final)
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
+print(
+    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
+)
+
+atol = 0.0  # ignored
+rtol = 2.3 * num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigx, sigy, emittance_x, emittance_y, emittance_t],
+    [
+        1.559531175539e-3,
+        2.205510139392e-3,
+        1.0e-6,
+        2.0e-6,
+        1.0e-6,
+    ],
+    rtol=rtol,
+    atol=atol,
+)

--- a/examples/solenoid_restart/input_solenoid.in
+++ b/examples/solenoid_restart/input_solenoid.in
@@ -1,0 +1,44 @@
+###############################################################################
+# Reference Particle
+###############################################################################
+beam.kin_energy = 250.0
+beam.particle = proton
+
+# ignored
+beam.charge = 1.0e-9
+beam.units = static
+beam.distribution = empty
+
+
+###############################################################################
+# Beamline: lattice elements and segments
+###############################################################################
+lattice.elements = source monitor sols monitor
+lattice.nslice = 1
+
+source.type = source
+source.distribution = openPMD
+source.openpmd_path = "../solenoid/diags/openPMD/monitor.h5"
+
+monitor.type = beam_monitor
+monitor.backend = h5
+
+sol1.type = solenoid
+sol1.ds = 3.820395
+sol1.ks = 0.8223219329893234
+
+sols.type = line
+sols.elements = sol1
+sols.repeat = 3
+
+###############################################################################
+# Algorithms
+###############################################################################
+algo.particle_shape = 2
+algo.space_charge = false
+
+
+###############################################################################
+# Diagnostics
+###############################################################################
+diag.slice_step_diagnostics = true

--- a/examples/solenoid_restart/run_solenoid.py
+++ b/examples/solenoid_restart/run_solenoid.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Marco Garten, Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+from impactx import ImpactX, elements, push
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# load a 250 MeV proton beam with an initial
+# horizontal rms emittance of 1 um and an
+# initial vertical rms emittance of 2 um
+kin_energy_MeV = 250.0  # reference energy
+
+#   reference particle
+pc = sim.particle_container()
+ref = pc.ref_particle()
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
+
+#   load particle bunch from file
+push(pc, elements.Source("openPMD", "../solenoid.py/diags/openPMD/monitor.h5"))
+
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+
+# design the accelerator lattice
+sol1 = elements.Sol(name="sol1", ds=3.820395, ks=0.8223219329893234)
+sim.lattice.append(monitor)
+sim.lattice.extend([sol1] * 3)
+sim.lattice.append(monitor)
+
+# run simulation
+sim.track_particles()
+
+# clean shutdown
+sim.finalize()

--- a/src/elements/All.H
+++ b/src/elements/All.H
@@ -35,9 +35,10 @@
 #include "RFCavity.H"
 #include "Sbend.H"
 #include "ShortRF.H"
-#include "Sol.H"
 #include "SoftSol.H"
 #include "SoftQuad.H"
+#include "Sol.H"
+#include "Source.H"
 #include "TaperedPL.H"
 #include "ThinDipole.H"
 #include "diagnostics/openPMD.H"
@@ -77,6 +78,7 @@ namespace impactx::elements
         SoftSolenoid,
         SoftQuadrupole,
         Sol,
+        Source,
         TaperedPL,
         ThinDipole
     >;

--- a/src/elements/All.H
+++ b/src/elements/All.H
@@ -41,7 +41,7 @@
 #include "Source.H"
 #include "TaperedPL.H"
 #include "ThinDipole.H"
-#include "diagnostics/openPMD.H"
+#include "diagnostics/BeamMonitor.H"
 
 #include <variant>
 

--- a/src/elements/CMakeLists.txt
+++ b/src/elements/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(lib
   PRIVATE
     Aperture.cpp
     Programmable.cpp
+    Source.cpp
 )
 
 add_subdirectory(diagnostics)

--- a/src/elements/Source.H
+++ b/src/elements/Source.H
@@ -1,0 +1,93 @@
+/* Copyright 2022-2025 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_SOURCE_H
+#define IMPACTX_SOURCE_H
+
+#include "particles/ImpactXParticleContainer.H"
+#include "mixin/lineartransport.H"
+#include "mixin/named.H"
+#include "mixin/nofinalize.H"
+#include "mixin/thin.H"
+
+#include <stdexcept>
+#include <string>
+
+
+namespace impactx::elements
+{
+    struct Source
+    : public mixin::Named,
+      public mixin::LinearTransport<Source>,
+      public mixin::Thin,
+      public mixin::NoFinalize
+    {
+        static constexpr auto type = "Source";
+        using PType = ImpactXParticleContainer::ParticleType;
+
+        /** A particle source
+         *
+         * @param distribution Must read "openPMD" for this constructor
+         * @param openpmd_path path to openPMD series as accepted by openPMD::Series
+         * @param name a user defined and not necessarily unique name of the element
+         */
+        Source (
+            std::string distribution,
+            std::string openpmd_path,
+            std::optional<std::string> name = std::nullopt
+        )
+        : Named(std::move(name)),
+          m_distribution(distribution),
+          m_series_name(std::move(openpmd_path))
+        {
+            if (distribution != "openPMD") {
+                throw std::runtime_error("Only 'openPMD' distribution is supported if openpmd_path is provided!");
+            }
+        }
+
+        /** Initialize/Load particles.
+         *
+         * Particles are relative to the reference particle.
+         *
+         * @param[in,out] pc particle container to push
+         * @param[in] step global step for diagnostics
+         * @param[in] period for periodic lattices, this is the current period (turn or cycle)
+         */
+        void operator() (
+            ImpactXParticleContainer & pc,
+            [[maybe_unused]] int step,
+            [[maybe_unused]] int period
+        );
+
+        /** This function returns the linear transport map.
+         *
+         * @param[in] refpart reference particle
+         * @returns 6x6 transport matrix
+         */
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
+        Map6x6
+        transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
+        {
+            // nothing to do
+            return Map6x6::Identity();
+        }
+
+        /** This does nothing to the reference particle. */
+        using Thin::operator();
+
+        /** This pushes the covariance matrix. */
+        using LinearTransport::operator();
+
+        std::string m_distribution; //! Distribution type of particles in the source
+        std::string m_series_name; //! openPMD filename
+    };
+
+} // namespace impactx
+
+#endif  // IMPACTX_SOURCE_H

--- a/src/elements/Source.cpp
+++ b/src/elements/Source.cpp
@@ -12,49 +12,13 @@
 #include <AMReX_REAL.H>
 
 #ifdef ImpactX_USE_OPENPMD
+#   include "elements/diagnostics/openPMD.H"
 #   include <openPMD/openPMD.hpp>
 namespace io = openPMD;
 #else
 #  include <stdexcept>
 #endif
 
-
-namespace detail
-{
-#ifdef ImpactX_USE_OPENPMD
-    /** Unclutter a real_names to openPMD record
-     *
-     * TODO: move to ABLASTR
-     *
-     * @param fullName name as in real_names variable
-     * @return pair of openPMD record and component name
-     */
-    inline std::pair< std::string, std::string >
-    name2openPMD ( const std::string& fullName )
-    {
-        std::string record_name = fullName;
-        std::string component_name = io::RecordComponent::SCALAR;
-
-        // we use "_" as separator in names to group vector records
-        std::size_t const startComp = fullName.find_last_of('_');
-        if( startComp != std::string::npos ) {  // non-scalar
-            record_name = fullName.substr(0, startComp);
-            component_name = fullName.substr(startComp + 1u);
-        }
-        return make_pair(record_name, component_name);
-    }
-
-    io::RecordComponent get_component_record (
-            io::ParticleSpecies & species,
-            std::string comp_name
-    )
-    {
-        // handle scalar and non-scalar records by name
-        const auto [record_name, component_name] = name2openPMD(std::move(comp_name));
-        return species[record_name][component_name];
-    }
-#endif
-} // namespace detail
 
 namespace impactx::elements
 {
@@ -85,7 +49,7 @@ namespace impactx::elements
 
         auto const scalar = openPMD::RecordComponent::SCALAR;
         auto const getComponentRecord = [&beam](std::string comp_name) {
-            return detail::get_component_record(beam, std::move(comp_name));
+            return diagnostics::detail::get_component_record(beam, std::move(comp_name));
         };
 
         int const npart = beam["id"][scalar].getExtent()[0];  // how many particles to read total

--- a/src/elements/Source.cpp
+++ b/src/elements/Source.cpp
@@ -44,11 +44,11 @@ namespace detail
         return make_pair(record_name, component_name);
     }
 
-    // TODO: move to ablastr
     io::RecordComponent get_component_record (
             io::ParticleSpecies & species,
             std::string comp_name
-    ) {
+    )
+    {
         // handle scalar and non-scalar records by name
         const auto [record_name, component_name] = name2openPMD(std::move(comp_name));
         return species[record_name][component_name];
@@ -63,7 +63,7 @@ namespace impactx::elements
         ImpactXParticleContainer & pc,
         int,
         int
-        )
+    )
     {
 #ifdef ImpactX_USE_OPENPMD
         auto series = io::Series(m_series_name, io::Access::READ_ONLY

--- a/src/elements/Source.cpp
+++ b/src/elements/Source.cpp
@@ -1,0 +1,164 @@
+/* Copyright 2022-2025 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "elements/Source.H"
+
+#include <AMReX_REAL.H>
+
+#ifdef ImpactX_USE_OPENPMD
+#   include <openPMD/openPMD.hpp>
+namespace io = openPMD;
+#else
+#  include <stdexcept>
+#endif
+
+
+namespace detail
+{
+#ifdef ImpactX_USE_OPENPMD
+    /** Unclutter a real_names to openPMD record
+     *
+     * TODO: move to ABLASTR
+     *
+     * @param fullName name as in real_names variable
+     * @return pair of openPMD record and component name
+     */
+    inline std::pair< std::string, std::string >
+    name2openPMD ( const std::string& fullName )
+    {
+        std::string record_name = fullName;
+        std::string component_name = io::RecordComponent::SCALAR;
+
+        // we use "_" as separator in names to group vector records
+        std::size_t const startComp = fullName.find_last_of('_');
+        if( startComp != std::string::npos ) {  // non-scalar
+            record_name = fullName.substr(0, startComp);
+            component_name = fullName.substr(startComp + 1u);
+        }
+        return make_pair(record_name, component_name);
+    }
+
+    // TODO: move to ablastr
+    io::RecordComponent get_component_record (
+            io::ParticleSpecies & species,
+            std::string comp_name
+    ) {
+        // handle scalar and non-scalar records by name
+        const auto [record_name, component_name] = name2openPMD(std::move(comp_name));
+        return species[record_name][component_name];
+    }
+#endif
+} // namespace detail
+
+namespace impactx::elements
+{
+    void
+    Source::operator() (
+        ImpactXParticleContainer & pc,
+        int,
+        int
+        )
+    {
+#ifdef ImpactX_USE_OPENPMD
+        auto series = io::Series(m_series_name, io::Access::READ_ONLY
+#   if openPMD_HAVE_MPI==1
+            , amrex::ParallelDescriptor::Communicator()
+#   endif
+        );
+
+        // read the last iteration (highest openPMD iteration)
+        // TODO: later we can make this an option
+        int const read_iteration = std::prev(series.iterations.end())->first;
+        io::Iteration iteration = series.iterations[read_iteration];
+
+        // TODO: later we can make the particle species name an option
+        std::string const species_name = "beam";
+        io::ParticleSpecies beam = iteration.particles[species_name];
+        // TODO: later we can make the bunch charge an option (i.e., allow rescaling a distribution)
+        amrex::ParticleReal bunch_charge = beam.getAttribute("charge_C").get<amrex::ParticleReal>();
+
+        auto const scalar = openPMD::RecordComponent::SCALAR;
+        auto const getComponentRecord = [&beam](std::string comp_name) {
+            return detail::get_component_record(beam, std::move(comp_name));
+        };
+
+        int const npart = beam["id"][scalar].getExtent()[0];  // how many particles to read total
+
+        // TODO: read reference particle (optional?)
+
+        // read the particles
+
+        // Logic: We initialize 1/Nth of particles, independent of their
+        // position, per MPI rank. We then measure the distribution's spatial
+        // extent, create a grid, resize it to fit the beam, and then
+        // redistribute particles so that they reside on the correct MPI rank.
+        int const myproc = amrex::ParallelDescriptor::MyProc();
+        int const nprocs = amrex::ParallelDescriptor::NProcs();
+        int const navg = npart / nprocs;  // note: integer division
+        int const nleft = npart - navg * nprocs;
+        std::uint64_t const npart_this_proc = (myproc < nleft) ? navg+1 : navg;  // add 1 to each proc until distributed
+        std::uint64_t npart_before_this_proc = (myproc < nleft) ? (navg+1) * myproc : navg * myproc + nleft;
+        auto const rel_part_this_proc =
+            amrex::ParticleReal(npart_this_proc) / amrex::ParticleReal(npart);
+
+        // alloc data for particle attributes
+        std::map<std::string, amrex::Gpu::PinnedVector<amrex::ParticleReal>> pinned_SoA;
+        std::vector<std::string> real_soa_names = pc.GetRealSoANames();
+        for (auto real_idx = 0; real_idx < pc.NumRealComps(); real_idx++) {
+            pinned_SoA[real_soa_names.at(real_idx)].resize(npart_this_proc);
+        }
+
+        // read from file
+        // idcpu: TODO
+        //amrex::Gpu::PinnedVector<std::uint64_t> pinned_idcpu(npart_this_proc);
+        //beam["id"][scalar].loadChunkRaw(pinned_idcpu.data(), {npart_before_this_proc}, {npart_this_proc});
+        // SoA: Real
+        {
+            for (auto real_idx = 0; real_idx < pc.NumRealComps(); real_idx++) {
+                auto const component_name = real_soa_names.at(real_idx);
+                getComponentRecord(component_name).loadChunkRaw(
+                    pinned_SoA[component_name].data(),
+                    {npart_before_this_proc},
+                    {npart_this_proc}
+                );
+            }
+        }
+        // SoA: Int
+        std::vector<std::string> int_soa_names = pc.GetIntSoANames();
+        static_assert(IntSoA::nattribs == 0); // not yet used
+        if (!int_soa_names.empty())
+            throw std::runtime_error("BeamMonitor: int_soa_names output not yet implemented!");
+
+        series.flush();
+        series.close();
+
+        // copy to device
+        std::map<std::string, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_SoA;
+        for (auto real_idx = 0; real_idx < pc.NumRealComps(); real_idx++) {
+            auto const component_name = real_soa_names.at(real_idx);
+            d_SoA[component_name].resize(npart_this_proc);
+            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, pinned_SoA[component_name].begin(), pinned_SoA[component_name].end(), d_SoA[component_name].begin());
+        }
+
+        // finalize distributions and deallocate temporary device global memory
+        amrex::Gpu::streamSynchronize();
+
+        // TODO: at this point, we ignore the "id", "qm" and "weighting" in the file. Could be improved
+        pc.AddNParticles(d_SoA["position_x"], d_SoA["position_y"], d_SoA["position_t"],
+                         d_SoA["momentum_x"], d_SoA["momentum_y"], d_SoA["momentum_t"],
+                         pc.GetRefParticle().qm_ratio_SI(),
+                         bunch_charge * rel_part_this_proc);
+
+#else  // ImpactX_USE_OPENPMD
+        amrex::ignore_unused(pc);
+        throw std::runtime_error("BeamMonitor: openPMD not compiled");
+#endif  // ImpactX_USE_OPENPMD
+    }
+
+} // namespace impactx

--- a/src/elements/diagnostics/AdditionalProperties.cpp
+++ b/src/elements/diagnostics/AdditionalProperties.cpp
@@ -8,7 +8,8 @@
  * License: BSD-3-Clause-LBNL
  */
 
-#include "openPMD.H"
+#include "BeamMonitor.H"
+
 #include "diagnostics/NonlinearLensInvariants.H"
 #include "particles/ImpactXParticleContainer.H"
 

--- a/src/elements/diagnostics/BeamMonitor.H
+++ b/src/elements/diagnostics/BeamMonitor.H
@@ -7,8 +7,8 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
-#ifndef IMPACTX_ELEMENTS_DIAGS_OPENPMD_H
-#define IMPACTX_ELEMENTS_DIAGS_OPENPMD_H
+#ifndef IMPACTX_ELEMENTS_DIAGS_BEAMMONITOR_H
+#define IMPACTX_ELEMENTS_DIAGS_BEAMMONITOR_H
 
 #include "elements/mixin/thin.H"
 #include "particles/CovarianceMatrix.H"
@@ -207,4 +207,4 @@ namespace detail
 
 } // namespace impactx::diagnostics
 
-#endif // IMPACTX_ELEMENTS_DIAGS_OPENPMD_H
+#endif // IMPACTX_ELEMENTS_DIAGS_BEAMMONITOR_H

--- a/src/elements/diagnostics/BeamMonitor.cpp
+++ b/src/elements/diagnostics/BeamMonitor.cpp
@@ -20,6 +20,7 @@
 #include <AMReX_ParmParse.H>
 
 #ifdef ImpactX_USE_OPENPMD
+#   include "elements/diagnostics/openPMD.H"
 #   include <openPMD/openPMD.hpp>
 namespace io = openPMD;
 #endif
@@ -31,8 +32,7 @@ namespace io = openPMD;
 
 namespace impactx::elements::diagnostics
 {
-namespace detail
-{
+namespace detail {
     ImpactXParticleCounter::ImpactXParticleCounter (ParticleContainer & pc)
     {
         m_MPISize = amrex::ParallelDescriptor::NProcs();
@@ -68,17 +68,16 @@ namespace detail
         }
     }
 
-
-// get the offset in the overall particle id collection
-//
-// note: this is a MPI-collective operation
-//
-// input: num of particles  of from each   processor
-//
-// output:
-//     offset within <all> the particles in the comm
-//     sum of all particles in the comm
-//
+    // get the offset in the overall particle id collection
+    //
+    // note: this is a MPI-collective operation
+    //
+    // input: num of particles  of from each   processor
+    //
+    // output:
+    //     offset within <all> the particles in the comm
+    //     sum of all particles in the comm
+    //
     void
     ImpactXParticleCounter::GetParticleOffsetOfProcessor (
             const long& numParticles,
@@ -103,39 +102,6 @@ namespace detail
 #endif
     }
 
-#ifdef ImpactX_USE_OPENPMD
-    /** Unclutter a real_names to openPMD record
-     *
-     * TODO: move to ABLASTR
-     *
-     * @param fullName name as in real_names variable
-     * @return pair of openPMD record and component name
-     */
-    inline std::pair< std::string, std::string >
-    name2openPMD ( const std::string& fullName )
-    {
-        std::string record_name = fullName;
-        std::string component_name = io::RecordComponent::SCALAR;
-
-        // we use "_" as separator in names to group vector records
-        std::size_t const startComp = fullName.find_last_of('_');
-        if( startComp != std::string::npos ) {  // non-scalar
-            record_name = fullName.substr(0, startComp);
-            component_name = fullName.substr(startComp + 1u);
-        }
-        return make_pair(record_name, component_name);
-    }
-
-    // TODO: move to ablastr
-    io::RecordComponent get_component_record (
-        io::ParticleSpecies & species,
-        std::string comp_name
-    ) {
-        // handle scalar and non-scalar records by name
-        const auto [record_name, component_name] = name2openPMD(std::move(comp_name));
-        return species[record_name][component_name];
-    }
-#endif
 } // namespace detail
 
     void BeamMonitor::finalize ()

--- a/src/elements/diagnostics/BeamMonitor.cpp
+++ b/src/elements/diagnostics/BeamMonitor.cpp
@@ -8,7 +8,8 @@
  * License: BSD-3-Clause-LBNL
  */
 
-#include "openPMD.H"
+#include "BeamMonitor.H"
+
 #include "ImpactXVersion.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "diagnostics/ReducedBeamCharacteristics.H"

--- a/src/elements/diagnostics/CMakeLists.txt
+++ b/src/elements/diagnostics/CMakeLists.txt
@@ -1,5 +1,5 @@
 target_sources(lib
   PRIVATE
     AdditionalProperties.cpp
-    openPMD.cpp
+    BeamMonitor.cpp
 )

--- a/src/elements/diagnostics/CMakeLists.txt
+++ b/src/elements/diagnostics/CMakeLists.txt
@@ -3,3 +3,10 @@ target_sources(lib
     AdditionalProperties.cpp
     BeamMonitor.cpp
 )
+
+if(ImpactX_OPENPMD)
+    target_sources(lib
+      PRIVATE
+        openPMD.cpp
+    )
+endif()

--- a/src/elements/diagnostics/openPMD.H
+++ b/src/elements/diagnostics/openPMD.H
@@ -1,0 +1,43 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_OPENPMD_H
+#define IMPACTX_OPENPMD_H
+
+#ifdef ImpactX_USE_OPENPMD
+#   include <openPMD/openPMD.hpp>
+#endif
+
+#include <string>
+#include <utility>
+
+
+namespace impactx::elements::diagnostics::detail
+{
+#ifdef ImpactX_USE_OPENPMD
+    /** Unclutter a real_names to openPMD record
+     *
+     * @TODO move to ABLASTR
+     *
+     * @param fullName name as in real_names variable
+     * @return pair of openPMD record and component name
+     */
+    std::pair< std::string, std::string >
+    name2openPMD (const std::string& fullName);
+
+
+    //! TODO@ move to ablastr
+    openPMD::RecordComponent get_component_record (
+        openPMD::ParticleSpecies & species,
+        std::string comp_name
+    );
+#endif
+} // namespace impactx::elements::diagnostics::detail
+
+#endif // IMPACTX_OPENPMD_H

--- a/src/elements/diagnostics/openPMD.cpp
+++ b/src/elements/diagnostics/openPMD.cpp
@@ -1,0 +1,45 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "elements/diagnostics/openPMD.H"
+
+
+namespace impactx::elements::diagnostics::detail
+{
+#ifdef ImpactX_USE_OPENPMD
+    namespace io = openPMD;
+
+
+    std::pair< std::string, std::string >
+    name2openPMD (const std::string& fullName)
+    {
+        std::string record_name = fullName;
+        std::string component_name = io::RecordComponent::SCALAR;
+
+        // we use "_" as separator in names to group vector records
+        std::size_t const startComp = fullName.find_last_of('_');
+        if( startComp != std::string::npos ) {  // non-scalar
+            record_name = fullName.substr(0, startComp);
+            component_name = fullName.substr(startComp + 1u);
+        }
+        return make_pair(record_name, component_name);
+    }
+
+
+    io::RecordComponent get_component_record (
+        io::ParticleSpecies & species,
+        std::string comp_name
+    )
+    {
+        // handle scalar and non-scalar records by name
+        const auto [record_name, component_name] = name2openPMD(std::move(comp_name));
+        return species[record_name][component_name];
+    }
+#endif
+} // namespace impactx::elements::diagnostics::detail

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -503,6 +503,17 @@ namespace detail
             }
 
             m_lattice.emplace_back(diagnostics::BeamMonitor(openpmd_name, openpmd_backend, openpmd_encoding, period_sample_intervals));
+        } else if (element_type == "source")
+        {
+            std::string distribution, openpmd_path;
+            pp_element.get("distribution", distribution);
+
+            if (distribution == "openPMD")
+            {
+                pp_element.get("openpmd_path", openpmd_path);
+            }
+
+            m_lattice.emplace_back( Source(distribution, openpmd_path, element_name) );
         } else if (element_type == "line")
         {
             // Parse the lattice elements for the sub-lattice in the line

--- a/src/initialization/Validate.cpp
+++ b/src/initialization/Validate.cpp
@@ -14,6 +14,7 @@
 #include <AMReX_INT.H>
 
 #include <stdexcept>
+#include <string_view>
 
 
 namespace impactx
@@ -37,9 +38,19 @@ namespace impactx
                 nParticles += amr_data->track_particles.m_particle_container->NumberOfParticlesAtLevel(lev);
             }
             if (nParticles == 0)
-                throw std::runtime_error("No particles found. Cannot run evolve without a beam.");
-            if (nParticles == 1)
+            {
+                // do we have a source element as the first element of the beamline?
+                auto & first_element = m_lattice.front();
+                std::visit([](auto&& element){
+                    if (std::string_view(element.type) != std::string_view("Source")) {
+                        throw std::runtime_error("No particles found. Cannot run evolve without a beam.");
+                    }
+                }, first_element);
+            }
+            else if (nParticles == 1)
+            {
                 throw std::runtime_error("Only one particle found. This is not yet supported: https://github.com/ECP-WarpX/impactx/issues/44");
+            }
         }
 
         // elements

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -1455,6 +1455,41 @@ void init_elements(py::module& m)
     register_beamoptics_push(py_SoftSolenoid);
     register_envelope_push(py_SoftSolenoid);
 
+    py::class_<Source, elements::mixin::Named, elements::mixin::Thin> py_Source(me, "Source");
+    py_Source
+        .def("__repr__",
+             [](Source const & src) {
+                 return element_name(
+                     src,
+                     std::make_pair("distribution", src.m_distribution),
+                     std::make_pair("path", src.m_series_name)
+                 );
+             }
+        )
+        .def(py::init<
+             std::string,
+             std::string,
+             std::optional<std::string>
+         >(),
+             py::arg("distribution"),
+             py::arg("openpmd_path"),
+             py::arg("name") = py::none(),
+             "A particle source."
+        )
+        .def_property("distribution",
+            [](Source & src) { return src.m_distribution; },
+            [](Source & src, std::string distribution) { src.m_distribution = distribution; },
+            "Distribution type of particles in the source"
+        )
+        .def_property("series_name",
+            [](Source & src) { return src.m_series_name; },
+            [](Source & src, std::string series_name) { src.m_series_name = series_name; },
+            "Path to openPMD series as accepted by openPMD_api.Series"
+        )
+    ;
+    register_beamoptics_push(py_Source);
+    register_envelope_push(py_Source);
+
     py::class_<Sol, elements::mixin::Named, elements::mixin::Thick, elements::mixin::Alignment, elements::mixin::PipeAperture> py_Sol(me, "Sol");
     py_Sol
         .def("__repr__",


### PR DESCRIPTION
Add a new element `Source` that reads openPMD files from our beam monitors. Add an example in Python. Close #97

This can also be used to restart a simulation that was checkpointed at a beam monitor.

- [x] Python example
- [x] input file example
- [x] documentation

## Follow-Up Ideas

This is designed intentionally as a new element. In the future, we probably restructure our initial distribution logic to also go into this element, so that "from file" is just one of its options.

Not needed for Sirepo, but we will also add an option to use this from inputs files:
- For other projects, we will implement t-to-s transforms (for WarpX) and other options, as documented in inline TODOs.
- We will add a control option: restore reference particle (for restarts) yes/no