### PR TITLE
Python: `setuptools[core]`

### DIFF
--- a/.github/workflows/dependencies/clang-san-openmpi.sh
+++ b/.github/workflows/dependencies/clang-san-openmpi.sh
@@ -29,7 +29,7 @@ sudo apt-get install -y \
     wget
 
 python3 -m pip install -U pip
-python3 -m pip install -U build packaging setuptools wheel
+python3 -m pip install -U build packaging setuptools[core] wheel
 python3 -m pip install -U cmake
 python3 -m pip install -U -r requirements_mpi.txt
 python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt

--- a/.github/workflows/dependencies/clang-tidy.sh
+++ b/.github/workflows/dependencies/clang-tidy.sh
@@ -28,7 +28,7 @@ sudo apt-get install -y \
     wget
 
 python3 -m pip install -U pip
-python3 -m pip install -U build packaging setuptools wheel
+python3 -m pip install -U build packaging setuptools[core] wheel
 python3 -m pip install -U cmake
 python3 -m pip install -U -r requirements_mpi.txt
 python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt

--- a/.github/workflows/dependencies/gcc-openmpi.sh
+++ b/.github/workflows/dependencies/gcc-openmpi.sh
@@ -25,7 +25,7 @@ sudo apt-get install -y \
     wget
 
 python3 -m pip install -U pip
-python3 -m pip install -U build packaging setuptools wheel
+python3 -m pip install -U build packaging setuptools[core] wheel
 python3 -m pip install -U cmake
 python3 -m pip install -U -r requirements_mpi.txt
 python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt

--- a/.github/workflows/dependencies/gcc.sh
+++ b/.github/workflows/dependencies/gcc.sh
@@ -23,7 +23,7 @@ sudo apt-get install -y \
     wget
 
 python3 -m pip install -U pip
-python3 -m pip install -U build packaging setuptools wheel
+python3 -m pip install -U build packaging setuptools[core] wheel
 python3 -m pip install -U cmake
 python3 -m pip install -U -r requirements.txt
 python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,7 +38,7 @@ jobs:
     - name: install pip dependencies
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade build packaging setuptools wheel pytest
+        python3 -m pip install --upgrade build packaging setuptools[core] wheel pytest
         python3 -m pip install --upgrade -r requirements_mpi.txt
         python3 -m pip install --upgrade -r src/python/impactx/dashboard/requirements.txt
         python3 -m pip install --upgrade -r examples/requirements.txt

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -81,7 +81,7 @@ jobs:
         $env:HDF5_USE_STATIC_LIBRARIES = "ON"
 
         python3 -m pip install -U pip
-        python3 -m pip install -U build packaging setuptools wheel
+        python3 -m pip install -U build packaging setuptools[core] wheel
         python3 -m pip install -U -r requirements.txt
         python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt
         python3 -m pip install -U -r examples/requirements.txt
@@ -203,7 +203,7 @@ jobs:
         set "HDF5_USE_STATIC_LIBRARIES=ON"
 
         python3 -m pip install -U pip
-        python3 -m pip install -U build packaging setuptools wheel
+        python3 -m pip install -U build packaging setuptools[core] wheel
         python3 -m pip install -U -r requirements.txt
         python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt
         python3 -m pip install -U -r examples/requirements.txt

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Examples:
 In order to run our tests, you need to have a few Python packages installed:
 ```console
 python3 -m pip install --upgrade pip
-python3 -m pip install --upgrade build packaging setuptools wheel pytest
+python3 -m pip install --upgrade build packaging setuptools[core] wheel pytest
 python3 -m pip install --upgrade -r tests/python/requirements.txt
 ```
 

--- a/docs/source/developers/testing.rst
+++ b/docs/source/developers/testing.rst
@@ -13,7 +13,7 @@ In order to run our tests, you need to have a few :ref:`Python packages installe
 .. code-block:: sh
 
    python3 -m pip install -U pip
-   python3 -m pip install -U build packaging setuptools wheel pytest
+   python3 -m pip install -U build packaging setuptools[core] wheel pytest
    python3 -m pip install -r examples/requirements.txt
 
 Run

--- a/docs/source/install/cmake.rst
+++ b/docs/source/install/cmake.rst
@@ -36,7 +36,7 @@ ImpactX depends on popular third party software.
    .. code-block:: bash
 
       python3 -m pip install -U pip
-      python3 -m pip install -U build packaging setuptools wheel pytest
+      python3 -m pip install -U build packaging setuptools[core] wheel pytest
       python3 -m pip install -U -r examples/requirements.txt
 
 

--- a/docs/source/install/hpc/lumi-csc/install_cpu_dependencies.sh
+++ b/docs/source/install/hpc/lumi-csc/install_cpu_dependencies.sh
@@ -111,7 +111,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/docs/source/install/hpc/lumi-csc/install_gpu_dependencies.sh
+++ b/docs/source/install/hpc/lumi-csc/install_gpu_dependencies.sh
@@ -111,7 +111,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/docs/source/install/hpc/perlmutter-nersc/install_cpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_cpu_dependencies.sh
@@ -117,7 +117,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
@@ -117,7 +117,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas


### PR DESCRIPTION
The pip instructions for setuptools require now to specify the `[core]` argument, otherwise dependent packages are used from the system and are usually outdated, which causes errors.

X-ref:
- https://setuptools.pypa.io/en/latest/userguide/quickstart.html
- https://github.com/pypa/setuptools/issues/4483#issuecomment-2236528158