### PR TITLE
Split up particles over multiple tiles for OpenMP

### DIFF
--- a/examples/fodo_programmable/run_fodo_programmable.py
+++ b/examples/fodo_programmable/run_fodo_programmable.py
@@ -117,7 +117,6 @@ pge1.nslice = ns
 pge1.beam_particles = lambda pti, refpart: my_drift(pge1, pti, refpart)
 pge1.ref_particle = lambda refpart: my_ref_drift(pge1, refpart)
 pge1.ds = 0.25
-pge1.threadsafe = True  # allow OpenMP threading for speed
 
 # attention: assignment is a reference for pge2 = pge1
 
@@ -126,7 +125,6 @@ pge2.nslice = ns
 pge2.beam_particles = lambda pti, refpart: my_drift(pge2, pti, refpart)
 pge2.ref_particle = lambda refpart: my_ref_drift(pge2, refpart)
 pge2.ds = 0.5
-pge2.threadsafe = True  # allow OpenMP threading for speed
 
 # add beam diagnostics
 monitor = elements.BeamMonitor("monitor", backend="h5")

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -94,13 +94,11 @@ namespace impactx {
         // init blocks / grids & MultiFabs
         amr_data->InitFromScratch(0.0);
 
-        // alloc particle containers
-        //   have to resize here, not in the constructor because grids have not
+        // prepare particle containers
+        //   have to do this here, not in the constructor because grids have not
         //   been built when constructor was called.
-        amr_data->track_particles.m_particle_container->reserveData();
-        amr_data->track_particles.m_particle_container->resizeData();
-        amr_data->track_particles.m_particles_lost->reserveData();
-        amr_data->track_particles.m_particles_lost->resizeData();
+        amr_data->track_particles.m_particle_container->prepare();
+        amr_data->track_particles.m_particles_lost->prepare();
 
         // register shortcut
         amr_data->track_particles.m_particle_container->SetLostParticleContainer(amr_data->track_particles.m_particles_lost.get());

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -143,6 +143,12 @@ namespace impactx
         //! Destruct a particle container
         virtual ~ImpactXParticleContainer() = default;
 
+	/**
+	   Prepares the container for use. This sets the tile size to a
+	   sensible default and resizes the underyling data structures.
+	 */
+	void prepare ();
+
         /** Add new particles to the container for fixed s.
          *
          * Note: This can only be used *after* the initialization (grids) have

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -143,11 +143,11 @@ namespace impactx
         //! Destruct a particle container
         virtual ~ImpactXParticleContainer() = default;
 
-	/**
-	   Prepares the container for use. This sets the tile size to a
-	   sensible default and resizes the underyling data structures.
-	 */
-	void prepare ();
+    /**
+       Prepares the container for use. This sets the tile size to a
+       sensible default and resizes the underyling data structures.
+     */
+    void prepare ();
 
         /** Add new particles to the container for fixed s.
          *

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -143,11 +143,12 @@ namespace impactx
         //! Destruct a particle container
         virtual ~ImpactXParticleContainer() = default;
 
-    /**
-       Prepares the container for use. This sets the tile size to a
-       sensible default and resizes the underyling data structures.
-     */
-    void prepare ();
+        /** Prepares the container for use.
+         *
+         * This sets the tile size to a sensible default and resizes the
+         * underlying data structures.
+         */
+        void prepare ();
 
         /** Add new particles to the container for fixed s.
          *

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -145,7 +145,10 @@ namespace impactx
         while ((n_logical < nthreads) && (ntry++ < max_tries)) {
             int idim = (ntry % 2) + 1;  // alternate between 1 and 2
             tile_size[idim] /= 2;
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(tile_size[idim] > 0);
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(tile_size[idim] > 0,
+                                             "Failed to set proper tile size for the number of OpenMP threads. "
+                                             "Consider lowering the number of OpenMP threads via the environment variable OMP_NUM_THREADS."
+                                             );
             n_logical = numTilesInBox(ba[gid], true, tile_size);
         }
 

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -130,8 +130,8 @@ namespace impactx
         // number of particles to add
         int const np = x.size();
 
-        // we add particles to lev 0, tile 0 of the first box assigned to this proc
-        int lid = 0, gid = 0, tid = 0;
+        // we add particles to lev 0, grid 0
+        int lid = 0, gid = 0;
         {
             const auto& pmap = ParticleDistributionMap(lid).ProcessorMap();
             auto it = std::find(pmap.begin(), pmap.end(), amrex::ParallelDescriptor::MyProc());
@@ -141,65 +141,94 @@ namespace impactx
                 gid = *it;
             }
         }
-        auto& particle_tile = DefineAndReturnParticleTile(lid, gid, tid);
 
-        auto old_np = particle_tile.numParticles();
-        auto new_np = old_np + np;
-        particle_tile.resize(new_np);
-
-        // Update NextID to include particles created in this function
-        int pid;
-#ifdef AMREX_USE_OMP
-#pragma omp critical (add_beam_nextid)
+	int nthreads = 1;
+#if defined(AMREX_USE_OMP)
+	nthreads = omp_get_max_threads();
 #endif
-        {
-            pid = ParticleType::NextID();
-            ParticleType::NextID(pid+np);
-        }
+
+	const auto& ba = ParticleBoxArray(lid);
+	auto n_logical =  numTilesInBox(ba[gid], true, tile_size);
+
+	if (n_logical < nthreads ) {
+	    amrex::Print() << "Too few tiles for the number of OpenMP threads. Parallelization will be poor. \n";
+	}
+
+	for (int ithr = 0; ithr < nthreads; ++ithr) {
+	    DefineAndReturnParticleTile(lid, gid, ithr);
+	}
+
+	int pid = ParticleType::NextID();
+	ParticleType::NextID(pid+np);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
         static_cast<amrex::Long>(pid) + static_cast<amrex::Long>(np) < amrex::LongParticleIds::LastParticleID,
             "ERROR: overflow on particle id numbers");
 
-        const int cpuid = amrex::ParallelDescriptor::MyProc();
+#if defined(AMREX_USE_OMP)
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+	{
+	    int tid = omp_get_thread_num();
+	    int nr = np / nthreads;
+	    int nlft = np - nr*nthreads;
 
-        auto & soa = particle_tile.GetStructOfArrays().GetRealData();
-        amrex::ParticleReal * const AMREX_RESTRICT x_arr = soa[RealSoA::x].dataPtr();
-        amrex::ParticleReal * const AMREX_RESTRICT y_arr = soa[RealSoA::y].dataPtr();
-        amrex::ParticleReal * const AMREX_RESTRICT t_arr = soa[RealSoA::t].dataPtr();
-        amrex::ParticleReal * const AMREX_RESTRICT px_arr = soa[RealSoA::px].dataPtr();
-        amrex::ParticleReal * const AMREX_RESTRICT py_arr = soa[RealSoA::py].dataPtr();
-        amrex::ParticleReal * const AMREX_RESTRICT pt_arr = soa[RealSoA::pt].dataPtr();
-        amrex::ParticleReal * const AMREX_RESTRICT qm_arr = soa[RealSoA::qm].dataPtr();
-        amrex::ParticleReal * const AMREX_RESTRICT w_arr  = soa[RealSoA::w ].dataPtr();
+	    int num_to_add = 0;
+	    int my_index =0;
+	    if (tid < nlft) { // get nr+1 items
+		my_index = tid * (nr+1);
+		num_to_add = nr+1;
+	    } else {         // get nr items
+		my_index = tid * nr + nlft;
+		num_to_add = nr;
+	    }
 
-        uint64_t * const AMREX_RESTRICT idcpu_arr = particle_tile.GetStructOfArrays().GetIdCPUData().dataPtr();
+	    auto& particle_tile = ParticlesAt(lid, gid, tid);
+	    auto old_np = particle_tile.numParticles();
+	    auto new_np = old_np + num_to_add;
+	    particle_tile.resize(new_np);
 
-        amrex::ParticleReal const * const AMREX_RESTRICT x_ptr = x.data();
-        amrex::ParticleReal const * const AMREX_RESTRICT y_ptr = y.data();
-        amrex::ParticleReal const * const AMREX_RESTRICT t_ptr = t.data();
-        amrex::ParticleReal const * const AMREX_RESTRICT px_ptr = px.data();
-        amrex::ParticleReal const * const AMREX_RESTRICT py_ptr = py.data();
-        amrex::ParticleReal const * const AMREX_RESTRICT pt_ptr = pt.data();
+	    const int cpuid = amrex::ParallelDescriptor::MyProc();
 
-        amrex::ParallelFor(np,
-        [=] AMREX_GPU_DEVICE (int i) noexcept
-        {
-            idcpu_arr[old_np+i] = amrex::SetParticleIDandCPU(pid + i, cpuid);
+	    auto & soa = particle_tile.GetStructOfArrays().GetRealData();
+	    amrex::ParticleReal * const AMREX_RESTRICT x_arr = soa[RealSoA::x].dataPtr();
+	    amrex::ParticleReal * const AMREX_RESTRICT y_arr = soa[RealSoA::y].dataPtr();
+	    amrex::ParticleReal * const AMREX_RESTRICT t_arr = soa[RealSoA::t].dataPtr();
+	    amrex::ParticleReal * const AMREX_RESTRICT px_arr = soa[RealSoA::px].dataPtr();
+	    amrex::ParticleReal * const AMREX_RESTRICT py_arr = soa[RealSoA::py].dataPtr();
+	    amrex::ParticleReal * const AMREX_RESTRICT pt_arr = soa[RealSoA::pt].dataPtr();
+	    amrex::ParticleReal * const AMREX_RESTRICT qm_arr = soa[RealSoA::qm].dataPtr();
+	    amrex::ParticleReal * const AMREX_RESTRICT w_arr  = soa[RealSoA::w ].dataPtr();
 
-            x_arr[old_np+i] = x_ptr[i];
-            y_arr[old_np+i] = y_ptr[i];
-            t_arr[old_np+i] = t_ptr[i];
+	    uint64_t * const AMREX_RESTRICT idcpu_arr = particle_tile.GetStructOfArrays().GetIdCPUData().dataPtr();
 
-            px_arr[old_np+i] = px_ptr[i];
-            py_arr[old_np+i] = py_ptr[i];
-            pt_arr[old_np+i] = pt_ptr[i];
-            qm_arr[old_np+i] = qm;
-            w_arr[old_np+i]  = bchchg/ablastr::constant::SI::q_e/np;
-        });
+	    amrex::ParticleReal const * const AMREX_RESTRICT x_ptr = x.data();
+	    amrex::ParticleReal const * const AMREX_RESTRICT y_ptr = y.data();
+	    amrex::ParticleReal const * const AMREX_RESTRICT t_ptr = t.data();
+	    amrex::ParticleReal const * const AMREX_RESTRICT px_ptr = px.data();
+	    amrex::ParticleReal const * const AMREX_RESTRICT py_ptr = py.data();
+	    amrex::ParticleReal const * const AMREX_RESTRICT pt_ptr = pt.data();
 
-        // safety first: in case passed attribute arrays were temporary, we
-        // want to make sure the ParallelFor has ended here
-        amrex::Gpu::streamSynchronize();
+	    amrex::ParallelFor(num_to_add,
+	        [=] AMREX_GPU_DEVICE (int i) noexcept
+		{
+		    idcpu_arr[old_np+i] = amrex::SetParticleIDandCPU(pid + my_index + i, cpuid);
+
+		    x_arr[old_np+i] = x_ptr[my_index+i];
+		    y_arr[old_np+i] = y_ptr[my_index+i];
+		    t_arr[old_np+i] = t_ptr[my_index+i];
+
+		    px_arr[old_np+i] = px_ptr[my_index+i];
+		    py_arr[old_np+i] = py_ptr[my_index+i];
+		    pt_arr[old_np+i] = pt_ptr[my_index+i];
+
+		    qm_arr[old_np+i] = qm;
+		    w_arr[old_np+i]  = bchchg/ablastr::constant::SI::q_e/np;
+		});
+	}
+
+	// safety first: in case passed attribute arrays were temporary, we
+	// want to make sure the ParallelFor has ended here
+	amrex::Gpu::streamSynchronize();
     }
 
     void

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -111,9 +111,9 @@ namespace impactx
     void
     ImpactXParticleContainer::prepare ()
     {
-	// make sure we have at least one box with enough tiles for each OpenMP thread
+    // make sure we have at least one box with enough tiles for each OpenMP thread
 
-	// make sure level 0, grid 0 exists
+    // make sure level 0, grid 0 exists
         int lid = 0, gid = 0;
         {
             const auto& pmap = ParticleDistributionMap(lid).ProcessorMap();
@@ -125,29 +125,29 @@ namespace impactx
             }
         }
 
-	int nthreads = 1;
+    int nthreads = 1;
 #if defined(AMREX_USE_OMP)
-	nthreads = omp_get_max_threads();
+    nthreads = omp_get_max_threads();
 #endif
 
-	const auto& ba = ParticleBoxArray(lid);
-	auto n_logical =  numTilesInBox(ba[gid], true, tile_size);
+    const auto& ba = ParticleBoxArray(lid);
+    auto n_logical =  numTilesInBox(ba[gid], true, tile_size);
 
-	int ntry = 0;
-	while ((n_logical < nthreads) && (ntry++ < 6)) {
-	    int idim = (ntry % 2) + 1;  // alternate between 1 and 2
-	    tile_size[idim] /= 2;
-	    n_logical =  numTilesInBox(ba[gid], true, tile_size);
-	}
+    int ntry = 0;
+    while ((n_logical < nthreads) && (ntry++ < 6)) {
+        int idim = (ntry % 2) + 1;  // alternate between 1 and 2
+        tile_size[idim] /= 2;
+        n_logical =  numTilesInBox(ba[gid], true, tile_size);
+    }
 
-	if (n_logical < nthreads ) {
-	    amrex::Abort(
-		"ImpactParticleContainer::prepare() could not find good tile size for the number of OpenMP threads"
-		);
-	}
+    if (n_logical < nthreads ) {
+        amrex::Abort(
+        "ImpactParticleContainer::prepare() could not find good tile size for the number of OpenMP threads"
+        );
+    }
 
-	reserveData();
-	resizeData();
+    reserveData();
+    resizeData();
     }
 
     void
@@ -205,27 +205,27 @@ namespace impactx
 #if defined(AMREX_USE_OMP)
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-	{
+    {
             int tid = 1;
 #if defined(AMREX_USE_OMP)
-	    tid = omp_get_thread_num();
+        tid = omp_get_thread_num();
 #endif
 
             // we split up the np particles onto multiple tiles.
             // some tiles will get nr and some will get nlft.
             int nr = np / nthreads;
-	    int nlft = np - nr*nthreads;
+        int nlft = np - nr*nthreads;
 
-	    int num_to_add = 0; /* how many particles this tile will get*/
-	    int my_index = 0;
+        int num_to_add = 0; /* how many particles this tile will get*/
+        int my_index = 0;
 
-	    if (tid < nlft) { // get nr+1 items
-		my_index = tid * (nr+1);
-		num_to_add = nr+1;
-	    } else {         // get nr items
-		my_index = tid * nr + nlft;
-		num_to_add = nr;
-	    }
+        if (tid < nlft) { // get nr+1 items
+        my_index = tid * (nr+1);
+        num_to_add = nr+1;
+        } else {         // get nr items
+        my_index = tid * nr + nlft;
+        num_to_add = nr;
+        }
 
         auto& particle_tile = ParticlesAt(lid, gid, tid);
         auto old_np = particle_tile.numParticles();

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -231,7 +231,7 @@ namespace impactx
             // leftovers, however, the first n_leftover threads
             // will get one extra
             int n_regular  = np / nthreads;
-            int n_leftover = np - nr*nthreads;
+            int n_leftover = np - n_regular*nthreads;
 
             int num_to_add = 0; /* how many particles this tile will get*/
             int my_offset = 0; /*  offset into global arrays x, y, etc. for this thread*/

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -195,7 +195,7 @@ namespace impactx
 #endif
 
         // split up particles over nthreads tiles
-        AMREX_ALWAYS_ASSERT(numTilesInBox(ParticleBoxArray(lid)[gid], true, tile_size) >= nthreads);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(numTilesInBox(ParticleBoxArray(lid)[gid], true, tile_size) >= nthreads, "Not enough tiles for the number of OpenMP threads - please try reducing particles.tile_size or increasing the number of cells in the domain.");
         for (int ithr = 0; ithr < nthreads; ++ithr) {
             DefineAndReturnParticleTile(lid, gid, ithr);
         }

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -137,6 +137,7 @@ namespace impactx
         while ((n_logical < nthreads) && (ntry++ < 6)) {
             int idim = (ntry % 2) + 1;  // alternate between 1 and 2
             tile_size[idim] /= 2;
+            AMREX_ALWAYS_ASSERT(tile_size[idim] > 0);
             n_logical = numTilesInBox(ba[gid], true, tile_size);
         }
 

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -129,7 +129,9 @@ namespace impactx
 #if defined(AMREX_USE_OMP)
         nthreads = omp_get_max_threads();
 #endif
-
+    /**
+        When running without space charge and OpenMP parallelization, we need to make sure we have enough tiles on level 0, grid 0 to thread over the available tiles. We try to set the tile_size appropriately here. The tiles start as (long, 8, 8) in (x, y, z). So we try to reduce the tile size in the y and z directions alternately until there are enough tiles for the number of threads. 
+    */
         const auto& ba = ParticleBoxArray(lid);
         auto n_logical = numTilesInBox(ba[gid], true, tile_size);
 

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -141,7 +141,7 @@ namespace impactx
         auto n_logical = numTilesInBox(ba[gid], true, tile_size);
 
         int ntry = 0;
-        constexpr int max_tries;
+        constexpr int max_tries = 6;
         while ((n_logical < nthreads) && (ntry++ < max_tries)) {
             int idim = (ntry % 2) + 1;  // alternate between 1 and 2
             tile_size[idim] /= 2;

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -130,7 +130,7 @@ namespace impactx
         nthreads = omp_get_max_threads();
 #endif
     /**
-        When running without space charge and OpenMP parallelization, we need to make sure we have enough tiles on level 0, grid 0 to thread over the available tiles. We try to set the tile_size appropriately here. The tiles start as (long, 8, 8) in (x, y, z). So we try to reduce the tile size in the y and z directions alternately until there are enough tiles for the number of threads. 
+        When running without space charge and OpenMP parallelization, we need to make sure we have enough tiles on level 0, grid 0 to thread over the available tiles. We try to set the tile_size appropriately here. The tiles start as (long, 8, 8) in (x, y, z). So we try to reduce the tile size in the y and z directions alternately until there are enough tiles for the number of threads.
     */
         const auto& ba = ParticleBoxArray(lid);
         auto n_logical = numTilesInBox(ba[gid], true, tile_size);

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -220,7 +220,7 @@ namespace impactx
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         {
-            int tid = 1;
+            int tid = 0;
 #if defined(AMREX_USE_OMP)
             tid = omp_get_thread_num();
 #endif


### PR DESCRIPTION
I now get, on [this](https://github.com/BLAST-ImpactX/impactx-benchmarks/blob/main/drift_impactx.py) example, the following timings for `track_particles` on 1, 2, and 4 threads:

`1.893`
`1.017`
`0.5939`

Fix #847