### PR TITLE
Examples: No `del` Needed

### DIFF
--- a/examples/fodo_tune/run_fodo_tune.py
+++ b/examples/fodo_tune/run_fodo_tune.py
@@ -6,7 +6,6 @@
 #
 # -*- coding: utf-8 -*-
 
-import amrex.space3d as amr
 from impactx import ImpactX, distribution, elements
 
 sim = ImpactX()
@@ -67,5 +66,4 @@ sim.periods = 100
 sim.track_particles()
 
 # clean shutdown
-del sim
-amr.finalize()
+sim.finalize()

--- a/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
+++ b/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
@@ -359,4 +359,3 @@ sim.lattice.extend([monitor])
 
 sim.track_particles()
 sim.finalize()
-del sim

--- a/tests/python/test_transformation.py
+++ b/tests/python/test_transformation.py
@@ -73,7 +73,6 @@ def test_transformation():
 
     # finalize simulation
     sim.finalize()
-    del sim
 
     # assert that forward-inverse transformation of the beam leaves beam unchanged
     atol = 1e-14


### PR DESCRIPTION
Since we have `sim.finalize()` we do not need to explicitly `del` the sim object, because we do not rely on when the Python garbage collector is run anymore (which is good).