### PR TITLE
[WIP] Write `impactx_used_inputs`

### DIFF
--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -14,6 +14,8 @@
 #include "diagnostics/DiagnosticOutput.H"
 #include "particles/wakefields/HandleWakefield.H"
 
+#include <ablastr/utils/UsedInputsFile.H>
+
 #include <AMReX.H>
 #include <AMReX_AmrParGDB.H>
 #include <AMReX_BLProfiler.H>
@@ -116,6 +118,15 @@ namespace impactx {
                 std::cout << "\nGrids Summary:\n";
                 amr_data->printGridSummary(std::cout, 0, amr_data->finestLevel());
             }
+        }
+
+        // write parameters
+        {
+            std::string filename = "impactx_used_inputs";
+            amrex::ParmParse pp_impactx("impactx");
+            pp_impactx.queryAdd("used_inputs_file", filename);
+
+            ablastr::utils::write_used_inputs_file(filename);
         }
 
         // keep track that init is done


### PR DESCRIPTION
Similar to [WarpX](https://warpx.readthedocs.io/en/latest/usage/parameters.html#overall-simulation-parameters), write out the values of `amrex::ParmParse` that we use to initialize/control the simulation.

- [ ] Python control
- [x] ABLASTR: implement support to disable & quiet print (besides writing to `/dev/null`) https://github.com/ECP-WarpX/WarpX/pull/5733
- [ ] docs