### PR TITLE
Dashboard: Add impactx examples

### DIFF
--- a/src/python/impactx/dashboard/Input/utils.py
+++ b/src/python/impactx/dashboard/Input/utils.py
@@ -126,6 +126,7 @@ class GeneralFunctions:
             state.dirty("max_level")
             state.variables = [{"name": "", "value": "", "error_message": ""}]
             state.dirty("variables")
+            state.selected_impactx_example = None
 
     @staticmethod
     def set_state_to_numeric(state_name: str) -> None:

--- a/src/python/impactx/dashboard/Toolbar/__init__.py
+++ b/src/python/impactx/dashboard/Toolbar/__init__.py
@@ -1,6 +1,6 @@
 from ..Input.components.card import CardComponents
-from .examples_loader.loader import DashboardExamplesLoader
 from ..Input.utils import GeneralFunctions
+from .examples_loader.loader import DashboardExamplesLoader
 
 __all__ = [
     "CardComponents",

--- a/src/python/impactx/dashboard/Toolbar/__init__.py
+++ b/src/python/impactx/dashboard/Toolbar/__init__.py
@@ -1,7 +1,9 @@
 from ..Input.components.card import CardComponents
+from .examples_loader.loader import DashboardExamplesLoader
 from ..Input.utils import GeneralFunctions
 
 __all__ = [
     "CardComponents",
+    "DashboardExamplesLoader",
     "GeneralFunctions",
 ]

--- a/src/python/impactx/dashboard/Toolbar/examples_loader/loader.py
+++ b/src/python/impactx/dashboard/Toolbar/examples_loader/loader.py
@@ -25,7 +25,6 @@ DASHBOARD_EXAMPLES = {
     # "iota_lattice/run_iotalattice.py",
     # "cyclotron/run_cyclotron.py",
     # "dogleg/run_dogleg.py",
-
 }
 
 

--- a/src/python/impactx/dashboard/Toolbar/examples_loader/loader.py
+++ b/src/python/impactx/dashboard/Toolbar/examples_loader/loader.py
@@ -23,7 +23,7 @@ DASHBOARD_EXAMPLES = {
     "kurth/run_kurth_10nC_periodic.py",
     "expanding_beam/run_expanding_fft.py",
     "expanding_beam/run_expanding_envelope.py",
-    "iota_lattice/run_iotalattice.py",
+    # "iota_lattice/run_iotalattice.py",
     "cyclotron/run_cyclotron.py",
     "dogleg/run_dogleg.py",
 }

--- a/src/python/impactx/dashboard/Toolbar/examples_loader/loader.py
+++ b/src/python/impactx/dashboard/Toolbar/examples_loader/loader.py
@@ -1,0 +1,92 @@
+"""
+This file is part of ImpactX
+Copyright 2025 ImpactX contributors
+Authors: Parthib Roy
+License: BSD-3-Clause-LBNL
+"""
+
+from pathlib import Path
+
+from ... import state
+from ...Input.utils import GeneralFunctions
+from ..file_imports.ui_populator import populate_impactx_simulation_file_to_ui
+
+
+state.impactx_example_list = []
+
+
+DASHBOARD_EXAMPLES = {
+    "fodo/run_fodo.py",
+    "chicane/run_chicane_csr.py",
+    "fodo_space_charge/run_fodo_envelope_sc.py",
+    "apochromatic/run_apochromatic.py",
+    "kurth/run_kurth_10nC_periodic.py",
+    "expanding_beam/run_expanding_fft.py",
+    "expanding_beam/run_expanding_envelope.py",
+    "iota_lattice/run_iotalattice.py",
+    "cyclotron/run_cyclotron.py",
+    "dogleg/run_dogleg.py",
+}
+
+
+class DashboardExamplesLoader:
+    @state.change("impactx_example")
+    def on_selected_impactx_example_change(**kwargs):
+        if state.impactx_example is None:
+            GeneralFunctions.reset_inputs("all")
+        if state.impactx_example in state.impactx_example_list:
+            example_script = DashboardExamplesLoader._get_example_content(
+                state.impactx_example
+            )
+            if example_script:
+                populate_impactx_simulation_file_to_ui(example_script)
+
+    @staticmethod
+    def get_impactx_path() -> Path:
+        """
+        Helper method to find the impactx/examples parent directory.
+        For now, just utilized to load the file names of the impactx examples
+        and retrieve the script in string format.
+        Potentially, this could be used to locate other impactx directories.
+        """
+
+        current_directory = Path(__file__).resolve()
+
+        for parent in current_directory.parents:
+            desired_path = parent / "examples"
+            if parent.name == "impactx" and desired_path.is_dir():
+                return parent
+
+        return None
+
+    @staticmethod
+    def _get_example_content(file_name: str) -> dict:
+        """
+        Retrieve the selected ImpactX example file and populate the UI with its values.
+        """
+
+        impactx_directory = DashboardExamplesLoader.get_impactx_path()
+        impactx_example_file_path = impactx_directory / "examples" / file_name
+
+        file_content_as_str = impactx_example_file_path.read_text()
+        file_dict = {"content": file_content_as_str.encode("utf-8")}
+
+        return file_dict
+
+    @staticmethod
+    def load_impactx_examples() -> None:
+        """
+        Loads only the ImpactX example files defined in DASHBOARD_EXAMPLES
+        to state.impact_example_list.
+        """
+
+        state.impactx_example_list.clear()
+
+        impactx_directory = DashboardExamplesLoader.get_impactx_path()
+        impactx_examples_directory = impactx_directory / "examples"
+
+        for path in impactx_examples_directory.glob("**/run*"):
+            relative_path = path.relative_to(impactx_examples_directory)
+            relative_str = str(relative_path)
+            if relative_str in DASHBOARD_EXAMPLES:
+                state.impactx_example_list.append(relative_str)

--- a/src/python/impactx/dashboard/Toolbar/examples_loader/loader.py
+++ b/src/python/impactx/dashboard/Toolbar/examples_loader/loader.py
@@ -11,7 +11,6 @@ from ... import state
 from ...Input.utils import GeneralFunctions
 from ..file_imports.ui_populator import populate_impactx_simulation_file_to_ui
 
-
 state.impactx_example_list = []
 
 

--- a/src/python/impactx/dashboard/Toolbar/examples_loader/loader.py
+++ b/src/python/impactx/dashboard/Toolbar/examples_loader/loader.py
@@ -16,15 +16,16 @@ state.impactx_example_list = []
 
 DASHBOARD_EXAMPLES = {
     "fodo/run_fodo.py",
-    "chicane/run_chicane_csr.py",
-    "fodo_space_charge/run_fodo_envelope_sc.py",
-    "apochromatic/run_apochromatic.py",
-    "kurth/run_kurth_10nC_periodic.py",
-    "expanding_beam/run_expanding_fft.py",
-    "expanding_beam/run_expanding_envelope.py",
+    # "chicane/run_chicane_csr.py",
+    # "fodo_space_charge/run_fodo_envelope_sc.py",
+    # "apochromatic/run_apochromatic.py",
+    # "kurth/run_kurth_10nC_periodic.py",
+    # "expanding_beam/run_expanding_fft.py",
+    # "expanding_beam/run_expanding_envelope.py",
     # "iota_lattice/run_iotalattice.py",
-    "cyclotron/run_cyclotron.py",
-    "dogleg/run_dogleg.py",
+    # "cyclotron/run_cyclotron.py",
+    # "dogleg/run_dogleg.py",
+
 }
 
 

--- a/src/python/impactx/dashboard/Toolbar/general.py
+++ b/src/python/impactx/dashboard/Toolbar/general.py
@@ -62,6 +62,7 @@ class GeneralToolbar:
         if toolbar_name == "input":
             (GeneralToolbar.dashboard_info(),)
             vuetify.VSpacer()
+            InputToolbar.select_impactx_example()
             InputToolbar.import_button()
             InputToolbar.export_button()
             InputToolbar.reset_inputs_button()

--- a/src/python/impactx/dashboard/Toolbar/input.py
+++ b/src/python/impactx/dashboard/Toolbar/input.py
@@ -7,11 +7,12 @@ License: BSD-3-Clause-LBNL
 """
 
 from .. import ctrl, html, state, vuetify
+from ..Input.components import InputComponents
 from ..Input.components.card import CardComponents
 from ..Input.utils import GeneralFunctions
 from ..Run.simulation import dashboard_sim_inputs
 from .examples_loader.loader import DashboardExamplesLoader
-from ..Input.components import InputComponents
+
 state.expand_all_sections = False
 
 

--- a/src/python/impactx/dashboard/Toolbar/input.py
+++ b/src/python/impactx/dashboard/Toolbar/input.py
@@ -10,7 +10,8 @@ from .. import ctrl, html, state, vuetify
 from ..Input.components.card import CardComponents
 from ..Input.utils import GeneralFunctions
 from ..Run.simulation import dashboard_sim_inputs
-
+from .examples_loader.loader import DashboardExamplesLoader
+from ..Input.components import InputComponents
 state.expand_all_sections = False
 
 
@@ -32,6 +33,22 @@ class InputToolbar:
         Called when the reset button is clicked.
         """
         GeneralFunctions.reset_inputs("all")
+
+    @staticmethod
+    def select_impactx_example():
+        DashboardExamplesLoader.load_impactx_examples()
+        InputComponents.autocomplete(
+            label="Select an example",
+            v_model=("impactx_example", None),
+            items=("impactx_example_list",),
+            placeholder="fodo/run_fodo.py",
+            persistent_placeholder=True,
+            variant="outlined",
+            hide_details=True,
+            clearable=True,
+            style="max-width: 250px",
+            classes="mr-2",
+        )
 
     @staticmethod
     def export_button() -> vuetify.VBtn:


### PR DESCRIPTION
Dashboard users can now pick and choose which ImpactX example to load on the dashboard. Serves as a great user feature and a good testing functionality to evaluate the performance of the dashboard parser and it's ability to handle various types of inputs.

While users can now select any impactx example, the dashboard parser needs updating for more flexibility in reading different types of file formats and the addition of variable referencing for the lattice configuration (https://github.com/BLAST-ImpactX/impactx/pull/829) needs to be completed for better usage. 

TODO:
- [x] Merge #930 
- [x] Merge #981
- [ ] Merge https://github.com/BLAST-ImpactX/impactx/pull/1140