### PR TITLE
Dashboard: Simplify imports

### DIFF
--- a/src/python/impactx/dashboard/Analyze/__init__.py
+++ b/src/python/impactx/dashboard/Analyze/__init__.py
@@ -1,0 +1,7 @@
+from .analyzeFunctions import AnalyzeFunctions
+from .plot_ParameterEvolutionOverS.overS import line_plot_1d
+
+__all__ = [
+    "AnalyzeFunctions",
+    "line_plot_1d",
+]

--- a/src/python/impactx/dashboard/Analyze/analyzeFunctions.py
+++ b/src/python/impactx/dashboard/Analyze/analyzeFunctions.py
@@ -8,7 +8,7 @@ License: BSD-3-Clause-LBNL
 
 import pandas as pd
 
-from ..trame_setup import setup_server
+from .. import setup_server
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/Analyze/plotsMain.py
+++ b/src/python/impactx/dashboard/Analyze/plotsMain.py
@@ -12,8 +12,7 @@ import os
 from trame.widgets import matplotlib, plotly
 
 from .. import setup_server, vuetify
-from .analyzeFunctions import AnalyzeFunctions
-from .plot_ParameterEvolutionOverS.overS import line_plot_1d
+from . import AnalyzeFunctions, line_plot_1d
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/Analyze/plotsMain.py
+++ b/src/python/impactx/dashboard/Analyze/plotsMain.py
@@ -9,8 +9,9 @@ License: BSD-3-Clause-LBNL
 import glob
 import os
 
-from trame.widgets import matplotlib, plotly, vuetify
+from trame.widgets import matplotlib, plotly
 
+from .. import vuetify
 from ..trame_setup import setup_server
 from .analyzeFunctions import AnalyzeFunctions
 from .plot_ParameterEvolutionOverS.overS import line_plot_1d

--- a/src/python/impactx/dashboard/Analyze/plotsMain.py
+++ b/src/python/impactx/dashboard/Analyze/plotsMain.py
@@ -11,8 +11,7 @@ import os
 
 from trame.widgets import matplotlib, plotly
 
-from .. import vuetify
-from ..trame_setup import setup_server
+from .. import setup_server, vuetify
 from .analyzeFunctions import AnalyzeFunctions
 from .plot_ParameterEvolutionOverS.overS import line_plot_1d
 

--- a/src/python/impactx/dashboard/Input/__init__.py
+++ b/src/python/impactx/dashboard/Input/__init__.py
@@ -1,5 +1,3 @@
-from trame.widgets import vuetify as vuetify
-
 from ..trame_setup import setup_server
 from .components import CardComponents, InputComponents, NavigationComponents
 from .defaults import DashboardDefaults
@@ -8,7 +6,6 @@ from .generalFunctions import generalFunctions
 __all__ = [
     "InputComponents",
     "CardComponents",
-    "vuetify",
     "DashboardDefaults",
     "NavigationComponents",
     "generalFunctions",

--- a/src/python/impactx/dashboard/Input/__init__.py
+++ b/src/python/impactx/dashboard/Input/__init__.py
@@ -1,4 +1,3 @@
-from ..trame_setup import setup_server
 from .components import CardComponents, InputComponents, NavigationComponents
 from .defaults import DashboardDefaults
 from .generalFunctions import generalFunctions
@@ -9,5 +8,4 @@ __all__ = [
     "DashboardDefaults",
     "NavigationComponents",
     "generalFunctions",
-    "setup_server",
 ]

--- a/src/python/impactx/dashboard/Input/components.py
+++ b/src/python/impactx/dashboard/Input/components.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
-from . import setup_server, vuetify
+from .. import vuetify
+from . import setup_server
 from .generalFunctions import generalFunctions
 
 server, state, ctrl = setup_server()

--- a/src/python/impactx/dashboard/Input/components.py
+++ b/src/python/impactx/dashboard/Input/components.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
-from .. import vuetify
-from . import setup_server
+from .. import setup_server, vuetify
 from .generalFunctions import generalFunctions
 
 server, state, ctrl = setup_server()

--- a/src/python/impactx/dashboard/Input/csrConfiguration/csrMain.py
+++ b/src/python/impactx/dashboard/Input/csrConfiguration/csrMain.py
@@ -1,4 +1,5 @@
-from .. import CardComponents, InputComponents, setup_server, vuetify
+from ... import vuetify
+from .. import CardComponents, InputComponents, setup_server
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/Input/csrConfiguration/csrMain.py
+++ b/src/python/impactx/dashboard/Input/csrConfiguration/csrMain.py
@@ -1,5 +1,5 @@
-from ... import vuetify
-from .. import CardComponents, InputComponents, setup_server
+from ... import setup_server, vuetify
+from .. import CardComponents, InputComponents
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/Input/distributionParameters/__init__.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/__init__.py
@@ -1,0 +1,5 @@
+from .distributionFunctions import DistributionFunctions
+
+__all__ = [
+    "DistributionFunctions",
+]

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionFunctions.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionFunctions.py
@@ -1,4 +1,4 @@
-from ...trame_setup import setup_server
+from ... import setup_server
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -12,14 +12,8 @@ from distribution_input_helpers import twiss
 
 from impactx import distribution
 
-from ... import vuetify
-from .. import (
-    CardComponents,
-    DashboardDefaults,
-    InputComponents,
-    generalFunctions,
-    setup_server,
-)
+from ... import setup_server, vuetify
+from .. import CardComponents, DashboardDefaults, InputComponents, generalFunctions
 from .distributionFunctions import DistributionFunctions
 
 server, state, ctrl = setup_server()

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -14,7 +14,7 @@ from impactx import distribution
 
 from ... import setup_server, vuetify
 from .. import CardComponents, DashboardDefaults, InputComponents, generalFunctions
-from .distributionFunctions import DistributionFunctions
+from . import DistributionFunctions
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -12,13 +12,13 @@ from distribution_input_helpers import twiss
 
 from impactx import distribution
 
+from ... import vuetify
 from .. import (
     CardComponents,
     DashboardDefaults,
     InputComponents,
     generalFunctions,
     setup_server,
-    vuetify,
 )
 from .distributionFunctions import DistributionFunctions
 

--- a/src/python/impactx/dashboard/Input/generalFunctions.py
+++ b/src/python/impactx/dashboard/Input/generalFunctions.py
@@ -12,7 +12,7 @@ import re
 import subprocess
 import webbrowser
 
-from ..trame_setup import setup_server
+from .. import setup_server
 from .defaults import DashboardDefaults
 
 server, state, ctrl = setup_server()

--- a/src/python/impactx/dashboard/Input/inputParameters/__init__.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/__init__.py
@@ -1,0 +1,5 @@
+from .inputFunctions import InputFunctions
+
+__all__ = [
+    "InputFunctions",
+]

--- a/src/python/impactx/dashboard/Input/inputParameters/inputFunctions.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputFunctions.py
@@ -6,7 +6,7 @@ Authors: Parthib Roy, Axel Huebl
 License: BSD-3-Clause-LBNL
 """
 
-from ...trame_setup import setup_server
+from ... import setup_server
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
@@ -8,7 +8,7 @@ License: BSD-3-Clause-LBNL
 
 from ... import setup_server, vuetify
 from .. import CardComponents, DashboardDefaults, InputComponents, generalFunctions
-from .inputFunctions import InputFunctions
+from . import InputFunctions
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
@@ -6,14 +6,8 @@ Authors: Parthib Roy, Axel Huebl
 License: BSD-3-Clause-LBNL
 """
 
-from ... import vuetify
-from .. import (
-    CardComponents,
-    DashboardDefaults,
-    InputComponents,
-    generalFunctions,
-    setup_server,
-)
+from ... import setup_server, vuetify
+from .. import CardComponents, DashboardDefaults, InputComponents, generalFunctions
 from .inputFunctions import InputFunctions
 
 server, state, ctrl = setup_server()

--- a/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
@@ -6,13 +6,13 @@ Authors: Parthib Roy, Axel Huebl
 License: BSD-3-Clause-LBNL
 """
 
+from ... import vuetify
 from .. import (
     CardComponents,
     DashboardDefaults,
     InputComponents,
     generalFunctions,
     setup_server,
-    vuetify,
 )
 from .inputFunctions import InputFunctions
 

--- a/src/python/impactx/dashboard/Input/latticeConfiguration/latticeMain.py
+++ b/src/python/impactx/dashboard/Input/latticeConfiguration/latticeMain.py
@@ -8,14 +8,8 @@ License: BSD-3-Clause-LBNL
 
 from impactx import elements
 
-from ... import vuetify
-from .. import (
-    CardComponents,
-    InputComponents,
-    NavigationComponents,
-    generalFunctions,
-    setup_server,
-)
+from ... import setup_server, vuetify
+from .. import CardComponents, InputComponents, NavigationComponents, generalFunctions
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/Input/latticeConfiguration/latticeMain.py
+++ b/src/python/impactx/dashboard/Input/latticeConfiguration/latticeMain.py
@@ -8,13 +8,13 @@ License: BSD-3-Clause-LBNL
 
 from impactx import elements
 
+from ... import vuetify
 from .. import (
     CardComponents,
     InputComponents,
     NavigationComponents,
     generalFunctions,
     setup_server,
-    vuetify,
 )
 
 server, state, ctrl = setup_server()

--- a/src/python/impactx/dashboard/Input/space_charge_configuration/__init__.py
+++ b/src/python/impactx/dashboard/Input/space_charge_configuration/__init__.py
@@ -1,0 +1,5 @@
+from .spaceChargeFunctions import SpaceChargeFunctions
+
+__all__ = [
+    "SpaceChargeFunctions",
+]

--- a/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeFunctions.py
+++ b/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeFunctions.py
@@ -1,5 +1,5 @@
 from ... import setup_server
-from ..generalFunctions import generalFunctions
+from .. import generalFunctions
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeFunctions.py
+++ b/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeFunctions.py
@@ -1,4 +1,4 @@
-from ...trame_setup import setup_server
+from ... import setup_server
 from ..generalFunctions import generalFunctions
 
 server, state, ctrl = setup_server()

--- a/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeMain.py
+++ b/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeMain.py
@@ -1,10 +1,10 @@
+from ... import vuetify
 from .. import (
     CardComponents,
     InputComponents,
     NavigationComponents,
     generalFunctions,
     setup_server,
-    vuetify,
 )
 from .spaceChargeFunctions import SpaceChargeFunctions
 

--- a/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeMain.py
+++ b/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeMain.py
@@ -1,11 +1,5 @@
-from ... import vuetify
-from .. import (
-    CardComponents,
-    InputComponents,
-    NavigationComponents,
-    generalFunctions,
-    setup_server,
-)
+from ... import setup_server, vuetify
+from .. import CardComponents, InputComponents, NavigationComponents, generalFunctions
 from .spaceChargeFunctions import SpaceChargeFunctions
 
 server, state, ctrl = setup_server()

--- a/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeMain.py
+++ b/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeMain.py
@@ -1,6 +1,6 @@
 from ... import setup_server, vuetify
 from .. import CardComponents, InputComponents, NavigationComponents, generalFunctions
-from .spaceChargeFunctions import SpaceChargeFunctions
+from . import SpaceChargeFunctions
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/Run/controls.py
+++ b/src/python/impactx/dashboard/Run/controls.py
@@ -3,8 +3,8 @@ import io
 
 from wurlitzer import pipes
 
+from .. import setup_server
 from ..simulation import run_simulation
-from ..trame_setup import setup_server
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/Toolbar/controls.py
+++ b/src/python/impactx/dashboard/Toolbar/controls.py
@@ -6,8 +6,9 @@ Authors: Parthib Roy, Axel Huebl
 License: BSD-3-Clause-LBNL
 """
 
-from trame.widgets import html, vuetify
+from trame.widgets import html
 
+from .. import vuetify
 from ..Analyze.plotsMain import available_plot_options, load_dataTable_data, update_plot
 from ..Input.generalFunctions import generalFunctions
 from ..Run.controls import execute_impactx_sim

--- a/src/python/impactx/dashboard/Toolbar/controls.py
+++ b/src/python/impactx/dashboard/Toolbar/controls.py
@@ -8,11 +8,10 @@ License: BSD-3-Clause-LBNL
 
 from trame.widgets import html
 
-from .. import vuetify
+from .. import setup_server, vuetify
 from ..Analyze.plotsMain import available_plot_options, load_dataTable_data, update_plot
 from ..Input.generalFunctions import generalFunctions
 from ..Run.controls import execute_impactx_sim
-from ..trame_setup import setup_server
 from .exportTemplate import input_file
 from .importParser import DashboardParser
 

--- a/src/python/impactx/dashboard/Toolbar/exportTemplate.py
+++ b/src/python/impactx/dashboard/Toolbar/exportTemplate.py
@@ -1,6 +1,6 @@
+from .. import setup_server
 from ..Input.distributionParameters.distributionFunctions import DistributionFunctions
 from ..Input.latticeConfiguration.latticeMain import parameter_input_checker_for_lattice
-from ..trame_setup import setup_server
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/Toolbar/importParser.py
+++ b/src/python/impactx/dashboard/Toolbar/importParser.py
@@ -1,3 +1,4 @@
+from .. import setup_server
 from ..Input.distributionParameters.distributionMain import (
     on_distribution_parameter_change,
     populate_distribution_parameters,
@@ -6,7 +7,6 @@ from ..Input.latticeConfiguration.latticeMain import (
     add_lattice_element,
     on_lattice_element_parameter_change,
 )
-from ..trame_setup import setup_server
 from .importParserHelper import DashboardParserHelper
 
 server, state, ctrl = setup_server()

--- a/src/python/impactx/dashboard/__init__.py
+++ b/src/python/impactx/dashboard/__init__.py
@@ -1,12 +1,32 @@
 from trame.widgets import vuetify as vuetify
 
 # isort: off
+
 from .trame_setup import setup_server
+from .Toolbar.controls import GeneralToolbar
+
+from .Analyze.plotsMain import AnalyzeSimulation
+from .Input.csrConfiguration.csrMain import csrConfiguration
+from .Input.distributionParameters.distributionMain import DistributionParameters
+from .Input.inputParameters.inputMain import InputParameters
+from .Input.latticeConfiguration.latticeMain import LatticeConfiguration
+from .Input.components import NavigationComponents
+from .Input.space_charge_configuration.spaceChargeMain import SpaceChargeConfiguration
+
 from .jupyterApplication import JupyterMainApplication as JupyterApp
 # isort: on
+
 
 __all__ = [
     "JupyterApp",
     "setup_server",
     "vuetify",
+    "AnalyzeSimulation",
+    "NavigationComponents",
+    "csrConfiguration",
+    "DistributionParameters",
+    "InputParameters",
+    "LatticeConfiguration",
+    "SpaceChargeConfiguration",
+    "GeneralToolbar",
 ]

--- a/src/python/impactx/dashboard/__init__.py
+++ b/src/python/impactx/dashboard/__init__.py
@@ -1,5 +1,8 @@
+from trame.widgets import vuetify as vuetify
+
 from .jupyterApplication import JupyterMainApplication as JupyterApp
 
 __all__ = [
     "JupyterApp",
+    "vuetify",
 ]

--- a/src/python/impactx/dashboard/__init__.py
+++ b/src/python/impactx/dashboard/__init__.py
@@ -1,8 +1,12 @@
 from trame.widgets import vuetify as vuetify
 
+# isort: off
+from .trame_setup import setup_server
 from .jupyterApplication import JupyterMainApplication as JupyterApp
+# isort: on
 
 __all__ = [
     "JupyterApp",
+    "setup_server",
     "vuetify",
 ]

--- a/src/python/impactx/dashboard/__main__.py
+++ b/src/python/impactx/dashboard/__main__.py
@@ -12,7 +12,7 @@ from trame.ui.router import RouterViewLayout
 from trame.ui.vuetify import SinglePageWithDrawerLayout
 from trame.widgets import router, xterm
 
-from . import vuetify
+from . import setup_server, vuetify
 from .Analyze.plotsMain import AnalyzeSimulation
 from .Input.components import NavigationComponents
 from .Input.csrConfiguration.csrMain import csrConfiguration
@@ -22,7 +22,6 @@ from .Input.latticeConfiguration.latticeMain import LatticeConfiguration
 from .Input.space_charge_configuration.spaceChargeMain import SpaceChargeConfiguration
 from .start import main
 from .Toolbar.controls import GeneralToolbar
-from .trame_setup import setup_server
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/__main__.py
+++ b/src/python/impactx/dashboard/__main__.py
@@ -10,8 +10,9 @@ import sys
 
 from trame.ui.router import RouterViewLayout
 from trame.ui.vuetify import SinglePageWithDrawerLayout
-from trame.widgets import router, vuetify, xterm
+from trame.widgets import router, xterm
 
+from . import vuetify
 from .Analyze.plotsMain import AnalyzeSimulation
 from .Input.components import NavigationComponents
 from .Input.csrConfiguration.csrMain import csrConfiguration

--- a/src/python/impactx/dashboard/__main__.py
+++ b/src/python/impactx/dashboard/__main__.py
@@ -12,16 +12,19 @@ from trame.ui.router import RouterViewLayout
 from trame.ui.vuetify import SinglePageWithDrawerLayout
 from trame.widgets import router, xterm
 
-from . import setup_server, vuetify
-from .Analyze.plotsMain import AnalyzeSimulation
-from .Input.components import NavigationComponents
-from .Input.csrConfiguration.csrMain import csrConfiguration
-from .Input.distributionParameters.distributionMain import DistributionParameters
-from .Input.inputParameters.inputMain import InputParameters
-from .Input.latticeConfiguration.latticeMain import LatticeConfiguration
-from .Input.space_charge_configuration.spaceChargeMain import SpaceChargeConfiguration
+from . import (
+    AnalyzeSimulation,
+    DistributionParameters,
+    GeneralToolbar,
+    InputParameters,
+    LatticeConfiguration,
+    NavigationComponents,
+    SpaceChargeConfiguration,
+    csrConfiguration,
+    setup_server,
+    vuetify,
+)
 from .start import main
-from .Toolbar.controls import GeneralToolbar
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/simulation.py
+++ b/src/python/impactx/dashboard/simulation.py
@@ -6,7 +6,7 @@ Authors: Parthib Roy, Axel Huebl
 License: BSD-3-Clause-LBNL
 """
 
-from .trame_setup import setup_server
+from . import setup_server
 
 server, state, ctrl = setup_server()
 

--- a/src/python/impactx/dashboard/start.py
+++ b/src/python/impactx/dashboard/start.py
@@ -6,8 +6,8 @@ Authors: Parthib Roy, Axel Huebl
 License: BSD-3-Clause-LBNL
 """
 
+from . import setup_server
 from .Input.defaults import DashboardDefaults
-from .trame_setup import setup_server
 
 server, state, ctrl = setup_server()
 


### PR DESCRIPTION
Centralized some dashboard imports. Most notably the Vuetify library, which is a step that simplifies the migration to Vuetify3 and future releases. 