### PR TITLE
RTD: Fix GA Integration

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,3 +15,4 @@ sphinx>=2.0
 sphinx-copybutton
 sphinx-design
 sphinx_rtd_theme>=0.3.1
+sphinxcontrib-googleanalytics

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,8 +48,13 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_rtd_theme",
+    "sphinxcontrib.googleanalytics",
     "breathe",
 ]
+
+# Google Analytics
+googleanalytics_id = "G-WV5RZSK640"
+googleanalytics_enabled = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
GA was dropped from RTD in early Oct, 2024. This adds it again.