### PR TITLE
Mode: Reference Orbit Tracking

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -21,8 +21,8 @@ Tracking Modes
   Mode that specifies how the beam is tracked:
 
   * ``particles`` (default): symplectic particle tracking
-  * ``reference_orbit``: *not yet implemented*, only tracking of the reference particle orbit
   * ``envelope``: beam envelop (covariance matrix) tracking, through linearized transport maps
+  * ``reference_orbit``: only tracking of the reference particle orbit
 
 
 .. _running-cpp-parameters-particle:

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -233,6 +233,10 @@ Collective Effects & Overall Simulation Parameters
 
       Run the envelope tracking simulation loop.
 
+   .. py:method:: track_reference()
+
+      Run the reference orbit tracking simulation loop.
+
    .. py:method:: resize_mesh()
 
       Resize the mesh :py:attr:`~domain` based on the :py:attr:`~dynamic_size` and related parameters.

--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -114,6 +114,10 @@ namespace impactx
          */
         void track_envelope ();
 
+        /** Run the reference orbit tracking simulation loop
+         */
+        void track_reference (RefPart & ref);
+
         /** Query input for warning logger variables and set up warning logger accordingly
          *
          * Input variables are: ``always_warn_immediately`` and ``abort_on_warning_threshold``.

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -136,7 +136,16 @@ namespace impactx {
         else if (track == "envelope") {
             track_envelope();
         }
-        // TODO: reference_orbit only tracking
+        else if (track == "reference_orbit") {
+            if (!amr_data->track_reference.m_ref.has_value())
+            {
+                throw std::runtime_error("evolve: Reference particle not set.");
+            }
+            track_reference(amr_data->track_reference.m_ref.value());
+        }
+        else {
+            throw std::runtime_error("Unknown tracking algorithm: algo.track=" + track);
+        }
     }
 
 } // namespace impactx

--- a/src/initialization/AmrCoreData.H
+++ b/src/initialization/AmrCoreData.H
@@ -93,6 +93,14 @@ namespace impactx::initialization
 
         } track_envelope;
 
+        /** Data needed for the reference orbit tracking mode */
+        struct TrackModeReference
+        {
+            /** The reference particle */
+            std::optional<RefPart> m_ref;
+
+        } track_reference;
+
         void ErrorEst (
             [[maybe_unused]] int lev,
             [[maybe_unused]] amrex::TagBoxArray& tags,

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -467,5 +467,9 @@ namespace impactx
             auto dist = initialization::read_distribution(pp_dist);
             amr_data->track_envelope.m_cm = impactx::initialization::create_covariance_matrix(dist);
         }
+        else if (track == "reference_orbit")
+        {
+            amr_data->track_reference.m_ref = initialization::read_reference_particle(pp_dist);
+        }
     }
 } // namespace impactx

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -470,6 +470,9 @@ void init_ImpactX (py::module& m)
         .def("track_envelope", &ImpactX::track_envelope,
              "Run the envelope tracking simulation loop."
         )
+        .def("track_reference", &ImpactX::track_reference,
+             "Run the reference orbit tracking simulation loop."
+        )
 
         .def("resize_mesh", &ImpactX::ResizeMesh,
              "Resize the mesh :py:attr:`~domain` based on the :py:attr:`~dynamic_size` and related parameters."

--- a/src/tracking/CMakeLists.txt
+++ b/src/tracking/CMakeLists.txt
@@ -2,4 +2,5 @@ target_sources(lib
   PRIVATE
     envelope.cpp
     particles.cpp
+    reference.cpp
 )

--- a/src/tracking/reference.cpp
+++ b/src/tracking/reference.cpp
@@ -25,9 +25,9 @@
 namespace impactx
 {
     void
-    ImpactX::track_envelope ()
+    ImpactX::track_reference (RefPart & ref)
     {
-        BL_PROFILE("ImpactX::track_envelope");
+        BL_PROFILE("ImpactX::track_reference");
 
         // verbosity
         amrex::ParmParse pp_impactx("impactx");
@@ -41,23 +41,12 @@ namespace impactx
         // check typos in inputs after step 1
         bool early_params_checked = false;
 
-        // access beam data
-        if (!amr_data->track_envelope.m_ref.has_value())
-        {
-            throw std::runtime_error("track_envelope: Reference particle not set.");
-        }
-        if (!amr_data->track_envelope.m_cm.has_value())
-        {
-            throw std::runtime_error("track_envelope: Envelope (covariance matrix) not set.");
-        }
-        auto & ref = amr_data->track_envelope.m_ref.value();
-        auto & cm = amr_data->track_envelope.m_cm.value();
-
         // output of init state
         amrex::ParmParse pp_diag("diag");
         bool diag_enable = true;
         pp_diag.queryAdd("enable", diag_enable);
-        if (verbose > 0) {
+        if (verbose > 0)
+        {
             amrex::Print() << " Diagnostics: " << diag_enable << "\n";
         }
 
@@ -69,26 +58,6 @@ namespace impactx
             // print initial reference particle to file
             diagnostics::DiagnosticOutput(ref, "diags/ref_particle");
 
-            // print the initial values of reduced beam characteristics
-            diagnostics::DiagnosticOutput(cm, ref, "diags/reduced_beam_characteristics");
-
-        }
-
-        amrex::ParmParse const pp_algo("algo");
-        bool space_charge = false;
-        pp_algo.query("space_charge", space_charge);
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!space_charge, "Space charge not yet implemented for envelope tracking.");
-        if (verbose > 0)
-        {
-            amrex::Print() << " Space Charge effects: " << space_charge << "\n";
-        }
-
-        bool csr = false;
-        pp_algo.query("csr", csr);
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!csr, "CSR not yet implemented for envelope tracking.");
-        if (verbose > 0)
-        {
-            amrex::Print() << " CSR effects: " << csr << "\n";
         }
 
         // periods through the lattice
@@ -98,12 +67,11 @@ namespace impactx
         for (int period=0; period < num_periods; ++period)
         {
             // loop over all beamline elements
-            for (auto &element_variant: m_lattice)
-            {
+            for (auto &element_variant: m_lattice) {
                 // update element edge of the reference particle
-                amr_data->track_particles.m_particle_container->SetRefParticleEdge();
+                ref.sedge = ref.s;
 
-                // number of slices used for the application of space charge
+                // number of slices through the element
                 int nslice = 1;
                 amrex::ParticleReal slice_ds; // in meters
                 std::visit([&nslice, &slice_ds](auto &&element)
@@ -112,28 +80,21 @@ namespace impactx
                     slice_ds = element.ds() / nslice;
                 }, element_variant);
 
-                // sub-steps for space charge within the element
+                // sub-steps within the element
                 for (int slice_step = 0; slice_step < nslice; ++slice_step)
                 {
-                    BL_PROFILE("ImpactX::track_envelope::slice_step");
+                    BL_PROFILE("ImpactX::track_reference::slice_step");
                     step++;
-                    if (verbose > 0)
-                    {
+                    if (verbose > 0) {
                         amrex::Print() << " ++++ Starting step=" << step
                                        << " slice_step=" << slice_step << "\n";
                     }
 
-                    std::visit([&ref, &cm](auto&& element)
+                    std::visit([&ref](auto&& element)
                     {
                         // push reference particle in global coordinates
-                        {
-                            BL_PROFILE("impactx::Push::RefPart");
-                            element(ref);
-                        }
-
-                        // push Covariance Matrix
-                        element(cm, ref);
-
+                        BL_PROFILE("impactx::Push::RefPart");
+                        element(ref);
                     }, element_variant);
 
                     // just prints an empty newline at the end of the slice_step
@@ -151,16 +112,12 @@ namespace impactx
                     {
                         // print slice step reference particle to file
                         diagnostics::DiagnosticOutput(ref, "diags/ref_particle", step, true);
-
-                        // print slice step reduced beam characteristics to file
-                        diagnostics::DiagnosticOutput(cm, ref, "diags/reduced_beam_characteristics", step, true);
-
                     }
 
                     // inputs: unused parameters (e.g. typos) check after step 1 has finished
                     if (!early_params_checked) { early_params_checked = early_param_check(); }
 
-                } // end in-element space-charge slice-step loop
+                } // end in-element slice-step loop
 
             } // end beamline element loop
 
@@ -170,9 +127,6 @@ namespace impactx
         {
             // print final reference particle to file
             diagnostics::DiagnosticOutput(ref, "diags/ref_particle_final", step);
-
-            // print the final values of the reduced beam characteristics
-            diagnostics::DiagnosticOutput(cm, ref, "diags/reduced_beam_characteristics_final", step);
         }
 
         // loop over all beamline elements & finalize them


### PR DESCRIPTION
Add a simulation mode that only tracks the reference orbit. Close #622

- [x] implementation
- [x] documentation
- [ ] example(s): follow-up PR(s)