### PR TITLE
Make Linear Elements Fast

### DIFF
--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -93,6 +93,18 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle (unused)
+         */
+        void compute_constants ([[maybe_unused]] RefPart const & refpart)
+        {
+            Alignment::compute_constants(refpart);
+        }
+
         /** This is an aperture functor, so that a variable of this type can be used like an
          *  aperture function.
          *
@@ -114,7 +126,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT pt,
             uint64_t & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt

--- a/src/elements/Buncher.H
+++ b/src/elements/Buncher.H
@@ -64,8 +64,30 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // find beta*gamma^2
+            amrex::ParticleReal const betgam2 = std::pow(refpart.pt, 2) - 1.0_prt;
+
+            m_neg_kV = -m_k * m_V;
+            m_kV_r2bg2 = -m_neg_kV / (2.0_prt * betgam2);
+        }
+
         /** This is a buncher functor, so that a variable of this type can be used like a
          *  buncher function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -74,27 +96,24 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index (unused)
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                amrex::ParticleReal & AMREX_RESTRICT x,
-                amrex::ParticleReal & AMREX_RESTRICT y,
-                amrex::ParticleReal & AMREX_RESTRICT t,
-                amrex::ParticleReal & AMREX_RESTRICT px,
-                amrex::ParticleReal & AMREX_RESTRICT py,
-                amrex::ParticleReal & AMREX_RESTRICT pt,
-                [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
-                RefPart const & refpart) const {
-
+            amrex::ParticleReal & AMREX_RESTRICT x,
+            amrex::ParticleReal & AMREX_RESTRICT y,
+            amrex::ParticleReal & AMREX_RESTRICT t,
+            amrex::ParticleReal & AMREX_RESTRICT px,
+            amrex::ParticleReal & AMREX_RESTRICT py,
+            amrex::ParticleReal & AMREX_RESTRICT pt,
+            [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
             using namespace amrex::literals; // for _rt and _prt
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
-
-            // access reference particle values to find (beta*gamma)^2
-            amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
 
             // intialize output values of momenta
             amrex::ParticleReal pxout = px;
@@ -102,9 +121,9 @@ namespace impactx::elements
             amrex::ParticleReal ptout = pt;
 
             // advance position and momentum
-            pxout = px + m_k*m_V/(2.0_prt*betgam2)*x;
-            pyout = py + m_k*m_V/(2.0_prt*betgam2)*y;
-            ptout = pt - m_k*m_V*t;
+            pxout = px + m_kV_r2bg2 * x;
+            pyout = py + m_kV_r2bg2 * y;
+            ptout = pt + m_neg_kV   * t;
 
             // assign updated momenta
             px = pxout;
@@ -136,6 +155,12 @@ namespace impactx::elements
 
         amrex::ParticleReal m_V; //! normalized (max) RF voltage drop.
         amrex::ParticleReal m_k; //! RF wavenumber in 1/m.
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_neg_kV;    //! -m_k*m_V
+        amrex::ParticleReal m_kV_r2bg2;  //! m_k*m_V/(2.0_prt*betgam2)
     };
 
 } // namespace impactx

--- a/src/elements/CFbend.H
+++ b/src/elements/CFbend.H
@@ -81,7 +81,68 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
+            // find beta*gamma^2, beta
+            amrex::ParticleReal const betgam2 = std::pow(refpart.pt, 2) - 1_prt;
+            amrex::ParticleReal const bet = refpart.beta();
+            amrex::ParticleReal const ibetgam2 = 1_prt / betgam2;
+            amrex::ParticleReal const b2rc2 = std::pow(bet, 2) * std::pow(m_rc, 2);
+
+            // update horizontal and longitudinal phase space variables
+            amrex::ParticleReal const gx = m_k + std::pow(m_rc,-2);
+            amrex::ParticleReal const omega_x = std::sqrt(std::abs(gx));
+
+            // update vertical phase space variables
+            amrex::ParticleReal const gy = -m_k;
+            amrex::ParticleReal const omega_y = std::sqrt(std::abs(gy));
+
+            // trigonometry
+            auto const [sinx, cosx] = amrex::Math::sincos(omega_x * slice_ds);
+            amrex::ParticleReal const sinhx = std::sinh(omega_x * slice_ds);
+            amrex::ParticleReal const coshx = std::cosh(omega_x * slice_ds);
+            auto const [siny, cosy] = amrex::Math::sincos(omega_y * slice_ds);
+            amrex::ParticleReal const sinhy = std::sinh(omega_y * slice_ds);
+            amrex::ParticleReal const coshy = std::cosh(omega_y * slice_ds);
+
+            amrex::ParticleReal const igbrc = 1_prt / (gx * bet * m_rc);
+            amrex::ParticleReal const iobrc = 1_prt / (omega_x * bet * m_rc);
+            amrex::ParticleReal const igobr = 1_prt / (gx * omega_x * b2rc2);
+
+            m_R11 = gx > 0_prt ? cosx : coshx;
+            m_R12 = gx > 0_prt ? sinx / omega_x : sinhx / omega_x;
+            m_R16 = gx > 0_prt ? -(1_prt - cosx) * igbrc : -(1_prt - coshx) * igbrc;
+            m_R21 = gx > 0_prt ? -omega_x * sinx : omega_x * sinhx;
+            m_R22 = gx > 0_prt ? cosx : coshx;
+            m_R26 = gx > 0_prt ? -sinx * iobrc : -sinhx * iobrc;
+            m_R33 = gy > 0_prt ? cosy : coshy;
+            m_R34 = gy > 0_prt ? siny / omega_y : sinhy / omega_y;
+            m_R43 = gy > 0_prt ? -omega_y * siny : omega_y * sinhy;
+            m_R44 = gy > 0_prt ? cosy : coshy;
+            m_R51 = gx > 0_prt ? sinx * iobrc : sinhx * iobrc;
+            m_R52 = gx > 0_prt ? (1_prt - cosx) * igbrc : (1_prt - coshx) * igbrc;
+            m_R56 = gx > 0_prt ?
+                slice_ds * ibetgam2 + (sinx  - omega_x * slice_ds) * igobr :
+                slice_ds * ibetgam2 + (sinhx - omega_x * slice_ds) * igobr;
+        }
+
         /** This is a cfbend functor, so that a variable of this type can be used like a cfbend function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -90,7 +151,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -101,7 +162,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             uint64_t & AMREX_RESTRICT idcpu,
-            RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -119,68 +180,17 @@ namespace impactx::elements
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;
 
-            // length of the current slice
-            amrex::ParticleReal const slice_ds = m_ds / nslice();
-
-            // access reference particle values to find beta*gamma^2
-            amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
-            amrex::ParticleReal const bet = std::sqrt(betgam2/(1.0_prt + betgam2));
-
             // update horizontal and longitudinal phase space variables
-            amrex::ParticleReal const gx = m_k + std::pow(m_rc,-2);
-            amrex::ParticleReal const omegax = std::sqrt(std::abs(gx));
-
-            if(gx > 0.0) {
-                // calculate expensive terms once
-                auto const [sinx, cosx] = amrex::Math::sincos(omegax * slice_ds);
-                amrex::ParticleReal const r56 = slice_ds/betgam2
-                    + (sinx - omegax*slice_ds)/(gx*omegax * std::pow(bet,2) * std::pow(m_rc,2));
-
-                // advance position and momentum (focusing)
-                x = cosx*xout + sinx/omegax*px - (1.0_prt - cosx)/(gx*bet*m_rc)*pt;
-                pxout = -omegax*sinx*xout + cosx*px - sinx/(omegax*bet*m_rc)*pt;
-
-                t = sinx/(omegax*bet*m_rc)*xout + (1.0_prt - cosx)/(gx*bet*m_rc)*px
-                    + tout + r56*pt;
-                ptout = pt;
-            } else {
-                // calculate expensive terms once
-                amrex::ParticleReal const sinhx = std::sinh(omegax * slice_ds);
-                amrex::ParticleReal const coshx = std::cosh(omegax * slice_ds);
-                amrex::ParticleReal const r56 = slice_ds/betgam2
-                    + (sinhx - omegax*slice_ds)/(gx*omegax * std::pow(bet,2) * std::pow(m_rc,2));
-
-                // advance position and momentum (defocusing)
-                x = coshx*xout + sinhx/omegax*px - (1.0_prt - coshx)/(gx*bet*m_rc)*pt;
-                pxout = omegax*sinhx*xout + coshx*px - sinhx/(omegax*bet*m_rc)*pt;
-
-                t = sinhx/(omegax*bet*m_rc)*xout + (1.0_prt - coshx)/(gx*bet*m_rc)*px
-                    + tout + r56*pt;
-                ptout = pt;
-            }
+            //   advance position and momentum: (de)focusing
+            x =     m_R11 * xout + m_R12 * px + m_R16 * pt;
+            pxout = m_R21 * xout + m_R22 * px + m_R26 * pt;
+            t =     m_R51 * xout + m_R52 * px + m_R56 * pt + tout;
+            ptout = pt;
 
             // update vertical phase space variables
-            amrex::ParticleReal const gy = -m_k;
-            amrex::ParticleReal const omegay = std::sqrt(std::abs(gy));
-
-            if(gy > 0.0) {
-                // calculate expensive terms once
-                auto const [siny, cosy] = amrex::Math::sincos(omegay * slice_ds);
-
-                // advance position and momentum (focusing)
-                y = cosy*yout + siny/omegay*py;
-                pyout = -omegay*siny*yout + cosy*py;
-
-            } else {
-                // calculate expensive terms once
-                amrex::ParticleReal const sinhy = std::sinh(omegay * slice_ds);
-                amrex::ParticleReal const coshy = std::cosh(omegay * slice_ds);
-
-                // advance position and momentum (defocusing)
-                y = coshy*yout + sinhy/omegay*py;
-                pyout = omegay*sinhy*yout + coshy*py;
-            }
+            //   advance position and momentum (de)focusing
+            y =     m_R33 * yout + m_R34 * py;
+            pyout = m_R43 * yout + m_R44 * py;
 
             // assign updated momenta
             px = pxout;
@@ -257,6 +267,11 @@ namespace impactx::elements
 
         amrex::ParticleReal m_rc; //! bend radius in m
         amrex::ParticleReal m_k;  //! quadrupole strength in m^(-2)
+
+    private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_R11, m_R12, m_R16, m_R21, m_R22, m_R26, m_R33, m_R34, m_R43, m_R44, m_R51, m_R52, m_R56;
     };
 
 } // namespace impactx

--- a/src/elements/ChrDrift.H
+++ b/src/elements/ChrDrift.H
@@ -74,6 +74,29 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // length of the current slice
+            m_slice_ds = m_ds / nslice();
+
+            // access reference particle values to find beta, gamma
+            m_beta = refpart.beta();
+            m_gamma = refpart.gamma();
+
+            m_const1 = 1_prt / (2_prt * std::pow(m_beta,3) * std::pow(m_gamma, 2));
+        }
+
         /** This is a chrdrift functor, so that a variable of this type can be used like a chrdrift function.
          *
          * @param x particle position in x
@@ -83,7 +106,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -94,7 +117,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             uint64_t & AMREX_RESTRICT idcpu,
-            RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -112,30 +135,22 @@ namespace impactx::elements
             amrex::ParticleReal const pyout = py;
             amrex::ParticleReal const ptout = pt;
 
-            // length of the current slice
-            amrex::ParticleReal const slice_ds = m_ds / nslice();
-
-            // access reference particle values to find beta, gamma
-            amrex::ParticleReal const bet = refpart.beta();
-            amrex::ParticleReal const gam = refpart.gamma();
-
             // compute particle momentum deviation delta + 1
-            amrex::ParticleReal delta1;
-            delta1 = std::sqrt(1_prt - 2_prt*pt/bet + std::pow(pt,2));
+            amrex::ParticleReal const idelta1 = 1_prt / std::sqrt(1_prt - 2_prt*pt/m_beta + std::pow(pt,2));
 
             // advance transverse position and momentum (drift)
-            x = xout + slice_ds * px / delta1;
+            x = xout + m_slice_ds * px * idelta1;
             // pxout = px;
-            y = yout + slice_ds * py / delta1;
+            y = yout + m_slice_ds * py * idelta1;
             // pyout = py;
 
             // the corresponding symplectic update to t
             amrex::ParticleReal term = 2_prt * std::pow(pt,2) + std::pow(px,2) + std::pow(py,2);
-            term = 2_prt - 4_prt*bet*pt + std::pow(bet,2)*term;
-            term = -2_prt + std::pow(gam,2)*term;
-            term = (-1_prt+bet*pt)*term;
-            term = term/(2_prt * std::pow(bet,3) * std::pow(gam,2));
-            t = tout - slice_ds * (1_prt / bet + term /std::pow(delta1, 3));
+            term = 2_prt - 4_prt*m_beta*pt + std::pow(m_beta,2)*term;
+            term = -2_prt + std::pow(m_gamma, 2)*term;
+            term = (-1_prt+m_beta*pt)*term;
+            term = term * m_const1;
+            t = tout - m_slice_ds * (1_prt / m_beta + term * std::pow(idelta1, 3));
             // ptout = pt;
 
             // assign updated momenta
@@ -201,6 +216,14 @@ namespace impactx::elements
             throw std::runtime_error(std::string(type) + ": Envelope tracking is not yet implemented!");
             return Map6x6::Identity();
         }
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_slice_ds;  //! m_ds / nslice();
+        amrex::ParticleReal m_beta;
+        amrex::ParticleReal m_gamma;
+        amrex::ParticleReal m_const1;
     };
 
 } // namespace impactx

--- a/src/elements/ChrPlasmaLens.H
+++ b/src/elements/ChrPlasmaLens.H
@@ -83,6 +83,29 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // length of the current slice
+            m_slice_ds = m_ds / nslice();
+
+            // access reference particle values to find beta
+            m_beta = refpart.beta();
+
+            // normalize focusing strength units to MAD-X convention if needed
+            m_g = m_unit == 1 ? m_k / refpart.rigidity_Tm() : m_k;
+        }
+
         /** This is a chrplasmalens functor, so that a variable of this type can be used like a chrplasmalens function.
          *
          * @param x particle position in x
@@ -92,7 +115,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -103,7 +126,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             uint64_t & AMREX_RESTRICT idcpu,
-            RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -111,26 +134,13 @@ namespace impactx::elements
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
 
-            // length of the current slice
-            amrex::ParticleReal const slice_ds = m_ds / nslice();
-
-            // access reference particle values to find beta
-            amrex::ParticleReal const bet = refpart.beta();
-
-            // normalize focusing strength units to MAD-X convention if needed
-            amrex::ParticleReal g = m_k;
-            if (m_unit == 1) {
-                  g = m_k / refpart.rigidity_Tm();
-            }
-
             // compute particle momentum deviation delta + 1
-            amrex::ParticleReal delta1;
-            delta1 = std::sqrt(1_prt - 2_prt*pt/bet + std::pow(pt,2));
+            amrex::ParticleReal const delta1 = std::sqrt(1_prt - 2_prt*pt/m_beta + std::pow(pt,2));
             amrex::ParticleReal const delta = delta1 - 1_prt;
 
             // compute phase advance per unit length in s (in rad/m)
             // chromatic dependence on delta is included
-            amrex::ParticleReal const omega = std::sqrt(std::abs(g)/delta1);
+            amrex::ParticleReal const omega = std::sqrt(std::abs(m_g)/delta1);
 
             // initialize output values
             amrex::ParticleReal xout = x;
@@ -147,7 +157,7 @@ namespace impactx::elements
             amrex::ParticleReal p1 = px;
             amrex::ParticleReal p2 = py;
 
-            auto const [sin_ods, cos_ods] = amrex::Math::sincos(omega*slice_ds);
+            auto const [sin_ods, cos_ods] = amrex::Math::sincos(omega*m_slice_ds);
 
             // advance transverse position and momentum (focusing)
             xout = cos_ods * x + sin_ods / (omega * delta1) * px;
@@ -159,17 +169,17 @@ namespace impactx::elements
             // advance longitudinal position and momentum
 
             // the corresponding symplectic update to t
-            amrex::ParticleReal const term = pt + delta/bet;
-            amrex::ParticleReal const t0 = t - term*slice_ds/delta1;
+            amrex::ParticleReal const term = pt + delta/m_beta;
+            amrex::ParticleReal const t0 = t - term*m_slice_ds/delta1;
 
             amrex::ParticleReal const w = omega*delta1;
-            amrex::ParticleReal const term1 = -(std::pow(p2,2)-pow(q2,2) * std::pow(w,2)) * std::sin(2_prt*slice_ds*omega);
-            amrex::ParticleReal const term2 = -(std::pow(p1,2)-pow(q1,2) * std::pow(w,2)) * std::sin(2_prt*slice_ds*omega);
-            amrex::ParticleReal const term3 = -2_prt*q2*p2*w * std::cos(2_prt*slice_ds*omega);
-            amrex::ParticleReal const term4 = -2_prt*q1*p1*w * std::cos(2_prt*slice_ds*omega);
+            amrex::ParticleReal const term1 = -(std::pow(p2,2)-std::pow(q2,2) * std::pow(w,2)) * std::sin(2_prt*m_slice_ds*omega);
+            amrex::ParticleReal const term2 = -(std::pow(p1,2)-std::pow(q1,2) * std::pow(w,2)) * std::sin(2_prt*m_slice_ds*omega);
+            amrex::ParticleReal const term3 = -2_prt*q2*p2*w * std::cos(2_prt*m_slice_ds*omega);
+            amrex::ParticleReal const term4 = -2_prt*q1*p1*w * std::cos(2_prt*m_slice_ds*omega);
             amrex::ParticleReal const term5 = 2_prt*omega*(q1*p1*delta1 + q2*p2*delta1
-                                        -(std::pow(p1,2) + std::pow(p2,2))*slice_ds - (std::pow(q1,2) + std::pow(q2,2)) * std::pow(w,2)*slice_ds);
-            t = t0 + (-1_prt+bet*pt)/(8_prt*bet * std::pow(delta1,3)*omega)
+                                        -(std::pow(p1,2) + std::pow(p2,2))*m_slice_ds - (std::pow(q1,2) + std::pow(q2,2)) * std::pow(w,2)*m_slice_ds);
+            t = t0 + (-1_prt+m_beta*pt)/(8_prt*m_beta * std::pow(delta1,3)*omega)
                      *(term1+term2+term3+term4+term5);
 
             // ptout = pt;
@@ -221,7 +231,7 @@ namespace impactx::elements
             refpart.t = t - step*pt;
 
             // advance integrated path length
-            refpart.s = s + slice_ds;
+            refpart.s = s + m_slice_ds;
         }
 
         /** This pushes the covariance matrix. */
@@ -242,6 +252,13 @@ namespace impactx::elements
 
         amrex::ParticleReal m_k; //! focusing strength in 1/m^2 (or T/m)
         int m_unit; //! unit specification for focusing strength
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_slice_ds;  //! m_ds / nslice();
+        amrex::ParticleReal m_beta;
+        amrex::ParticleReal m_g;
     };
 
 } // namespace impactx

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -85,6 +85,33 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // length of the current slice
+            m_slice_ds = m_ds / nslice();
+
+            // access reference particle values to find beta and gamma
+            m_beta = refpart.beta();
+            m_gamma = refpart.gamma();
+
+            // normalize quad units to MAD-X convention if needed
+            m_g = m_unit == 1 ? m_k / refpart.rigidity_Tm() : m_k;
+
+            m_const1 = 1_prt / (2_prt * std::pow(m_beta, 3) * std::pow(m_gamma, 2));
+        }
+
         /** This is a chrquad functor, so that a variable of this type can be used like a chrquad function.
          *
          * @param x particle position in x
@@ -94,7 +121,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -105,7 +132,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             uint64_t & AMREX_RESTRICT idcpu,
-            RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -118,27 +145,13 @@ namespace impactx::elements
             amrex::ParticleReal const yout = y;
             amrex::ParticleReal const tout = t;
 
-            // length of the current slice
-            amrex::ParticleReal const slice_ds = m_ds / nslice();
-
-            // access reference particle values to find beta and gamma
-            amrex::ParticleReal const bet = refpart.beta();
-            amrex::ParticleReal const gam = refpart.gamma();
-
-            // normalize quad units to MAD-X convention if needed
-            amrex::ParticleReal g = m_k;
-            if (m_unit == 1) {
-                  g = m_k / refpart.rigidity_Tm();
-            }
-
             // compute particle momentum deviation delta + 1
-            amrex::ParticleReal delta1;
-            delta1 = std::sqrt(1_prt - 2_prt*pt/bet + std::pow(pt,2));
+            amrex::ParticleReal const delta1 = std::sqrt(1_prt - 2_prt*pt/m_beta + std::pow(pt,2));
             amrex::ParticleReal const delta = delta1 - 1_prt;
 
             // compute phase advance per unit length in s (in rad/m)
             // chromatic dependence on delta is included
-            amrex::ParticleReal const omega = std::sqrt(std::abs(g)/delta1);
+            amrex::ParticleReal const omega = std::sqrt(std::abs(m_g)/delta1);
 
             // intialize output values of momenta
             amrex::ParticleReal pxout = px;
@@ -151,67 +164,72 @@ namespace impactx::elements
             amrex::ParticleReal p1 = px;
             amrex::ParticleReal p2 = py;
 
-            if(g > 0.0) {
+            if (m_g > 0_prt)
+            {
                // advance transverse position and momentum (focusing quad)
-               x = std::cos(omega*slice_ds) * xout +
-                                  std::sin(omega*slice_ds)/(omega*delta1)*px;
-               pxout = -omega * delta1 *std::sin(omega*slice_ds) * xout + std::cos(omega * slice_ds) * px;
+               x = std::cos(omega*m_slice_ds) * xout +
+                   std::sin(omega*m_slice_ds) / (omega*delta1)*px;
+               pxout = -omega * delta1 *std::sin(omega*m_slice_ds) * xout + std::cos(omega * m_slice_ds) * px;
 
-               y = std::cosh(omega*slice_ds) * yout +
-                                   std::sinh(omega*slice_ds)/(omega*delta1)*py;
-               pyout = omega * delta1 * std::sinh(omega*slice_ds) * yout + std::cosh(omega * slice_ds) * py;
+               y = std::cosh(omega*m_slice_ds) * yout +
+                   std::sinh(omega*m_slice_ds) / (omega*delta1)*py;
+               pyout = omega * delta1 * std::sinh(omega*m_slice_ds) * yout + std::cosh(omega * m_slice_ds) * py;
 
-            } else if (g < 0.0) {
+            } else if (m_g < 0_prt)
+            {
                // advance transverse position and momentum (defocusing quad)
-               x = std::cosh(omega*slice_ds) * xout +
-                                   std::sinh(omega*slice_ds)/(omega*delta1)*px;
-               pxout = omega * delta1 * std::sinh(omega*slice_ds) * xout + std::cosh(omega * slice_ds) * px;
+               x = std::cosh(omega*m_slice_ds) * xout +
+                   std::sinh(omega*m_slice_ds) / (omega*delta1)*px;
+               pxout = omega * delta1 * std::sinh(omega*m_slice_ds) * xout + std::cosh(omega * m_slice_ds) * px;
 
-               y = std::cos(omega*slice_ds) * yout +
-                                  std::sin(omega*slice_ds)/(omega*delta1)*py;
-               pyout = -omega * delta1 *std::sin(omega*slice_ds) * yout + std::cos(omega * slice_ds) * py;
+               y = std::cos(omega*m_slice_ds) * yout +
+                   std::sin(omega*m_slice_ds) / (omega*delta1) * py;
+               pyout = -omega * delta1 * std::sin(omega*m_slice_ds) * yout + std::cos(omega * m_slice_ds) * py;
 
                q1 = yout;
                q2 = xout;
                p1 = py;
                p2 = px;
-            } else {
+            } else
+            {
                // advance transverse position and momentum (zero focusing strength = drift)
-               x = xout + slice_ds * px / delta1;
+               x = xout + m_slice_ds * px / delta1;
                // pxout = px;
-               y = yout + slice_ds * py / delta1;
+               y = yout + m_slice_ds * py / delta1;
                // pyout = py;
             }
 
 
             // advance longitudinal position and momentum
 
-            if (g == 0.0) {
+            if (m_g == 0.0)
+            {
                // the corresponding symplectic update to t (zero strength = drift)
                amrex::ParticleReal term = 2_prt * std::pow(pt,2) + std::pow(px,2) + std::pow(py,2);
-               term = 2_prt - 4_prt*bet*pt + std::pow(bet,2)*term;
-               term = -2_prt + std::pow(gam,2)*term;
-               term = (-1_prt+bet*pt)*term;
-               term = term/(2_prt * std::pow(bet,3) * std::pow(gam,2));
-               t = tout - slice_ds * (1_prt / bet + term /std::pow(delta1, 3));
+               term = 2_prt - 4_prt * m_beta * pt + std::pow(m_beta,2) * term;
+               term = -2_prt + std::pow(m_gamma, 2)*term;
+               term = (-1_prt + m_beta * pt) * term;
+               term = term * m_const1;
+               t = tout - m_slice_ds * (1_prt / m_beta + term / std::pow(delta1, 3));
                // ptout = pt;
 
-            } else {
-               // the corresponding symplectic update to t (nonzero strength)
-               amrex::ParticleReal const term = pt + delta/bet;
-               amrex::ParticleReal const t0 = tout - term * slice_ds / delta1;
+            } else
+            {
+                // the corresponding symplectic update to t (nonzero strength)
+                amrex::ParticleReal const term = pt + delta / m_beta;
+                amrex::ParticleReal const t0 = tout - term * m_slice_ds / delta1;
 
-               amrex::ParticleReal const w = omega*delta1;
-               amrex::ParticleReal const term1 = -(std::pow(p2,2) + std::pow(q2,2) * std::pow(w,2))*std::sinh(2_prt*slice_ds*omega);
-               amrex::ParticleReal const term2 = -(std::pow(p1,2)-pow(q1,2) * std::pow(w,2)) * std::sin(2_prt*slice_ds*omega);
-               amrex::ParticleReal const term3 = -2_prt*q2*p2*w*std::cosh(2_prt*slice_ds*omega);
-               amrex::ParticleReal const term4 = -2_prt*q1*p1*w * std::cos(2_prt*slice_ds*omega);
-               amrex::ParticleReal const term5 = 2_prt*omega*(q1*p1*delta1 + q2*p2*delta1
-                                           -(std::pow(p1,2) + std::pow(p2,2))*slice_ds - (std::pow(q1,2)-pow(q2,2)) * std::pow(w,2)*slice_ds);
-               t = t0 + (-1_prt+bet*pt)/(8_prt*bet * std::pow(delta1,3)*omega)
-                        *(term1+term2+term3+term4+term5);
+                amrex::ParticleReal const w = omega * delta1;
+                amrex::ParticleReal const term1 = -(std::pow(p2,2) + std::pow(q2,2) * std::pow(w,2)) * std::sinh(2_prt*m_slice_ds*omega);
+                amrex::ParticleReal const term2 = -(std::pow(p1,2) - std::pow(q1,2) * std::pow(w,2)) * std::sin(2_prt*m_slice_ds*omega);
+                amrex::ParticleReal const term3 = -2_prt * q2 * p2 * w * std::cosh(2_prt*m_slice_ds*omega);
+                amrex::ParticleReal const term4 = -2_prt * q1 * p1 * w * std::cos(2_prt*m_slice_ds*omega);
+                amrex::ParticleReal const term5 =  2_prt * omega * (q1*p1*delta1 + q2*p2*delta1
+                    -(std::pow(p1,2) + std::pow(p2,2))*m_slice_ds - (std::pow(q1,2)-std::pow(q2,2)) * std::pow(w,2)*m_slice_ds);
+                t = t0 + (-1_prt+m_beta*pt)
+                       / (8_prt*m_beta * std::pow(delta1,3)*omega)
+                       * (term1+term2+term3+term4+term5);
                // ptout = pt;
-
              }
 
             // assign updated momenta
@@ -250,7 +268,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds /std::sqrt(std::pow(pt,2)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds / std::sqrt(std::pow(pt,2)-1.0_prt);
 
             // advance position and momentum (straight element)
             refpart.x = x + step*px;
@@ -280,6 +298,15 @@ namespace impactx::elements
 
         amrex::ParticleReal m_k; //! quadrupole strength in 1/m^2 (or T/m)
         int m_unit; //! unit specification for quad strength
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_slice_ds;  //! m_ds / nslice();
+        amrex::ParticleReal m_beta;
+        amrex::ParticleReal m_gamma;
+        amrex::ParticleReal m_g;
+        amrex::ParticleReal m_const1;
     };
 
 } // namespace impactx

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -81,7 +81,36 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // length of the current slice
+            m_slice_ds = m_ds / nslice();
+
+            // access reference particle values (final, initial):
+            m_ptf_ref = refpart.pt;
+            m_pti_ref = m_ptf_ref + m_ez * m_slice_ds;
+            m_bgf = std::sqrt(std::pow(m_ptf_ref, 2) - 1.0_prt);
+            m_bgi = std::sqrt(std::pow(m_pti_ref, 2) - 1.0_prt);
+
+            // compute focusing constant (1/m) and rotation angle (in rad)
+            m_alpha = m_bz / 2.0_prt;
+            m_alpha_iez = m_alpha / m_ez;
+        }
+
         /** This is a chracc functor, so that a variable of this type can be used like a chracc function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -90,7 +119,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -101,7 +130,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             uint64_t & AMREX_RESTRICT idcpu,
-            RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -109,41 +138,32 @@ namespace impactx::elements
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
 
-            // length of the current slice
-            amrex::ParticleReal const slice_ds = m_ds / nslice();
-
-            // access reference particle values (final, initial):
-            amrex::ParticleReal const ptf_ref = refpart.pt;
-            amrex::ParticleReal const pti_ref = ptf_ref + m_ez*slice_ds;
-            amrex::ParticleReal const bgf = std::sqrt(std::pow(ptf_ref, 2) - 1.0_prt);
-            amrex::ParticleReal const bgi = std::sqrt(std::pow(pti_ref, 2) - 1.0_prt);
-
             // initial conversion from static to dynamic units:
-            px = px*bgi;
-            py = py*bgi;
-            pt = pt*bgi;
+            px = px * m_bgi;
+            py = py * m_bgi;
+            pt = pt * m_bgi;
 
             // compute intermediate quantities related to acceleration
-            amrex::ParticleReal const pti_tot = pti_ref + pt;
-            amrex::ParticleReal const ptf_tot = ptf_ref + pt;
-            amrex::ParticleReal const pti_tot2 = std::pow(pti_tot,2);
-            amrex::ParticleReal const ptf_tot2 = std::pow(ptf_tot,2);
+            amrex::ParticleReal const pti_tot = m_pti_ref + pt;
+            amrex::ParticleReal const ptf_tot = m_ptf_ref + pt;
+            amrex::ParticleReal const pti_tot2 = std::pow(pti_tot, 2);
+            amrex::ParticleReal const ptf_tot2 = std::pow(ptf_tot, 2);
 
             // check whether particle lies within the domain of map definition
             if (pti_tot2 <= 1_prt || ptf_tot2 <= 1_prt) {
                 amrex::ParticleIDWrapper{idcpu}.make_invalid();
             } else {
-                amrex::ParticleReal const pzi_tot = std::sqrt(std::pow(pti_tot,2)-1_prt);
-                amrex::ParticleReal const pzf_tot = std::sqrt(std::pow(ptf_tot,2)-1_prt);
-                amrex::ParticleReal const pzi_ref = std::sqrt(std::pow(pti_ref,2)-1_prt);
-                amrex::ParticleReal const pzf_ref = std::sqrt(std::pow(ptf_ref,2)-1_prt);
+                amrex::ParticleReal const pzi_tot = std::sqrt(std::pow(pti_tot, 2) - 1_prt);
+                amrex::ParticleReal const pzf_tot = std::sqrt(std::pow(ptf_tot, 2) - 1_prt);
+                amrex::ParticleReal const pzi_ref = std::sqrt(std::pow(m_pti_ref, 2) - 1_prt);
+                amrex::ParticleReal const pzf_ref = std::sqrt(std::pow(m_ptf_ref, 2) - 1_prt);
 
                 amrex::ParticleReal const numer = -ptf_tot + pzf_tot;
                 amrex::ParticleReal const denom = -pti_tot + pzi_tot;
 
                 // compute focusing constant (1/m) and rotation angle (in rad)
-                amrex::ParticleReal const alpha = m_bz/2.0_prt;
-                amrex::ParticleReal const theta = alpha/m_ez*std::log(numer/denom);
+                amrex::ParticleReal const theta = m_alpha_iez * std::log(numer / denom);
+                auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
 
                 // intialize output values
                 amrex::ParticleReal xout = x;
@@ -154,15 +174,18 @@ namespace impactx::elements
                 amrex::ParticleReal ptout = pt;
 
                 // advance positions and momenta using map for focusing
-                xout = std::cos(theta)*x + std::sin(theta)/alpha*px;
-                pxout = -alpha * std::sin(theta)*x + std::cos(theta)*px;
+                xout = cos_theta * x + sin_theta / m_alpha * px;
+                pxout = -m_alpha * sin_theta * x + cos_theta * px;
 
-                yout = std::cos(theta)*y + std::sin(theta)/alpha*py;
-                pyout = -alpha * std::sin(theta)*y + std::cos(theta)*py;
+                yout = cos_theta * y + sin_theta / m_alpha * py;
+                pyout = -m_alpha * sin_theta * y + cos_theta * py;
 
                 // the correct symplectic update for t
-                tout = t + (pzf_tot - pzf_ref - pzi_tot + pzi_ref)/m_ez;
-                tout = tout + (1_prt/pzi_tot - 1_prt/pzf_tot)*(std::pow(py-alpha*x,2) + std::pow(px+alpha*y,2))/(2_prt*m_ez);
+                tout = t + (pzf_tot - pzf_ref - pzi_tot + pzi_ref) / m_ez;
+                tout += (1_prt/pzi_tot - 1_prt/pzf_tot)
+                      * (std::pow(py - m_alpha * x, 2) +
+                         std::pow(px + m_alpha * y, 2))
+                      / (2_prt * m_ez);
                 ptout = pt;
 
                 // assign intermediate momenta
@@ -171,11 +194,11 @@ namespace impactx::elements
                 pt = ptout;
 
                 // advance positions and momenta using map for rotation
-                x = std::cos(theta)*xout + std::sin(theta)*yout;
-                pxout = std::cos(theta)*px + std::sin(theta)*py;
+                x = cos_theta * xout + sin_theta * yout;
+                pxout = cos_theta * px + sin_theta * py;
 
-                y = -std::sin(theta)*xout + std::cos(theta)*yout;
-                pyout = -std::sin(theta)*px + std::cos(theta)*py;
+                y = -sin_theta * xout + cos_theta * yout;
+                pyout = -sin_theta * px + cos_theta * py;
 
                 t = tout;
                 ptout = pt;
@@ -188,9 +211,9 @@ namespace impactx::elements
             }
 
             // final conversion from dynamic to static units:
-            px = px/bgf;
-            py = py/bgf;
-            pt = pt/bgf;
+            px = px / m_bgf;
+            py = py / m_bgf;
+            pt = pt / m_bgf;
 
             // apply transverse aperture
             apply_aperture(x, y, idcpu);
@@ -267,6 +290,13 @@ namespace impactx::elements
 
         amrex::ParticleReal m_ez; //! electric field strength in 1/m
         amrex::ParticleReal m_bz; //! magnetic field strength in 1/m
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_slice_ds;  //! m_ds / nslice();
+        amrex::ParticleReal m_ptf_ref, m_pti_ref, m_bgf, m_bgi;
+        amrex::ParticleReal m_alpha, m_alpha_iez;
     };
 
 } // namespace impactx

--- a/src/elements/ConstF.H
+++ b/src/elements/ConstF.H
@@ -78,7 +78,46 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
+            // find beta*gamma^2
+            amrex::ParticleReal const betgam2 = std::pow(refpart.pt, 2) - 1.0_prt;
+
+            // trigo
+            auto const [sin_kxds, cos_kxds] = amrex::Math::sincos(m_kx * slice_ds);
+            m_cos_kxds = cos_kxds;
+            m_const_x = -m_kx * sin_kxds;
+            auto const [sin_kyds, cos_kyds] = amrex::Math::sincos(m_ky * slice_ds);
+            m_cos_kyds = cos_kyds;
+            m_const_y = -m_ky * sin_kyds;
+            auto const [sin_ktds, cos_ktds] = amrex::Math::sincos(m_kt * slice_ds);
+            m_cos_ktds = cos_ktds;
+            m_const_t = -m_kt * betgam2 * sin_ktds;
+
+            // intermediate quantities - to avoid division by zero
+            m_sincx = m_kx > 0 ? std::sin(m_kx * slice_ds) / m_kx : slice_ds;
+            m_sincy = m_ky > 0 ? std::sin(m_ky * slice_ds) / m_ky : slice_ds;
+            amrex::ParticleReal const sinct = m_kt > 0 ? std::sin(m_kt * slice_ds) / m_kt : slice_ds;
+            m_const_pt = sinct / betgam2;
+        }
+
         /** This pushes a single particle, relative to the reference particle
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -87,27 +126,24 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                amrex::ParticleReal & AMREX_RESTRICT x,
-                amrex::ParticleReal & AMREX_RESTRICT y,
-                amrex::ParticleReal & AMREX_RESTRICT t,
-                amrex::ParticleReal & AMREX_RESTRICT px,
-                amrex::ParticleReal & AMREX_RESTRICT py,
-                amrex::ParticleReal & AMREX_RESTRICT pt,
-                uint64_t & AMREX_RESTRICT idcpu,
-                RefPart const & refpart) const {
-
+            amrex::ParticleReal & AMREX_RESTRICT x,
+            amrex::ParticleReal & AMREX_RESTRICT y,
+            amrex::ParticleReal & AMREX_RESTRICT t,
+            amrex::ParticleReal & AMREX_RESTRICT px,
+            amrex::ParticleReal & AMREX_RESTRICT py,
+            amrex::ParticleReal & AMREX_RESTRICT pt,
+            uint64_t & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
             using namespace amrex::literals; // for _rt and _prt
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
-
-            // access reference particle values to find beta*gamma^2
-            amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
 
             // intialize output values
             amrex::ParticleReal xout = x;
@@ -117,23 +153,15 @@ namespace impactx::elements
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;
 
-            // length of the current slice
-            amrex::ParticleReal const slice_ds = m_ds / nslice();
-
-            // intermediate quantities - to avoid division by zero
-            amrex::ParticleReal const sincx = (m_kx > 0) ? std::sin(m_kx*slice_ds)/m_kx : slice_ds;
-            amrex::ParticleReal const sincy = (m_ky > 0) ? std::sin(m_ky*slice_ds)/m_ky : slice_ds;
-            amrex::ParticleReal const sinct = (m_kt > 0) ? std::sin(m_kt*slice_ds)/m_kt : slice_ds;
-
             // advance position and momentum
-            xout = std::cos(m_kx*slice_ds)*x + sincx*px;
-            pxout = -m_kx * std::sin(m_kx*slice_ds)*x + std::cos(m_kx*slice_ds)*px;
+            xout = m_cos_kxds * x + m_sincx    * px;
+            pxout = m_const_x * x + m_cos_kxds * px;
 
-            yout = std::cos(m_ky*slice_ds)*y + sincy*py;
-            pyout = -m_ky * std::sin(m_ky*slice_ds)*y + std::cos(m_ky*slice_ds)*py;
+            yout = m_cos_kyds * y + m_sincy    * py;
+            pyout = m_const_y * y + m_cos_kyds * py;
 
-            tout = std::cos(m_kt*slice_ds)*t + sinct/(betgam2)*pt;
-            ptout = -(m_kt*betgam2) * std::sin(m_kt*slice_ds)*t + std::cos(m_kt*slice_ds)*pt;
+            tout = m_cos_ktds * t + m_const_pt * pt;
+            ptout = m_const_t * t + m_cos_ktds * pt;
 
             // assign updated values
             x = xout;
@@ -174,7 +202,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds /std::sqrt(std::pow(pt, 2)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds / std::sqrt(std::pow(pt, 2) - 1.0_prt);
 
             // advance position and momentum (straight element)
             refpart.x = x + step*px;
@@ -206,6 +234,13 @@ namespace impactx::elements
         amrex::ParticleReal m_kx; //! focusing x strength in 1/m
         amrex::ParticleReal m_ky; //! focusing y strength in 1/m
         amrex::ParticleReal m_kt; //! focusing t strength in 1/m
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_sincx, m_sincy;
+        amrex::ParticleReal m_const_x, m_const_y, m_const_t, m_const_pt;
+        amrex::ParticleReal m_cos_kxds, m_cos_kyds, m_cos_ktds;
     };
 
 } // namespace impactx

--- a/src/elements/DipEdge.H
+++ b/src/elements/DipEdge.H
@@ -75,12 +75,39 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle (unused)
+         */
+        void compute_constants ([[maybe_unused]] RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // edge focusing matrix elements (zero gap)
+            m_R21 = std::tan(m_psi) / m_rc;
+
+            // first-order effect of nonzero gap
+            auto const [sin_psi, cos_psi] = amrex::Math::sincos(m_psi);
+            amrex::ParticleReal const vf = (1.0_prt + std::pow(sin_psi, 2))
+                / std::pow(cos_psi, 3)
+                * m_g * m_K2 / std::pow(m_rc, 2);
+
+            m_R43 = vf - m_R21;
+        }
+
         /** This is a dipedge functor, so that a variable of this type can be used like a
          *  dipedge function.
          *
+         * The @see compute_constants method must be called before pushing particles through this operator.
+         *
          * @param x particle position in x
          * @param y particle position in y
-         * @param t particle position in t
+         * @param t particle position in t (unchanged)
          * @param px particle momentum in x
          * @param py particle momentum in y
          * @param pt particle momentum in t (unchanged)
@@ -89,33 +116,25 @@ namespace impactx::elements
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                amrex::ParticleReal & AMREX_RESTRICT x,
-                amrex::ParticleReal & AMREX_RESTRICT y,
-                [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT t,
-                amrex::ParticleReal & AMREX_RESTRICT px,
-                amrex::ParticleReal & AMREX_RESTRICT py,
-                [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT pt,
-                [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
-                [[maybe_unused]] RefPart const & refpart) const {
+            amrex::ParticleReal & AMREX_RESTRICT x,
+            amrex::ParticleReal & AMREX_RESTRICT y,
+            [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT t,
+            amrex::ParticleReal & AMREX_RESTRICT px,
+            amrex::ParticleReal & AMREX_RESTRICT py,
+            [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT pt,
+            [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
 
             using namespace amrex::literals; // for _rt and _prt
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
 
-            // edge focusing matrix elements (zero gap)
-            amrex::ParticleReal const R21 = std::tan(m_psi)/m_rc;
-            amrex::ParticleReal R43 = -R21;
-            amrex::ParticleReal vf = 0;
-
-            // first-order effect of nonzero gap
-            vf = (1.0_prt + std::pow(sin(m_psi),2))/(std::pow(cos(m_psi),3));
-            vf *= m_g * m_K2/(std::pow(m_rc,2));
-            R43 += vf;
-
             // apply edge focusing
-            px = px + R21*x;
-            py = py + R43*y;
+            px = px + m_R21 * x;
+            py = py + m_R43 * y;
 
             // undo shift due to alignment errors of the element
             shift_out(x, y, px, py);
@@ -163,6 +182,11 @@ namespace impactx::elements
         amrex::ParticleReal m_rc; //! bend radius in m
         amrex::ParticleReal m_g; //! gap parameter in m
         amrex::ParticleReal m_K2; //! fringe field integral
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_R21, m_R43;
     };
 
 } // namespace impactx

--- a/src/elements/Drift.H
+++ b/src/elements/Drift.H
@@ -72,7 +72,31 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // length of the current slice
+            m_slice_ds = m_ds / nslice();
+
+            // find beta*gamma^2
+            m_betgam2 = std::pow(refpart.pt, 2) - 1.0_prt;
+
+            m_slice_bg = m_slice_ds / m_betgam2;
+        }
+
         /** This is a drift functor, so that a variable of this type can be used like a drift function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -81,7 +105,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -92,7 +116,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             uint64_t & AMREX_RESTRICT idcpu,
-            RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -108,19 +132,12 @@ namespace impactx::elements
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;
 
-            // length of the current slice
-            amrex::ParticleReal const slice_ds = m_ds / nslice();
-
-            // access reference particle values to find beta*gamma^2
-            amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
-
             // advance position and momentum (drift)
-            xout = x + slice_ds * px;
+            xout = x + m_slice_ds * px;
             // pxout = px;
-            yout = y + slice_ds * py;
+            yout = y + m_slice_ds * py;
             // pyout = py;
-            tout = t + (slice_ds/betgam2) * pt;
+            tout = t + m_slice_bg * pt;
             // ptout = pt;
 
             // assign updated values
@@ -202,6 +219,13 @@ namespace impactx::elements
 
             return R;
         }
+
+    private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_slice_ds;  //! m_ds / nslice();
+        amrex::ParticleReal m_betgam2;   //! beta*gamma^2
+        amrex::ParticleReal m_slice_bg;  //! m_slice_ds / m_betgam2
     };
 
 } // namespace impactx

--- a/src/elements/Empty.H
+++ b/src/elements/Empty.H
@@ -45,6 +45,12 @@ namespace impactx::elements
             // nothing to do
         }
 
+        /** Compute and cache the constants for the push - nothing to do here */
+        void compute_constants (RefPart const & /* refpart */)
+        {
+            // nothing to do
+        }
+
         /** Push all particles - nothing to do here */
         void operator() (
             ImpactXParticleContainer::iterator & /* pti */,
@@ -96,7 +102,7 @@ namespace impactx::elements
             [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT py,
             [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT pt,
             [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             // nothing to do

--- a/src/elements/ExactDrift.H
+++ b/src/elements/ExactDrift.H
@@ -71,8 +71,31 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // length of the current slice
+            m_slice_ds = m_ds / nslice();
+
+            // access reference particle values to find beta, 1/(beta*gamma)**2
+            m_ibeta = 1_prt / refpart.beta();
+            m_ibetagam2 = 1_prt / std::pow(refpart.beta_gamma(), 2);
+        }
+
         /** This is an exactdrift functor, so that a variable of this type can be used like
          *  an exactdrift function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -81,18 +104,18 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                amrex::ParticleReal & AMREX_RESTRICT x,
-                amrex::ParticleReal & AMREX_RESTRICT y,
-                amrex::ParticleReal & AMREX_RESTRICT t,
-                amrex::ParticleReal & AMREX_RESTRICT px,
-                amrex::ParticleReal & AMREX_RESTRICT py,
-                amrex::ParticleReal & AMREX_RESTRICT pt,
-                uint64_t & AMREX_RESTRICT idcpu,
-                RefPart const & refpart
+            amrex::ParticleReal & AMREX_RESTRICT x,
+            amrex::ParticleReal & AMREX_RESTRICT y,
+            amrex::ParticleReal & AMREX_RESTRICT t,
+            amrex::ParticleReal & AMREX_RESTRICT px,
+            amrex::ParticleReal & AMREX_RESTRICT py,
+            amrex::ParticleReal & AMREX_RESTRICT pt,
+            uint64_t & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -110,23 +133,20 @@ namespace impactx::elements
             amrex::ParticleReal const pyout = py;
             amrex::ParticleReal const ptout = pt;
 
-            // length of the current slice
-            amrex::ParticleReal const slice_ds = m_ds / nslice();
-
-            // access reference particle values to find beta, beta*gamma
-            amrex::ParticleReal const bet = refpart.beta();
-            amrex::ParticleReal const betgam = refpart.beta_gamma();
-
             // compute the radical in the denominator (= pz):
-            amrex::ParticleReal const pzden = std::sqrt(std::pow(pt-1_prt/bet,2) -
-                                1_prt / std::pow(betgam,2) - std::pow(px,2) - std::pow(py,2));
+            amrex::ParticleReal const inv_pzden = 1_prt / std::sqrt(
+                std::pow(pt - m_ibeta, 2) -
+                m_ibetagam2 -
+                std::pow(px, 2) -
+                std::pow(py, 2)
+            );
 
             // advance position and momentum (exact drift)
-            x = xout + slice_ds * px / pzden;
+            x = xout + m_slice_ds * px * inv_pzden;
             // pxout = px;
-            y = yout + slice_ds * py / pzden;
+            y = yout + m_slice_ds * py * inv_pzden;
             // pyout = py;
-            t = tout - slice_ds * (1_prt / bet + (pt-1_prt/bet)/pzden);
+            t = tout - m_slice_ds * (m_ibeta + (pt - m_ibeta) * inv_pzden);
             // ptout = pt;
 
             // assign updated momenta
@@ -175,7 +195,6 @@ namespace impactx::elements
 
             // advance integrated path length
             refpart.s = s + slice_ds;
-
         }
 
         /** This pushes the covariance matrix. */
@@ -193,6 +212,12 @@ namespace impactx::elements
             throw std::runtime_error(std::string(type) + ": Envelope tracking is not yet implemented!");
             return Map6x6::Identity();
         }
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_slice_ds;  //! m_ds / nslice();
+        amrex::ParticleReal m_ibeta, m_ibetagam2;
     };
 
 } // namespace impactx

--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -97,6 +97,33 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // angle of arc for the current slice
+            m_slice_phi = m_phi / nslice();
+            auto const [sin_phi, cos_phi] = amrex::Math::sincos(m_slice_phi);
+            m_sin_phi = sin_phi;
+            m_cos_phi = cos_phi;
+
+            // access reference particle values to find beta
+            m_ibeta = 1_prt / refpart.beta();
+
+            // reference particle's orbital radius
+            m_rc = this->rc(refpart);
+        }
+
         /** This is an ExactSbend functor, so that a variable of this type can be used like an ExactSbend function.
          *
          * @param x particle position in x
@@ -106,7 +133,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -117,7 +144,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             uint64_t & AMREX_RESTRICT idcpu,
-            RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -130,50 +157,44 @@ namespace impactx::elements
             amrex::ParticleReal const yout = y;
             amrex::ParticleReal const tout = t;
 
-            // angle of arc for the current slice
-            amrex::ParticleReal const slice_phi = m_phi / nslice();
-
-            // access reference particle values to find beta
-            amrex::ParticleReal const bet = refpart.beta();
-
-            // reference particle's orbital radius
-            amrex::ParticleReal const rc = this->rc(refpart);
-
             // intialize output values of momenta
             amrex::ParticleReal pxout = px;
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;
 
             // assign intermediate quantities
-            amrex::ParticleReal const pperp2 = std::pow(pt,2)-2.0_prt/bet*pt-pow(py,2)+1.0_prt;
+            amrex::ParticleReal const pperp2 = std::pow(pt,2)-2.0_prt * m_ibeta * pt - std::pow(py,2)+1.0_prt;
             amrex::ParticleReal const px2 = std::pow(px,2);
             // determine if particle lies within the domain of map definition
-            if (pperp2 <= px2) {
+            if (pperp2 <= px2)
+            {
                 amrex::ParticleIDWrapper{idcpu}.make_invalid();
-            } else {
+            } else
+            {
                 amrex::ParticleReal const pperp = std::sqrt(pperp2);
                 amrex::ParticleReal const pzi = std::sqrt(std::pow(pperp,2) - std::pow(px,2));
-                amrex::ParticleReal const rho = rc + xout;
-                auto const [sin_phi, cos_phi] = amrex::Math::sincos(slice_phi);
+                amrex::ParticleReal const rho = m_rc + xout;
 
                 // update momenta
-                pxout = px*cos_phi + (pzi - rho/rc)*sin_phi;
+                pxout = px * m_cos_phi + (pzi - rho / m_rc) * m_sin_phi;
                 pyout = py;
                 ptout = pt;
 
                 // angle of momentum rotation
                 amrex::ParticleReal const px2f = std::pow(pxout,2);
                 // determine if particle lies within domain of map definition
-                if (pperp2 <= px2f) {
+                if (pperp2 <= px2f)
+                {
                     amrex::ParticleIDWrapper{idcpu}.make_invalid();
-                } else {
-                    amrex::ParticleReal const pzf = std::sqrt(std::pow(pperp,2)-pow(pxout,2));
-                    amrex::ParticleReal const theta = slice_phi + std::asin(px/pperp) - std::asin(pxout/pperp);
+                } else
+                {
+                    amrex::ParticleReal const pzf = std::sqrt(std::pow(pperp,2)-std::pow(pxout,2));
+                    amrex::ParticleReal const theta = m_slice_phi + std::asin(px/pperp) - std::asin(pxout/pperp);
 
                     // update position coordinates
-                    x = -rc + rho*cos_phi + rc*(pzf + px*sin_phi - pzi*cos_phi);
-                    y = yout + theta * rc * py;
-                    t = tout - theta * rc * (pt - 1.0_prt / bet) - m_phi * rc / bet;
+                    x = -m_rc + rho*m_cos_phi + m_rc*(pzf + px*m_sin_phi - pzi*m_cos_phi);
+                    y = yout + theta * m_rc * py;
+                    t = tout - theta * m_rc * (pt - 1.0_prt * m_ibeta) - m_phi * m_rc * m_ibeta;
 
                     // assign updated momenta
                     px = pxout;
@@ -233,7 +254,6 @@ namespace impactx::elements
 
             // advance integrated path length
             refpart.s = s + slice_ds;
-
         }
 
         /** This pushes the covariance matrix. */
@@ -254,6 +274,11 @@ namespace impactx::elements
 
         amrex::ParticleReal m_phi; //! bend angle in radians
         amrex::ParticleReal m_B;  //! magnetic field in T
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_slice_phi, m_ibeta, m_rc, m_sin_phi, m_cos_phi;
     };
 
 } // namespace impactx

--- a/src/elements/Kicker.H
+++ b/src/elements/Kicker.H
@@ -74,8 +74,27 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // normalize quad units to MAD-X convention if needed
+            m_p_scale = m_unit == UnitSystem::Tm ? 1.0_prt / refpart.rigidity_Tm() : 1.0_prt;
+        }
+
         /** This is a transverse kicker functor, so that a variable of this type can be
          * used like a function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -95,7 +114,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -109,12 +128,8 @@ namespace impactx::elements
             amrex::ParticleReal const tout = t;
 
             // normalize quad units to MAD-X convention if needed
-            amrex::ParticleReal dpx = m_xkick;
-            amrex::ParticleReal dpy = m_ykick;
-            if (m_unit == UnitSystem::Tm) {
-                  dpx /= refpart.rigidity_Tm();
-                  dpy /= refpart.rigidity_Tm();
-            }
+            amrex::ParticleReal const dpx = m_xkick * m_p_scale;
+            amrex::ParticleReal const dpy = m_ykick * m_p_scale;
 
             // intialize output values of momenta
             amrex::ParticleReal pxout = px;
@@ -162,6 +177,11 @@ namespace impactx::elements
         amrex::ParticleReal m_xkick; //! horizontal kick strength
         amrex::ParticleReal m_ykick; //! vertical kick strength
         UnitSystem m_unit; //! Kicks are for 0 dimensionless, or for 1 in T-m."
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_p_scale;  // either 1 or the inverse rigidity
     };
 
 } // namespace impactx

--- a/src/elements/LinearMap.H
+++ b/src/elements/LinearMap.H
@@ -87,7 +87,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt

--- a/src/elements/Marker.H
+++ b/src/elements/Marker.H
@@ -49,6 +49,12 @@ namespace impactx::elements
             // nothing to do
         }
 
+        /** Compute and cache the constants for the push - nothing to do here */
+        void compute_constants (RefPart const & /* refpart */)
+        {
+            // nothing to do
+        }
+
         /** Push all particles - nothing to do here */
         void operator() (
             ImpactXParticleContainer::iterator & /* pti */,
@@ -77,7 +83,7 @@ namespace impactx::elements
             [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT py,
             [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT pt,
             [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             // nothing to do

--- a/src/elements/Multipole.H
+++ b/src/elements/Multipole.H
@@ -73,8 +73,29 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // assign complex position and complex multipole strength
+            m_alpha = {m_Kn, m_Ks};
+
+            m_inv_factorial = 1.0_prt / static_cast<amrex::ParticleReal>(m_mfactorial);
+        }
+
         /** This is a multipole functor, so that a variable of this type can be used like a
          *  multipole function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -87,14 +108,14 @@ namespace impactx::elements
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-                amrex::ParticleReal & AMREX_RESTRICT x,
-                amrex::ParticleReal & AMREX_RESTRICT y,
-                [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT t,
-                amrex::ParticleReal & AMREX_RESTRICT px,
-                amrex::ParticleReal & AMREX_RESTRICT py,
-                amrex::ParticleReal & AMREX_RESTRICT pt,
-                [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
-                [[maybe_unused]] RefPart const & refpart
+            amrex::ParticleReal & AMREX_RESTRICT x,
+            amrex::ParticleReal & AMREX_RESTRICT y,
+            [[maybe_unused]] amrex::ParticleReal & AMREX_RESTRICT t,
+            amrex::ParticleReal & AMREX_RESTRICT px,
+            amrex::ParticleReal & AMREX_RESTRICT py,
+            amrex::ParticleReal & AMREX_RESTRICT pt,
+            [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -119,14 +140,12 @@ namespace impactx::elements
 
             // assign complex position and complex multipole strength
             Complex const zeta(x, y);
-            Complex const alpha(m_Kn, m_Ks);
 
             // compute complex momentum kick
             int const m = m_multipole - 1;
-            Complex kick = amrex::pow(zeta, m);
-            kick *= alpha;
-            amrex::ParticleReal const dpx = -1.0_prt*kick.m_real/m_mfactorial;
-            amrex::ParticleReal const dpy = kick.m_imag/m_mfactorial;
+            Complex const kick = amrex::pow(zeta, m) * m_alpha;
+            amrex::ParticleReal const dpx = -1.0_prt * kick.m_real * m_inv_factorial;
+            amrex::ParticleReal const dpy = kick.m_imag * m_inv_factorial;
 
             // advance position and momentum
             // xout = x;
@@ -174,6 +193,11 @@ namespace impactx::elements
         amrex::ParticleReal m_Kn; //! integrated normal multipole coefficient
         amrex::ParticleReal m_Ks; //! integrated skew multipole coefficient
 
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::GpuComplex<amrex::ParticleReal> m_alpha;
+        amrex::ParticleReal m_inv_factorial;
     };
 
 } // namespace impactx

--- a/src/elements/NonlinearLens.H
+++ b/src/elements/NonlinearLens.H
@@ -70,8 +70,27 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            m_inv_cnll = 1.0_prt / m_cnll;
+            m_kick = -m_knll * m_inv_cnll;
+        }
+
         /** This is a nonlinear lens functor, so that a variable of this type
          *  can be used like a nonlinear lens function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -91,7 +110,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -116,7 +135,7 @@ namespace impactx::elements
 
             // assign complex position zeta = (x + iy)/cnll
             Complex zeta(x, y);
-            zeta = zeta/m_cnll;
+            zeta = zeta * m_inv_cnll;
             Complex const re1(1.0_prt, 0.0_prt);
             Complex const im1(0.0_prt, 1.0_prt);
 
@@ -134,9 +153,8 @@ namespace impactx::elements
             dF = dF + carcsin / amrex::pow(croot, 3);
 
             // compute momentum kick
-            amrex::ParticleReal const kick = -m_knll/m_cnll;
-            amrex::ParticleReal const dpx = kick*dF.m_real;
-            amrex::ParticleReal const dpy = -kick*dF.m_imag;
+            amrex::ParticleReal const dpx = +m_kick * dF.m_real;
+            amrex::ParticleReal const dpy = -m_kick * dF.m_imag;
 
             // advance position and momentum
             // xout = x;
@@ -181,6 +199,12 @@ namespace impactx::elements
 
         amrex::ParticleReal m_knll; //! integrated strength of the nonlinear lens (m)
         amrex::ParticleReal m_cnll; //! distance of singularities from the origin (m)
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_inv_cnll;  //! 1 / m_cnll
+        amrex::ParticleReal m_kick;
     };
 
 } // namespace impactx

--- a/src/elements/PRot.H
+++ b/src/elements/PRot.H
@@ -64,8 +64,34 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            // access reference particle values to find 1/beta
+            m_inv_beta = 1.0_prt / refpart.beta();
+
+            // store rotation angle and initial, final values of pz
+            amrex::ParticleReal const theta = m_phi_out - m_phi_in;
+            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
+            m_sin_theta = sin_theta;
+            m_cos_theta = cos_theta;
+            auto const [sin_phi_in, cos_phi_in] = amrex::Math::sincos(m_phi_in);
+            m_sin_phi_in = sin_phi_in;
+            m_cos_phi_in = cos_phi_in;
+        }
+
         /** This is a prot functor, so that a variable of this type can be used like a
          *  prot function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -74,7 +100,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index (unused)
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -85,13 +111,10 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
-            RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // access reference particle values to find beta:
-            amrex::ParticleReal const beta = refpart.beta();
 
             // intialize output values
             amrex::ParticleReal xout = x;
@@ -101,23 +124,23 @@ namespace impactx::elements
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;
 
-            // store rotation angle and initial, final values of pz
-            amrex::ParticleReal const theta = m_phi_out - m_phi_in;
-            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
-            auto const [sin_phi_in, cos_phi_in] = amrex::Math::sincos(m_phi_in);
-
-            amrex::ParticleReal const pz = std::sqrt(1.0_prt - 2.0_prt*pt/beta
-               + std::pow(pt,2) - std::pow(py,2) - std::pow(px + sin_phi_in,2));
-            amrex::ParticleReal const pzf = pz*cos_theta - (px + sin_phi_in)*sin_theta;
+            amrex::ParticleReal const pz = std::sqrt(
+                1.0_prt -
+                2.0_prt * pt * m_inv_beta +
+                std::pow(pt, 2) -
+                std::pow(py, 2) -
+                std::pow(px + m_sin_phi_in, 2)
+            );
+            amrex::ParticleReal const pzf = pz * m_cos_theta - (px + m_sin_phi_in) * m_sin_theta;
 
             // advance position and momentum
-            xout = x*pz/pzf;
-            pxout = px*cos_theta + (pz - cos_phi_in)*sin_theta;
+            xout = x * pz / pzf;
+            pxout = px * m_cos_theta + (pz - m_cos_phi_in) * m_sin_theta;
 
-            yout = y + py*x*sin_theta/pzf;
+            yout = y + py * x * m_sin_theta / pzf;
             pyout = py;
 
-            tout = t - (pt - 1.0_prt/beta)*x*sin_theta/pzf;
+            tout = t - (pt - m_inv_beta) * x * m_sin_theta / pzf;
             ptout = pt;
 
             // assign updated values
@@ -150,6 +173,11 @@ namespace impactx::elements
 
         amrex::ParticleReal m_phi_in; //! normalized (max) RF voltage drop.
         amrex::ParticleReal m_phi_out; //! RF wavenumber in 1/m.
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_inv_beta, m_sin_theta, m_cos_theta, m_sin_phi_in, m_cos_phi_in;
     };
 
 } // namespace impactx

--- a/src/elements/PlaneXYRot.H
+++ b/src/elements/PlaneXYRot.H
@@ -69,8 +69,27 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            Alignment::compute_constants(refpart);
+
+            // store sin(phi) and cos(phi)
+            auto const [sin_phi, cos_phi] = amrex::Math::sincos(m_phi);
+            m_sin_phi = sin_phi;
+            m_cos_phi = cos_phi;
+        }
+
         /** This is a prot functor, so that a variable of this type can be used like a
          *  prot function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -90,11 +109,9 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
-            using namespace amrex::literals; // for _rt and _prt
-
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
 
@@ -106,15 +123,12 @@ namespace impactx::elements
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;
 
-            // store sin(phi) and cos(phi)
-            auto const [sin_phi, cos_phi] = amrex::Math::sincos(m_phi);
-
             // advance position and momentum
-            xout = x*cos_phi - y*sin_phi;
-            pxout = px*cos_phi - py*sin_phi;
+            xout = x * m_cos_phi - y * m_sin_phi;
+            pxout = px * m_cos_phi - py * m_sin_phi;
 
-            yout = x*sin_phi + y*cos_phi;
-            pyout = px*sin_phi + py*cos_phi;
+            yout = x * m_sin_phi + y * m_cos_phi;
+            pyout = px * m_sin_phi + py * m_cos_phi;
 
             // tout = t;
             // ptout = pt;
@@ -151,6 +165,11 @@ namespace impactx::elements
         }
 
         amrex::ParticleReal m_phi; //! angle of rotation (rad)
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_sin_phi, m_cos_phi;
     };
 
 } // namespace impactx

--- a/src/elements/Quad.H
+++ b/src/elements/Quad.H
@@ -76,7 +76,38 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // length of the current slice
+            m_slice_ds = m_ds / nslice();
+
+            amrex::ParticleReal const pt_ref = refpart.pt;
+            // find beta*gamma^2
+            m_betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
+            m_slice_bg = m_slice_ds / m_betgam2;
+
+            // compute phase advance per unit length in s (in rad/m)
+            m_omega = std::sqrt(std::abs(m_k));
+            m_sin_omega_ds = std::sin(m_omega*m_slice_ds);
+            m_cos_omega_ds = std::cos(m_omega*m_slice_ds);
+            m_sinh_omega_ds = std::sinh(m_omega*m_slice_ds);
+            m_cosh_omega_ds = std::cosh(m_omega*m_slice_ds);
+        }
+
         /** This is a quad functor, so that a variable of this type can be used like a quad function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -85,7 +116,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -96,23 +127,13 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             uint64_t & AMREX_RESTRICT idcpu,
-            RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
-
-            // length of the current slice
-            amrex::ParticleReal const slice_ds = m_ds / nslice();
-
-            // access reference particle values to find beta*gamma^2
-            amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
-
-            // compute phase advance per unit length in s (in rad/m)
-            amrex::ParticleReal const omega = std::sqrt(std::abs(m_k));
 
             // intialize output values
             amrex::ParticleReal xout = x;
@@ -122,35 +143,36 @@ namespace impactx::elements
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal const ptout = pt;
 
-            if (m_k > 0.0) {
+            if (m_k > 0.0_prt)
+            {
                 // advance position and momentum (focusing quad)
-                xout = std::cos(omega*slice_ds)*x + std::sin(omega*slice_ds)/omega*px;
-                pxout = -omega*std::sin(omega*slice_ds)*x + std::cos(omega*slice_ds)*px;
+                xout = m_cos_omega_ds*x + m_sin_omega_ds/m_omega*px;
+                pxout = -m_omega*m_sin_omega_ds*x + m_cos_omega_ds*px;
 
-                yout = std::cosh(omega*slice_ds)*y + std::sinh(omega*slice_ds)/omega*py;
-                pyout = omega*std::sinh(omega*slice_ds)*y + std::cosh(omega*slice_ds)*py;
+                yout = m_cosh_omega_ds*y + m_sinh_omega_ds/m_omega*py;
+                pyout = m_omega*m_sinh_omega_ds*y + m_cosh_omega_ds*py;
 
-                tout = t + (slice_ds/betgam2)*pt;
+                tout = t + (m_slice_bg)*pt;
                 // ptout = pt;
-            } else if (m_k < 0.0) {
+            } else if (m_k < 0.0_prt)
+            {
                 // advance position and momentum (defocusing quad)
-                xout = std::cosh(omega*slice_ds)*x + std::sinh(omega*slice_ds)/omega*px;
-                pxout = omega*std::sinh(omega*slice_ds)*x + std::cosh(omega*slice_ds)*px;
+                xout = m_cosh_omega_ds*x + m_sinh_omega_ds/m_omega*px;
+                pxout = m_omega*m_sinh_omega_ds*x + m_cosh_omega_ds*px;
 
-                yout = std::cos(omega*slice_ds)*y + std::sin(omega*slice_ds)/omega*py;
-                pyout = -omega*std::sin(omega*slice_ds)*y + std::cos(omega*slice_ds)*py;
+                yout = m_cos_omega_ds*y + m_sin_omega_ds/m_omega*py;
+                pyout = -m_omega*m_sin_omega_ds*y + m_cos_omega_ds*py;
 
-                tout = t + (slice_ds/betgam2)*pt;
+                tout = t + m_slice_bg*pt;
                 // ptout = pt;
             } else {
                 // advance position and momentum (zero strength = drift)
-                xout = x + slice_ds * px;
+                xout = x + m_slice_ds * px;
                 // pxout = px;
-                yout = y + slice_ds * py;
+                yout = y + m_slice_ds * py;
                 // pyout = py;
-                tout = t + (slice_ds/betgam2) * pt;
+                tout = t + m_slice_bg * pt;
                 // ptout = pt;
-
             }
 
             // assign updated values
@@ -173,7 +195,7 @@ namespace impactx::elements
          * @param[in,out] refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void operator() (RefPart & AMREX_RESTRICT refpart) const {
+        void operator() (RefPart & AMREX_RESTRICT refpart) const {  // TODO: update as well, but needs more careful placement of calc_constants
 
             using namespace amrex::literals; // for _rt and _prt
 
@@ -210,7 +232,7 @@ namespace impactx::elements
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE
         Map6x6
-        transport_map (RefPart const & AMREX_RESTRICT refpart) const
+        transport_map (RefPart const & AMREX_RESTRICT refpart) const  // TODO: update as well, but needs more careful placement of calc_constants
         {
             using namespace amrex::literals; // for _rt and _prt
 
@@ -248,9 +270,9 @@ namespace impactx::elements
                 R(4,4) = std::cos(omega*slice_ds);
                 R(5,6) = slice_ds/betgam2;
             } else {
-                R(1,2) = slice_ds;
-                R(3,4) = slice_ds;
-                R(5,6) = slice_ds / betgam2;
+                R(1,2) = m_slice_ds;
+                R(3,4) = m_slice_ds;
+                R(5,6) = m_slice_ds / betgam2;
             }
 
             return R;
@@ -260,6 +282,18 @@ namespace impactx::elements
         using LinearTransport::operator();
 
         amrex::ParticleReal m_k; //! quadrupole strength in 1/m
+
+    private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_slice_ds;       //! m_ds / nslice();
+        amrex::ParticleReal m_betgam2;        //! beta*gamma^2
+        amrex::ParticleReal m_slice_bg;       //! m_slice_ds / m_betgam2
+        amrex::ParticleReal m_omega;          //! std::sqrt(std::abs(m_k)) compute phase advance per unit length in s (in rad/m)
+        amrex::ParticleReal m_sin_omega_ds;   //! std::sin(omega*slice_ds)
+        amrex::ParticleReal m_cos_omega_ds;   //! std::cos(omega*slice_ds)
+        amrex::ParticleReal m_sinh_omega_ds;  //! std::sinh(omega*slice_ds)
+        amrex::ParticleReal m_cosh_omega_ds;  //! std::cosh(omega*slice_ds)
     };
 
 } // namespace impactx

--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -187,8 +187,24 @@ namespace RFCavityData
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+        }
+
         /** This is an RF cavity functor, so that a variable of this type can be used like
          *  an RF cavity function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -208,7 +224,7 @@ namespace RFCavityData
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             uint64_t & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & refpart
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt

--- a/src/elements/Sbend.H
+++ b/src/elements/Sbend.H
@@ -74,7 +74,44 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
+            // access reference particle values
+            amrex::ParticleReal const ibet = 1.0_prt / refpart.beta();
+
+            // calculate expensive terms once
+            amrex::ParticleReal const theta = slice_ds / m_rc;
+            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
+
+            m_R11 = cos_theta;
+            m_R12 = m_rc * sin_theta;
+            m_R16 = -m_rc * ibet * (1.0_prt - cos_theta);
+            m_R21 = -sin_theta / m_rc;
+            // m_R22 = m_R11
+            m_R26 = -sin_theta * ibet;
+            m_R34 = m_rc * theta;
+            // m_R51 = -m_R26
+            // m_R52 = -m_R16
+            m_R56 = m_rc * (-theta + sin_theta * ibet * ibet);
+        }
+
         /** This is a sbend functor, so that a variable of this type can be used like a sbend function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -83,7 +120,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -94,7 +131,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             uint64_t & AMREX_RESTRICT idcpu,
-            RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -112,30 +149,28 @@ namespace impactx::elements
             amrex::ParticleReal const pyout = py;
             amrex::ParticleReal const ptout = pt;
 
-            // length of the current slice
-            amrex::ParticleReal const slice_ds = m_ds / nslice();
-
-            // access reference particle values to find beta*gamma^2
-            amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
-            amrex::ParticleReal const bet = std::sqrt(betgam2/(1.0_prt + betgam2));
-
-            // calculate expensive terms once
-            amrex::ParticleReal const theta = slice_ds/m_rc;
-            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
-
             // advance position and momentum (sector bend)
-            xout = cos_theta*x + m_rc*sin_theta*px
-                       - (m_rc/bet)*(1.0_prt - cos_theta)*pt;
+            amrex::ParticleReal const R22 =  m_R11;
+            amrex::ParticleReal const R51 = -m_R26;
+            amrex::ParticleReal const R52 = -m_R16;
 
-            pxout = -sin_theta/m_rc*x + cos_theta*px - sin_theta/bet*pt;
+            xout = m_R11 * x
+                 + m_R12 * px
+                 + m_R16 * pt;
 
-            yout = y + m_rc*theta*py;
+            pxout = m_R21 * x
+                  +   R22 * px
+                  + m_R26 * pt;
+
+            yout =         y
+                 + m_R34 * py;
 
             // pyout = py;
 
-            tout = sin_theta/bet*x + m_rc/bet*(1.0_prt - cos_theta)*px + t
-                       + m_rc*(-theta+sin_theta/(bet*bet))*pt;
+            tout =   R51 * x
+                 +   R52 * px
+                 +         t
+                 + m_R56 * pt;
 
             // ptout = pt;
 
@@ -244,6 +279,11 @@ namespace impactx::elements
         }
 
         amrex::ParticleReal m_rc; //! bend radius in m
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_R11, m_R12, m_R16, m_R21, m_R26, m_R34, m_R56;
     };
 
 } // namespace impactx

--- a/src/elements/ShortRF.H
+++ b/src/elements/ShortRF.H
@@ -68,8 +68,37 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // Define parameters and intermediate constants
+            using ablastr::constant::math::pi;
+            using ablastr::constant::SI::c;
+            m_k = 2.0_prt * pi / c * m_freq;
+            m_phi = m_phase * pi / 180.0_prt;
+
+            // access reference particle values (final, initial):
+            amrex::ParticleReal const ptf_ref = refpart.pt;
+            m_V_cos_phi = m_V * std::cos(m_phi);
+            amrex::ParticleReal const pti_ref = ptf_ref + m_V_cos_phi;
+            m_bgf = std::sqrt(std::pow(ptf_ref, 2) - 1.0_prt);
+            m_bgi = std::sqrt(std::pow(pti_ref, 2) - 1.0_prt);
+        }
+
         /** This is a shortrf functor, so that a variable of this type can be used like a
          *  shortrf function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -78,7 +107,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index (unused)
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -89,7 +118,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
-            RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
 
@@ -98,22 +127,10 @@ namespace impactx::elements
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
 
-            // Define parameters and intermediate constants
-            using ablastr::constant::math::pi;
-            using ablastr::constant::SI::c;
-            amrex::ParticleReal const k = (2.0_prt*pi/c)*m_freq;
-            amrex::ParticleReal const phi = m_phase*(pi/180.0_prt);
-
-            // access reference particle values (final, initial):
-            amrex::ParticleReal const ptf_ref = refpart.pt;
-            amrex::ParticleReal const pti_ref = ptf_ref + m_V * std::cos(phi);
-            amrex::ParticleReal const bgf = std::sqrt(std::pow(ptf_ref, 2) - 1.0_prt);
-            amrex::ParticleReal const bgi = std::sqrt(std::pow(pti_ref, 2) - 1.0_prt);
-
             // initial conversion from static to dynamic units:
-            px = px*bgi;
-            py = py*bgi;
-            pt = pt*bgi;
+            px = px * m_bgi;
+            py = py * m_bgi;
+            pt = pt * m_bgi;
 
             // intialize output values
             amrex::ParticleReal xout = x;
@@ -131,7 +148,7 @@ namespace impactx::elements
             pyout = py;
 
             // tout = t;
-            ptout = pt - m_V * std::cos(k*t + phi) + m_V * std::cos(phi);
+            ptout = pt - m_V * std::cos(m_k * t + m_phi) + m_V_cos_phi;
 
             // assign updated values
             x = xout;
@@ -142,9 +159,9 @@ namespace impactx::elements
             pt = ptout;
 
             // final conversion from dynamic to static units:
-            px = px/bgf;
-            py = py/bgf;
-            pt = pt/bgf;
+            px = px / m_bgf;
+            py = py / m_bgf;
+            pt = pt / m_bgf;
 
             // undo shift due to alignment errors of the element
             shift_out(x, y, px, py);
@@ -241,6 +258,11 @@ namespace impactx::elements
         amrex::ParticleReal m_V; //! normalized (max) RF voltage drop.
         amrex::ParticleReal m_freq; //! RF frequency in Hz.
         amrex::ParticleReal m_phase; //! reference RF phase in degrees.
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_k, m_phi, m_V_cos_phi, m_bgi, m_bgf;
     };
 
 } // namespace impactx

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -192,8 +192,24 @@ namespace SoftQuadrupoleData
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+        }
+
         /** This is a soft-edge quadrupole functor, so that a variable of this type can be used
          *  like a soft-edge quadrupole function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -213,7 +229,7 @@ namespace SoftQuadrupoleData
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             uint64_t & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & refpart
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -203,8 +203,24 @@ namespace SoftSolenoidData
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+        }
+
         /** This is a soft-edge solenoid functor, so that a variable of this type can be used
          *  like a soft-edge solenoid function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -224,7 +240,7 @@ namespace SoftSolenoidData
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             uint64_t & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & refpart
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt

--- a/src/elements/Sol.H
+++ b/src/elements/Sol.H
@@ -76,7 +76,41 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
+            // access reference particle values to find beta*gamma^2
+            amrex::ParticleReal const betgam2 = std::pow(refpart.pt, 2) - 1.0_prt;
+
+            // compute phase advance per unit length (in rad/m) and
+            // rotation angle (in rad)
+            amrex::ParticleReal const alpha = m_ks / 2.0_prt;
+            amrex::ParticleReal const theta = alpha*slice_ds;
+            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
+
+            m_sin_theta = sin_theta;
+            m_cos_theta = cos_theta;
+            m_sin_theta_ialpha = sin_theta / alpha;
+            m_neg_alpha_sin_theta = -alpha * sin_theta;
+            m_ds_bg2 = slice_ds / betgam2;
+        }
+
         /** This is a sol functor, so that a variable of this type can be used like a sol function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -85,7 +119,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -96,25 +130,13 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             uint64_t & AMREX_RESTRICT idcpu,
-            RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
-
-            // length of the current slice
-            amrex::ParticleReal const slice_ds = m_ds / nslice();
-
-            // access reference particle values to find beta*gamma^2
-            amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
-
-            // compute phase advance per unit length (in rad/m) and
-            // rotation angle (in rad)
-            amrex::ParticleReal const alpha = m_ks / 2.0_prt;
-            amrex::ParticleReal const theta = alpha*slice_ds;
 
             // intialize output values
             amrex::ParticleReal xout = x;
@@ -125,14 +147,17 @@ namespace impactx::elements
             amrex::ParticleReal ptout = pt;
 
             // advance positions and momenta using map for focusing
-            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
-            xout = cos_theta*x + sin_theta/alpha*px;
-            pxout = -alpha*sin_theta*x + cos_theta*px;
+            xout = m_cos_theta        * x
+                 + m_sin_theta_ialpha * px;
+            pxout = m_neg_alpha_sin_theta * x
+                  + m_cos_theta           * px;
 
-            yout = cos_theta*y + sin_theta/alpha*py;
-            pyout = -alpha*sin_theta*y + cos_theta*py;
+            yout = m_cos_theta        * y
+                 + m_sin_theta_ialpha * py;
+            pyout = m_neg_alpha_sin_theta * y
+                  + m_cos_theta           * py;
 
-            tout = t + (slice_ds/betgam2)*pt;
+            tout = t + m_ds_bg2 * pt;
             ptout = pt;
 
             // assign intermediate momenta
@@ -141,11 +166,15 @@ namespace impactx::elements
             pt = ptout;
 
             // advance positions and momenta using map for rotation
-            x = cos_theta*xout + sin_theta*yout;
-            pxout = cos_theta*px + sin_theta*py;
+            x = m_cos_theta * xout
+              + m_sin_theta * yout;
+            pxout = m_cos_theta * px
+                  + m_sin_theta * py;
 
-            y = -sin_theta*xout + cos_theta*yout;
-            pyout = -sin_theta*px + cos_theta*py;
+            y = -m_sin_theta * xout
+               + m_cos_theta * yout;
+            pyout = -m_sin_theta * px
+                   + m_cos_theta * py;
 
             t = tout;
             ptout = pt;
@@ -215,6 +244,11 @@ namespace impactx::elements
         }
 
         amrex::ParticleReal m_ks; //! solenoid strength in 1/m
+
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_ds_bg2, m_cos_theta, m_sin_theta, m_sin_theta_ialpha, m_neg_alpha_sin_theta;
     };
 
 } // namespace impactx

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -72,8 +72,31 @@ namespace impactx::elements
         /** Push all particles */
         using BeamOptic::operator();
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // access reference particle to find relativistic beta
+            m_beta = refpart.beta();
+
+            // compute the effective (equivalent) arc length and curvature
+            m_ds = m_theta * m_rc;
+            m_kx = 1.0_prt / m_rc;
+        }
+
         /** This is a multipole functor, so that a variable of this type can be used like a
          *  multipole function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -82,7 +105,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index (unused)
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -93,7 +116,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
-            RefPart const & refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -106,30 +129,23 @@ namespace impactx::elements
             amrex::ParticleReal const yout = y;
             amrex::ParticleReal const tout = t;
 
-            // access reference particle to find relativistic beta
-            amrex::ParticleReal const beta_ref = refpart.beta();
-
             // intialize output values of momenta
             amrex::ParticleReal pxout = px;
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;
 
             // compute the function expressing dp/p in terms of pt (labeled f in Ripken etc.)
-            amrex::ParticleReal f = -1.0_prt + std::sqrt(1.0_prt - 2.0_prt*pt/beta_ref + std::pow(pt,2));
-            amrex::ParticleReal fprime = (1.0_prt - beta_ref*pt)/(beta_ref*(1.0_prt + f));
-
-            // compute the effective (equivalent) arc length and curvature
-            amrex::ParticleReal ds = m_theta*m_rc;
-            amrex::ParticleReal kx = 1.0_prt/m_rc;
+            amrex::ParticleReal const f = -1.0_prt + std::sqrt(1.0_prt - 2.0_prt * pt / m_beta + std::pow(pt, 2));
+            amrex::ParticleReal const fprime = (1.0_prt - m_beta*pt) / (m_beta * (1.0_prt + f));
 
             // advance position and momentum
             x = xout;
-            pxout = px - std::pow(kx,2) * ds * xout + kx * ds * f; //eq (3.2b)
+            pxout = px - std::pow(m_kx, 2) * m_ds * xout + m_kx * m_ds * f; //eq (3.2b)
 
             y = yout;
             pyout = py;
 
-            t = tout + kx * xout * ds * fprime; //eq (3.2e)
+            t = tout + m_kx * xout * m_ds * fprime; //eq (3.2e)
             ptout = pt;
 
             // assign updated momenta
@@ -179,9 +195,15 @@ namespace impactx::elements
             return Map6x6::Identity();
         }
 
-        amrex::ParticleReal m_theta; //! dipole bending angle (rad)
-        amrex::ParticleReal m_rc; //! curvature radius (m)
+        amrex::ParticleReal m_theta;  //! dipole bending angle (rad)
+        amrex::ParticleReal m_rc;     //! curvature radius (m)
 
+      private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_beta;  //! beta of the reference particle
+        amrex::ParticleReal m_ds;    //! effective (equivalent) arc length
+        amrex::ParticleReal m_kx;    //! effective (equivalent) curvature
     };
 
 } // namespace impactx

--- a/src/elements/mixin/alignment.H
+++ b/src/elements/mixin/alignment.H
@@ -50,7 +50,23 @@ namespace impactx::elements::mixin
 
         ~Alignment () = default;
 
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants ([[maybe_unused]] RefPart const & refpart)
+        {
+            auto const [sin_rotation, cos_rotation] = amrex::Math::sincos(m_rotation);
+            m_sin_rotation = sin_rotation;
+            m_cos_rotation = cos_rotation;
+        }
+
         /** Shift the particle into the alignment error frame
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param[inout] x horizontal position relative to reference particle
          * @param[inout] y vertical position relative to reference particle
@@ -65,22 +81,22 @@ namespace impactx::elements::mixin
             amrex::ParticleReal & AMREX_RESTRICT py
         ) const
         {
-            auto const [sin_rotation, cos_rotation] = amrex::Math::sincos(m_rotation);
-
             // position
             amrex::ParticleReal const xc = x - m_dx;
             amrex::ParticleReal const yc = y - m_dy;
-            x =  xc * cos_rotation + yc * sin_rotation;
-            y = -xc * sin_rotation + yc * cos_rotation;
+            x =  xc * m_cos_rotation + yc * m_sin_rotation;
+            y = -xc * m_sin_rotation + yc * m_cos_rotation;
 
             // momentum
             amrex::ParticleReal const pxc = px;
             amrex::ParticleReal const pyc = py;
-            px =  pxc * cos_rotation + pyc * sin_rotation;
-            py = -pxc * sin_rotation + pyc * cos_rotation;
+            px =  pxc * m_cos_rotation + pyc * m_sin_rotation;
+            py = -pxc * m_sin_rotation + pyc * m_cos_rotation;
         }
 
         /** Shift the particle out of the alignment error frame
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param[inout] x horizontal position relative to reference particle
          * @param[inout] y vertical position relative to reference particle
@@ -95,21 +111,19 @@ namespace impactx::elements::mixin
             amrex::ParticleReal & AMREX_RESTRICT py
         ) const
         {
-            auto const [sin_rotation, cos_rotation] = amrex::Math::sincos(m_rotation);
-
             // position
             amrex::ParticleReal const xc = x;
             amrex::ParticleReal const yc = y;
-            x = xc * cos_rotation - yc * sin_rotation;
-            y = xc * sin_rotation + yc * cos_rotation;
+            x = xc * m_cos_rotation - yc * m_sin_rotation;
+            y = xc * m_sin_rotation + yc * m_cos_rotation;
             x += m_dx;
             y += m_dy;
 
             // momentum
             amrex::ParticleReal const pxc = px;
             amrex::ParticleReal const pyc = py;
-            px = pxc * cos_rotation - pyc * sin_rotation;
-            py = pxc * sin_rotation + pyc * cos_rotation;
+            px = pxc * m_cos_rotation - pyc * m_sin_rotation;
+            py = pxc * m_sin_rotation + pyc * m_cos_rotation;
         }
 
         /** Horizontal translation error
@@ -145,6 +159,12 @@ namespace impactx::elements::mixin
         amrex::ParticleReal m_dx = 0; //! horizontal translation error [m]
         amrex::ParticleReal m_dy = 0; //! vertical translation error [m]
         amrex::ParticleReal m_rotation = 0; //! rotation error in the transverse plane [rad]
+
+    private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_sin_rotation;  //! std::sin(m_rotation)
+        amrex::ParticleReal m_cos_rotation;  //! std::cos(m_rotation)
     };
 
 } // namespace impactx::elements::mixin

--- a/src/elements/mixin/beamoptic.H
+++ b/src/elements/mixin/beamoptic.H
@@ -69,6 +69,9 @@ namespace detail
               m_part_idcpu(part_idcpu),
               m_ref_part(std::move(ref_part))
         {
+            // pre-compute and cache constants that are independent of the
+            // individually tracked particle
+            m_element.compute_constants(m_ref_part);
         }
 
         PushSingleParticle () = delete;
@@ -100,7 +103,7 @@ namespace detail
         }
 
     private:
-        T_Element const m_element;
+        T_Element m_element;
         amrex::ParticleReal* const AMREX_RESTRICT m_part_x;
         amrex::ParticleReal* const AMREX_RESTRICT m_part_y;
         amrex::ParticleReal* const AMREX_RESTRICT m_part_t;
@@ -108,7 +111,7 @@ namespace detail
         amrex::ParticleReal* const AMREX_RESTRICT m_part_py;
         amrex::ParticleReal* const AMREX_RESTRICT m_part_pt;
         uint64_t* const AMREX_RESTRICT m_part_idcpu;
-        RefPart const m_ref_part;
+        RefPart m_ref_part;
     };
 
     /** This pushes all particles on a particle iterator tile/box
@@ -133,7 +136,8 @@ namespace detail
         uint64_t* const AMREX_RESTRICT part_idcpu = pti.GetStructOfArrays().GetIdCPUData().dataPtr();
 
         detail::PushSingleParticle<T_Element> const pushSingleParticle(
-                element, part_x, part_y, part_t, part_px, part_py, part_pt, part_idcpu, ref_part);
+            element, part_x, part_y, part_t, part_px, part_py, part_pt, part_idcpu, ref_part);
+
         //   loop over beam particles in the box
         amrex::ParallelFor(np, pushSingleParticle);
     }


### PR DESCRIPTION
Make linear elements as fast as possible by:
- calculating constants that depend on the element config and reference particle properties before pushing all particles,
- instead of using a Matrix-Vector calculation (as in LinearElement), we rely on the fact that those matrices are sparse and keep the multiply-adds explicit.

## Example: 1 CPU core run of a single `Quad`, 100M particles.

- System: Laptop: 12th Gen Intel(R) Core(TM) i9-12900H, performance core w/ performance power mode on.
- CXXFLAGS: `export CXXFLAGS="-Ofast -march=native"`
- CMake: default (+Python + FFT) via `-DImpactX_PYTHON=ON -DImpactX_FFT=ON`
- threading: off via `export OMP_NUM_THREADS=1`

Execution (best of 5):
```
./quad_impactx.py &
taskset -cp 6 $!
```
[quad_impactx.py.txt](https://github.com/user-attachments/files/18949267/quad_impactx.py.txt)

### Development
```
Execution time ImpactX: 5.1419 seconds (51.42ns / particle)
```

### This PR (11x faster)
```
Execution time ImpactX: 0.4675 seconds (4.67ns / particle)
```

Close #849

- [x] decide on general structure
- [x] go through all 40+ elements...