### PR TITLE
CI: Ubuntu 22.04+

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -12,8 +12,8 @@ jobs:
 #   https://github.com/ComputationalRadiationPhysics/picongpu/blob/0.5.0/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
 #   https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/
   build_nvcc:
-    name: NVCC 11.3.1 SP
-    runs-on: ubuntu-20.04
+    name: NVCC 11.7.1 SP
+    runs-on: ubuntu-22.04
     if: github.event.pull_request.draft == false
     env:
       CXXFLAGS: "-Werror"

--- a/.github/workflows/dependencies/nvcc11-openmpi.sh
+++ b/.github/workflows/dependencies/nvcc11-openmpi.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2021-2023 The ImpactX Community
+# Copyright 2021-2025 The ImpactX Community
 #
 # License: BSD-3-Clause-LBNL
 # Authors: Axel Huebl
@@ -22,22 +22,22 @@ sudo apt-get install -y \
     pkg-config          \
     wget
 
-sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /" \
+sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
+echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64 /" \
     | sudo tee /etc/apt/sources.list.d/cuda.list
 
 sudo apt-get update
 sudo apt-get install -y          \
-    cuda-command-line-tools-11-3 \
-    cuda-compiler-11-3           \
-    cuda-cupti-dev-11-3          \
-    cuda-minimal-build-11-3      \
-    cuda-nvml-dev-11-3           \
-    cuda-nvtx-11-3               \
-    libcufft-dev-11-3            \
-    libcurand-dev-11-3           \
-    libcusparse-dev-11-3
-sudo ln -s cuda-11.3 /usr/local/cuda
+    cuda-command-line-tools-11-7 \
+    cuda-compiler-11-7           \
+    cuda-cupti-dev-11-7          \
+    cuda-minimal-build-11-7      \
+    cuda-nvml-dev-11-7           \
+    cuda-nvtx-11-7               \
+    libcufft-dev-11-7            \
+    libcurand-dev-11-7           \
+    libcusparse-dev-11-7
+sudo ln -s cuda-11.7 /usr/local/cuda
 
 # cmake-easyinstall
 #
@@ -49,7 +49,7 @@ export CEI_TMP="/tmp/cei"
 # ccache 4.2+
 #
 CXXFLAGS="" cmake-easyinstall --prefix=/usr/local \
-    git+https://github.com/ccache/ccache.git@v4.6 \
+    git+https://github.com/ccache/ccache.git@v4.10.2 \
     -DCMAKE_BUILD_TYPE=Release        \
     -DENABLE_DOCUMENTATION=OFF        \
     -DENABLE_TESTING=OFF              \

--- a/docs/source/install/dependencies.rst
+++ b/docs/source/install/dependencies.rst
@@ -18,7 +18,7 @@ Optional dependencies include:
 - for on-node accelerated compute *one of either*:
 
   - `OpenMP 3.1+ <https://www.openmp.org>`__: for threaded CPU execution or
-  - `CUDA Toolkit 11.0+ (11.3+ recommended) <https://developer.nvidia.com/cuda-downloads>`__: for Nvidia GPU support (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`_) or
+  - `CUDA Toolkit 11.7+ <https://developer.nvidia.com/cuda-downloads>`__: for Nvidia GPU support (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`_) or
   - `ROCm 5.2+ (5.5+ recommended) <https://gpuopen.com/learn/amd-lab-notes/amd-lab-notes-rocm-installation-readme/>`__: for AMD GPU support
 - `FFTW3 <http://www.fftw.org>`__: for algorithms such as IGF space charge solver or CSR when running on CPU or with SYCL
 


### PR DESCRIPTION
Ubuntu 20.04 is about to be dropped by GH actions. This means we need to increase our CUDA requirement to at least 11.7+ because we cannot test older versions anymore.