### PR TITLE
Examples: Update `track_particles()`

### DIFF
--- a/examples/aperture/run_aperture_periodic.py
+++ b/examples/aperture/run_aperture_periodic.py
@@ -63,7 +63,7 @@ sim.lattice.extend(
 )
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/fodo_userdef/run_fodo_userdef.py
+++ b/examples/fodo_userdef/run_fodo_userdef.py
@@ -83,7 +83,7 @@ fodo = [
 sim.lattice.extend(fodo)
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()

--- a/examples/linear_map/run_map.py
+++ b/examples/linear_map/run_map.py
@@ -98,7 +98,7 @@ sim.lattice.extend(map)
 sim.periods = 4
 
 # run simulation
-sim.evolve()
+sim.track_particles()
 
 # clean shutdown
 sim.finalize()


### PR DESCRIPTION
Update three examples that still use `sim.evolve()`, so new users do not pick up the legacy syntax that we will eventually remove.