### PR TITLE
Python: TinyProfiler Control

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -232,6 +232,23 @@ Collective Effects & Overall Simulation Parameters
       Controls how much information is printed to the terminal, when running ImpactX.
       ``0`` for silent, higher is more verbose. Default is ``1``.
 
+   .. py:property:: tiny_profiler
+
+      This parameter can be used to disable tiny profiling including CArena memory profiling at runtime.
+      Default is ``True``.
+
+   .. py:property:: memory_profiler
+
+      This parameter can be used to disable tiny profiler's memory arena profiling at runtime.
+      If ```tiny_profiler`` is ``False``, this parameter has no effects.
+      Default is ``True``.
+
+   .. py:property:: tiny_profiler_file
+
+      If this parameter is empty (default), the output of tiny profiling is dumped on the default out stream of AMReX.
+      If it's not empty, it specifies the file name for the output.
+      Note that ``"/dev/null"`` is a special name that mean no output.
+
    .. py:method:: evolve()
 
       Run the main simulation loop (deprecated, use ``track_particles``)

--- a/examples/optimize_triplet/run_triplet.py
+++ b/examples/optimize_triplet/run_triplet.py
@@ -87,6 +87,7 @@ def run(parameters: tuple, write_particles=False, write_reduced=False) -> dict:
 
     if verbose is False:
         sim.verbose = 0
+        sim.tiny_profiler = False
 
     # set numerical parameters and IO control
     sim.particle_shape = 2  # B-spline order

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -421,6 +421,40 @@ void init_ImpactX (py::module& m)
             "``0`` for silent, higher is more verbose. Default is ``1``."
         )
 
+        .def_property("tiny_profiler",
+            [](ImpactX & /* ix */){
+                return detail::get_or_throw<bool>("tiny_profiler", "enabled");
+            },
+            [](ImpactX & /* ix */, bool enabled) {
+                amrex::ParmParse pp_tiny_profiler("tiny_profiler");
+                pp_tiny_profiler.add("enabled", enabled);
+            },
+            "This parameter can be used to disable tiny profiling including CArena memory profiling at runtime."
+        )
+        .def_property("memory_profiler",
+            [](ImpactX & /* ix */){
+                return detail::get_or_throw<bool>("tiny_profiler", "memprof_enabled");
+            },
+            [](ImpactX & /* ix */, bool memprof_enabled) {
+                amrex::ParmParse pp_tiny_profiler("tiny_profiler");
+                pp_tiny_profiler.add("memprof_enabled", memprof_enabled);
+            },
+            "This parameter can be used to disable tiny profiler's memory arena profiling at runtime. "
+            "If tiny_profiler.enabled is false, this parameter has no effects."
+        )
+        .def_property("tiny_profiler_file",
+            [](ImpactX & /* ix */){
+                return detail::get_or_throw<std::string>("tiny_profiler", "output_file");
+            },
+            [](ImpactX & /* ix */, std::string output_file) {
+                amrex::ParmParse pp_tiny_profiler("tiny_profiler");
+                pp_tiny_profiler.add("output_file", output_file);
+            },
+            "If this parameter is empty, the output of tiny profiling is dumped on the default out stream of AMReX. "
+            "If it's not empty, it specifies the file name for the output. "
+            "Note that /dev/null is a special name that mean a null file."
+        )
+
         .def("deposit_charge",
             [](ImpactX & ix) {
                 // transform from x',y',t to x,y,z


### PR DESCRIPTION
Add Python properties to control the tiny profiler at runtime.

Close #894