### PR TITLE
Surrogate Example: Fix LaTeX String

### DIFF
--- a/examples/pytorch_surrogate_model/visualize_ml_surrogate_15_stage.py
+++ b/examples/pytorch_surrogate_model/visualize_ml_surrogate_15_stage.py
@@ -128,7 +128,7 @@ def plot_beam_df(
     axT,
     unit=1e6,
     unit_z=1e3,
-    unit_label="$\mu$m",
+    unit_label=r"$\mu$m",
     unit_z_label="mm",
     alpha=1.0,
     cmap=None,


### PR DESCRIPTION
Fix:
```
SyntaxWarning: invalid escape sequence '\m'
```