### PR TITLE
Docs: Fix HTML5 for Install Logos

### DIFF
--- a/docs/source/install/users.rst
+++ b/docs/source/install/users.rst
@@ -6,7 +6,7 @@ Users
 .. raw:: html
 
    <style>
-   .rst-content .section>img {
+   .rst-content section>img {
        width: 30px;
        margin-bottom: 0;
        margin-top: 0;


### PR DESCRIPTION
With the update to HTML5 in docutils, we need to modernize our CSS code that does fancy logos in the user install section.

Similar to https://github.com/BLAST-WarpX/warpx/pull/3588

Fixes the layout issue on this page: https://impactx.readthedocs.io/en/latest/install/users.html
![image](https://github.com/user-attachments/assets/158c4e23-a77b-4f0b-9a87-154ccaddacc1)

Follow-up to #905