### PR TITLE
[WIP] Dashboard: Add run modes and 2D/3D space charge options

### DIFF
--- a/src/python/impactx/dashboard/Input/defaults.py
+++ b/src/python/impactx/dashboard/Input/defaults.py
@@ -36,6 +36,7 @@ class DashboardDefaults:
     }
 
     INPUT_PARAMETERS = {
+        "tracking_mode": "Particle Tracking",
         "charge_qe": -1,
         "mass_MeV": 0.51099895,
         "npart": 1000,
@@ -85,6 +86,11 @@ class DashboardDefaults:
         "poisson_solver_list": ["fft", "multigrid"],
         "particle_shape_list": [1, 2, 3],
         "max_level_list": [0, 1, 2, 3, 4],
+        "tracking_mode_list": [
+            "Particle Tracking",
+            "Envelope Tracking",
+            "Reference Tracking",
+        ],
     }
 
     # -------------------------------------------------------------------------

--- a/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
@@ -29,8 +29,8 @@ class InputParameters(CardBase):
             InputFunctions.update_kin_energy_sim_value()
 
     @state.change("tracking_mode")
-    def on_tracking_mode_change(tracking_mode, **kwargs) -> None:
-        if tracking_mode in ("Envelope Tracking", "Reference Tracking"):
+    def on_tracking_mode_change(**kwargs) -> None:
+        if state.tracking_mode in ("Envelope Tracking", "Reference Tracking"):
             state.space_charge = False
             state.csr = False
 

--- a/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
@@ -33,6 +33,10 @@ class InputParameters(CardBase):
             CardComponents.input_header(self.HEADER_NAME)
             with vuetify.VCardText(**self.CARD_TEXT_OVERFLOW):
                 with vuetify.VRow(**self.ROW_STYLE):
+                    with vuetify.VCol(cols=5.5):
+                        InputComponents.select(
+                            label="Tracking Mode",
+                        )
                     with vuetify.VCol(cols="auto"):
                         vuetify.VCheckbox(
                             label="Space Charge",

--- a/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
@@ -28,6 +28,18 @@ class InputParameters(CardBase):
         if state.kin_energy_on_ui != 0:
             InputFunctions.update_kin_energy_sim_value()
 
+    @state.change("tracking_mode")
+    def on_tracking_mode_change(tracking_mode, **kwargs) -> None:
+        if tracking_mode in ("Envelope Tracking", "Reference Tracking"):
+            state.space_charge = False
+            state.csr = False
+
+            state.disable_space_charge = True
+            state.disable_csr = True
+        else:
+            state.disable_space_charge = False
+            state.disable_csr = False
+
     def card_content(self):
         with vuetify.VCard(style=self.collapsable):
             CardComponents.input_header(self.HEADER_NAME)
@@ -42,12 +54,14 @@ class InputParameters(CardBase):
                             label="Space Charge",
                             v_model=("space_charge", False),
                             dense=True,
+                            disabled=("disable_space_charge",),
                         )
                     with vuetify.VCol(cols="auto"):
                         vuetify.VCheckbox(
                             label="CSR",
                             v_model=("csr", False),
                             dense=True,
+                            disabled=("disable_csr",),
                         )
                 with vuetify.VRow(**self.ROW_STYLE):
                     with vuetify.VCol(cols=6):

--- a/src/python/impactx/dashboard/simulation.py
+++ b/src/python/impactx/dashboard/simulation.py
@@ -81,7 +81,7 @@ def run_simulation():
             sim.init_envelope(ref, distribution),
             sim.track_envelope(),
         ),
-        "Reference Tracking": sim.track_reference,
+        "Reference Tracking": lambda: sim.track_reference(ref),
     }
 
     # simulate

--- a/src/python/impactx/dashboard/simulation.py
+++ b/src/python/impactx/dashboard/simulation.py
@@ -71,11 +71,16 @@ def run_simulation():
     sim.add_particles(bunch_charge_C, distribution, npart)
 
     lattice_configuration = lattice_elements()
-
     sim.lattice.extend(lattice_configuration)
 
+    tracking_modes = {
+        "Particle Tracking": sim.track_particles,
+        "Envelope Tracking": sim.track_envelope,
+        "Reference Tracking": sim.track_reference,
+    }
+
     # simulate
-    sim.evolve()
+    tracking_modes[state.tracking_mode]()
 
     generate_phase_space(pc)
 

--- a/src/python/impactx/dashboard/simulation.py
+++ b/src/python/impactx/dashboard/simulation.py
@@ -68,20 +68,26 @@ def run_simulation():
     )
 
     distribution = distribution_parameters()
-    sim.add_particles(bunch_charge_C, distribution, npart)
 
     lattice_configuration = lattice_elements()
     sim.lattice.extend(lattice_configuration)
 
     tracking_modes = {
-        "Particle Tracking": sim.track_particles,
-        "Envelope Tracking": sim.track_envelope,
+        "Particle Tracking": lambda: (
+            sim.add_particles(bunch_charge_C, distribution, npart),
+            sim.track_particles(),
+        ),
+        "Envelope Tracking": lambda: (
+            sim.init_envelope(ref, distribution),
+            sim.track_envelope(),
+        ),
         "Reference Tracking": sim.track_reference,
     }
 
     # simulate
     tracking_modes[state.tracking_mode]()
 
-    generate_phase_space(pc)
+    if state.tracking_mode == "Particle Tracking":
+        generate_phase_space(pc)
 
     sim.finalize()


### PR DESCRIPTION
Adds `track_envelope` and `track_reference` options to the dashboard.

Merge after https://github.com/BLAST-ImpactX/impactx/pull/855 and https://github.com/BLAST-ImpactX/impactx/pull/857