### PR TITLE
Fix: AMReX External Target

### DIFF
--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -1,6 +1,7 @@
 macro(find_ablastr)
     # if pyAMReX is external, AMReX must be as well
-    if(DEFINED ImpactX_pyamrex_internal AND NOT ImpactX_pyamrex_internal)
+    if(ImpactX_amrex_internal AND NOT ImpactX_pyamrex_internal)
+        message(WARNING "AMReX requested as internal superbuild, but pyAMReX as external. Changing to both external.")
         set(ImpactX_amrex_internal OFF CACHE BOOL
             "Download & build AMReX" FORCE)
     endif()
@@ -92,10 +93,11 @@ macro(find_ablastr)
                 enable_language(CUDA)
             endif()
             add_subdirectory(${ImpactX_ablastr_src} _deps/localablastr-build/)
-            # TODO: this is a bit hacky, check if we find a variable like
-            #       fetchedamrex_SOURCE_DIR or FETCHCONTENT_SOURCE_DIR_FETCHEDAMREX
-            #       or AMReX_DIR or AMReX_MODULE_PATH that we could use for the named path instead
-            list(APPEND CMAKE_MODULE_PATH "${FETCHCONTENT_BASE_DIR}/fetchedamrex-src/Tools/CMake")
+            if(DEFINED AMReX_DIR)
+                list(APPEND CMAKE_MODULE_PATH "${AMReX_DIR}/AMReXCMakeModules")
+            else()
+                list(APPEND CMAKE_MODULE_PATH "${FETCHCONTENT_BASE_DIR}/fetchedamrex-src/Tools/CMake")
+            endif()
         else()
             if(ImpactX_COMPUTE STREQUAL CUDA)
                 enable_language(CUDA)
@@ -106,7 +108,11 @@ macro(find_ablastr)
                 BUILD_IN_SOURCE 0
             )
             FetchContent_MakeAvailable(fetchedablastr)
-            list(APPEND CMAKE_MODULE_PATH "${FETCHCONTENT_BASE_DIR}/fetchedamrex-src/Tools/CMake")
+            if(DEFINED AMReX_DIR)
+                list(APPEND CMAKE_MODULE_PATH "${AMReX_DIR}/AMReXCMakeModules")
+            else()
+                list(APPEND CMAKE_MODULE_PATH "${FETCHCONTENT_BASE_DIR}/fetchedamrex-src/Tools/CMake")
+            endif()
 
             # advanced fetch options
             mark_as_advanced(FETCHCONTENT_BASE_DIR)
@@ -134,6 +140,11 @@ macro(find_ablastr)
 
     # AMReX CMake helper scripts
     list(APPEND CMAKE_MODULE_PATH "${AMReX_DIR}/AMReXCMakeModules")
+
+    # ABLASTR's find_package(AMReX) might not re-export on ImpactX_amrex_internal==FALSE
+    if(NOT TARGET AMReX::amrex)
+        find_package(AMReX CONFIG REQUIRED)
+    endif()
 
     # transitive control for openPMD external
     if(NOT ImpactX_openpmd_src AND NOT ImpactX_openpmd_internal)


### PR DESCRIPTION
In a superbuild where only AMReX is external, the `AMReX::amrex*` targets from the ABLASTR sub-project `find_package` call are not globally available. Hit `find_package` once more to tab into the cache and make it available.

Needed for https://github.com/BLAST-ImpactX/impactx-wheels