### PR TITLE
Dashboard: Add tooltips

### DIFF
--- a/src/python/impactx/dashboard/Input/components.py
+++ b/src/python/impactx/dashboard/Input/components.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
-from .. import setup_server, vuetify
+from .. import html, setup_server, vuetify
+from .defaults import TooltipDefaults
 from .generalFunctions import generalFunctions
 
 server, state, ctrl = setup_server()
@@ -121,17 +122,22 @@ class InputComponents:
         if v_model_name is None:
             v_model_name = label.lower().replace(" ", "_")
 
-        return vuetify.VTextField(
-            label=label,
-            v_model=(v_model_name,),
-            error_messages=(f"{v_model_name}_error_message", []),
-            type="number",
-            step=generalFunctions.get_default(f"{v_model_name}", "steps"),
-            suffix=generalFunctions.get_default(f"{v_model_name}", "units"),
-            __properties=["step"],
-            dense=True,
-            **kwargs,
-        )
+        with vuetify.VTooltip(**TooltipDefaults.TOOLTIP_STYLE):
+            with vuetify.Template(v_slot_activator="{ on, attrs }"):
+                vuetify.VTextField(
+                    label=label,
+                    v_model=(v_model_name,),
+                    error_messages=(f"{v_model_name}_error_message", []),
+                    type="number",
+                    step=generalFunctions.get_default(f"{v_model_name}", "steps"),
+                    suffix=generalFunctions.get_default(f"{v_model_name}", "units"),
+                    __properties=["step"],
+                    dense=True,
+                    v_on="on",
+                    v_bind="attrs",
+                    **kwargs,
+                )
+            html.Span(TooltipDefaults.TOOLTIP.get(v_model_name))
 
 
 class NavigationComponents:

--- a/src/python/impactx/dashboard/Input/components.py
+++ b/src/python/impactx/dashboard/Input/components.py
@@ -92,13 +92,18 @@ class InputComponents:
                 generalFunctions.get_default(f"{v_model_name}_list", "default_values"),
             )
 
-        return vuetify.VSelect(
-            label=label,
-            v_model=(v_model_name,),
-            items=items,
-            dense=True,
-            **kwargs,
-        )
+        with vuetify.VTooltip(**TooltipDefaults.TOOLTIP_STYLE):
+            with vuetify.Template(v_slot_activator="{ on, attrs }"):
+                vuetify.VSelect(
+                    label=label,
+                    v_model=(v_model_name,),
+                    items=items,
+                    dense=True,
+                    **kwargs,
+                    v_on="on",
+                    v_bind="attrs",
+                )
+            html.Span(TooltipDefaults.TOOLTIP.get(v_model_name))
 
     @staticmethod
     def text_field(

--- a/src/python/impactx/dashboard/Input/defaults.py
+++ b/src/python/impactx/dashboard/Input/defaults.py
@@ -1,3 +1,8 @@
+from impactx.impactx_pybind import ImpactX, RefPart
+
+from .defaults_helper import InputDefaultsHelper
+
+
 class DashboardDefaults:
     """
     Defaults for input parameters in the ImpactX dashboard.
@@ -113,3 +118,18 @@ class DashboardDefaults:
         "beta": "m",
         "emitt": "m",
     }
+
+
+class TooltipDefaults:
+    """
+    Defaults for input toolips in the ImpactX dashboard.
+    """
+
+    TOOLTIP_STYLE = {
+        "bottom": True,
+        "nudge_top": "20",
+    }
+
+    TOOLTIP = InputDefaultsHelper.get_docstrings(
+        [RefPart, ImpactX], DashboardDefaults.DEFAULT_VALUES
+    )

--- a/src/python/impactx/dashboard/Input/defaults_helper.py
+++ b/src/python/impactx/dashboard/Input/defaults_helper.py
@@ -1,0 +1,34 @@
+import inspect
+
+
+class InputDefaultsHelper:
+    """
+    Methods in this class are used to dynamically parse
+    core ImpactX data (default values, docstrings, etc.)
+    """
+
+    @staticmethod
+    def get_docstrings(classes, default_list) -> dict:
+        """
+        Retrieves docstrings for each method and property
+        in the provided clases.
+
+        :param classes: The class names to parse docstrings with.
+        :param defaults_list: The dictionary of defaults value.
+        """
+
+        docstrings = {}
+
+        for each_class in classes:
+            for name, attribute in inspect.getmembers(each_class):
+                if name not in default_list:
+                    continue
+
+                is_method = inspect.isfunction(attribute)
+                is_property = inspect.isdatadescriptor(attribute)
+
+                if is_method or is_property:
+                    docstring = inspect.getdoc(attribute) or ""
+                    docstrings[name] = docstring
+
+        return docstrings

--- a/src/python/impactx/dashboard/Input/defaults_helper.py
+++ b/src/python/impactx/dashboard/Input/defaults_helper.py
@@ -1,5 +1,5 @@
-from typing import List, Type, Dict
 import inspect
+from typing import Dict, List, Type
 
 
 class InputDefaultsHelper:
@@ -9,7 +9,9 @@ class InputDefaultsHelper:
     """
 
     @staticmethod
-    def get_docstrings(class_names: List[Type], default_list: Dict[str, any]) -> Dict[str, str]:
+    def get_docstrings(
+        class_names: List[Type], default_list: Dict[str, any]
+    ) -> Dict[str, str]:
         """
         Retrieves docstrings for each method and property
         in the provided clases.

--- a/src/python/impactx/dashboard/Input/defaults_helper.py
+++ b/src/python/impactx/dashboard/Input/defaults_helper.py
@@ -1,3 +1,4 @@
+from typing import List, Type, Dict
 import inspect
 
 
@@ -8,7 +9,7 @@ class InputDefaultsHelper:
     """
 
     @staticmethod
-    def get_docstrings(classes, default_list) -> dict:
+    def get_docstrings(class_names: List[Type], default_list: Dict[str, any]) -> Dict[str, str]:
         """
         Retrieves docstrings for each method and property
         in the provided clases.
@@ -19,7 +20,7 @@ class InputDefaultsHelper:
 
         docstrings = {}
 
-        for each_class in classes:
+        for each_class in class_names:
             for name, attribute in inspect.getmembers(each_class):
                 if name not in default_list:
                     continue

--- a/src/python/impactx/dashboard/__init__.py
+++ b/src/python/impactx/dashboard/__init__.py
@@ -1,5 +1,6 @@
-from trame.widgets import vuetify as vuetify
 from trame.widgets import html
+from trame.widgets import vuetify as vuetify
+
 # isort: off
 
 from .trame_setup import setup_server

--- a/src/python/impactx/dashboard/__init__.py
+++ b/src/python/impactx/dashboard/__init__.py
@@ -1,5 +1,5 @@
 from trame.widgets import vuetify as vuetify
-
+from trame.widgets import html
 # isort: off
 
 from .trame_setup import setup_server
@@ -18,6 +18,7 @@ from .jupyterApplication import JupyterMainApplication as JupyterApp
 
 
 __all__ = [
+    "html",
     "JupyterApp",
     "setup_server",
     "vuetify",


### PR DESCRIPTION
### Replacing https://github.com/ECP-WarpX/impactx/pull/759, resolves https://github.com/ECP-WarpX/impactx/issues/722
The core functionality works by taking a list of class names where the docstrings are located, scanning through each property and method that matches a key in the DEFAULTS dictionary, and then outputting a dictionary with the appropriate tooltip.

For example, in `defaults.py` we can have something like:
```python
INPUT_PARAMETERS = {
    "charge_qe": -1,
}
```
When we call:
```py
get_docstrings([RefPart, ImpactX], INPUT_PARAMETERS )
```
the function iterates through each property and method  in the two classes until it finds:
```py
@property
def charge_qe(self) -> float:
    """
    Get reference particle charge (positive elementary charge)
    """
```
It then appends the extracted docstring to the output dictionary, resulting in something like:
```py
TOOLTIPS = {
    "charge_qe": "Get reference particle charge (positive elementary charge)",
}
```
**Note:** The tooltips are not added to the distribution/lattice configuration sections. A separate PR is needed to update defaults.py with the correct defaults to enable tooltips for those sections.
