### PR TITLE
Utilize shared state in dashboard

### DIFF
--- a/src/python/impactx/dashboard/Input/components.py
+++ b/src/python/impactx/dashboard/Input/components.py
@@ -104,8 +104,14 @@ class InputComponents:
         label: str, v_model_name: Optional[str] = None, **kwargs
     ) -> vuetify.VTextField:
         """
-        Creates a Vuetify VTextField component with
-        pre-filled components.
+        Creates a Vuetify VTextField component with the following default components:
+        - error_message state: It's init value is an empty list.
+        - step: The step value of the input (either set in defaults.py), or
+          by default is set to 1.
+        - suffix: The unit of the input (either set in defauts.py), or
+          by default is empty.
+        - type: set to 'number' to only allow a numeric input.
+        - dense: set to 'true' to minimize space usage.
 
         :param label: Display label
         :param v_model_name: v_model binding name. Optional, as default name

--- a/src/python/impactx/dashboard/Input/csrConfiguration/csrMain.py
+++ b/src/python/impactx/dashboard/Input/csrConfiguration/csrMain.py
@@ -23,5 +23,4 @@ class csrConfiguration:
                     with vuetify.VCol(classes="py-0"):
                         InputComponents.text_field(
                             label="CSR Bins",
-                            input=(ctrl.input_change, "['csr_bins']"),
                         )

--- a/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
@@ -17,26 +17,32 @@ server, state, ctrl = setup_server()
 # -----------------------------------------------------------------------------
 
 
-@ctrl.add("input_change")
-def validate_and_convert_to_correct_type(state_name):
-    value = getattr(state, state_name)
-    desired_type = DashboardDefaults.TYPES[state_name]
-    validation_name = f"{state_name}_error_message"
-    conditions = DashboardDefaults.VALIDATION_CONDITION.get(state_name, None)
+DEFAULTS = list(DashboardDefaults.INPUT_PARAMETERS.keys())
 
-    validation_result = generalFunctions.validate_against(
-        value, desired_type, conditions
-    )
-    setattr(state, validation_name, validation_result)
-    generalFunctions.update_simulation_validation_status()
 
-    if validation_result == []:
-        converted_value = generalFunctions.convert_to_correct_type(value, desired_type)
+@state.change(*DEFAULTS)
+def on_input_state_change(**_):
+    state_changes = state.modified_keys & set(DEFAULTS)
+    for state_name in state_changes:
+        print(f"{state_name} = {state[state_name]}")
+        value = getattr(state, state_name)
+        desired_type = DashboardDefaults.TYPES.get(state_name, None)
+        validation_name = f"{state_name}_error_message"
+        conditions = DashboardDefaults.VALIDATION_CONDITION.get(state_name, None)
 
-        if getattr(state, state_name) != converted_value:
-            setattr(state, state_name, converted_value)
-            if state_name == "kin_energy_on_ui":
-                on_kin_energy_unit_change()
+        validation_result = generalFunctions.validate_against(
+            value, desired_type, conditions
+        )
+        setattr(state, validation_name, validation_result)
+        generalFunctions.update_simulation_validation_status()
+
+        if validation_result == []:
+            converted_value = generalFunctions.convert_to_correct_type(value, desired_type)
+
+            if getattr(state, state_name) != converted_value:
+                setattr(state, state_name, converted_value)
+                if state_name == "kin_energy_on_ui":
+                    on_kin_energy_unit_change()
 
 
 @state.change("kin_energy_unit")
@@ -81,27 +87,23 @@ class InputParameters:
                         InputComponents.text_field(
                             label="Ref. Particle Charge",
                             v_model_name="charge_qe",
-                            input=(ctrl.input_change, "['charge_qe']"),
                         )
                     with vuetify.VCol(cols=6, classes="py-0"):
                         InputComponents.text_field(
                             label="Ref. Particle Mass",
                             v_model_name="mass_MeV",
-                            input=(ctrl.input_change, "['mass_MeV']"),
                         )
                 with vuetify.VRow(classes="my-0"):
                     with vuetify.VCol(cols=12, classes="py-0"):
                         InputComponents.text_field(
                             label="Number of Particles",
                             v_model_name="npart",
-                            input=(ctrl.input_change, "['npart']"),
                         )
                 with vuetify.VRow(classes="my-2"):
                     with vuetify.VCol(cols=8, classes="py-0"):
                         InputComponents.text_field(
                             label="Kinetic Energy",
                             v_model_name="kin_energy_on_ui",
-                            input=(ctrl.input_change, "['kin_energy_on_ui']"),
                             classes="mr-2",
                         )
                     with vuetify.VCol(cols=4, classes="py-0"):
@@ -114,5 +116,4 @@ class InputParameters:
                         InputComponents.text_field(
                             label="Bunch Charge",
                             v_model_name="bunch_charge_C",
-                            input=(ctrl.input_change, "['bunch_charge_C']"),
                         )

--- a/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
@@ -7,66 +7,21 @@ License: BSD-3-Clause-LBNL
 """
 
 from ... import setup_server, vuetify
-from .. import CardComponents, DashboardDefaults, InputComponents, generalFunctions
+from .. import CardComponents, InputComponents
 from . import InputFunctions
 
 server, state, ctrl = setup_server()
-
-# -----------------------------------------------------------------------------
-# Callbacks
-# -----------------------------------------------------------------------------
-
-
-input_parameters_defaults = list(DashboardDefaults.INPUT_PARAMETERS.keys())
-space_charge_defaults = list(DashboardDefaults.CSR.keys())
-INPUT_DEFAULTS = input_parameters_defaults + space_charge_defaults
-
-
-@state.change(*INPUT_DEFAULTS)
-def on_input_state_change(**_):
-    state_changes = state.modified_keys & set(INPUT_DEFAULTS)
-    for state_name in state_changes:
-        if type(state[state_name]) is str:
-            print(
-                f"{state_name} = {state[state_name]} and type: {type(state[state_name])}"
-            )
-            value = getattr(state, state_name)
-            desired_type = DashboardDefaults.TYPES.get(state_name, None)
-            validation_name = f"{state_name}_error_message"
-            conditions = DashboardDefaults.VALIDATION_CONDITION.get(state_name, None)
-
-            validation_result = generalFunctions.validate_against(
-                value, desired_type, conditions
-            )
-            setattr(state, validation_name, validation_result)
-            generalFunctions.update_simulation_validation_status()
-
-            if validation_result == []:
-                converted_value = generalFunctions.convert_to_correct_type(
-                    value, desired_type
-                )
-
-                if getattr(state, state_name) != converted_value:
-                    setattr(state, state_name, converted_value)
-                    if state_name == "kin_energy_on_ui":
-                        on_kin_energy_unit_change()
-
-
-@state.change("kin_energy_unit")
-def on_kin_energy_unit_change(**kwargs) -> None:
-    if state.kin_energy_on_ui != 0:
-        InputFunctions.update_kin_energy_sim_value()
-
-
-# -----------------------------------------------------------------------------
-# Content
-# -----------------------------------------------------------------------------
 
 
 class InputParameters:
     """
     User-Input section for beam properties.
     """
+
+    @state.change("kin_energy_unit")
+    def on_kin_energy_unit_change(**kwargs) -> None:
+        if state.kin_energy_on_ui != 0:
+            InputFunctions.update_kin_energy_sim_value()
 
     def card(self):
         """

--- a/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
@@ -24,25 +24,30 @@ DEFAULTS = list(DashboardDefaults.INPUT_PARAMETERS.keys())
 def on_input_state_change(**_):
     state_changes = state.modified_keys & set(DEFAULTS)
     for state_name in state_changes:
-        print(f"{state_name} = {state[state_name]}")
-        value = getattr(state, state_name)
-        desired_type = DashboardDefaults.TYPES.get(state_name, None)
-        validation_name = f"{state_name}_error_message"
-        conditions = DashboardDefaults.VALIDATION_CONDITION.get(state_name, None)
+        if type(state[state_name]) is str:
+            print(
+                f"{state_name} = {state[state_name]} and type: {type(state[state_name])}"
+            )
+            value = getattr(state, state_name)
+            desired_type = DashboardDefaults.TYPES.get(state_name, None)
+            validation_name = f"{state_name}_error_message"
+            conditions = DashboardDefaults.VALIDATION_CONDITION.get(state_name, None)
 
-        validation_result = generalFunctions.validate_against(
-            value, desired_type, conditions
-        )
-        setattr(state, validation_name, validation_result)
-        generalFunctions.update_simulation_validation_status()
+            validation_result = generalFunctions.validate_against(
+                value, desired_type, conditions
+            )
+            setattr(state, validation_name, validation_result)
+            generalFunctions.update_simulation_validation_status()
 
-        if validation_result == []:
-            converted_value = generalFunctions.convert_to_correct_type(value, desired_type)
+            if validation_result == []:
+                converted_value = generalFunctions.convert_to_correct_type(
+                    value, desired_type
+                )
 
-            if getattr(state, state_name) != converted_value:
-                setattr(state, state_name, converted_value)
-                if state_name == "kin_energy_on_ui":
-                    on_kin_energy_unit_change()
+                if getattr(state, state_name) != converted_value:
+                    setattr(state, state_name, converted_value)
+                    if state_name == "kin_energy_on_ui":
+                        on_kin_energy_unit_change()
 
 
 @state.change("kin_energy_unit")

--- a/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
@@ -17,12 +17,14 @@ server, state, ctrl = setup_server()
 # -----------------------------------------------------------------------------
 
 
-DEFAULTS = list(DashboardDefaults.INPUT_PARAMETERS.keys())
+input_parameters_defaults = list(DashboardDefaults.INPUT_PARAMETERS.keys())
+space_charge_defaults = list(DashboardDefaults.CSR.keys())
+INPUT_DEFAULTS = input_parameters_defaults + space_charge_defaults
 
 
-@state.change(*DEFAULTS)
+@state.change(*INPUT_DEFAULTS)
 def on_input_state_change(**_):
-    state_changes = state.modified_keys & set(DEFAULTS)
+    state_changes = state.modified_keys & set(INPUT_DEFAULTS)
     for state_name in state_changes:
         if type(state[state_name]) is str:
             print(

--- a/src/python/impactx/dashboard/Input/shared.py
+++ b/src/python/impactx/dashboard/Input/shared.py
@@ -11,7 +11,6 @@ INPUT_DEFAULTS = input_parameters_defaults + space_charge_defaults
 
 
 class SharedUtilities:
-    
     @staticmethod
     @state.change(*INPUT_DEFAULTS)
     def on_input_state_change(**_):

--- a/src/python/impactx/dashboard/Input/shared.py
+++ b/src/python/impactx/dashboard/Input/shared.py
@@ -1,0 +1,44 @@
+from .. import setup_server
+from ..Input.inputParameters.inputMain import InputParameters
+from . import DashboardDefaults, generalFunctions
+
+server, state, ctrl = setup_server()
+
+
+input_parameters_defaults = list(DashboardDefaults.INPUT_PARAMETERS.keys())
+space_charge_defaults = list(DashboardDefaults.CSR.keys())
+INPUT_DEFAULTS = input_parameters_defaults + space_charge_defaults
+
+
+class SharedUtilities:
+    @staticmethod
+    @state.change(*INPUT_DEFAULTS)
+    def on_input_state_change(**_):
+        state_changes = state.modified_keys & set(INPUT_DEFAULTS)
+        for state_name in state_changes:
+            if type(state[state_name]) is str:
+                print(
+                    f"{state_name} = {state[state_name]} and type: {type(state[state_name])}"
+                )
+                value = getattr(state, state_name)
+                desired_type = DashboardDefaults.TYPES.get(state_name, None)
+                validation_name = f"{state_name}_error_message"
+                conditions = DashboardDefaults.VALIDATION_CONDITION.get(
+                    state_name, None
+                )
+
+                validation_result = generalFunctions.validate_against(
+                    value, desired_type, conditions
+                )
+                setattr(state, validation_name, validation_result)
+                generalFunctions.update_simulation_validation_status()
+
+                if validation_result == []:
+                    converted_value = generalFunctions.convert_to_correct_type(
+                        value, desired_type
+                    )
+
+                    if getattr(state, state_name) != converted_value:
+                        setattr(state, state_name, converted_value)
+                        if state_name == "kin_energy_on_ui":
+                            InputParameters.on_kin_energy_unit_change()

--- a/src/python/impactx/dashboard/Input/shared.py
+++ b/src/python/impactx/dashboard/Input/shared.py
@@ -11,15 +11,13 @@ INPUT_DEFAULTS = input_parameters_defaults + space_charge_defaults
 
 
 class SharedUtilities:
+    
     @staticmethod
     @state.change(*INPUT_DEFAULTS)
     def on_input_state_change(**_):
         state_changes = state.modified_keys & set(INPUT_DEFAULTS)
         for state_name in state_changes:
             if type(state[state_name]) is str:
-                print(
-                    f"{state_name} = {state[state_name]} and type: {type(state[state_name])}"
-                )
                 value = getattr(state, state_name)
                 desired_type = DashboardDefaults.TYPES.get(state_name, None)
                 validation_name = f"{state_name}_error_message"

--- a/src/python/impactx/dashboard/__main__.py
+++ b/src/python/impactx/dashboard/__main__.py
@@ -28,9 +28,9 @@ from .start import main
 
 server, state, ctrl = setup_server()
 
-# -----------------------------------------------------------------------------
-# Router Views
-# -----------------------------------------------------------------------------
+from .Input.shared import SharedUtilities
+
+shared_utilities = SharedUtilities()
 
 inputParameters = InputParameters()
 


### PR DESCRIPTION
This PR leverages the new [shared state functionality](https://github.com/Kitware/trame/discussions/661) to simplify the dashboard code. Instead of making controller calls for tasks like validation and numeric conversion, we now use a single state change callback to handle these actions efficiently. This reduces redundant code and improves maintainability.


The changes in this PR apply to the **input parameters** and **CSR** sections. The **distribution, space charge, and lattice configuration sections** are not using the shared state approach due to their nested state structures.

Additionally, the docstring of the custom `text_field` method is updated for clarity.