### PR TITLE
PyTorch Example: HDF5

### DIFF
--- a/examples/pytorch_surrogate_model/analyze_ml_surrogate_15_stage.py
+++ b/examples/pytorch_surrogate_model/analyze_ml_surrogate_15_stage.py
@@ -35,7 +35,7 @@ def get_moments(beam):
 
 
 # initial/final beam
-series = io.Series("diags/openPMD/monitor.bp", io.Access.read_only)
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
 last_step = list(series.iterations)[-1]
 initial = series.iterations[1].particles["beam"].to_df()
 final = series.iterations[last_step].particles["beam"].to_df()

--- a/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
+++ b/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
@@ -332,7 +332,7 @@ for i in range(N_stage):
     lpa.threadsafe = False
     lpa_stages.append(lpa)
 
-monitor = elements.BeamMonitor("monitor")
+monitor = elements.BeamMonitor("monitor", backend="h5")
 for i in range(N_stage):
     sim.lattice.extend(
         [

--- a/examples/pytorch_surrogate_model/visualize_ml_surrogate_15_stage.py
+++ b/examples/pytorch_surrogate_model/visualize_ml_surrogate_15_stage.py
@@ -395,7 +395,7 @@ else:
 
 ######## plot phase spaces ###########
 beam_impactx_surrogate_series = io.Series(
-    "diags/openPMD/monitor.bp", io.Access.read_only
+    "diags/openPMD/monitor.h5", io.Access.read_only
 )
 impactx_surrogate_steps = list(beam_impactx_surrogate_series.iterations)
 


### PR DESCRIPTION
In CI/Examples we use `.h5` for the `BeamMonitor`, because it is easier to more install/broadly available in environments. Update this for our PyTorch example to be in sync with the other examples we have.