### PR TITLE
Tests: `amrex.the_arena_init_size=0`

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -95,16 +95,20 @@ function(add_impactx_test name input is_mpi analysis_script plot_script)
                  WORKING_DIRECTORY ${THIS_WORKING_DIR}
         )
         # TODO:
-        # amrex.throw_exception = 1
-        # amrex.signal_handling = 0
+        # amrex.throw_exception=1
+        # amrex.signal_handling=0
+        # amrex.the_arena_init_size=0
         impactx_test_set_pythonpath(${name}.run)
     else()
         add_test(NAME ${name}.run
                  COMMAND
                     ${THIS_MPI_TEST_EXE} $<TARGET_FILE:app> ${INPUTS_FILE}
                         amrex.abort_on_unused_inputs=1
-                        amrex.throw_exception = 1
-                        amrex.signal_handling = 0
+                        amrex.throw_exception=1
+                        amrex.signal_handling=0
+                        # allocate GPU memory on-demand instead of pre-allocating 3/4th
+                        # to enable parallel test runs on the same GPU
+                        amrex.the_arena_init_size=0
                         impactx.always_warn_immediately=1
                         impactx.abort_on_warning_threshold=low
                         ${INPUTS_ARGS}

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -35,6 +35,10 @@ def amrex_init(tmpdir):
                 "amrex.signal_handling=0",
                 # abort GPU runs if out-of-memory instead of swapping to host RAM
                 "amrex.abort_on_out_of_gpu_memory=1",
+                # allocate GPU memory on-demand instead of pre-allocating 3/4th
+                # to enable parallel test runs on the same GPU
+                # https://amrex-codes.github.io/amrex/docs_html/RuntimeParameters.html?highlight=arena#memory
+                "amrex.the_arena_init_size=0",
             ]
         )
         yield


### PR DESCRIPTION
`amrex.the_arena_init_size=0` is default on CPU but not GPU. In order to run tests in parallel on the same GPU (e.g., `ctest --test-dir build -j 6`), we need to change the default so the first test does not allocate 3/4th of the memory of the GPU (to speed up later allocations in a pre-allocated heap).

This currently only applies to app tests and pytest, but not yet to the Python CTests. Need to add an extra option for those, because we cannot inject CLI options.