### PR TITLE
Fix: SEdge in Envelope Mode

### DIFF
--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -96,7 +96,7 @@ namespace impactx
             // loop over all beamline elements
             for (auto &element_variant: m_lattice) {
                 // update element edge of the reference particle
-                amr_data->track_particles.m_particle_container->SetRefParticleEdge();
+                ref.sedge = ref.s;
 
                 // number of slices used for the application of space charge
                 int nslice = 1;


### PR DESCRIPTION
Assign the `sedge = s` to the correct reference particle variable in envelope tracking. Follow-up to #814