### PR TITLE
Fix: RTD Builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 Axel Huebl
+# Copyright 2021-2025 Axel Huebl
 #
 # This file is part of ImpactX
 #
@@ -7,16 +7,19 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "mambaforge-latest"
+    # python: "3.11"
 
 sphinx:
-   configuration: docs/source/conf.py
+  configuration: docs/source/conf.py
 
-python:
-   install:
-   - requirements: docs/requirements.txt
+conda:
+  environment: docs/conda.yml
+# python:
+#   install:
+#   - requirements: docs/requirements.txt
 
 formats:
   - htmlzip

--- a/docs/conda.yml
+++ b/docs/conda.yml
@@ -1,0 +1,12 @@
+name: readthedocs
+
+channels:
+  - conda-forge
+  - nodefaults
+
+dependencies:
+  - python
+  - doxygen
+  - pip
+  - pip:
+    - -r requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,14 +5,18 @@
 # License: BSD-3-Clause-LBNL
 
 breathe
-# docutils 0.17 breaks HTML tags & RTD theme
-# https://github.com/sphinx-doc/sphinx/issues/9001
-docutils<=0.16
+docutils>=0.17.1
+
 pybind11-stubgen  # type hints in pyi files
+pybtex
 pygments
 recommonmark
-sphinx>=2.0
+# Sphinx<7.2 because we are waiting for
+#   https://github.com/breathe-doc/breathe/issues/943
+sphinx>=5.3,<7.2
 sphinx-copybutton
 sphinx-design
-sphinx_rtd_theme>=0.3.1
+sphinx_rtd_theme>=1.1.1
+sphinxcontrib-bibtex
 sphinxcontrib-googleanalytics
+sphinxcontrib-napoleon


### PR DESCRIPTION
The pip-based installer fails/stalls out. Switch to conda as in WarpX.