### PR TITLE
Lattice Helper: `insert_element_every_ds`

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -511,7 +511,7 @@ For the input from Twiss parameters in Python, please use the helper function ``
 Lattice Elements
 ----------------
 
-This module provides elements for the accelerator lattice.
+This module provides elements and methods for the accelerator lattice.
 
 .. py:class:: impactx.elements.KnownElementsList
 
@@ -535,8 +535,6 @@ This module provides elements for the accelerator lattice.
 
       :param madx_file: file name to MAD-X file with beamline elements
       :param nslice: number of slices used for the application of space charge
-
-Every lattice element provides a ``.to_dict()`` method, which can be used to serialize its configuration.
 
 .. py:class:: impactx.elements.CFbend(ds, rc, k, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, nslice=1, name=None)
 
@@ -1133,6 +1131,23 @@ Every lattice element provides a ``.to_dict()`` method, which can be used to ser
    .. py:property:: unit
 
       unit specification for plasma lens focusing strength
+
+
+Methods
+"""""""
+
+Each lattice element provides a ``.to_dict()`` method, which can be used to serialize its configuration.
+
+
+.. py:function:: elements.transformation.insert_element_every_ds(list, ds, element)
+
+   Insert an element every s into an element list.
+
+   Splits up every element that is on s = N * ds for N>0.
+
+   :param list: element lattice list
+   :param ds: spacing in meters along s to add an element
+   :param element: the extra element to add every s
 
 
 Coordinate Transformation

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -41,6 +41,9 @@ namespace impactx {
 
     void ImpactX::finalize ()
     {
+        // loop over all beamline elements & finalize them
+        finalize_elements();
+
         if (m_grids_initialized)
         {
             m_lattice.clear();

--- a/src/elements/CMakeLists.txt
+++ b/src/elements/CMakeLists.txt
@@ -6,3 +6,4 @@ target_sources(lib
 )
 
 add_subdirectory(diagnostics)
+add_subdirectory(transformation)

--- a/src/elements/transformation/CMakeLists.txt
+++ b/src/elements/transformation/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(lib
+  PRIVATE
+    Insert.cpp
+)

--- a/src/elements/transformation/Insert.H
+++ b/src/elements/transformation/Insert.H
@@ -1,0 +1,40 @@
+/* Copyright 2022-2025 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_TRANSFORM_LATTICE_INSERT_H
+#define IMPACTX_TRANSFORM_LATTICE_INSERT_H
+
+#include "elements/All.H"
+
+#include <AMReX_REAL.H>
+
+#include <list>
+
+
+namespace impactx::elements::transformation
+{
+    /** Insert an element every s into an element list
+     *
+     * Splits up every element that is on s = N * ds for N>0.
+     *
+     * @param[in] list element lattice list
+     * @param[in] ds spacing in meters along s to add an element
+     * @param[in] element the extra element to add every s
+     * @return modified list with inserted elements
+     */
+    std::list<elements::KnownElements>
+    insert_element_every_ds (
+        std::list<elements::KnownElements> list,
+        amrex::ParticleReal ds,
+        elements::KnownElements element
+    );
+
+} // namespace impactx::elements::transformation
+
+#endif // IMPACTX_TRANSFORM_LATTICE_INSERT_H

--- a/src/elements/transformation/Insert.cpp
+++ b/src/elements/transformation/Insert.cpp
@@ -1,0 +1,117 @@
+/* Copyright 2022-2025 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "elements/transformation/Insert.H"
+
+#include <stdexcept>
+#include <type_traits>
+#include <variant>
+
+
+namespace impactx::elements::transformation
+{
+    std::list<elements::KnownElements>
+    insert_element_every_ds (
+        std::list<elements::KnownElements> list,
+        amrex::ParticleReal ds,
+        elements::KnownElements element
+    )
+    {
+        // algorithm below is so far only implemented for thin elements to insert
+        amrex::ParticleReal new_element_ds = 0.0;  // in meters
+        std::visit([&new_element_ds](auto &&new_element)
+        {
+            new_element_ds = new_element.ds();
+        }, element);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            new_element_ds == 0,
+            "insert_element_ever_s: Only thin elements are supported."
+        );
+
+        std::list<elements::KnownElements> new_list;
+
+        amrex::ParticleReal s = 0.0;  // in meters   // TODO: if we can avoid a global s, we can avoid wasting significant digits for long lattices
+        amrex::ParticleReal s_next_insert = ds;  // in meters
+
+        while (!list.empty())
+        {
+            // copy out front element
+            elements::KnownElements cur_element_variant = list.front();
+            list.pop_front();
+
+            // check where the current element ends
+            amrex::ParticleReal cur_s_out;  // in meters
+            std::visit([&s, &cur_s_out](auto &&cur_element)
+            {
+                cur_s_out = s + cur_element.ds();
+            }, cur_element_variant);
+
+            // case 1: current element is thick and ends after next insert
+            if (s_next_insert < cur_s_out)
+            {
+                amrex::ParticleReal const s_rel_insert = s_next_insert - s;
+
+                // split element and shorten each part
+                elements::KnownElements cur_element_leftover = cur_element_variant;
+                std::visit([&s_rel_insert](auto &&cur_element)
+                {
+                    if constexpr(std::is_base_of_v<elements::mixin::Thin, std::decay_t<decltype(cur_element)>>)
+                    {
+                        throw std::runtime_error("insert_element_ever_s: Thin element cannot be split.");
+                    }
+                    else {
+                        cur_element.m_ds = s_rel_insert;
+                    }
+                }, cur_element_variant);
+                std::visit([&s_rel_insert](auto &&cur_element_left)
+                {
+                    if constexpr(std::is_base_of_v<elements::mixin::Thin, std::decay_t<decltype(cur_element_left)>>)
+                    {
+                        throw std::runtime_error("insert_element_ever_s: Thin element cannot be split.");
+                    }
+                    else {
+                        cur_element_left.m_ds -= s_rel_insert;
+                        cur_element_left.set_name(cur_element_left.name() + "_leftover");
+                    }
+                }, cur_element_leftover);
+
+                // insert element in between
+                new_list.push_back(cur_element_variant);
+                new_list.push_back(element);
+
+                // add leftover element to front of old list
+                list.push_front(cur_element_leftover);
+
+                s += s_rel_insert;
+                s_next_insert += ds;
+            }
+            // case 2: current element ends exactly with next insert
+            else if (s_next_insert == cur_s_out) {
+                // copy current element
+                new_list.push_back(cur_element_variant);
+                // insert element
+                new_list.push_back(element);
+
+                s = cur_s_out;
+                s_next_insert += ds;
+            }
+            // case 3: current element ends before next insert
+            else {
+                // thin element or element too thin to slice in ds
+                new_list.push_back(cur_element_variant);
+
+                s = cur_s_out;
+                // unchanged: s_next_insert
+            }
+        }
+
+        return new_list;
+    }
+
+} // namespace impactx::elements::transformation

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -8,6 +8,9 @@
 #include <particles/Push.H>
 #include <elements/All.H>
 #include <elements/mixin/lineartransport.H>
+#include <elements/transformation/Insert.H>
+
+#include <AMReX.H>
 
 #include <AMReX_REAL.H>
 
@@ -18,6 +21,7 @@
 #include <utility>
 #include <variant>
 #include <vector>
+#include <particles/transformation/CoordinateTransformation.H>
 
 namespace py = pybind11;
 using namespace impactx;
@@ -390,6 +394,7 @@ void init_elements(py::module& m)
             },
             "Scale factor (in meters^(1/2)) of the IOTA nonlinear magnetic insert element used for computing H and I."
         )
+        .def("finalize", &diagnostics::BeamMonitor::finalize)
     ;
     register_push(py_BeamMonitor);
 
@@ -2107,4 +2112,20 @@ void init_elements(py::module& m)
             return py::make_iterator(v.begin(), v.end());
         }, py::keep_alive<0, 1>()) /* Keep list alive while iterator is used */
     ;
+
+
+    // lattice transformations
+    py::module_ met = me.def_submodule(
+        "transformation",
+        "Transform and modify lattices"
+    );
+
+    met.def(
+        "insert_element_every_ds",
+        &impactx::elements::transformation::insert_element_every_ds,
+        py::arg("list"),
+        py::arg("ds"),
+        py::arg("element"),
+        "Insert an element every s into an element list"
+    );
 }

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -210,8 +210,5 @@ namespace impactx
             // print the final values of the reduced beam characteristics
             diagnostics::DiagnosticOutput(cm, ref, "diags/reduced_beam_characteristics_final", step);
         }
-
-        // loop over all beamline elements & finalize them
-        finalize_elements();
     }
 } // namespace impactx

--- a/src/tracking/particles.cpp
+++ b/src/tracking/particles.cpp
@@ -179,8 +179,5 @@ namespace impactx
                 output_lost.finalize();
             }
         }
-
-        // loop over all beamline elements & finalize them
-        finalize_elements();
     }
 } // namespace impactx

--- a/src/tracking/reference.cpp
+++ b/src/tracking/reference.cpp
@@ -144,8 +144,5 @@ namespace impactx
             // print final reference particle to file
             diagnostics::DiagnosticOutput(ref, "diags/ref_particle_final", step);
         }
-
-        // loop over all beamline elements & finalize them
-        finalize_elements();
     }
 } // namespace impactx

--- a/tests/python/test_lattice_insert.py
+++ b/tests/python/test_lattice_insert.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 The ImpactX Community
+#
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+
+from impactx import elements
+
+
+def test_element_insert():
+    """
+    This tests the lattice element insert every ds elements.
+    """
+    monitor = elements.BeamMonitor("monitor", backend="h5")
+
+    fodo = [
+        elements.Drift(name="drift1", ds=0.25),
+        elements.Quad(name="quad1", ds=1.0, k=1.0),
+        elements.Drift(name="drift2", ds=0.5),
+        elements.Quad(name="quad2", ds=1.0, k=-1.0),
+        elements.Drift(name="drift3", ds=0.25),
+    ]
+
+    fodo = elements.transformation.insert_element_every_ds(
+        # todo: avoid that we need to cast
+        elements.KnownElementsList(fodo),
+        ds=0.1,
+        element=monitor,
+    )
+
+    inserted_monitors = list(
+        filter(lambda el: el.to_dict()["type"] == "BeamMonitor", fodo)
+    )
+
+    assert len(fodo) == 63
+    assert len(inserted_monitors) == 29
+
+    # clean shutdown
+    monitor.finalize()


### PR DESCRIPTION
Add a helper to split a lattice every `ds` to insert another thin element, e.g., a BeamMonitor.

Close #537

### Tasks

- [ ] better name? `insert_elements()`, `insert(...)`, `splice(...)`, ...?
- [x] implementation
- [x] Python bindings
- [x] user-facing docs
- [x] example/test