### PR TITLE
Fix `beam.units = static`

### DIFF
--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -452,10 +452,8 @@ namespace impactx
 
             if (unit_type == "static") {
                 amrex::Print() << "Static units" << std::endl;
-            } else if (unit_type == "dynamic") {
-                amrex::Print() << "Dynamic units" << std::endl;
             } else {
-                throw std::runtime_error("Unknown units (static/dynamic): " + unit_type);
+                throw std::runtime_error("Unknown units (use 'static'): " + unit_type);
             }
 
             amrex::Print() << "Initialized beam distribution parameters" << std::endl;


### PR DESCRIPTION
Currently, we only support (and document correctly) "static" units, but the user was able to also pass "dynamic", upon which we did print "Dynamic units" but then still used static ones.

This now errors out correctly for anything else than "static" until we implement another variant.