### PR TITLE
Treat zero-field special case in bending dipoles

### DIFF
--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -37,6 +37,7 @@ Single Particle Dynamics
    examples/coupled_optics/README.rst
    examples/linear_map/README.rst
    examples/scraping_beam/README.rst
+   examples/reversibility/README.rst
 
 
 Collective Effects

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1333,3 +1333,19 @@ add_impactx_test(FODO.envelope.sc.py
     examples/fodo_space_charge/analysis_fodo_envelope_sc.py
     OFF  # no plot script yet
 )
+
+# Bending Dipole with Zero Field Strength ######################
+#   
+# no space charge
+add_impactx_test(zero-bend-inverse
+    examples/reversibility/input_zero_bend_inverse.in
+    ON   # ImpactX MPI-parallel
+    examples/reversibility/analysis_zero_bend_inverse.py
+    OFF  # no plot script yet
+)
+add_impactx_test(zero-bend-inverse.py
+    examples/reversibility/run_zero_bend_inverse.py
+    OFF   # ImpactX MPI-parallel
+    examples/reversibility/analysis_zero_bend_inverse.py
+    OFF  # no plot script yet
+) 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1335,7 +1335,7 @@ add_impactx_test(FODO.envelope.sc.py
 )
 
 # Bending Dipole with Zero Field Strength ######################
-#   
+#
 # no space charge
 add_impactx_test(zero-bend-inverse
     examples/reversibility/input_zero_bend_inverse.in
@@ -1348,4 +1348,4 @@ add_impactx_test(zero-bend-inverse.py
     OFF   # ImpactX MPI-parallel
     examples/reversibility/analysis_zero_bend_inverse.py
     OFF  # no plot script yet
-) 
+)

--- a/examples/reversibility/README.rst
+++ b/examples/reversibility/README.rst
@@ -1,0 +1,54 @@
+.. _examples-zero-bend-inverse:
+
+Bending Dipole with Zero Field Strength
+========================================
+
+This example tests the effect of a bending dipole with zero field strength, as represented using the elements Sbend and ExactSbend.
+
+In the limiting case of zero field strength, the effect of the dipole should be identical to that of a drift of the same length.
+
+To test this, the map for a dipole is applied, and this is followed by applying the inverse map for a drift of the corresponding length.
+
+We use a 2 GeV electron beam, identical to the distribution used in the test "examples-rotation".
+
+The second moments of x, y, and t should be exactly unchanged.
+
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+
+
+Run
+---
+
+This example can be run **either** as:
+
+* **Python** script: ``python3 run_zero_bend_inverse.py`` or
+* ImpactX **executable** using an input file: ``impactx input_zero_bend_inverse.in``
+
+For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+
+.. tab-set::
+
+   .. tab-item:: Python: Script
+
+       .. literalinclude:: run_zero_bend_inverse.py
+          :language: python3
+          :caption: You can copy this file from ``examples/reversibility/run_zero_bend_inverse.py``.
+
+   .. tab-item:: Executable: Input File
+
+       .. literalinclude:: input_zero_bend_inverse.in
+          :language: ini
+          :caption: You can copy this file from ``examples/reversibility/input_zero_bend_inverse.in``.
+
+
+Analyze
+-------
+
+We run the following script to analyze correctness:
+
+.. dropdown:: Script ``analysis_zero_bend_inverse.py``
+
+   .. literalinclude:: analysis_zero_bend_inverse.py
+      :language: python3
+      :caption: You can copy this file from ``examples/reversibility/analysis_zero_bend_inverse.py``.
+

--- a/examples/reversibility/README.rst
+++ b/examples/reversibility/README.rst
@@ -51,4 +51,3 @@ We run the following script to analyze correctness:
    .. literalinclude:: analysis_zero_bend_inverse.py
       :language: python3
       :caption: You can copy this file from ``examples/reversibility/analysis_zero_bend_inverse.py``.
-

--- a/examples/reversibility/analysis_zero_bend_inverse.py
+++ b/examples/reversibility/analysis_zero_bend_inverse.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+
+import numpy as np
+import openpmd_api as io
+from scipy.stats import moment
+
+
+def get_moments(beam):
+    """Calculate standard deviations of beam position & momenta
+    and emittance values
+
+    Returns
+    -------
+    sigx, sigy, sigt, emittance_x, emittance_y, emittance_t
+    """
+    sigx = moment(beam["position_x"], moment=2) ** 0.5  # variance -> std dev.
+    sigpx = moment(beam["momentum_x"], moment=2) ** 0.5
+    sigy = moment(beam["position_y"], moment=2) ** 0.5
+    sigpy = moment(beam["momentum_y"], moment=2) ** 0.5
+    sigt = moment(beam["position_t"], moment=2) ** 0.5
+    sigpt = moment(beam["momentum_t"], moment=2) ** 0.5
+
+    epstrms = beam.cov(ddof=0)
+    emittance_x = (sigx**2 * sigpx**2 - epstrms["position_x"]["momentum_x"] ** 2) ** 0.5
+    emittance_y = (sigy**2 * sigpy**2 - epstrms["position_y"]["momentum_y"] ** 2) ** 0.5
+    emittance_t = (sigt**2 * sigpt**2 - epstrms["position_t"]["momentum_t"] ** 2) ** 0.5
+
+    return (sigx, sigy, sigt, emittance_x, emittance_y, emittance_t)
+
+
+# initial/final beam
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+last_step = list(series.iterations)[-1]
+initial = series.iterations[1].particles["beam"].to_df()
+final = series.iterations[last_step].particles["beam"].to_df()
+
+# compare number of particles
+num_particles = 10000
+assert num_particles == len(initial)
+assert num_particles == len(final)
+
+print("Initial Beam:")
+sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(initial)
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
+print(
+    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
+)
+
+atol = 0.0  # ignored
+rtol = 1.5 * num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
+    [
+        4.0e-03,
+        4.0e-03,
+        1.0e-03,
+        1.2e-06,
+        1.2e-06,
+        2.0e-06,
+    ],
+    rtol=rtol,
+    atol=atol,
+)
+
+
+print("")
+print("Final Beam:")
+sigxf, sigyf, sigtf, emittance_xf, emittance_yf, emittance_tf = get_moments(final)
+print(f"  sigx={sigxf:e} sigy={sigyf:e} sigt={sigtf:e}")
+print(
+    f"  emittance_x={emittance_xf:e} emittance_y={emittance_yf:e} emittance_t={emittance_tf:e}"
+)
+
+atol = 0.0  # ignored
+rtol = 1.0e-12  # exact to within roundoff tolerance
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigxf, sigyf, sigtf, emittance_xf, emittance_yf, emittance_tf],
+    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
+    rtol=rtol,
+    atol=atol,
+)

--- a/examples/reversibility/input_zero_bend_inverse.in
+++ b/examples/reversibility/input_zero_bend_inverse.in
@@ -1,0 +1,51 @@
+###############################################################################
+# Particle Beam(s)
+###############################################################################
+beam.npart = 10000
+beam.units = static
+beam.kin_energy = 2.0e3
+beam.charge = 1.0e-9
+beam.particle = electron
+beam.distribution = waterbag
+beam.lambdaX = 4.0e-3
+beam.lambdaY = beam.lambdaX
+beam.lambdaT = 1.0e-3
+beam.lambdaPx = 3.0e-4
+beam.lambdaPy = beam.lambdaPx
+beam.lambdaPt = 2.0e-3
+
+
+###############################################################################
+# Beamline: lattice elements and segments
+###############################################################################
+lattice.elements = monitor bend1 inv_drift1 bend2 inv_drift2 monitor
+lattice.nslice = 24
+
+monitor.type = beam_monitor
+monitor.backend = h5
+
+bend1.type = sbend # a zero-field "sbend" is equivalent to a "drift"
+bend1.ds = 10.0
+bend1.rc = 0.0
+
+bend2.type = sbend_exact # a zero-field "sbend_exact" is equivalent to a "drift_exact"
+bend2.ds = 5.0
+bend2.phi = 0.0
+
+inv_drift1.type = drift
+inv_drift1.ds = -bend1.ds
+
+inv_drift2.type = drift_exact
+inv_drift2.ds = -bend2.ds
+
+###############################################################################
+# Algorithms
+###############################################################################
+algo.particle_shape = 2
+algo.space_charge = false
+
+###############################################################################
+# Diagnostics
+###############################################################################
+diag.slice_step_diagnostics = true
+

--- a/examples/reversibility/input_zero_bend_inverse.in
+++ b/examples/reversibility/input_zero_bend_inverse.in
@@ -48,4 +48,3 @@ algo.space_charge = false
 # Diagnostics
 ###############################################################################
 diag.slice_step_diagnostics = true
-

--- a/examples/reversibility/run_zero_bend_inverse.py
+++ b/examples/reversibility/run_zero_bend_inverse.py
@@ -44,10 +44,10 @@ sim.add_particles(bunch_charge_C, distr, npart)
 monitor = elements.BeamMonitor("monitor", backend="h5")
 
 # design the accelerator lattice
-ns=24
+ns = 24
 
-length1=10.0
-length2=5.0
+length1 = 10.0
+length2 = 5.0
 
 linear_segment = [
     monitor,

--- a/examples/reversibility/run_zero_bend_inverse.py
+++ b/examples/reversibility/run_zero_bend_inverse.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Ryan Sandberg, Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+from impactx import ImpactX, distribution, elements
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# load a 2 GeV electron beam with an initial
+# unnormalized rms emittance of  nm
+kin_energy_MeV = 2.0e3  # reference energy
+bunch_charge_C = 1.0e-9  # used without space charge
+npart = 10000  # number of macro particles
+
+#   reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
+
+#   particle bunch
+distr = distribution.Waterbag(
+    lambdaX=4.0e-3,
+    lambdaY=4.0e-3,
+    lambdaT=1.0e-3,
+    lambdaPx=3.0e-4,
+    lambdaPy=3.0e-4,
+    lambdaPt=2.0e-3,
+)
+sim.add_particles(bunch_charge_C, distr, npart)
+
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+
+# design the accelerator lattice
+ns=24
+
+length1=10.0
+length2=5.0
+
+linear_segment = [
+    monitor,
+    elements.Sbend(name="bend1", ds=length1, rc=0.0, nslice=ns),
+    elements.Drift(name="inv_drift1", ds=-length1, nslice=ns),
+]
+
+nonlinear_segment = [
+    elements.ExactSbend(name="bend2", ds=length2, phi=0.0, nslice=ns),
+    elements.ExactDrift(name="inv_drift2", ds=-length2, nslice=ns),
+    monitor,
+]
+
+# assign a lattice segment
+sim.lattice.extend(linear_segment)
+sim.lattice.extend(nonlinear_segment)
+
+# run simulation
+sim.track_particles()
+
+# clean shutdown
+sim.finalize()

--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -111,14 +111,18 @@ namespace impactx::elements
 
             Alignment::compute_constants(refpart);
 
-            // angle of arc for the current slice
+            // arc length and angle of the current slice
+            m_slice_ds = m_ds / nslice();
             m_slice_phi = m_phi / nslice();
+
+            // trigonometric evaluations
             auto const [sin_phi, cos_phi] = amrex::Math::sincos(m_slice_phi);
             m_sin_phi = sin_phi;
             m_cos_phi = cos_phi;
 
-            // access reference particle values to find beta
+            // access reference particle values to find relativistic factors
             m_ibeta = 1_prt / refpart.beta();
+            m_ibetagam2 = 1_prt / std::pow(refpart.beta_gamma(), 2);
 
             // reference particle's orbital radius
             m_rc = this->rc(refpart);
@@ -162,45 +166,71 @@ namespace impactx::elements
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;
 
-            // assign intermediate quantities
-            amrex::ParticleReal const pperp2 = std::pow(pt,2)-2.0_prt * m_ibeta * pt - std::pow(py,2)+1.0_prt;
-            amrex::ParticleReal const px2 = std::pow(px,2);
-            // determine if particle lies within the domain of map definition
-            if (pperp2 <= px2)
-            {
-                amrex::ParticleIDWrapper{idcpu}.make_invalid();
-            } else
-            {
-                amrex::ParticleReal const pperp = std::sqrt(pperp2);
-                amrex::ParticleReal const pzi = std::sqrt(std::pow(pperp,2) - std::pow(px,2));
-                amrex::ParticleReal const rho = m_rc + xout;
+            // treat the special case of zero field
+            if (m_phi==0_prt && m_B==0_prt) {
+               // compute the radical in the denominator (= pz):
+               amrex::ParticleReal const inv_pzden = 1_prt / std::sqrt(
+                   std::pow(pt - m_ibeta, 2) -
+                   m_ibetagam2 -
+                   std::pow(px, 2) -
+                   std::pow(py, 2)
+               );
+            
+               // advance position and momentum (exact drift)
+               x = xout + m_slice_ds * px * inv_pzden;
+               // pxout = px;
+               y = yout + m_slice_ds * py * inv_pzden;
+               // pyout = py;
+               t = tout - m_slice_ds * (m_ibeta + (pt - m_ibeta) * inv_pzden);
+               // ptout = pt;
+            
+               // assign updated momenta
+               px = pxout;
+               py = pyout;
+               pt = ptout;
 
-                // update momenta
-                pxout = px * m_cos_phi + (pzi - rho / m_rc) * m_sin_phi;
-                pyout = py;
-                ptout = pt;
+            } else {
 
-                // angle of momentum rotation
-                amrex::ParticleReal const px2f = std::pow(pxout,2);
-                // determine if particle lies within domain of map definition
-                if (pperp2 <= px2f)
-                {
-                    amrex::ParticleIDWrapper{idcpu}.make_invalid();
-                } else
-                {
-                    amrex::ParticleReal const pzf = std::sqrt(std::pow(pperp,2)-std::pow(pxout,2));
-                    amrex::ParticleReal const theta = m_slice_phi + std::asin(px/pperp) - std::asin(pxout/pperp);
+               // assign intermediate quantities
+               amrex::ParticleReal const pperp2 = std::pow(pt,2)-2.0_prt * m_ibeta * pt - std::pow(py,2)+1.0_prt;
+               amrex::ParticleReal const px2 = std::pow(px,2);
+               // determine if particle lies within the domain of map definition
+               if (pperp2 <= px2)
+               {
+                   amrex::ParticleIDWrapper{idcpu}.make_invalid();
+               } else
+               {
+                   amrex::ParticleReal const pperp = std::sqrt(pperp2);
+                   amrex::ParticleReal const pzi = std::sqrt(std::pow(pperp,2) - std::pow(px,2));
+                   amrex::ParticleReal const rho = m_rc + xout;
 
-                    // update position coordinates
-                    x = -m_rc + rho*m_cos_phi + m_rc*(pzf + px*m_sin_phi - pzi*m_cos_phi);
-                    y = yout + theta * m_rc * py;
-                    t = tout - theta * m_rc * (pt - 1.0_prt * m_ibeta) - m_phi * m_rc * m_ibeta;
+                   // update momenta
+                   pxout = px * m_cos_phi + (pzi - rho / m_rc) * m_sin_phi;
+                   pyout = py;
+                   ptout = pt;
 
-                    // assign updated momenta
-                    px = pxout;
-                    py = pyout;
-                    pt = ptout;
-                }
+                   // angle of momentum rotation
+                   amrex::ParticleReal const px2f = std::pow(pxout,2);
+                   // determine if particle lies within domain of map definition
+                   if (pperp2 <= px2f)
+                   {
+                       amrex::ParticleIDWrapper{idcpu}.make_invalid();
+                   } else
+                   {
+                       amrex::ParticleReal const pzf = std::sqrt(std::pow(pperp,2)-std::pow(pxout,2));
+                       amrex::ParticleReal const theta = m_slice_phi + std::asin(px/pperp) - std::asin(pxout/pperp);
+
+                       // update position coordinates
+                       x = -m_rc + rho*m_cos_phi + m_rc*(pzf + px*m_sin_phi - pzi*m_cos_phi);
+                       y = yout + theta * m_rc * py;
+                       t = tout - theta * m_rc * (pt - 1.0_prt * m_ibeta) - m_phi * m_rc * m_ibeta;
+
+                       // assign updated momenta
+                       px = pxout;
+                       py = pyout;
+                       pt = ptout;
+                   }
+               }
             }
 
             // apply transverse aperture
@@ -233,24 +263,37 @@ namespace impactx::elements
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
-            // assign intermediate parameters
-            amrex::ParticleReal const theta = m_phi / nslice();
-            amrex::ParticleReal const rc = (m_B != 0_prt) ? refpart.rigidity_Tm() / m_B : m_ds / m_phi;
-            amrex::ParticleReal const B = refpart.beta_gamma() /rc;
+            // special case of zero field = an exact drift
+            if (m_phi==0_prt && m_B==0_prt) {
+               // advance position and momentum (drift)
+               amrex::ParticleReal const step = slice_ds /std::sqrt(std::pow(pt,2)-1.0_prt);
+               refpart.x = x + step*px;
+               refpart.y = y + step*py;
+               refpart.z = z + step*pz;
+               refpart.t = t - step*pt;
 
-            // calculate expensive terms once
-            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
+            } else {
 
-            // advance position and momentum (bend)
-            refpart.px = px*cos_theta - pz*sin_theta;
-            refpart.py = py;
-            refpart.pz = pz*cos_theta + px*sin_theta;
-            refpart.pt = pt;
+               // assign intermediate parameters
+               amrex::ParticleReal const theta = m_phi / nslice();
+               amrex::ParticleReal const rc = (m_B != 0_prt) ? refpart.rigidity_Tm() / m_B : m_ds / m_phi;
+               amrex::ParticleReal const B = refpart.beta_gamma() /rc;
 
-            refpart.x = x + (refpart.pz - pz)/B;
-            refpart.y = y + (theta/B)*py;
-            refpart.z = z - (refpart.px - px)/B;
-            refpart.t = t - (theta/B)*pt;
+               // calculate expensive terms once
+               auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
+
+               // advance position and momentum (bend)
+               refpart.px = px*cos_theta - pz*sin_theta;
+               refpart.py = py;
+               refpart.pz = pz*cos_theta + px*sin_theta;
+               refpart.pt = pt;
+
+               refpart.x = x + (refpart.pz - pz)/B;
+               refpart.y = y + (theta/B)*py;
+               refpart.z = z - (refpart.px - px)/B;
+               refpart.t = t - (theta/B)*pt;
+
+            }
 
             // advance integrated path length
             refpart.s = s + slice_ds;
@@ -278,7 +321,7 @@ namespace impactx::elements
       private:
         // constants that are independent of the individually tracked particle,
         // see: compute_constants() to refresh
-        amrex::ParticleReal m_slice_phi, m_ibeta, m_rc, m_sin_phi, m_cos_phi;
+        amrex::ParticleReal m_slice_ds, m_slice_phi, m_ibeta, m_ibetagam2, m_rc, m_sin_phi, m_cos_phi;
     };
 
 } // namespace impactx

--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -175,7 +175,7 @@ namespace impactx::elements
                    std::pow(px, 2) -
                    std::pow(py, 2)
                );
-            
+
                // advance position and momentum (exact drift)
                x = xout + m_slice_ds * px * inv_pzden;
                // pxout = px;
@@ -183,7 +183,7 @@ namespace impactx::elements
                // pyout = py;
                t = tout - m_slice_ds * (m_ibeta + (pt - m_ibeta) * inv_pzden);
                // ptout = pt;
-            
+
                // assign updated momenta
                px = pxout;
                py = pyout;

--- a/src/elements/Sbend.H
+++ b/src/elements/Sbend.H
@@ -283,24 +283,34 @@ namespace impactx::elements
             amrex::ParticleReal const betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
             amrex::ParticleReal const bet = std::sqrt(betgam2/(1.0_prt + betgam2));
 
-            // calculate expensive terms once
-            amrex::ParticleReal const theta = slice_ds/m_rc;
-            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
-
             // initialize linear map matrix elements
             Map6x6 R = Map6x6::Identity();
 
-            // assign linear map matrix elements
-            R(1,1) = cos_theta;
-            R(1,2) = m_rc*sin_theta;
-            R(1,6) = - (m_rc/bet)*(1.0_prt - cos_theta);
-            R(2,1) = -sin_theta/m_rc;
-            R(2,2) = cos_theta;
-            R(2,6) = - sin_theta/bet;
-            R(3,4) = m_rc*theta;
-            R(5,1) = sin_theta/bet;
-            R(5,2) = m_rc/bet*(1.0_prt - cos_theta);
-            R(5,6) = m_rc*(-theta+sin_theta/(bet*bet));
+            // treat the special case of zero field
+            if (m_rc==0.0_prt) {
+               R(1,2) = slice_ds;
+               R(3,4) = slice_ds;
+               R(5,6) = slice_ds / betgam2;
+
+            } else {
+
+               // calculate expensive terms once
+               amrex::ParticleReal const theta = slice_ds/m_rc;
+               auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
+
+               // assign linear map matrix elements
+               R(1,1) = cos_theta;
+               R(1,2) = m_rc*sin_theta;
+               R(1,6) = - (m_rc/bet)*(1.0_prt - cos_theta);
+               R(2,1) = -sin_theta/m_rc;
+               R(2,2) = cos_theta;
+               R(2,6) = - sin_theta/bet;
+               R(3,4) = m_rc*theta;
+               R(5,1) = sin_theta/bet;
+               R(5,2) = m_rc/bet*(1.0_prt - cos_theta);
+               R(5,6) = m_rc*(-theta+sin_theta/(bet*bet));
+
+            }
 
             return R;
         }

--- a/src/elements/Sbend.H
+++ b/src/elements/Sbend.H
@@ -92,21 +92,35 @@ namespace impactx::elements
 
             // access reference particle values
             amrex::ParticleReal const ibet = 1.0_prt / refpart.beta();
+            amrex::ParticleReal const ibetagam2 = 1_prt / std::pow(refpart.beta_gamma(), 2);
 
-            // calculate expensive terms once
-            amrex::ParticleReal const theta = slice_ds / m_rc;
-            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
+            // treat the special case of zero field (equivalent to a drift)
+            if (m_rc==0_prt) {
+               m_R11 = 1.0_prt;
+               m_R12 = slice_ds;
+               m_R16 = 0.0_prt;
+               m_R21 = 0.0_prt;
+               m_R26 = 0.0_prt;
+               m_R34 = slice_ds;
+               m_R56 = slice_ds * ibetagam2;
 
-            m_R11 = cos_theta;
-            m_R12 = m_rc * sin_theta;
-            m_R16 = -m_rc * ibet * (1.0_prt - cos_theta);
-            m_R21 = -sin_theta / m_rc;
-            // m_R22 = m_R11
-            m_R26 = -sin_theta * ibet;
-            m_R34 = m_rc * theta;
-            // m_R51 = -m_R26
-            // m_R52 = -m_R16
-            m_R56 = m_rc * (-theta + sin_theta * ibet * ibet);
+            } else {
+
+               // calculate expensive terms once
+               amrex::ParticleReal const theta = slice_ds / m_rc;
+               auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
+
+               m_R11 = cos_theta;
+               m_R12 = m_rc * sin_theta;
+               m_R16 = -m_rc * ibet * (1.0_prt - cos_theta);
+               m_R21 = -sin_theta / m_rc;
+               // m_R22 = m_R11
+               m_R26 = -sin_theta * ibet;
+               m_R34 = m_rc * theta;
+               // m_R51 = -m_R26
+               // m_R52 = -m_R16
+               m_R56 = m_rc * (-theta + sin_theta * ibet * ibet);
+           }
         }
 
         /** This is a sbend functor, so that a variable of this type can be used like a sbend function.
@@ -212,23 +226,36 @@ namespace impactx::elements
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
-            // assign intermediate parameter
-            amrex::ParticleReal const theta = slice_ds/m_rc;
-            amrex::ParticleReal const B = std::sqrt(std::pow(pt,2)-1.0_prt)/m_rc;
+            // treat the special case of zero field (drift)
+            if (m_rc == 0.0_prt) {
+               // advance position and momentum (drift)
+               amrex::ParticleReal const step = slice_ds /std::sqrt(std::pow(pt,2)-1.0_prt);           
+               refpart.x = x + step*px;
+               refpart.y = y + step*py;
+               refpart.z = z + step*pz;
+               refpart.t = t - step*pt;
 
-            // calculate expensive terms once
-            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
+            } else {
 
-            // advance position and momentum (bend)
-            refpart.px = px*cos_theta - pz*sin_theta;
-            refpart.py = py;
-            refpart.pz = pz*cos_theta + px*sin_theta;
-            refpart.pt = pt;
+               // assign intermediate parameter
+               amrex::ParticleReal const theta = slice_ds/m_rc;
+               amrex::ParticleReal const B = std::sqrt(std::pow(pt,2)-1.0_prt)/m_rc;
 
-            refpart.x = x + (refpart.pz - pz)/B;
-            refpart.y = y + (theta/B)*py;
-            refpart.z = z - (refpart.px - px)/B;
-            refpart.t = t - (theta/B)*pt;
+               // calculate expensive terms once
+               auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
+
+               // advance position and momentum (bend)
+               refpart.px = px*cos_theta - pz*sin_theta;
+               refpart.py = py;
+               refpart.pz = pz*cos_theta + px*sin_theta;
+               refpart.pt = pt;
+
+               refpart.x = x + (refpart.pz - pz)/B;
+               refpart.y = y + (theta/B)*py;
+               refpart.z = z - (refpart.px - px)/B;
+               refpart.t = t - (theta/B)*pt;
+
+            }
 
             // advance integrated path length
             refpart.s = s + slice_ds;

--- a/src/elements/Sbend.H
+++ b/src/elements/Sbend.H
@@ -229,7 +229,7 @@ namespace impactx::elements
             // treat the special case of zero field (drift)
             if (m_rc == 0.0_prt) {
                // advance position and momentum (drift)
-               amrex::ParticleReal const step = slice_ds /std::sqrt(std::pow(pt,2)-1.0_prt);           
+               amrex::ParticleReal const step = slice_ds /std::sqrt(std::pow(pt,2)-1.0_prt);
                refpart.x = x + step*px;
                refpart.y = y + step*py;
                refpart.z = z + step*pz;


### PR DESCRIPTION
The special case of dipoles with zero field should default to the corresponding drift map.

- [x] Treat ExactSbend as ExactDrift when `phi=B=0`
- [x] Treat Sbend as Drift when `rc=0`
- [x] Update covariance matrix push for this special case
- [x] Tests:  forward bend + inverse drift