### PR TITLE
BeamMonitor: No BP5 Group Based

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -180,7 +180,7 @@ If the same element name is used multiple times, then an output series is create
 * ``<element_name>.backend`` (``string``, default value: ``default``)
 
   `I/O backend <https://openpmd-api.readthedocs.io/en/latest/backends/overview.html>`_ for `openPMD <https://www.openPMD.org>`_ data dumps.
-  ``bp`` is the `ADIOS2 I/O library <https://csmd.ornl.gov/adios>`_, ``h5`` is the `HDF5 format <https://www.hdfgroup.org/solutions/hdf5/>`_, and ``json`` is a `simple text format <https://en.wikipedia.org/wiki/JSON>`_.
+  ``bp4``/``bp5`` is the `ADIOS2 I/O library <https://csmd.ornl.gov/adios>`_, ``h5`` is the `HDF5 format <https://www.hdfgroup.org/solutions/hdf5/>`_, and ``json`` is a `simple text format <https://en.wikipedia.org/wiki/JSON>`_.
   ``json`` only works with serial/single-rank jobs.
   By default, the first available backend in the order given above is taken.
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -711,7 +711,7 @@ This module provides elements for the accelerator lattice.
    If the same element ``name`` is used multiple times, then an output series is created with multiple outputs.
 
    The `I/O backend <https://openpmd-api.readthedocs.io/en/latest/backends/overview.html>`_ for `openPMD <https://www.openPMD.org>`_ data dumps.
-   ``bp`` is the `ADIOS2 I/O library <https://csmd.ornl.gov/adios>`_, ``h5`` is the `HDF5 format <https://www.hdfgroup.org/solutions/hdf5/>`_, and ``json`` is a `simple text format <https://en.wikipedia.org/wiki/JSON>`_.
+   ``bp4``/``bp5`` is the `ADIOS2 I/O library <https://csmd.ornl.gov/adios>`_, ``h5`` is the `HDF5 format <https://www.hdfgroup.org/solutions/hdf5/>`_, and ``json`` is a `simple text format <https://en.wikipedia.org/wiki/JSON>`_.
    ``json`` only works with serial/single-rank jobs.
    By default, the first available backend in the order given above is taken.
 

--- a/src/elements/diagnostics/BeamMonitor.H
+++ b/src/elements/diagnostics/BeamMonitor.H
@@ -77,7 +77,7 @@ namespace detail
          * Elements with the same series name are identical.
          *
          * @param series_name name of the data series, usually the element name
-         * @param backend file format backend for openPMD, e.g., "bp" or "h5"
+         * @param backend file format backend for openPMD, e.g., "bp5", "bp4", or "h5"
          * @param encoding openPMD iteration encoding: "v"ariable based, "f"ile based, "g"roup based (default)
          * @param period_sample_intervals for periodic lattice, only output every Nth period (turn)
          */

--- a/src/elements/diagnostics/BeamMonitor.cpp
+++ b/src/elements/diagnostics/BeamMonitor.cpp
@@ -126,11 +126,11 @@ namespace detail {
     {
 #ifdef ImpactX_USE_OPENPMD
         // pick first available backend if default is chosen
-        if( m_OpenPMDFileType == "default" )
+        if (m_OpenPMDFileType == "default")
 #   if openPMD_HAVE_ADIOS2==1
-        m_OpenPMDFileType = "bp";
+        m_OpenPMDFileType = "bp4";
 #   elif openPMD_HAVE_ADIOS1==1
-        m_OpenPMDFileType = "bp";
+        m_OpenPMDFileType = "bp";  // bp3
 #   elif openPMD_HAVE_HDF5==1
         m_OpenPMDFileType = "h5";
 #   else
@@ -139,12 +139,19 @@ namespace detail {
 
         // encoding of iterations in the series
         openPMD::IterationEncoding series_encoding = openPMD::IterationEncoding::groupBased;
-        if ( "v" == encoding )
+        if ("v" == encoding)
             series_encoding = openPMD::IterationEncoding::variableBased;
-        else if ( "g" == encoding )
+        else if ("g" == encoding)
             series_encoding = openPMD::IterationEncoding::groupBased;
-        else if ( "f" == encoding )
+        else if ("f" == encoding)
             series_encoding = openPMD::IterationEncoding::fileBased;
+
+        // BP5 does not support groupBased (metadata explosion)
+        if ((m_OpenPMDFileType == "bp5" || m_OpenPMDFileType == "bp") &&
+            (series_encoding == openPMD::IterationEncoding::groupBased))
+        {
+            throw std::runtime_error("BeamMonitor: groupBased encoding not supported for BP5.");
+        }
 
         amrex::ParmParse pp_diag("diag");
         // turn filter


### PR DESCRIPTION
Default to BP4 for now with group based encoding.
Disallow BP5 with group based encoding.

Follow-up: default to BP5 with variable based encoding, once support is final in reading (openPMD-api).

Fix #868

cc @franzpoeschel