### PR TITLE
Fix eigenemittance column labels (CSV)

### DIFF
--- a/src/diagnostics/DiagnosticOutput.cpp
+++ b/src/diagnostics/DiagnosticOutput.cpp
@@ -67,7 +67,7 @@ namespace
             if (compute_eigenemittances)
             {
                 file_handler << " "
-                             << "emittance_xn" << " " << "emittance_yn" << " " << "emittance_tn";
+                             << "emittance_1" << " " << "emittance_2" << " " << "emittance_3";
             }
             file_handler << " " << "charge_C"
                          << "\n";


### PR DESCRIPTION
This fixes an error introduced in labeling of the reduced diagnostics output file (CSV only) in the case when `eigenemittances = true`.