### PR TITLE
Dashboard: Add documentation sidebar

### DIFF
--- a/src/python/impactx/dashboard/Input/components.py
+++ b/src/python/impactx/dashboard/Input/components.py
@@ -41,32 +41,10 @@ class CardComponents:
         :param section_name: The name for the input section.
         """
 
-        def open_documentation():
-            """
-            Retrieves the documentation link with the provided section_name
-            and opens the documentation sidebar on the dashoard.
-            """
-           
-            DOCUMENTATION = {
-                "input_parameters": "https://impactx.readthedocs.io/en/latest/usage/python.html#impactx.ImpactX",
-                "lattice_configuration": "https://impactx.readthedocs.io/en/latest/usage/python.html#lattice-elements",
-                "distribution_parameters": "https://impactx.readthedocs.io/en/latest/usage/python.html#initial-beam-distributions",
-                "space_charge": "https://impactx.readthedocs.io/en/latest/usage/parameters.html#space-charge",
-                "csr": "https://impactx.readthedocs.io/en/latest/usage/parameters.html#coherent-synchrotron-radiation-csr",
-            }
-
-
-            new_url = DOCUMENTATION.get(section_name)
-            if state.documentation_drawer_open and state.documentation_url == new_url:
-                state.documentation_drawer_open = False
-            else:
-                state.documentation_url = new_url
-                state.documentation_drawer_open = True
-
         return vuetify.VIcon(
             "mdi-information",
             style="color: #00313C;",
-            click=open_documentation,
+            click=lambda: generalFunctions.open_documentation(section_name),
         )
 
     @staticmethod

--- a/src/python/impactx/dashboard/Input/components.py
+++ b/src/python/impactx/dashboard/Input/components.py
@@ -1,10 +1,13 @@
 from typing import Optional
 
 from .. import html, setup_server, vuetify
-from .defaults import TooltipDefaults
+from .defaults import DashboardDefaults, TooltipDefaults
 from .generalFunctions import generalFunctions
 
 server, state, ctrl = setup_server()
+
+state.documentation_drawer_open = False
+state.documentation_url = ""
 
 
 class CardComponents:
@@ -38,10 +41,18 @@ class CardComponents:
         :param section_name: The name for the input section.
         """
 
+        def open_documentation():
+            new_url = DashboardDefaults.DOCUMENTATION.get(section_name)
+            if state.documentation_drawer_open and state.documentation_url == new_url:
+                state.documentation_drawer_open = False
+            else:
+                state.documentation_url = new_url
+                state.documentation_drawer_open = True
+
         return vuetify.VIcon(
             "mdi-information",
             style="color: #00313C;",
-            click=lambda: generalFunctions.documentation(section_name),
+            click=open_documentation,
         )
 
     @staticmethod
@@ -187,3 +198,21 @@ class NavigationComponents:
                 for tab_name in tab_names:
                     vuetify.VTab(tab_name)
             vuetify.VDivider()
+
+    @staticmethod
+    def create_documentation_drawer():
+        with vuetify.VNavigationDrawer(
+            v_model=("documentation_drawer_open",),
+            absolute=True,
+            right=True,
+            hide_overlay=True,
+            style="width: 30vw; top: 64px !important; height: calc(100vh - 64px) !important; position: fixed;",
+        ):
+            with vuetify.VContainer(
+                fluid=True,
+                classes="pa-0 fill-height",
+            ):
+                html.Iframe(
+                    src=("documentation_url",),
+                    style="width: 100%; height: 100%; border: none;",
+                )

--- a/src/python/impactx/dashboard/Input/components.py
+++ b/src/python/impactx/dashboard/Input/components.py
@@ -206,7 +206,7 @@ class NavigationComponents:
             absolute=True,
             right=True,
             hide_overlay=True,
-            style="width: 30vw; top: 64px !important; height: calc(100vh - 64px) !important; position: fixed;",
+            style="width: 30vw; top: 64px !important;  position: fixed;",
         ):
             with vuetify.VContainer(
                 fluid=True,

--- a/src/python/impactx/dashboard/Input/components.py
+++ b/src/python/impactx/dashboard/Input/components.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
+from .defaults import TooltipDefaults
 from .. import html, setup_server, vuetify
-from .defaults import DashboardDefaults, TooltipDefaults
 from .generalFunctions import generalFunctions
 
 server, state, ctrl = setup_server()
@@ -42,7 +42,21 @@ class CardComponents:
         """
 
         def open_documentation():
-            new_url = DashboardDefaults.DOCUMENTATION.get(section_name)
+            """
+            Retrieves the documentation link with the provided section_name
+            and opens the documentation sidebar on the dashoard.
+            """
+           
+            DOCUMENTATION = {
+                "input_parameters": "https://impactx.readthedocs.io/en/latest/usage/python.html#impactx.ImpactX",
+                "lattice_configuration": "https://impactx.readthedocs.io/en/latest/usage/python.html#lattice-elements",
+                "distribution_parameters": "https://impactx.readthedocs.io/en/latest/usage/python.html#initial-beam-distributions",
+                "space_charge": "https://impactx.readthedocs.io/en/latest/usage/parameters.html#space-charge",
+                "csr": "https://impactx.readthedocs.io/en/latest/usage/parameters.html#coherent-synchrotron-radiation-csr",
+            }
+
+
+            new_url = DOCUMENTATION.get(section_name)
             if state.documentation_drawer_open and state.documentation_url == new_url:
                 state.documentation_drawer_open = False
             else:

--- a/src/python/impactx/dashboard/Input/components.py
+++ b/src/python/impactx/dashboard/Input/components.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
-from .defaults import TooltipDefaults
 from .. import html, setup_server, vuetify
+from .defaults import TooltipDefaults
 from .generalFunctions import generalFunctions
 
 server, state, ctrl = setup_server()

--- a/src/python/impactx/dashboard/Input/defaults.py
+++ b/src/python/impactx/dashboard/Input/defaults.py
@@ -118,7 +118,7 @@ class DashboardDefaults:
         "beta": "m",
         "emitt": "m",
     }
-    
+
     DOCUMENTATION = {
         "input_parameters": "https://impactx.readthedocs.io/en/latest/usage/python.html#impactx.ImpactX",
         "lattice_configuration": "https://impactx.readthedocs.io/en/latest/usage/python.html#lattice-elements",
@@ -141,4 +141,3 @@ class TooltipDefaults:
     TOOLTIP = InputDefaultsHelper.get_docstrings(
         [RefPart, ImpactX], DashboardDefaults.DEFAULT_VALUES
     )
-

--- a/src/python/impactx/dashboard/Input/defaults.py
+++ b/src/python/impactx/dashboard/Input/defaults.py
@@ -120,7 +120,7 @@ class DashboardDefaults:
     }
     
     DOCUMENTATION = {
-        "input_parameters": "https://impactx.readthedocs.io/en/latest/usage/python.html#general",
+        "input_parameters": "https://impactx.readthedocs.io/en/latest/usage/python.html#impactx.ImpactX",
         "lattice_configuration": "https://impactx.readthedocs.io/en/latest/usage/python.html#lattice-elements",
         "distribution_parameters": "https://impactx.readthedocs.io/en/latest/usage/python.html#initial-beam-distributions",
         "space_charge": "https://impactx.readthedocs.io/en/latest/usage/parameters.html#space-charge",

--- a/src/python/impactx/dashboard/Input/defaults.py
+++ b/src/python/impactx/dashboard/Input/defaults.py
@@ -118,6 +118,14 @@ class DashboardDefaults:
         "beta": "m",
         "emitt": "m",
     }
+    
+    DOCUMENTATION = {
+        "input_parameters": "https://impactx.readthedocs.io/en/latest/usage/python.html#general",
+        "lattice_configuration": "https://impactx.readthedocs.io/en/latest/usage/python.html#lattice-elements",
+        "distribution_parameters": "https://impactx.readthedocs.io/en/latest/usage/python.html#initial-beam-distributions",
+        "space_charge": "https://impactx.readthedocs.io/en/latest/usage/parameters.html#space-charge",
+        "csr": "https://impactx.readthedocs.io/en/latest/usage/parameters.html#coherent-synchrotron-radiation-csr",
+    }
 
 
 class TooltipDefaults:
@@ -133,3 +141,4 @@ class TooltipDefaults:
     TOOLTIP = InputDefaultsHelper.get_docstrings(
         [RefPart, ImpactX], DashboardDefaults.DEFAULT_VALUES
     )
+

--- a/src/python/impactx/dashboard/Input/generalFunctions.py
+++ b/src/python/impactx/dashboard/Input/generalFunctions.py
@@ -21,6 +21,22 @@ server, state, ctrl = setup_server()
 
 class generalFunctions:
     @staticmethod
+    def open_documentation(section_name):
+        """
+        Retrieves the documentation link with the provided section_name
+        and opens the documentation sidebar on the dashoard.
+
+        :param section_name: The name for the input section.
+        """
+
+        new_url = DashboardDefaults.DOCUMENTATION.get(section_name)
+        if state.documentation_drawer_open and state.documentation_url == new_url:
+            state.documentation_drawer_open = False
+        else:
+            state.documentation_url = new_url
+            state.documentation_drawer_open = True
+
+    @staticmethod
     def get_default(parameter, type):
         parameter_type_dictionary = getattr(DashboardDefaults, f"{type.upper()}", None)
         parameter_default = parameter_type_dictionary.get(parameter)

--- a/src/python/impactx/dashboard/Input/generalFunctions.py
+++ b/src/python/impactx/dashboard/Input/generalFunctions.py
@@ -7,10 +7,7 @@ License: BSD-3-Clause-LBNL
 """
 
 import inspect
-import os
 import re
-import subprocess
-import webbrowser
 
 from .. import setup_server
 from .defaults import DashboardDefaults
@@ -23,29 +20,6 @@ server, state, ctrl = setup_server()
 
 
 class generalFunctions:
-    @staticmethod
-    def documentation(section_name):
-        """
-        Opens a tab to the specified section link in the documentation.
-        :param section_name (str): The name of the documentation section to open.
-        """
-        url_dict = {
-            "input_parameters": "https://impactx.readthedocs.io/en/latest/usage/python.html#general",
-            "lattice_configuration": "https://impactx.readthedocs.io/en/latest/usage/python.html#lattice-elements",
-            "distribution_parameters": "https://impactx.readthedocs.io/en/latest/usage/python.html#initial-beam-distributions",
-            "space_charge": "https://impactx.readthedocs.io/en/latest/usage/parameters.html#space-charge",
-            "csr": "https://impactx.readthedocs.io/en/latest/usage/parameters.html#coherent-synchrotron-radiation-csr",
-        }
-
-        url = url_dict.get(section_name)
-        if url is None:
-            raise ValueError(f"Invalid section name: {section_name}")
-
-        if "WSL_DISTRO_NAME" in os.environ:
-            subprocess.run(["explorer.exe", url])
-        else:
-            webbrowser.open_new_tab(url)
-
     @staticmethod
     def get_default(parameter, type):
         parameter_type_dictionary = getattr(DashboardDefaults, f"{type.upper()}", None)

--- a/src/python/impactx/dashboard/__init__.py
+++ b/src/python/impactx/dashboard/__init__.py
@@ -1,6 +1,5 @@
 from trame.widgets import html
 from trame.widgets import vuetify as vuetify
-from trame.widgets import html
 
 # isort: off
 

--- a/src/python/impactx/dashboard/__init__.py
+++ b/src/python/impactx/dashboard/__init__.py
@@ -1,5 +1,6 @@
 from trame.widgets import html
 from trame.widgets import vuetify as vuetify
+from trame.widgets import html
 
 # isort: off
 
@@ -22,6 +23,7 @@ __all__ = [
     "html",
     "JupyterApp",
     "setup_server",
+    "html",
     "vuetify",
     "AnalyzeSimulation",
     "NavigationComponents",

--- a/src/python/impactx/dashboard/__main__.py
+++ b/src/python/impactx/dashboard/__main__.py
@@ -90,6 +90,7 @@ def application():
             NavigationComponents.create_route("Analyze", "mdi-chart-box-multiple")
 
         with layout.content:
+            NavigationComponents.create_documentation_drawer()
             router.RouterView()
             init_terminal()
     return layout


### PR DESCRIPTION
Documentation appears in a sidebar instead of opening in a new tab.


https://github.com/user-attachments/assets/ecaa1c0e-c388-490f-ae68-b7cda24e71e2



After https://github.com/ECP-WarpX/impactx/pull/834 is merged, need to make some minor changes