### PR TITLE
Implement Strang splitting with space charge

### DIFF
--- a/examples/expanding_beam/analysis_expanding_envelope.py
+++ b/examples/expanding_beam/analysis_expanding_envelope.py
@@ -104,9 +104,9 @@ print(f"  rtol={rtol} (ignored: atol~={atol})")
 assert np.allclose(
     [sig_xf, sig_yf, sig_tf],
     [
-        9.029112e-04,
-        9.029112e-04,
-        1.841402e-06,
+        8.94427191e-04,
+        8.94427191e-04,
+        1.824483738e-06,
     ],
     rtol=rtol,
     atol=atol,

--- a/examples/kurth/analysis_kurth_10nC_periodic_envelope.py
+++ b/examples/kurth/analysis_kurth_10nC_periodic_envelope.py
@@ -98,7 +98,7 @@ print(
 )
 
 atol = 0.0  # ignored
-rtol = 2.0e-3  # from random sampling of a smooth distribution
+rtol = 3.5e-3  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -66,7 +66,7 @@ namespace detail
         int nslice = nslice_default;
         pp_element.getWithParser("ds", ds);
         pp_element.queryAddWithParser("nslice", nslice);
-        nslice = std::floor(nslice/2.0)*2;  // ensure nslice is even
+        //nslice = std::floor(nslice/2.0)*2;  // ensure nslice is even
 
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nslice > 0,
                                          pp_element.getPrefix() + ".nslice must be > 0.");

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -66,6 +66,7 @@ namespace detail
         int nslice = nslice_default;
         pp_element.getWithParser("ds", ds);
         pp_element.queryAddWithParser("nslice", nslice);
+        nslice = std::floor(nslice/2.0)*2;  // ensure nslice is even
 
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nslice > 0,
                                          pp_element.getPrefix() + ".nslice must be > 0.");

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -66,7 +66,7 @@ namespace detail
         int nslice = nslice_default;
         pp_element.getWithParser("ds", ds);
         pp_element.queryAddWithParser("nslice", nslice);
-        //nslice = std::floor(nslice/2.0)*2;  // ensure nslice is even
+        nslice = 2*nslice;  // ensure nslice is even
 
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nslice > 0,
                                          pp_element.getPrefix() + ".nslice must be > 0.");

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -137,7 +137,8 @@ namespace impactx
                 }, element_variant);
 
                 // sub-steps for space charge within the element
-                for (int slice_step = 0; slice_step < nslice; ++slice_step)
+                int nsteps = std::floor(nslice/2.0);
+                for (int slice_step = 0; slice_step < nsteps; ++slice_step)
                 {
                     BL_PROFILE("ImpactX::track_envelope::slice_step");
                     step++;
@@ -147,14 +148,27 @@ namespace impactx
                                        << " slice_step=" << slice_step << "\n";
                     }
 
+                    std::visit([&ref, &cm](auto&& element)
+                    {
+                        // push reference particle in global coordinates
+                        {
+                            BL_PROFILE("impactx::Push::RefPart");
+                            element(ref);
+                        }  
+                    
+                        // push Covariance Matrix in external fields
+                        element(cm, ref);
+                                       
+                    }, element_variant);
+
                     if (space_charge == SpaceChargeAlgo::True_2D)
                     {
                         // push Covariance Matrix in 2D space charge fields
-                        envelope::spacecharge::space_charge2D_push(ref, cm, intensity, slice_ds);
+                        envelope::spacecharge::space_charge2D_push(ref, cm, intensity, 2*slice_ds);
                     } else if (space_charge == SpaceChargeAlgo::True_3D)
                     {
                         // push Covariance Matrix in 3D space charge fields
-                        envelope::spacecharge::space_charge3D_push(ref, cm, intensity, slice_ds);
+                        envelope::spacecharge::space_charge3D_push(ref, cm, intensity, 2*slice_ds);
                     } else {
                         amrex::Print() << "Warning: Space charge is off by default." << "\n";
                     }

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -154,11 +154,11 @@ namespace impactx
                         {
                             BL_PROFILE("impactx::Push::RefPart");
                             element(ref);
-                        }  
-                    
+                        }
+
                         // push Covariance Matrix in external fields
                         element(cm, ref);
-                                       
+
                     }, element_variant);
 
                     if (space_charge == SpaceChargeAlgo::True_2D)

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -137,7 +137,7 @@ namespace impactx
                 }, element_variant);
 
                 // sub-steps for space charge within the element
-                int nsteps = std::floor(nslice/2.0);
+                int nsteps = std::round(nslice/2.0);
                 for (int slice_step = 0; slice_step < nsteps; ++slice_step)
                 {
                     BL_PROFILE("ImpactX::track_envelope::slice_step");


### PR DESCRIPTION
This PR modifies the main tracking loop with collective effects to use a second-order Strang splitting.
- increases the accuracy of the space charge calculation by moving from first-order to second-order with respect to the slice step size, currently set by `nslice`
- ensures that integration in `s` is time-symmetric, which is needed for reversible back-tracking

Close #846 
- [x] simple implementation for the case that nslice is an even integer
- [x] implement and test in the envelope tracking loop
- [ ] implement and test in the particle tracking loop
- [ ] modify implementation for the case of general nslice
- [ ] add benchmark test(s)

A follow-up PR will address Issue #794 