### PR TITLE
Fix CUDA Shutdown of Element Dynamic Data

### DIFF
--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -89,17 +89,17 @@ namespace impactx::elements
 namespace RFCavityData
 {
     //! last used id for a created RF cavity
-    static inline int next_id = 0;
+    inline int next_id = 0;
 
     //! host: cosine coefficients in Fourier expansion of on-axis electric field Ez
-    static inline std::map<int, std::vector<amrex::ParticleReal>> h_cos_coef = {};
+    inline std::map<int, std::vector<amrex::ParticleReal>> h_cos_coef = {};
     //! host: sine coefficients in Fourier expansion of on-axis electric field Ez
-    static inline std::map<int, std::vector<amrex::ParticleReal>> h_sin_coef = {};
+    inline std::map<int, std::vector<amrex::ParticleReal>> h_sin_coef = {};
 
     //! device: cosine coefficients in Fourier expansion of on-axis electric field Ez
-    static inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_cos_coef = {};
+    inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_cos_coef = {};
     //! device: sine coefficients in Fourier expansion of on-axis electric field Ez
-    static inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_sin_coef = {};
+    inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_sin_coef = {};
 
 } // namespace RFCavityData
 

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -98,17 +98,17 @@ namespace impactx::elements
 namespace SoftQuadrupoleData
 {
     //! last used id for a created soft quad
-    static inline int next_id = 0;
+    inline int next_id = 0;
 
     //! host: cosine coefficients in Fourier expansion of on-axis magnetic field Bz
-    static inline std::map<int, std::vector<amrex::ParticleReal>> h_cos_coef = {};
+    inline std::map<int, std::vector<amrex::ParticleReal>> h_cos_coef = {};
     //! host: sine coefficients in Fourier expansion of on-axis magnetic field Bz
-    static inline std::map<int, std::vector<amrex::ParticleReal>> h_sin_coef = {};
+    inline std::map<int, std::vector<amrex::ParticleReal>> h_sin_coef = {};
 
     //! device: cosine coefficients in Fourier expansion of on-axis magnetic field Bz
-    static inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_cos_coef = {};
+    inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_cos_coef = {};
     //! device: sine coefficients in Fourier expansion of on-axis magnetic field Bz
-    static inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_sin_coef = {};
+    inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_sin_coef = {};
 
 } // namespace SoftQuadrupoleData
 

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -103,17 +103,17 @@ namespace impactx::elements
 namespace SoftSolenoidData
 {
     //! last used id for a created soft solenoid
-    static inline int next_id = 0;
+    inline int next_id = 0;
 
     //! host: cosine coefficients in Fourier expansion of on-axis magnetic field Bz
-    static inline std::map<int, std::vector<amrex::ParticleReal>> h_cos_coef = {};
+    inline std::map<int, std::vector<amrex::ParticleReal>> h_cos_coef = {};
     //! host: sine coefficients in Fourier expansion of on-axis magnetic field Bz
-    static inline std::map<int, std::vector<amrex::ParticleReal>> h_sin_coef = {};
+    inline std::map<int, std::vector<amrex::ParticleReal>> h_sin_coef = {};
 
     //! device: cosine coefficients in Fourier expansion of on-axis magnetic field Bz
-    static inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_cos_coef = {};
+    inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_cos_coef = {};
     //! device: sine coefficients in Fourier expansion of on-axis magnetic field Bz
-    static inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_sin_coef = {};
+    inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_sin_coef = {};
 
 } // namespace SoftSolenoidData
 


### PR DESCRIPTION
Elements: The `finalize()` functions did not have access to our map yet, because we did not share global visibility between TUs. This fixes it using the C++17 guaranteed `inline` declaration.

Fix #911