### PR TITLE
Add an exact nonlinear quadrupole

### DIFF
--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -38,6 +38,7 @@ Single Particle Dynamics
    examples/linear_map/README.rst
    examples/scraping_beam/README.rst
    examples/reversibility/README.rst
+   examples/symplectic_integration/README.rst
 
 
 Collective Effects

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -498,7 +498,10 @@ This requires these additional parameters:
 ``quad_exact`` for a Quadrupole magnet using the exact relativistic Hamiltonian, including all kinematic nonlinearities.
 Particle tracking is performed using symplectic integration based on the Hamiltonian splitting :math:`H = H_1 + H_2`.
 Here :math:`H_1` is the Hamiltonian for a linear quadrupole (containing all terms quadratic in the phase space variables),
-and :math:`H_2` is the remainder (including the kinematic square root).  This suggested splitting is based on:
+and :math:`H_2` is the remainder (including the kinematic square root).  This suggested splitting appears for example in:
+
+* D. L. Bruhwiler et al, in Proc. of EPAC 98, pp. 1171-1173 (1998).
+* E. Forest, J. Phys. A: Math. Gen. 39, 5321 (2006).
 
 This requires these additional parameters:
 

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -496,9 +496,9 @@ This requires these additional parameters:
 ^^^^^^^^^^^^^^^^^^
 
 ``quad_exact`` for a Quadrupole magnet using the exact relativistic Hamiltonian, including all kinematic nonlinearities.
-Particle tracking is performed using symplectic integration based on the Hamiltonian splitting `H = H_1 + H_2`.
-Here `H_1` is the Hamiltonian for a linear quadrupole (containing all terms quadratic in the phase space variables),
-and `H_2` is the remainder (including the kinematic square root).  This suggested splitting is based on:
+Particle tracking is performed using symplectic integration based on the Hamiltonian splitting :math:`H = H_1 + H_2`.
+Here :math:`H_1` is the Hamiltonian for a linear quadrupole (containing all terms quadratic in the phase space variables),
+and :math:`H_2` is the remainder (including the kinematic square root).  This suggested splitting is based on:
 
 This requires these additional parameters:
 

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -505,7 +505,7 @@ This requires these additional parameters:
 * ``<element_name>.ds`` (``float``, in meters) the segment length
 * ``<element_name>.k`` (``float``, in inverse meters squared OR in T/m) the quadrupole strength
   = (magnetic field gradient in T/m) / (magnetic rigidity in T-m) - if ``unit = 0``
-  
+
   OR = magnetic field gradient in T/m - if ``unit = 1``
 
   * k > 0 horizontal focusing

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -492,6 +492,36 @@ This requires these additional parameters:
 * ``<element_name>.nslice`` (``integer``) number of slices used for the application of space charge (default: ``1``)
 
 
+``quad_exact``
+^^^^^^^^^^^^^^^^^^
+
+``quad_exact`` for a Quadrupole magnet using the exact relativistic Hamiltonian, including all kinematic nonlinearities.
+Particle tracking is performed using symplectic integration based on the Hamiltonian splitting `H = H_1 + H_2`.
+Here `H_1` is the Hamiltonian for a linear quadrupole (containing all terms quadratic in the phase space variables),
+and `H_2` is the remainder (including the kinematic square root).  This suggested splitting is based on:
+
+This requires these additional parameters:
+
+* ``<element_name>.ds`` (``float``, in meters) the segment length
+* ``<element_name>.k`` (``float``, in inverse meters squared OR in T/m) the quadrupole strength
+  = (magnetic field gradient in T/m) / (magnetic rigidity in T-m) - if ``unit = 0``
+  
+  OR = magnetic field gradient in T/m - if ``unit = 1``
+
+  * k > 0 horizontal focusing
+  * k < 0 horizontal defocusing
+
+* ``<element_name>.unit`` (``integer``) specification of units (default: ``0``)
+* ``<element_name>.dx`` (``float``, in meters) horizontal translation error
+* ``<element_name>.dy`` (``float``, in meters) vertical translation error
+* ``<element_name>.rotation`` (``float``, in degrees) rotation error in the transverse plane
+* ``<element_name>.aperture_x`` (``float``, in meters) horizontal half-aperture (elliptical)
+* ``<element_name>.aperture_y`` (``float``, in meters) vertical half-aperture (elliptical)
+* ``<element_name>.int_order`` (``integer``) the order used for symplectic integration (2 or 4) (default: ``2``)
+* ``<element_name>.mapsteps`` (``integer``) number of integration steps per slice used for symplectic integration (default: ``10``)
+* ``<element_name>.nslice`` (``integer``) number of slices used for the application of space charge (default: ``1``)
+
+
 ``quadrupole_softedge``
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -886,21 +886,21 @@ This module provides elements and methods for the accelerator lattice.
    :param mapsteps: number of integration steps per slice used for symplectic integration
    :param nslice: number of slices used for the application of space charge
    :param name: an optional name for the element
-   
+
    .. py:property:: k
-   
+
       quadrupole strength in 1/m^2 (or T/m)
-   
+
    .. py:property:: unit
-   
+
       unit specification for quad strength
 
    .. py:property:: int_order
-   
+
       the order used for symplectic integration (2 or 4)
 
    .. py:property:: mapsteps
-   
+
       number of integration steps per slice used for symplectic integration
 
 .. py:class:: impactx.elements.ChrPlasmaLens(ds, k, unit=0, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, nslice=1, name=None)

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -863,6 +863,46 @@ This module provides elements and methods for the accelerator lattice.
 
       unit specification for quad strength
 
+.. py:class:: impactx.elements.ExactQuad(ds, k, unit=0, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, int_order=2, mapsteps=1, nslice=1, name=None)
+
+   A Quadrupole magnet using the exact relativistic Hamiltonian, including all kinematic nonlinearities.
+   Particle tracking is performed using symplectic integration based on the Hamiltonian splitting H = H_1 + H_2.
+   Here H_1 is the Hamiltonian for a linear quadrupole (containing all terms quadratic in the phase space variables),
+   and H_2 is the remainder (including the kinematic square root).  This suggested splitting is based on:
+
+   :param ds: Segment length in m.
+   :param k:  Quadrupole strength in m^(-2) (MADX convention, if unit = 0)
+              = (gradient in T/m) / (rigidity in T-m)
+          OR  Quadrupole strength in T/m (MaryLie convention, if unit = 1)
+              k > 0 horizontal focusing
+              k < 0 horizontal defocusing
+   :param unit: specification of units for quadrupole field strength
+   :param dx: horizontal translation error in m
+   :param dy: vertical translation error in m
+   :param rotation: rotation error in the transverse plane [degrees]
+   :param aperture_x: horizontal half-aperture (elliptical) in m
+   :param aperture_y: vertical half-aperture (elliptical) in m
+   :param int_order: the order used for symplectic integration (2 or 4)
+   :param mapsteps: number of integration steps per slice used for symplectic integration
+   :param nslice: number of slices used for the application of space charge
+   :param name: an optional name for the element
+   
+   .. py:property:: k
+   
+      quadrupole strength in 1/m^2 (or T/m)
+   
+   .. py:property:: unit
+   
+      unit specification for quad strength
+
+   .. py:property:: int_order
+   
+      the order used for symplectic integration (2 or 4)
+
+   .. py:property:: mapsteps
+   
+      number of integration steps per slice used for symplectic integration
+
 .. py:class:: impactx.elements.ChrPlasmaLens(ds, k, unit=0, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, nslice=1, name=None)
 
    An active cylindrically symmetric plasma lens, with chromatic effects included.

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -868,7 +868,10 @@ This module provides elements and methods for the accelerator lattice.
    A Quadrupole magnet using the exact relativistic Hamiltonian, including all kinematic nonlinearities.
    Particle tracking is performed using symplectic integration based on the Hamiltonian splitting H = H_1 + H_2.
    Here H_1 is the Hamiltonian for a linear quadrupole (containing all terms quadratic in the phase space variables),
-   and H_2 is the remainder (including the kinematic square root).  This suggested splitting is based on:
+   and H_2 is the remainder (including the kinematic square root).  This suggested splitting appears for example in:
+
+   D. L. Bruhwiler et al, in Proc. of EPAC 98, pp. 1171-1173 (1998).
+   E. Forest, J. Phys. A: Math. Gen. 39, 5321 (2006).
 
    :param ds: Segment length in m.
    :param k:  Quadrupole strength in m^(-2) (MADX convention, if unit = 0)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1365,7 +1365,7 @@ add_impactx_test(zero-bend-inverse.py
 )
 
 # Symplectic Integration in an Exact Nonlinear Quadrupole ##############
-#   
+#
 # no space charge
 add_impactx_test(examples-exact-quad
     examples/symplectic_integration/input_exact_quad.in

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -248,6 +248,20 @@ add_impactx_test(FODO.envelope.py
     OFF  # no plot script yet
 )
 
+# FODO Cell using nonlinear tracking ################################################
+#
+add_impactx_test(FODO-exact
+    examples/fodo/input_fodo_exact.in
+    ON  # ImpactX MPI-parallel
+    examples/fodo/analysis_fodo_exact.py
+    OFF  # no plot script yet
+)
+add_impactx_test(FODO-exact.py
+    examples/fodo/run_fodo_exact.py
+    ON  # ImpactX MPI-parallel
+    examples/fodo/analysis_fodo_exact.py
+    OFF  # no plot script yet
+)
 
 # Python: FODO Cell w/ programmed element for the Drifts ######################
 #

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1363,3 +1363,19 @@ add_impactx_test(zero-bend-inverse.py
     examples/reversibility/analysis_zero_bend_inverse.py
     OFF  # no plot script yet
 )
+
+# Symplectic Integration in an Exact Nonlinear Quadrupole ##############
+#   
+# no space charge
+add_impactx_test(examples-exact-quad
+    examples/symplectic_integration/input_exact_quad.in
+    ON   # ImpactX MPI-parallel
+    examples/symplectic_integration/analysis_exact_quad.py
+    OFF  # no plot script yet
+)
+add_impactx_test(examples-exact-quad.py
+    examples/symplectic_integration/run_exact_quad.py
+    ON   # ImpactX MPI-parallel
+    examples/symplectic_integration/analysis_exact_quad.py
+    OFF  # no plot script yet
+)

--- a/examples/fodo/README.rst
+++ b/examples/fodo/README.rst
@@ -137,3 +137,55 @@ We run the following script to analyze correctness:
    .. literalinclude:: analysis_fodo_envelope.py
       :language: python3
       :caption: You can copy this file from ``examples/fodo/analysis_fodo_envelope.py``.
+
+
+.. _examples-fodo-exact:
+
+FODO Cell Using Nonlinear Tracking
+===================================
+
+This is identical to the example ``examples-fodo``, except that fully nonlinear tracking is used based on the exact relativistic Hamiltonian.
+
+The kinematic nonlinear effects are essentially negligible, so this is primarily a test that the nonlinear elements correctly reproduce the results of linear tracking.
+
+The second moments of the particle distribution after the FODO cell should coincide with the second moments of the particle distribution before the FODO cell, to within the level expected due to 
+noise due to the finite particle population.
+
+In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+
+
+Run
+---
+
+This example can be run **either** as:
+
+* **Python** script: ``python3 run_fodo_exact.py`` or
+* ImpactX **executable** using an input file: ``impactx input_fodo_exact.in``
+
+For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+
+.. tab-set::
+
+   .. tab-item:: Python: Script
+
+       .. literalinclude:: run_fodo_exact.py
+          :language: python3
+          :caption: You can copy this file from ``examples/fodo/run_fodo_exact.py``.
+
+   .. tab-item:: Executable: Input File
+
+       .. literalinclude:: input_fodo_exact.in
+          :language: ini
+          :caption: You can copy this file from ``examples/fodo/input_fodo_exact.in``.
+
+
+Analyze
+
+We run the following script to analyze correctness:
+
+.. dropdown:: Script ``analysis_fodo_exact.py``
+
+   .. literalinclude:: analysis_fodo_exact.py
+      :language: python3
+      :caption: You can copy this file from ``examples/fodo/analysis_fodo_exact.py``.
+

--- a/examples/fodo/README.rst
+++ b/examples/fodo/README.rst
@@ -148,7 +148,7 @@ This is identical to the example ``examples-fodo``, except that fully nonlinear 
 
 The kinematic nonlinear effects are essentially negligible, so this is primarily a test that the nonlinear elements correctly reproduce the results of linear tracking.
 
-The second moments of the particle distribution after the FODO cell should coincide with the second moments of the particle distribution before the FODO cell, to within the level expected due to 
+The second moments of the particle distribution after the FODO cell should coincide with the second moments of the particle distribution before the FODO cell, to within the level expected due to
 noise due to the finite particle population.
 
 In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
@@ -188,4 +188,3 @@ We run the following script to analyze correctness:
    .. literalinclude:: analysis_fodo_exact.py
       :language: python3
       :caption: You can copy this file from ``examples/fodo/analysis_fodo_exact.py``.
-

--- a/examples/fodo/analysis_fodo_exact.py
+++ b/examples/fodo/analysis_fodo_exact.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+
+import numpy as np
+import openpmd_api as io
+from scipy.stats import moment
+
+
+def get_moments(beam):
+    """Calculate standard deviations of beam position & momenta
+    and emittance values
+
+    Returns
+    -------
+    sigx, sigy, sigt, emittance_x, emittance_y, emittance_t
+    """
+    sigx = moment(beam["position_x"], moment=2) ** 0.5  # variance -> std dev.
+    sigpx = moment(beam["momentum_x"], moment=2) ** 0.5
+    sigy = moment(beam["position_y"], moment=2) ** 0.5
+    sigpy = moment(beam["momentum_y"], moment=2) ** 0.5
+    sigt = moment(beam["position_t"], moment=2) ** 0.5
+    sigpt = moment(beam["momentum_t"], moment=2) ** 0.5
+
+    epstrms = beam.cov(ddof=0)
+    emittance_x = (sigx**2 * sigpx**2 - epstrms["position_x"]["momentum_x"] ** 2) ** 0.5
+    emittance_y = (sigy**2 * sigpy**2 - epstrms["position_y"]["momentum_y"] ** 2) ** 0.5
+    emittance_t = (sigt**2 * sigpt**2 - epstrms["position_t"]["momentum_t"] ** 2) ** 0.5
+
+    return (sigx, sigy, sigt, emittance_x, emittance_y, emittance_t)
+
+
+# initial/final beam
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+last_step = list(series.iterations)[-1]
+initial = series.iterations[1].particles["beam"].to_df()
+beam_final = series.iterations[last_step].particles["beam"]
+final = beam_final.to_df()
+
+# compare number of particles
+num_particles = 10000
+assert num_particles == len(initial)
+assert num_particles == len(final)
+
+print("Initial Beam:")
+sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(initial)
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
+print(
+    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
+)
+
+atol = 0.0  # ignored
+rtol = 2.2 * num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
+    [
+        7.5451170454175073e-005,
+        7.5441588239210947e-005,
+        9.9775878164077539e-004,
+        1.9959540393751392e-009,
+        2.0175015289132990e-009,
+        2.0013820193294972e-006,
+    ],
+    rtol=rtol,
+    atol=atol,
+)
+
+
+print("")
+print("Final Beam:")
+sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(final)
+s_ref = beam_final.get_attribute("s_ref")
+gamma_ref = beam_final.get_attribute("gamma_ref")
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
+print(
+    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}\n"
+    f"  s_ref={s_ref:e} gamma_ref={gamma_ref:e}"
+)
+
+atol = 0.0  # ignored
+rtol = 2.2 * num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t, s_ref, gamma_ref],
+    [
+        7.4790118496224206e-005,
+        7.5357525169680140e-005,
+        9.9775879288128088e-004,
+        1.9959539836392703e-009,
+        2.0175014668882125e-009,
+        2.0013820380883801e-006,
+        3.000000,
+        3.914902e003,
+    ],
+    rtol=rtol,
+    atol=atol,
+)

--- a/examples/fodo/input_fodo_exact.in
+++ b/examples/fodo/input_fodo_exact.in
@@ -1,0 +1,61 @@
+###############################################################################
+# Particle Beam(s)
+###############################################################################
+beam.npart = 10000
+beam.units = static
+beam.kin_energy = 2.0e3
+beam.charge = 1.0e-9
+beam.particle = electron
+beam.distribution = waterbag
+beam.lambdaX = 3.9984884770e-5
+beam.lambdaY = beam.lambdaX
+beam.lambdaT = 1.0e-3
+beam.lambdaPx = 2.6623538760e-5
+beam.lambdaPy = beam.lambdaPx
+beam.lambdaPt = 2.0e-3
+beam.muxpx = -0.846574929020762
+beam.muypy = -beam.muxpx
+beam.mutpt = 0.0
+
+
+###############################################################################
+# Beamline: lattice elements and segments
+###############################################################################
+lattice.elements = monitor drift1 monitor quad1 monitor drift2 monitor quad2 monitor drift3 monitor
+lattice.nslice = 1
+
+monitor.type = beam_monitor
+monitor.backend = h5
+
+drift1.type = drift_exact
+drift1.ds = 0.25
+
+quad1.type = quad_exact
+quad1.ds = 1.0
+quad1.k = 1.0
+quad1.int_order = 4
+quad1.mapsteps = 4
+
+drift2.type = drift_exact
+drift2.ds = 0.5
+
+quad2.type = quad_exact
+quad2.ds = 1.0
+quad2.k = -1.0
+quad2.int_order = 4
+quad2.mapsteps = 4
+
+drift3.type = drift_exact
+drift3.ds = 0.25
+
+
+###############################################################################
+# Algorithms
+###############################################################################
+algo.particle_shape = 2
+algo.space_charge = false
+
+###############################################################################
+# Diagnostics
+###############################################################################
+diag.slice_step_diagnostics = true

--- a/examples/fodo/run_fodo_exact.py
+++ b/examples/fodo/run_fodo_exact.py
@@ -56,7 +56,9 @@ fodo = [
     monitor,
     elements.ExactDrift(name="drift2", ds=0.5, nslice=ns),
     monitor,
-    elements.ExactQuad(name="quad2", ds=1.0, k=-1.0, int_order=4, nslice=ns, mapsteps=4),
+    elements.ExactQuad(
+        name="quad2", ds=1.0, k=-1.0, int_order=4, nslice=ns, mapsteps=4
+    ),
     monitor,
     elements.ExactDrift(name="drift3", ds=0.25, nslice=ns),
     monitor,

--- a/examples/fodo/run_fodo_exact.py
+++ b/examples/fodo/run_fodo_exact.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+from impactx import ImpactX, distribution, elements
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# load a 2 GeV electron beam with an initial
+# unnormalized rms emittance of 2 nm
+kin_energy_MeV = 2.0e3  # reference energy
+bunch_charge_C = 1.0e-9  # used with space charge
+npart = 10000  # number of macro particles
+
+#   reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
+
+#   particle bunch
+distr = distribution.Waterbag(
+    lambdaX=3.9984884770e-5,
+    lambdaY=3.9984884770e-5,
+    lambdaT=1.0e-3,
+    lambdaPx=2.6623538760e-5,
+    lambdaPy=2.6623538760e-5,
+    lambdaPt=2.0e-3,
+    muxpx=-0.846574929020762,
+    muypy=0.846574929020762,
+    mutpt=0.0,
+)
+sim.add_particles(bunch_charge_C, distr, npart)
+
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+
+# design the accelerator lattice)
+ns = 1  # number of slices per ds in the element
+fodo = [
+    monitor,
+    elements.ExactDrift(name="drift1", ds=0.25, nslice=ns),
+    monitor,
+    elements.ExactQuad(name="quad1", ds=1.0, k=1.0, int_order=4, nslice=ns, mapsteps=4),
+    monitor,
+    elements.ExactDrift(name="drift2", ds=0.5, nslice=ns),
+    monitor,
+    elements.ExactQuad(name="quad2", ds=1.0, k=-1.0, int_order=4, nslice=ns, mapsteps=4),
+    monitor,
+    elements.ExactDrift(name="drift3", ds=0.25, nslice=ns),
+    monitor,
+]
+# assign a fodo segment
+sim.lattice.extend(fodo)
+
+# run simulation
+sim.track_particles()
+
+# clean shutdown
+sim.finalize()

--- a/examples/symplectic_integration/README.rst
+++ b/examples/symplectic_integration/README.rst
@@ -1,0 +1,51 @@
+.. _examples-exact-quad:
+
+Symplectic Integration in an Exact Quadrupole
+==============================================
+
+This benchmark tests the use of the ExactQuad (quadrupole_exact) element for integrating through a quadrupole using the exact nonlinear Hamiltonian.
+
+A 25 pC electron bunch with 100 MeV total energy, a small initial rms beam size of (3.9, 3.9, 1.0) microns, 2 mrad transverse divergence and 2.5% energy spread undergoes rapid expansion followed 
+by transverse focusing in a quadrupole doublet.  The parameters are chosen such that chromatic focusing effects are important.
+
+In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+
+In addition, the Hamiltonian value is computed for each particle at the entrance and exit of the final quadrupole.  The change in the Hamiltonian value, taken relative to the standard deviation 
+:math:`\sigma_H` over particles, must be smaller than the allowed tolerance (here, taken to be 0.1%).
+
+Run
+---
+
+This example can be run **either** as:
+
+* **Python** script: ``python3 run_exact_quad.py`` or
+* ImpactX **executable** using an input file: ``impactx input_exact_quad.in``
+
+For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+
+.. tab-set::
+
+   .. tab-item:: Python: Script
+
+       .. literalinclude:: run_exact_quad.py
+          :language: python3
+          :caption: You can copy this file from ``examples/symplectic_integration/run_exact_quad.py``.
+
+   .. tab-item:: Executable: Input File
+
+       .. literalinclude:: input_exact_quad.in
+          :language: ini
+          :caption: You can copy this file from ``examples/symplectic_integration/input_exact_quad.in``.
+
+
+Analyze
+-------
+
+We run the following script to analyze correctness:
+
+.. dropdown:: Script ``analysis_exact_quad.py``
+
+   .. literalinclude:: analysis_exact_quad.py
+      :language: python3
+      :caption: You can copy this file from ``examples/symplectic_integration/analysis_exact_quad.py``.
+

--- a/examples/symplectic_integration/README.rst
+++ b/examples/symplectic_integration/README.rst
@@ -5,12 +5,12 @@ Symplectic Integration in an Exact Quadrupole
 
 This benchmark tests the use of the ExactQuad (quadrupole_exact) element for integrating through a quadrupole using the exact nonlinear Hamiltonian.
 
-A 25 pC electron bunch with 100 MeV total energy, a small initial rms beam size of (3.9, 3.9, 1.0) microns, 2 mrad transverse divergence and 2.5% energy spread undergoes rapid expansion followed 
+A 25 pC electron bunch with 100 MeV total energy, a small initial rms beam size of (3.9, 3.9, 1.0) microns, 2 mrad transverse divergence and 2.5% energy spread undergoes rapid expansion followed
 by transverse focusing in a quadrupole doublet.  The parameters are chosen such that chromatic focusing effects are important.
 
 In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
-In addition, the Hamiltonian value is computed for each particle at the entrance and exit of the final quadrupole.  The change in the Hamiltonian value, taken relative to the standard deviation 
+In addition, the Hamiltonian value is computed for each particle at the entrance and exit of the final quadrupole.  The change in the Hamiltonian value, taken relative to the standard deviation
 :math:`\sigma_H` over particles, must be smaller than the allowed tolerance (here, taken to be 0.1%).
 
 Run
@@ -48,4 +48,3 @@ We run the following script to analyze correctness:
    .. literalinclude:: analysis_exact_quad.py
       :language: python3
       :caption: You can copy this file from ``examples/symplectic_integration/analysis_exact_quad.py``.
-

--- a/examples/symplectic_integration/analysis_exact_quad.py
+++ b/examples/symplectic_integration/analysis_exact_quad.py
@@ -7,8 +7,9 @@
 
 import numpy as np
 import openpmd_api as io
+from scipy.constants import c, e, m_e
 from scipy.stats import moment
-from scipy.constants import m_e, e, c
+
 
 def get_moments(beam):
     """Calculate standard deviations of beam position & momenta
@@ -32,6 +33,7 @@ def get_moments(beam):
 
     return (sigx, sigy, sigt, emittance_x, emittance_y, emittance_t)
 
+
 # initial/final beam
 series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
 
@@ -45,10 +47,10 @@ final = beam_final.to_df()
 num_particles = 10000
 assert num_particles == len(initial)
 assert num_particles == len(final)
-    
+
 print("Initial Beam:")
 sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(initial)
-print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")  
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
 print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
 )
@@ -69,7 +71,7 @@ assert np.allclose(
     ],
     rtol=rtol,
     atol=atol,
-)   
+)
 
 print("")
 print("Final Beam:")
@@ -81,11 +83,11 @@ print(
     f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}\n"
     f"  s_ref={s_ref:e} gamma_ref={gamma_ref:e}"
 )
-    
+
 atol = 0.0  # ignored
 rtol = 2.2 * num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
-        
+
 assert np.allclose(
     [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
     [
@@ -117,17 +119,27 @@ ptf = beam_joined["momentum_t_final"]
 # Parameters appearing in the Hamiltonian
 beta_ref = beam_final.get_attribute("beta_ref")
 bg_ref = beam_final.get_attribute("beta_gamma_ref")
-rigidity = m_e*bg_ref*c/e
+rigidity = m_e * bg_ref * c / e
 B_gradient = 207.0
 k = B_gradient / rigidity
 
 # Evaluate the change in Hamiltonian value for each particle
-Hi = -np.sqrt(1.0 - 2.0/beta_ref*pti + pti**2 - pxi**2 - pyi**2) + (k/2.0)*(xi**2 - yi**2) - pti/beta_ref + 1.0
-Hf = -np.sqrt(1.0 - 2.0/beta_ref*ptf + ptf**2 - pxf**2 - pyf**2) + (k/2.0)*(xf**2 - yf**2) - ptf/beta_ref + 1.0
+Hi = (
+    -np.sqrt(1.0 - 2.0 / beta_ref * pti + pti**2 - pxi**2 - pyi**2)
+    + (k / 2.0) * (xi**2 - yi**2)
+    - pti / beta_ref
+    + 1.0
+)
+Hf = (
+    -np.sqrt(1.0 - 2.0 / beta_ref * ptf + ptf**2 - pxf**2 - pyf**2)
+    + (k / 2.0) * (xf**2 - yf**2)
+    - ptf / beta_ref
+    + 1.0
+)
 
 H_sigma = (np.std(Hi) + np.std(Hf)) / 2.0
 dH = (Hf - Hi).abs()
-dH_max_relative = dH.max()/H_sigma
+dH_max_relative = dH.max() / H_sigma
 
 # particle-wise comparison of H & I initial to final
 atol = 1.0e-3

--- a/examples/symplectic_integration/analysis_exact_quad.py
+++ b/examples/symplectic_integration/analysis_exact_quad.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+import numpy as np
+import openpmd_api as io
+from scipy.stats import moment
+from scipy.constants import m_e, e, c
+
+def get_moments(beam):
+    """Calculate standard deviations of beam position & momenta
+    and emittance values
+
+    Returns
+    -------
+    sigx, sigy, sigt, emittance_x, emittance_y, emittance_t
+    """
+    sigx = moment(beam["position_x"], moment=2) ** 0.5  # variance -> std dev.
+    sigpx = moment(beam["momentum_x"], moment=2) ** 0.5
+    sigy = moment(beam["position_y"], moment=2) ** 0.5
+    sigpy = moment(beam["momentum_y"], moment=2) ** 0.5
+    sigt = moment(beam["position_t"], moment=2) ** 0.5
+    sigpt = moment(beam["momentum_t"], moment=2) ** 0.5
+
+    epstrms = beam.cov(ddof=0)
+    emittance_x = (sigx**2 * sigpx**2 - epstrms["position_x"]["momentum_x"] ** 2) ** 0.5
+    emittance_y = (sigy**2 * sigpy**2 - epstrms["position_y"]["momentum_y"] ** 2) ** 0.5
+    emittance_t = (sigt**2 * sigpt**2 - epstrms["position_t"]["momentum_t"] ** 2) ** 0.5
+
+    return (sigx, sigy, sigt, emittance_x, emittance_y, emittance_t)
+
+# initial/final beam
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+
+initial_step = list(series.iterations)[0]
+last_step = list(series.iterations)[-1]
+initial = series.iterations[initial_step].particles["beam"].to_df()
+beam_final = series.iterations[last_step].particles["beam"]
+final = beam_final.to_df()
+
+# compare number of particles
+num_particles = 10000
+assert num_particles == len(initial)
+assert num_particles == len(final)
+    
+print("Initial Beam:")
+sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(initial)
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")  
+print(
+    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
+)
+
+atol = 0.0  # ignored
+rtol = 3.0 * num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
+    [
+        1.768569e-04,
+        1.195967e-04,
+        1.034426e-06,
+        1.356459e-08,
+        9.374827e-09,
+        2.581087e-08,
+    ],
+    rtol=rtol,
+    atol=atol,
+)   
+
+print("")
+print("Final Beam:")
+sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(final)
+s_ref = beam_final.get_attribute("s_ref")
+gamma_ref = beam_final.get_attribute("gamma_ref")
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
+print(
+    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}\n"
+    f"  s_ref={s_ref:e} gamma_ref={gamma_ref:e}"
+)
+    
+atol = 0.0  # ignored
+rtol = 2.2 * num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+        
+assert np.allclose(
+    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
+    [
+        2.458574e-04,
+        1.513417e-04,
+        1.068497e-06,
+        1.797301e-08,
+        1.009999e-08,
+        2.661524e-08,
+    ],
+    rtol=rtol,
+    atol=atol,
+)
+
+
+# join tables on particle ID, so we can compare the same particle initial->final
+beam_joined = final.join(initial, lsuffix="_final", rsuffix="_initial")
+xi = beam_joined["position_x_initial"]
+yi = beam_joined["position_y_initial"]
+pxi = beam_joined["momentum_x_initial"]
+pyi = beam_joined["momentum_y_initial"]
+pti = beam_joined["momentum_t_initial"]
+xf = beam_joined["position_x_final"]
+yf = beam_joined["position_y_final"]
+pxf = beam_joined["momentum_x_final"]
+pyf = beam_joined["momentum_y_final"]
+ptf = beam_joined["momentum_t_final"]
+
+# Parameters appearing in the Hamiltonian
+beta_ref = beam_final.get_attribute("beta_ref")
+bg_ref = beam_final.get_attribute("beta_gamma_ref")
+rigidity = m_e*bg_ref*c/e
+B_gradient = 207.0
+k = B_gradient / rigidity
+
+# Evaluate the change in Hamiltonian value for each particle
+Hi = -np.sqrt(1.0 - 2.0/beta_ref*pti + pti**2 - pxi**2 - pyi**2) + (k/2.0)*(xi**2 - yi**2) - pti/beta_ref + 1.0
+Hf = -np.sqrt(1.0 - 2.0/beta_ref*ptf + ptf**2 - pxf**2 - pyf**2) + (k/2.0)*(xf**2 - yf**2) - ptf/beta_ref + 1.0
+
+H_sigma = (np.std(Hi) + np.std(Hf)) / 2.0
+dH = (Hf - Hi).abs()
+dH_max_relative = dH.max()/H_sigma
+
+# particle-wise comparison of H & I initial to final
+atol = 1.0e-3
+rtol = 0.0  # large number
+print()
+print(f"  atol={atol} (ignored: rtol~={rtol})")
+
+print(f"  Standard deviation in H: H_sigma = {H_sigma}")
+print(f"  dH_max relative to H_sigma = {dH_max_relative}")
+assert np.allclose(dH_max_relative, 0.0, rtol=rtol, atol=atol)

--- a/examples/symplectic_integration/input_exact_quad.in
+++ b/examples/symplectic_integration/input_exact_quad.in
@@ -41,9 +41,9 @@ quad1.k = -207.0
 quad1.units = 1
 quad1.mapsteps = 5
 
-quad2.type = quad_exact    
+quad2.type = quad_exact
 quad2.ds = 0.02903
-quad2.k = 207.0   
+quad2.k = 207.0
 quad2.units = 1
 quad2.mapsteps = 5
 

--- a/examples/symplectic_integration/input_exact_quad.in
+++ b/examples/symplectic_integration/input_exact_quad.in
@@ -1,0 +1,60 @@
+###############################################################################
+# Particle Beam(s)
+###############################################################################
+beam.npart = 10000
+beam.units = static
+beam.kin_energy = 99.48900104
+beam.charge = 25.0e-12
+beam.particle = electron
+beam.distribution = triangle_from_twiss
+beam.alphaX = 0.0
+beam.alphaY = 0.0
+beam.alphaT = 0.0
+beam.betaX = 0.002
+beam.betaY = beam.betaX
+beam.betaT = 0.00004
+beam.emittX = 7.626114e-9
+beam.emittY = beam.emittX
+beam.emittT = 2.5e-08
+
+
+###############################################################################
+# Beamline: lattice elements and segments
+###############################################################################
+lattice.elements = monitor0 drift1 quad1 monitor1 quad2 monitor1
+lattice.nslice = 1
+
+monitor0.type = beam_monitor
+monitor0.name = "monitor0"
+monitor0.backend = h5
+
+monitor1.type = beam_monitor
+monitor1.name = "monitor"
+monitor1.backend = h5
+
+drift1.type = drift_exact
+drift1.ds = 0.046
+
+quad1.type = quad_exact
+quad1.ds = 0.02903
+quad1.k = -207.0
+quad1.units = 1
+quad1.mapsteps = 5
+
+quad2.type = quad_exact    
+quad2.ds = 0.02903
+quad2.k = 207.0   
+quad2.units = 1
+quad2.mapsteps = 5
+
+###############################################################################
+# Algorithms
+###############################################################################
+algo.particle_shape = 2
+algo.space_charge = false
+
+
+###############################################################################
+# Diagnostics
+###############################################################################
+diag.slice_step_diagnostics = true

--- a/examples/symplectic_integration/run_exact_quad.py
+++ b/examples/symplectic_integration/run_exact_quad.py
@@ -6,9 +6,10 @@
 #
 # -*- coding: utf-8 -*-
 
-from impactx import ImpactX, distribution, elements, twiss
-from scipy.constants import m_e, e, c
 import numpy as np
+from scipy.constants import c, e, m_e
+
+from impactx import ImpactX, distribution, elements, twiss
 
 sim = ImpactX()
 
@@ -32,21 +33,21 @@ ref = sim.particle_container().ref_particle()
 ref.set_charge_qe(-1.0).set_mass_MeV(mass_MeV).set_kin_energy_MeV(kin_energy_MeV)
 
 # factors converting the beam distribution to ImpactX input
-gamma = total_energy_MeV/mass_MeV
-bg = np.sqrt(gamma**2-1.0)
-sigma_tau = 1e-6  #in m
-sigma_p = 2.5e-2  #dimensionless
-rigidity = m_e*c*bg/e
+gamma = total_energy_MeV / mass_MeV
+bg = np.sqrt(gamma**2 - 1.0)
+sigma_tau = 1e-6  # in m
+sigma_p = 2.5e-2  # dimensionless
+rigidity = m_e * c * bg / e
 
 #   particle bunch
 distr = distribution.Triangle(
     **twiss(
         beta_x=0.002,
         beta_y=0.002,
-        beta_t=sigma_tau/sigma_p,
-        emitt_x=1.5e-6/bg,
-        emitt_y=1.5e-6/bg,
-        emitt_t=sigma_tau*sigma_p,
+        beta_t=sigma_tau / sigma_p,
+        emitt_x=1.5e-6 / bg,
+        emitt_y=1.5e-6 / bg,
+        emitt_t=sigma_tau * sigma_p,
         alpha_x=0.0,
         alpha_y=0.0,
         alpha_t=0.0,
@@ -64,15 +65,19 @@ monitor1 = elements.BeamMonitor("monitor", backend="h5")
 # element names consistent with HTU_base_lattice_matched.lte Elegant input
 
 drift1 = elements.ExactDrift(name="drift1", ds=0.046, nslice=ns)
-quad1 = elements.ExactQuad(name="quad1", ds=0.02903, k=-207.0, unit=1, mapsteps=5, nslice=ns)
-quad2 = elements.ExactQuad(name="quad2", ds=0.02890, k=207.0, unit=1, mapsteps=5, nslice=ns)
+quad1 = elements.ExactQuad(
+    name="quad1", ds=0.02903, k=-207.0, unit=1, mapsteps=5, nslice=ns
+)
+quad2 = elements.ExactQuad(
+    name="quad2", ds=0.02890, k=207.0, unit=1, mapsteps=5, nslice=ns
+)
 
 # set the lattice
 sim.lattice.append(monitor0)
 sim.lattice.append(drift1)
-sim.lattice.append(quad1)  
+sim.lattice.append(quad1)
 sim.lattice.append(monitor1)
-sim.lattice.append(quad2)  
+sim.lattice.append(quad2)
 sim.lattice.append(monitor1)
 
 # run simulation

--- a/examples/symplectic_integration/run_exact_quad.py
+++ b/examples/symplectic_integration/run_exact_quad.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+from impactx import ImpactX, distribution, elements, twiss
+from scipy.constants import m_e, e, c
+import numpy as np
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = False
+sim.slice_step_diagnostics = True
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# basic beam parameters
+total_energy_MeV = 100.0  # reference energy (total)
+mass_MeV = 0.510998950  # particle mass
+kin_energy_MeV = total_energy_MeV - mass_MeV
+bunch_charge_C = 25.0e-12  # used with space charge
+npart = 10000  # number of macro particles
+
+# set reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(-1.0).set_mass_MeV(mass_MeV).set_kin_energy_MeV(kin_energy_MeV)
+
+# factors converting the beam distribution to ImpactX input
+gamma = total_energy_MeV/mass_MeV
+bg = np.sqrt(gamma**2-1.0)
+sigma_tau = 1e-6  #in m
+sigma_p = 2.5e-2  #dimensionless
+rigidity = m_e*c*bg/e
+
+#   particle bunch
+distr = distribution.Triangle(
+    **twiss(
+        beta_x=0.002,
+        beta_y=0.002,
+        beta_t=sigma_tau/sigma_p,
+        emitt_x=1.5e-6/bg,
+        emitt_y=1.5e-6/bg,
+        emitt_t=sigma_tau*sigma_p,
+        alpha_x=0.0,
+        alpha_y=0.0,
+        alpha_t=0.0,
+    )
+)
+sim.add_particles(bunch_charge_C, distr, npart)
+
+# design the accelerator lattice
+ns = 1  # number of slices per ds in the element
+
+# add beam diagnostics
+monitor0 = elements.BeamMonitor("monitor0", backend="h5")
+monitor1 = elements.BeamMonitor("monitor", backend="h5")
+
+# element names consistent with HTU_base_lattice_matched.lte Elegant input
+
+drift1 = elements.ExactDrift(name="drift1", ds=0.046, nslice=ns)
+quad1 = elements.ExactQuad(name="quad1", ds=0.02903, k=-207.0, unit=1, mapsteps=5, nslice=ns)
+quad2 = elements.ExactQuad(name="quad2", ds=0.02890, k=207.0, unit=1, mapsteps=5, nslice=ns)
+
+# set the lattice
+sim.lattice.append(monitor0)
+sim.lattice.append(drift1)
+sim.lattice.append(quad1)  
+sim.lattice.append(monitor1)
+sim.lattice.append(quad2)  
+sim.lattice.append(monitor1)
+
+# run simulation
+sim.track_particles()
+
+# clean shutdown
+sim.finalize()

--- a/src/elements/All.H
+++ b/src/elements/All.H
@@ -22,6 +22,7 @@
 #include "Drift.H"
 #include "Empty.H"
 #include "ExactDrift.H"
+#include "ExactQuad.H"
 #include "ExactSbend.H"
 #include "Kicker.H"
 #include "LinearMap.H"
@@ -62,6 +63,7 @@ namespace impactx::elements
         DipEdge,
         Drift,
         ExactDrift,
+        ExactQuad,
         ExactSbend,
         Kicker,
         LinearMap,

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -174,7 +174,7 @@ namespace impactx::elements
                 integrators::symp4_integrate_particle(particle,zin,zout,nsteps,*this);
             } else {
                 integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);
-                throw std::runtime_error(std::string(type) + ": Order of integration must be 2 or 4.");
+                throw std::runtime_error("ExactQuad: Order of integration must be 2 or 4.");
             }
 
             // assign updated values

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -23,7 +23,6 @@
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Print.H>
-#include <ablastr/warn_manager/WarnManager.H>
 
 #include <cmath>
 
@@ -175,13 +174,7 @@ namespace impactx::elements
                 integrators::symp4_integrate_particle(particle,zin,zout,nsteps,*this);
             } else {
                 integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);
-                ablastr::warn_manager::WMRecordWarning(
-                        "Impactx::elements::ExactQuad",
-                        "The integer parameter int_order describing the order "
-                        "of symplectic integration in the external fields must "
-                        "be 2 or 4.  Order 2 is being used by default. ",
-                        ablastr::warn_manager::WarnPriority::medium
-                );
+                throw std::runtime_error(std::string(type) + ": Order of integration must be 2 or 4.");
             }
 
             // assign updated values

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -23,6 +23,7 @@
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Print.H>
+#include <ablastr/warn_manager/WarnManager.H>
 
 #include <cmath>
 
@@ -61,6 +62,7 @@ namespace impactx::elements
          * @param rotation_degree rotation error in the transverse plane [degrees]
          * @param aperture_x horizontal half-aperture in m
          * @param aperture_y vertical half-aperture in m
+         * @param int_order order used for symplectic integration (2 or 4)
          * @param mapsteps number of integration steps per slice used for
          *        particle push in the applied fields
          * @param nslice number of slices used for the application of space charge
@@ -75,6 +77,7 @@ namespace impactx::elements
             amrex::ParticleReal rotation_degree = 0,
             amrex::ParticleReal aperture_x = 0,
             amrex::ParticleReal aperture_y = 0,
+            int int_order = 2,
             int mapsteps = 1,
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
@@ -83,7 +86,7 @@ namespace impactx::elements
           Thick(ds, nslice),
           Alignment(dx, dy, rotation_degree),
           PipeAperture(aperture_x, aperture_y),
-          m_k(k),m_unit(unit),m_mapsteps(mapsteps)
+          m_k(k),m_unit(unit),m_int_order(int_order),m_mapsteps(mapsteps)
         {
         }
 
@@ -166,8 +169,20 @@ namespace impactx::elements
             };
 
             // call integrator to advance through slice
-            integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);
-//            integrators::symp4_integrate_particle(particle,zin,zout,nsteps,*this);
+            if (m_int_order == 2) {
+                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);
+            } else if (m_int_order == 4) {
+                integrators::symp4_integrate_particle(particle,zin,zout,nsteps,*this);
+            } else {
+                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);
+                ablastr::warn_manager::WMRecordWarning(
+                        "Impactx::elements::ExactQuad",
+                        "The integer parameter int_order describing the order "
+                        "of symplectic integration in the external fields must "
+                        "be 2 or 4.  Order 2 is being used by default. ",
+                        ablastr::warn_manager::WarnPriority::medium
+                );
+            }
 
             // assign updated values
             x = particle(1);
@@ -398,6 +413,7 @@ namespace impactx::elements
 
         amrex::ParticleReal m_k; //! quadrupole strength in 1/m^2 (or T/m)
         int m_unit; //! unit specification for quad strength
+        int m_int_order; //! order used for the symplectic integration (2 or 4)
         int m_mapsteps; //! number of integration steps per slice
 
     private:

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -283,12 +283,20 @@ namespace impactx::elements
             amrex::ParticleReal const t = particle(5);
             amrex::ParticleReal const pt = particle(6);
 
-            // Leave the coordinates unchanged for now.
-            particle(1) = x;
+            // compute the radical in the denominator (= pz):
+            amrex::ParticleReal const inv_pzden = 1_prt / std::sqrt(
+                std::pow(pt - m_ibeta, 2) -
+                m_ibetgam2 -
+                std::pow(px, 2) -
+                std::pow(py, 2)
+            );
+
+            // The momenta are not affected.
+            particle(1) = x + tau * px * (-1_prt + inv_pzden);
             particle(2) = px;
-            particle(3) = y;
+            particle(3) = y + tau * py * (-1_prt + inv_pzden);
             particle(4) = py;
-            particle(5) = t;
+            particle(5) = t + tau * (-m_ibeta - m_ibetgam2*pt + inv_pzden*(1_prt - pt*m_beta));
             particle(6) = pt;
         }
 

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -25,7 +25,7 @@
 #include <AMReX_Print.H>
 
 #include <cmath>
-
+#include <stdexcept>
 
 namespace impactx::elements
 {

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -260,7 +260,7 @@ namespace impactx::elements
             particle(5) = tout;
             particle(6) = ptout;
 
-            zeval = zeval;
+            zeval += 0_prt;
         }
 
         /** This pushes a particle in an ExactQuad element through
@@ -398,6 +398,7 @@ namespace impactx::elements
 
         amrex::ParticleReal m_k; //! quadrupole strength in 1/m^2 (or T/m)
         int m_unit; //! unit specification for quad strength
+        int m_mapsteps; //! number of integration steps per slice
 
     private:
         // constants that are independent of the individually tracked particle,
@@ -409,7 +410,6 @@ namespace impactx::elements
         amrex::ParticleReal m_ibeta;          //! 1 / m_beta
         amrex::ParticleReal m_g;              //! quadrupole strength in 1/m^2
         amrex::ParticleReal m_omega;
-        int m_mapsteps; //! number of integration steps per slice
     };
 
 } // namespace impactx

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -151,9 +151,9 @@ namespace impactx::elements
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
 
-            // coordinates within the quad
-            amrex::ParticleReal const s = refpart.s;
-            amrex::ParticleReal const sedge = refpart.sedge;
+            // coordinates within the quad (not needed)
+            //amrex::ParticleReal const s = refpart.s;
+            //amrex::ParticleReal const sedge = refpart.sedge;
 
             // numerical integration parameters
             amrex::ParticleReal const zin = 0_prt;
@@ -298,6 +298,8 @@ namespace impactx::elements
             particle(4) = py;
             particle(5) = t + tau * (-m_ibeta - m_ibetgam2*pt + inv_pzden*(1_prt - pt*m_beta));
             particle(6) = pt;
+
+            zeval += tau;
         }
 
 

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -112,7 +112,7 @@ namespace impactx::elements
             m_ibetgam2 = 1_prt / m_betgam2;
             m_beta = refpart.beta();
             m_ibeta = 1_prt / m_beta;
-        
+
             // normalize quad units to MAD-X convention if needed
             m_g = m_unit == 1 ? m_k / refpart.rigidity_Tm() : m_k;
 
@@ -154,13 +154,13 @@ namespace impactx::elements
             // coordinates within the quad
             amrex::ParticleReal const s = refpart.s;
             amrex::ParticleReal const sedge = refpart.sedge;
-         
+
             // numerical integration parameters
             amrex::ParticleReal const zin = 0_prt;
             amrex::ParticleReal const zout = m_slice_ds;
             int const nsteps = m_mapsteps;
 
-            // initialize phase space 6-vector 
+            // initialize phase space 6-vector
             amrex::SmallVector<amrex::ParticleReal, 6, 1> particle{
                 x, px, y, py, t, pt
             };
@@ -185,7 +185,7 @@ namespace impactx::elements
         }
 
         /** This pushes a particle in an ExactQuad element through
-         *  the symplectic map associated with H_1 in the Hamiltonian 
+         *  the symplectic map associated with H_1 in the Hamiltonian
          *  splitting H = H_1 + H_2.  This is exactly the linear
          *  map of a quadrupole.
          *
@@ -215,7 +215,7 @@ namespace impactx::elements
             amrex::ParticleReal ptout = pt;
 
             amrex::ParticleReal const sin_omega_ds = std::sin(m_omega*tau);
-            amrex::ParticleReal const cos_omega_ds = std::cos(m_omega*tau);  
+            amrex::ParticleReal const cos_omega_ds = std::cos(m_omega*tau);
             amrex::ParticleReal const sinh_omega_ds = std::sinh(m_omega*tau);
             amrex::ParticleReal const cosh_omega_ds = std::cosh(m_omega*tau);
             amrex::ParticleReal const slice_bg = tau / m_betgam2;
@@ -228,7 +228,7 @@ namespace impactx::elements
 
                 yout = cosh_omega_ds*y + sinh_omega_ds/m_omega*py;
                 pyout = m_omega*sinh_omega_ds*y + cosh_omega_ds*py;
-            
+
                 tout = t + (slice_bg)*pt;
                 // ptout = pt;
             } else if (m_g < 0.0_prt)
@@ -239,7 +239,7 @@ namespace impactx::elements
 
                 yout = cos_omega_ds*y + sin_omega_ds/m_omega*py;
                 pyout = -m_omega*sin_omega_ds*y + cos_omega_ds*py;
-         
+
                 tout = t + slice_bg*pt;
                 // ptout = pt;
             } else {
@@ -275,14 +275,14 @@ namespace impactx::elements
                    amrex::ParticleReal & zeval) const
         {
             using namespace amrex::literals; // for _rt and _prt
-            
+
             amrex::ParticleReal const x = particle(1);
             amrex::ParticleReal const px = particle(2);
             amrex::ParticleReal const y = particle(3);
             amrex::ParticleReal const py = particle(4);
             amrex::ParticleReal const t = particle(5);
             amrex::ParticleReal const pt = particle(6);
-            
+
             // Leave the coordinates unchanged for now.
             particle(1) = x;
             particle(2) = px;
@@ -341,11 +341,11 @@ namespace impactx::elements
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
-             
+
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
             amrex::ParticleReal const betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
-        
+
             // compute phase advance per unit length in s (in rad/m)
             amrex::ParticleReal const omega = std::sqrt(std::abs(m_k));
 
@@ -356,8 +356,8 @@ namespace impactx::elements
                 R(1,1) = std::cos(omega*slice_ds);
                 R(1,2) = std::sin(omega*slice_ds)/omega;
                 R(2,1) = -omega*std::sin(omega*slice_ds);
-                R(2,2) = std::cos(omega*slice_ds);  
-                R(3,3) = std::cosh(omega*slice_ds);   
+                R(2,2) = std::cos(omega*slice_ds);
+                R(3,3) = std::cosh(omega*slice_ds);
                 R(3,4) = std::sinh(omega*slice_ds)/omega;
                 R(4,3) = omega*std::sinh(omega*slice_ds);
                 R(4,4) = std::cosh(omega*slice_ds);
@@ -373,7 +373,7 @@ namespace impactx::elements
                 R(4,4) = std::cos(omega*slice_ds);
                 R(5,6) = slice_ds/betgam2;
             } else {
-                R(1,2) = m_slice_ds; 
+                R(1,2) = m_slice_ds;
                 R(3,4) = m_slice_ds;
                 R(5,6) = m_slice_ds / betgam2;
             }

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -1,0 +1,405 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Chad Mitchell, Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_EXACTQUAD_H
+#define IMPACTX_EXACTQUAD_H
+
+#include "particles/ImpactXParticleContainer.H"
+#include "particles/integrators/Integrators.H"
+#include "mixin/alignment.H"
+#include "mixin/pipeaperture.H"
+#include "mixin/beamoptic.H"
+#include "mixin/thick.H"
+#include "mixin/named.H"
+#include "mixin/nofinalize.H"
+#include "mixin/lineartransport.H"
+
+#include <AMReX_Extension.H>
+#include <AMReX_REAL.H>
+#include <AMReX_Print.H>
+
+#include <cmath>
+
+
+namespace impactx::elements
+{
+    struct ExactQuad
+    : public mixin::Named,
+      public mixin::BeamOptic<ExactQuad>,
+      public mixin::LinearTransport<ExactQuad>,
+      public mixin::Thick,
+      public mixin::Alignment,
+      public mixin::PipeAperture,
+      public mixin::NoFinalize
+    {
+        static constexpr auto type = "ExactQuad";
+        using PType = ImpactXParticleContainer::ParticleType;
+
+        /** A Quadrupole magnet treated using the exact Hamiltonian, which
+         *  includes all nonlinear kinematic effects.  Like the element Quad,
+         *  a hard-edge model of the magnetic field is used.  Symplectic
+         *  integration is used based on a splitting of the Hamiltonian
+         *  described in [to be cited].
+         *
+         * @param ds Segment length in m.
+         * @param k  Quadrupole strength in m^(-2) (MADX convention)
+         *           = (gradient in T/m) / (rigidity in T-m)
+         *        OR Quadrupole strength in T/m (MaryLie convention)
+         *           k > 0 horizontal focusing
+         *           k < 0 horizontal defocusing
+         * @param unit  Unit specification
+         *           unit = 0 MADX convention (default)
+         *           unit = 1 MaryLie convention
+         * @param dx horizontal translation error in m
+         * @param dy vertical translation error in m
+         * @param rotation_degree rotation error in the transverse plane [degrees]
+         * @param aperture_x horizontal half-aperture in m
+         * @param aperture_y vertical half-aperture in m
+         * @param mapsteps number of integration steps per slice used for
+         *        particle push in the applied fields
+         * @param nslice number of slices used for the application of space charge
+         * @param name a user defined and not necessarily unique name of the element
+         */
+        ExactQuad (
+            amrex::ParticleReal ds,
+            amrex::ParticleReal k,
+            int unit,
+            amrex::ParticleReal dx = 0,
+            amrex::ParticleReal dy = 0,
+            amrex::ParticleReal rotation_degree = 0,
+            amrex::ParticleReal aperture_x = 0,
+            amrex::ParticleReal aperture_y = 0,
+            int mapsteps = 1,
+            int nslice = 1,
+            std::optional<std::string> name = std::nullopt
+        )
+        : Named(std::move(name)),
+          Thick(ds, nslice),
+          Alignment(dx, dy, rotation_degree),
+          PipeAperture(aperture_x, aperture_y),
+          m_k(k),m_unit(unit),m_mapsteps(mapsteps)
+        {
+        }
+
+        /** Push all particles */
+        using BeamOptic::operator();
+
+        /** Compute and cache the constants for the push.
+         *
+         * In particular, used to pre-compute and cache variables that are
+         * independent of the individually tracked particle.
+         *
+         * @param refpart reference particle
+         */
+        void compute_constants (RefPart const & refpart)
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            Alignment::compute_constants(refpart);
+
+            // length of the current slice
+            m_slice_ds = m_ds / nslice();
+
+            // find beta*gamma^2
+            amrex::ParticleReal const pt_ref = refpart.pt;
+            m_betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
+            m_ibetgam2 = 1_prt / m_betgam2;
+            m_beta = refpart.beta();
+            m_ibeta = 1_prt / m_beta;
+        
+            // normalize quad units to MAD-X convention if needed
+            m_g = m_unit == 1 ? m_k / refpart.rigidity_Tm() : m_k;
+
+            // compute phase advance per unit length in s (in rad/m)
+            m_omega = std::sqrt(std::abs(m_g));
+
+        }
+
+        /** This is a quad functor, so that a variable of this type can be used like a quad function.
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
+         *
+         * @param x particle position in x
+         * @param y particle position in y
+         * @param t particle position in t
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param idcpu particle global index
+         * @param refpart reference particle (unused)
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void operator() (
+            amrex::ParticleReal & AMREX_RESTRICT x,
+            amrex::ParticleReal & AMREX_RESTRICT y,
+            amrex::ParticleReal & AMREX_RESTRICT t,
+            amrex::ParticleReal & AMREX_RESTRICT px,
+            amrex::ParticleReal & AMREX_RESTRICT py,
+            amrex::ParticleReal & AMREX_RESTRICT pt,
+            uint64_t & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            // shift due to alignment errors of the element
+            shift_in(x, y, px, py);
+
+            // coordinates within the quad
+            amrex::ParticleReal const s = refpart.s;
+            amrex::ParticleReal const sedge = refpart.sedge;
+         
+            // numerical integration parameters
+            amrex::ParticleReal const zin = 0_prt;
+            amrex::ParticleReal const zout = m_slice_ds;
+            int const nsteps = m_mapsteps;
+
+            // initialize phase space 6-vector 
+            amrex::SmallVector<amrex::ParticleReal, 6, 1> particle{
+                x, px, y, py, t, pt
+            };
+
+            // call integrator to advance through slice
+            integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);
+//            integrators::symp4_integrate_particle(particle,zin,zout,nsteps,*this);
+
+            // assign updated values
+            x = particle(1);
+            px = particle(2);
+            y = particle(3);
+            py = particle(4);
+            t = particle(5);
+            pt = particle(6);
+
+            // apply transverse aperture
+            apply_aperture(x, y, idcpu);
+
+            // undo shift due to alignment errors of the element
+            shift_out(x, y, px, py);
+        }
+
+        /** This pushes a particle in an ExactQuad element through
+         *  the symplectic map associated with H_1 in the Hamiltonian 
+         *  splitting H = H_1 + H_2.  This is exactly the linear
+         *  map of a quadrupole.
+         *
+         * @param tau Map step size in m
+         * @param[in,out] particle particle phase space 6-vector
+         * @param[in,out] zeval Longitudinal on-axis location in m
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void map1 (amrex::ParticleReal const tau,
+                   amrex::SmallVector<amrex::ParticleReal, 6, 1> & particle,
+                   amrex::ParticleReal & zeval) const
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            amrex::ParticleReal const x = particle(1);
+            amrex::ParticleReal const px = particle(2);
+            amrex::ParticleReal const y = particle(3);
+            amrex::ParticleReal const py = particle(4);
+            amrex::ParticleReal const t = particle(5);
+            amrex::ParticleReal const pt = particle(6);
+
+            amrex::ParticleReal xout = x;
+            amrex::ParticleReal pxout = px;
+            amrex::ParticleReal yout = y;
+            amrex::ParticleReal pyout = py;
+            amrex::ParticleReal tout = t;
+            amrex::ParticleReal ptout = pt;
+
+            amrex::ParticleReal const sin_omega_ds = std::sin(m_omega*tau);
+            amrex::ParticleReal const cos_omega_ds = std::cos(m_omega*tau);  
+            amrex::ParticleReal const sinh_omega_ds = std::sinh(m_omega*tau);
+            amrex::ParticleReal const cosh_omega_ds = std::cosh(m_omega*tau);
+            amrex::ParticleReal const slice_bg = tau / m_betgam2;
+
+            if (m_g > 0.0_prt)
+            {
+                // advance position and momentum (focusing quad)
+                xout = cos_omega_ds*x + sin_omega_ds/m_omega*px;
+                pxout = -m_omega*sin_omega_ds*x + cos_omega_ds*px;
+
+                yout = cosh_omega_ds*y + sinh_omega_ds/m_omega*py;
+                pyout = m_omega*sinh_omega_ds*y + cosh_omega_ds*py;
+            
+                tout = t + (slice_bg)*pt;
+                // ptout = pt;
+            } else if (m_g < 0.0_prt)
+            {
+                // advance position and momentum (defocusing quad)
+                xout = cosh_omega_ds*x + sinh_omega_ds/m_omega*px;
+                pxout = m_omega*sinh_omega_ds*x + cosh_omega_ds*px;
+
+                yout = cos_omega_ds*y + sin_omega_ds/m_omega*py;
+                pyout = -m_omega*sin_omega_ds*y + cos_omega_ds*py;
+         
+                tout = t + slice_bg*pt;
+                // ptout = pt;
+            } else {
+                // advance position and momentum (zero strength = drift)
+                xout = x + tau * px;
+                // pxout = px;
+                yout = y + tau * py;
+                // pyout = py;
+                tout = t + slice_bg * pt;
+                // ptout = pt;
+            }
+
+            // push particle coordinates
+            particle(1) = xout;
+            particle(2) = pxout;
+            particle(3) = yout;
+            particle(4) = pyout;
+            particle(5) = tout;
+            particle(6) = ptout;
+        }
+
+        /** This pushes a particle in an ExactQuad element through
+         *  the symplectic map associated with H_2 in the Hamiltonian
+         *  splitting H = H_1 + H_2.
+         *
+         * @param tau Map step size in m
+         * @param[in,out] particle particle phase space 6-vector
+         * @param[in,out] zeval Longitudinal on-axis location in m
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void map2 (amrex::ParticleReal const tau,
+                   amrex::SmallVector<amrex::ParticleReal, 6, 1> & particle,
+                   amrex::ParticleReal & zeval) const
+        {
+            using namespace amrex::literals; // for _rt and _prt
+            
+            amrex::ParticleReal const x = particle(1);
+            amrex::ParticleReal const px = particle(2);
+            amrex::ParticleReal const y = particle(3);
+            amrex::ParticleReal const py = particle(4);
+            amrex::ParticleReal const t = particle(5);
+            amrex::ParticleReal const pt = particle(6);
+            
+            // Leave the coordinates unchanged for now.
+            particle(1) = x;
+            particle(2) = px;
+            particle(3) = y;
+            particle(4) = py;
+            particle(5) = t;
+            particle(6) = pt;
+        }
+
+
+        /** This pushes the reference particle.
+         *
+         * @param[in,out] refpart reference particle
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void operator() (RefPart & AMREX_RESTRICT refpart) const {  // TODO: update as well, but needs more careful placement of calc_constants
+
+            using namespace amrex::literals; // for _rt and _prt
+
+            // assign input reference particle values
+            amrex::ParticleReal const x = refpart.x;
+            amrex::ParticleReal const px = refpart.px;
+            amrex::ParticleReal const y = refpart.y;
+            amrex::ParticleReal const py = refpart.py;
+            amrex::ParticleReal const z = refpart.z;
+            amrex::ParticleReal const pz = refpart.pz;
+            amrex::ParticleReal const t = refpart.t;
+            amrex::ParticleReal const pt = refpart.pt;
+            amrex::ParticleReal const s = refpart.s;
+
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
+            // assign intermediate parameter
+            amrex::ParticleReal const step = slice_ds / std::sqrt(std::pow(pt,2)-1.0_prt);
+
+            // advance position and momentum (straight element)
+            refpart.x = x + step*px;
+            refpart.y = y + step*py;
+            refpart.z = z + step*pz;
+            refpart.t = t - step*pt;
+
+            // advance integrated path length
+            refpart.s = s + slice_ds;
+        }
+
+        /** This function returns the linear transport map.
+         *
+         * @returns 6x6 transport matrix
+         */
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
+        Map6x6
+        transport_map (RefPart const & AMREX_RESTRICT refpart) const  // TODO: update as well, but needs more careful placement of calc_constants
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+             
+            // access reference particle values to find beta*gamma^2
+            amrex::ParticleReal const pt_ref = refpart.pt;
+            amrex::ParticleReal const betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
+        
+            // compute phase advance per unit length in s (in rad/m)
+            amrex::ParticleReal const omega = std::sqrt(std::abs(m_k));
+
+            // initialize linear map matrix elements
+            Map6x6 R = Map6x6::Identity();
+
+            if (m_k > 0.0) {
+                R(1,1) = std::cos(omega*slice_ds);
+                R(1,2) = std::sin(omega*slice_ds)/omega;
+                R(2,1) = -omega*std::sin(omega*slice_ds);
+                R(2,2) = std::cos(omega*slice_ds);  
+                R(3,3) = std::cosh(omega*slice_ds);   
+                R(3,4) = std::sinh(omega*slice_ds)/omega;
+                R(4,3) = omega*std::sinh(omega*slice_ds);
+                R(4,4) = std::cosh(omega*slice_ds);
+                R(5,6) = slice_ds/betgam2;
+            } else if (m_k < 0.0) {
+                R(1,1) = std::cosh(omega*slice_ds);
+                R(1,2) = std::sinh(omega*slice_ds)/omega;
+                R(2,1) = omega*std::sinh(omega*slice_ds);
+                R(2,2) = std::cosh(omega*slice_ds);
+                R(3,3) = std::cos(omega*slice_ds);
+                R(3,4) = std::sin(omega*slice_ds)/omega;
+                R(4,3) = -omega*std::sin(omega*slice_ds);
+                R(4,4) = std::cos(omega*slice_ds);
+                R(5,6) = slice_ds/betgam2;
+            } else {
+                R(1,2) = m_slice_ds; 
+                R(3,4) = m_slice_ds;
+                R(5,6) = m_slice_ds / betgam2;
+            }
+
+            return R;
+        }
+
+        /** This pushes the covariance matrix. */
+        using LinearTransport::operator();
+
+        amrex::ParticleReal m_k; //! quadrupole strength in 1/m^2 (or T/m)
+        int m_unit; //! unit specification for quad strength
+
+    private:
+        // constants that are independent of the individually tracked particle,
+        // see: compute_constants() to refresh
+        amrex::ParticleReal m_slice_ds;       //! m_ds / nslice();
+        amrex::ParticleReal m_betgam2;        //! beta*gamma^2
+        amrex::ParticleReal m_ibetgam2;       //! 1 / m_betgam2
+        amrex::ParticleReal m_beta;           //! beta
+        amrex::ParticleReal m_ibeta;          //! 1 / m_beta
+        amrex::ParticleReal m_g;              //! quadrupole strength in 1/m^2
+        amrex::ParticleReal m_omega;
+        int m_mapsteps; //! number of integration steps per slice
+    };
+
+} // namespace impactx
+
+#endif // IMPACTX_EXACTQUAD_H

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -167,13 +167,13 @@ namespace impactx::elements
                 x, px, y, py, t, pt
             };
 
-            // call integrator to advance through slice
+            // call integrator to advance through slice (int_order = 2 or 4, otherwise default 2)
             if (m_int_order == 2) {
                 integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);
             } else if (m_int_order == 4) {
                 integrators::symp4_integrate_particle(particle,zin,zout,nsteps,*this);
             } else {
-                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);  \\default
+                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);
             }
 
             // assign updated values

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -173,8 +173,7 @@ namespace impactx::elements
             } else if (m_int_order == 4) {
                 integrators::symp4_integrate_particle(particle,zin,zout,nsteps,*this);
             } else {
-                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);
-                throw std::runtime_error("ExactQuad: Order of integration must be 2 or 4.");
+                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);  \\default
             }
 
             // assign updated values

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -259,6 +259,8 @@ namespace impactx::elements
             particle(4) = pyout;
             particle(5) = tout;
             particle(6) = ptout;
+
+            zeval = zeval;
         }
 
         /** This pushes a particle in an ExactQuad element through

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -373,6 +373,20 @@ namespace detail
             auto b = detail::query_aperture(pp_element);
 
             m_lattice.emplace_back( ExactDrift(ds, a["dx"], a["dy"], a["rotation_degree"], b["aperture_x"], b["aperture_y"], nslice, element_name) );
+        } else if (element_type == "quad_exact")
+        {
+            auto const [ds, nslice] = detail::query_ds(pp_element, nslice_default);
+            auto a = detail::query_alignment(pp_element);
+            auto b = detail::query_aperture(pp_element);
+ 
+            amrex::ParticleReal k;
+            int units = 0;
+            int mapsteps = mapsteps_default;
+            pp_element.getWithParser("k", k);
+            pp_element.queryAddWithParser("units", units);
+            pp_element.queryAddWithParser("mapsteps", mapsteps);
+      
+            m_lattice.emplace_back( ExactQuad(ds, k, units, a["dx"], a["dy"], a["rotation_degree"], b["aperture_x"], b["aperture_y"], mapsteps, nslice, element_name) );
         } else if (element_type == "sbend_exact")
         {
             auto const [ds, nslice] = detail::query_ds(pp_element, nslice_default);
@@ -589,7 +603,7 @@ namespace detail
         pp_lattice.queryWithParser("nslice", nslice_default);
 
         // Default number of map integration steps per slice
-        int const mapsteps_default = 10;  // used only in RF cavity
+        int const mapsteps_default = 10;  // used only in a subset of elements
 
         // Loop through lattice elements
         for (std::string const & element_name : lattice_elements) {

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -387,7 +387,7 @@ namespace detail
             pp_element.queryAddWithParser("units", units);
             pp_element.queryAddWithParser("mapsteps", mapsteps);
 
-            m_lattice.emplace_back( ExactQuad(ds, k, units, a["dx"], a["dy"], a["rotation_degree"], b["aperture_x"], b["aperture_y"], int_order, mapsteps, nslice, 
+            m_lattice.emplace_back( ExactQuad(ds, k, units, a["dx"], a["dy"], a["rotation_degree"], b["aperture_x"], b["aperture_y"], int_order, mapsteps, nslice,
 element_name) );
         } else if (element_type == "sbend_exact")
         {

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -381,12 +381,14 @@ namespace detail
 
             amrex::ParticleReal k;
             int units = 0;
+            int int_order = 2;
             int mapsteps = mapsteps_default;
             pp_element.getWithParser("k", k);
             pp_element.queryAddWithParser("units", units);
             pp_element.queryAddWithParser("mapsteps", mapsteps);
 
-            m_lattice.emplace_back( ExactQuad(ds, k, units, a["dx"], a["dy"], a["rotation_degree"], b["aperture_x"], b["aperture_y"], mapsteps, nslice, element_name) );
+            m_lattice.emplace_back( ExactQuad(ds, k, units, a["dx"], a["dy"], a["rotation_degree"], b["aperture_x"], b["aperture_y"], int_order, mapsteps, nslice, 
+element_name) );
         } else if (element_type == "sbend_exact")
         {
             auto const [ds, nslice] = detail::query_ds(pp_element, nslice_default);

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -378,14 +378,14 @@ namespace detail
             auto const [ds, nslice] = detail::query_ds(pp_element, nslice_default);
             auto a = detail::query_alignment(pp_element);
             auto b = detail::query_aperture(pp_element);
- 
+
             amrex::ParticleReal k;
             int units = 0;
             int mapsteps = mapsteps_default;
             pp_element.getWithParser("k", k);
             pp_element.queryAddWithParser("units", units);
             pp_element.queryAddWithParser("mapsteps", mapsteps);
-      
+
             m_lattice.emplace_back( ExactQuad(ds, k, units, a["dx"], a["dy"], a["rotation_degree"], b["aperture_x"], b["aperture_y"], mapsteps, nslice, element_name) );
         } else if (element_type == "sbend_exact")
         {

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -385,6 +385,7 @@ namespace detail
             int mapsteps = mapsteps_default;
             pp_element.getWithParser("k", k);
             pp_element.queryAddWithParser("units", units);
+            pp_element.queryAddWithParser("int_order", int_order);
             pp_element.queryAddWithParser("mapsteps", mapsteps);
 
             m_lattice.emplace_back( ExactQuad(ds, k, units, a["dx"], a["dy"], a["rotation_degree"], b["aperture_x"], b["aperture_y"], int_order, mapsteps, nslice,

--- a/src/particles/integrators/Integrators.H
+++ b/src/particles/integrators/Integrators.H
@@ -172,7 +172,7 @@ namespace impactx::integrators
     * @param zout  Final value of independent variable (z-location)
     * @param nsteps  Number of integration steps
     * @param element  Element defining the two maps associated with H_1 and H_2
-    */  
+    */
     template <typename T_Element>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void symp2_integrate_particle (
@@ -181,23 +181,23 @@ namespace impactx::integrators
         amrex::ParticleReal const zout,
         int const nsteps,
         T_Element const & element
-    )   
+    )
     {
         using namespace amrex::literals; // for _rt and _prt
- 
+
         // initialize numerical integration parameters
         amrex::ParticleReal const dz = (zout-zin)/nsteps;
         amrex::ParticleReal const tau1 = dz/2.0_prt;
         amrex::ParticleReal const tau2 = dz;
-      
+
         // initialize the value of the independent variable
         amrex::ParticleReal zeval = zin;
-    
+
         // loop over integration steps
         for(int j=0; j < nsteps; ++j)
         {
             element.map1(tau1,particle,zeval);
-            element.map2(tau2,particle,zeval);   
+            element.map2(tau2,particle,zeval);
             element.map1(tau1,particle,zeval);
         }
     }
@@ -208,10 +208,10 @@ namespace impactx::integrators
     *  the two-terms splitting of symp2_integrate together with
     *  the method of Yoshida.
     *
-    *  H. Yoshida, Phys. Lett. A 150, 292-268 (1990). 
+    *  H. Yoshida, Phys. Lett. A 150, 292-268 (1990).
     *
     *  The form shown here appears, for example, in:
-    *   
+    *
     *  E. Forest and R. D. Ruth, Physica D 43, 105-117 (1990).
     *
     * @param particle  Particle phase space data in a 6-vector
@@ -228,10 +228,10 @@ namespace impactx::integrators
         amrex::ParticleReal const zout,
         int const nsteps,
         T_Element const & element
-    )   
-    {   
+    )
+    {
         using namespace amrex::literals; // for _rt and _prt
-    
+
         // initialize numerical integration parameters
         amrex::ParticleReal const dz = (zout-zin)/nsteps;
         amrex::ParticleReal const alpha = 1.0_prt - std::pow(2.0_prt,1.0/3.0);
@@ -239,10 +239,10 @@ namespace impactx::integrators
         amrex::ParticleReal const tau1 = tau2/2.0_prt;
         amrex::ParticleReal const tau3 = alpha*tau1;
         amrex::ParticleReal const tau4 = (alpha - 1.0_prt)*tau2;
-    
+
         // initialize the value of the independent variable
         amrex::ParticleReal zeval = zin;
-    
+
         // loop over integration steps
         for (int j=0; j < nsteps; ++j)
         {

--- a/src/particles/integrators/Integrators.H
+++ b/src/particles/integrators/Integrators.H
@@ -158,6 +158,104 @@ namespace impactx::integrators
             element.map1(tau1,refpart,zeval);
         }
     }
+
+   /** A second-order symplectic integrator based on a Hamiltonian
+    *  splitting H = H_1 + H_2.  This is a generalization of the second-
+    *  order leapfrog algorithm.  For a detailed overview:
+    *
+    *  E. Hairer et al, Geometric Numerical Integration:  Structure-
+    *  Preserving Algorithms for Ordinary Differential Equations,
+    *  2nd ed, Springer, Berlin, 2006.
+    *
+    * @param particle  Particle phase space data in a 6-vector
+    * @param zin  Initial value of independent variable (z-location)
+    * @param zout  Final value of independent variable (z-location)
+    * @param nsteps  Number of integration steps
+    * @param element  Element defining the two maps associated with H_1 and H_2
+    */  
+    template <typename T_Element>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void symp2_integrate_particle (
+        amrex::SmallVector<amrex::ParticleReal, 6, 1> & particle,
+        amrex::ParticleReal const zin,
+        amrex::ParticleReal const zout,
+        int const nsteps,
+        T_Element const & element
+    )   
+    {
+        using namespace amrex::literals; // for _rt and _prt
+ 
+        // initialize numerical integration parameters
+        amrex::ParticleReal const dz = (zout-zin)/nsteps;
+        amrex::ParticleReal const tau1 = dz/2.0_prt;
+        amrex::ParticleReal const tau2 = dz;
+      
+        // initialize the value of the independent variable
+        amrex::ParticleReal zeval = zin;
+    
+        // loop over integration steps
+        for(int j=0; j < nsteps; ++j)
+        {
+            element.map1(tau1,particle,zeval);
+            element.map2(tau2,particle,zeval);   
+            element.map1(tau1,particle,zeval);
+        }
+    }
+
+
+   /** A fourth-order symplectic integrator based on a Hamiltonian
+    *  splitting H = H_1 + H_2.  This is the result of applying
+    *  the two-terms splitting of symp2_integrate together with
+    *  the method of Yoshida.
+    *
+    *  H. Yoshida, Phys. Lett. A 150, 292-268 (1990). 
+    *
+    *  The form shown here appears, for example, in:
+    *   
+    *  E. Forest and R. D. Ruth, Physica D 43, 105-117 (1990).
+    *
+    * @param particle  Particle phase space data in a 6-vector
+    * @param zin  Initial value of independent variable (z-location)
+    * @param zout  Final value of independent variable (z-location)
+    * @param nsteps  Number of integration steps
+    * @param element  Element defining the two maps associated with H_1 and H_2
+    */
+    template <typename T_Element>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void symp4_integrate_particle (
+        amrex::SmallVector<amrex::ParticleReal, 6, 1> & particle,
+        amrex::ParticleReal const zin,
+        amrex::ParticleReal const zout,
+        int const nsteps,
+        T_Element const & element
+    )   
+    {   
+        using namespace amrex::literals; // for _rt and _prt
+    
+        // initialize numerical integration parameters
+        amrex::ParticleReal const dz = (zout-zin)/nsteps;
+        amrex::ParticleReal const alpha = 1.0_prt - std::pow(2.0_prt,1.0/3.0);
+        amrex::ParticleReal const tau2 = dz/(1.0_prt + alpha);
+        amrex::ParticleReal const tau1 = tau2/2.0_prt;
+        amrex::ParticleReal const tau3 = alpha*tau1;
+        amrex::ParticleReal const tau4 = (alpha - 1.0_prt)*tau2;
+    
+        // initialize the value of the independent variable
+        amrex::ParticleReal zeval = zin;
+    
+        // loop over integration steps
+        for (int j=0; j < nsteps; ++j)
+        {
+            element.map1(tau1,particle,zeval);
+            element.map2(tau2,particle,zeval);
+            element.map1(tau3,particle,zeval);
+            element.map2(tau4,particle,zeval);
+            element.map1(tau3,particle,zeval);
+            element.map2(tau2,particle,zeval);
+            element.map1(tau1,particle,zeval);
+        }
+    }
+
 } // namespace impactx::integrators
 
 #endif // IMPACTX_INTEGRATORS_H_

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -925,6 +925,70 @@ void init_elements(py::module& m)
     ;
     register_push(py_ExactDrift);
 
+    py::class_<ExactQuad, elements::mixin::Named, elements::mixin::Thick, elements::mixin::Alignment, elements::mixin::PipeAperture> py_ExactQuad(me, "ExactQuad");
+    py_ExactQuad
+        .def("__repr__",
+             [](ExactQuad const & exact_quad) {
+                 return element_name(
+                     exact_quad,
+                     std::make_pair("k", exact_quad.m_k),
+                     std::make_pair("unit", exact_quad.m_unit)
+                 );
+             }
+        )
+        .def("to_dict",
+             [](ExactQuad const & exact_quad) {
+                 return element_dict(
+                     exact_quad,
+                     std::make_pair("k", exact_quad.m_k),
+                     std::make_pair("unit", exact_quad.m_unit)
+                 );
+             }
+        )
+        .def(py::init<
+                amrex::ParticleReal,
+                amrex::ParticleReal,
+                int,
+                amrex::ParticleReal,
+                amrex::ParticleReal,
+                amrex::ParticleReal,
+                amrex::ParticleReal,
+                amrex::ParticleReal,
+                int,
+                int,
+                std::optional<std::string>
+             >(),
+             py::arg("ds"),
+             py::arg("k"),
+             py::arg("unit") = 0,
+             py::arg("dx") = 0,
+             py::arg("dy") = 0,
+             py::arg("rotation") = 0,
+             py::arg("aperture_x") = 0,
+             py::arg("aperture_y") = 0,
+             py::arg("mapsteps") = 1,
+             py::arg("nslice") = 1,
+             py::arg("name") = py::none(),
+             "A Quadrupole magnet using the exact nonlinear Hamiltonian."
+        )
+        .def_property("k",
+            [](ExactQuad & exact_quad) { return exact_quad.m_k; },
+            [](ExactQuad & exact_quad, amrex::ParticleReal k) { exact_quad.m_k = k; },
+            "quadrupole strength in 1/m^2 (or T/m)"
+        )
+        .def_property("unit",
+            [](ExactQuad & exact_quad) { return exact_quad.m_unit; },
+            [](ExactQuad & exact_quad, int unit) { exact_quad.m_unit = unit; },
+            "unit specification for quad strength"
+        )
+        .def_property("mapsteps",
+            [](ExactQuad & exact_quad) { return exact_quad.m_mapsteps; },
+            [](ExactQuad & exact_quad, int mapsteps) { exact_quad.m_mapsteps = mapsteps; },
+            "number of integration steps per slice used for map and reference particle push in applied fields"
+        )
+    ;
+    register_push(py_ExactQuad);
+
     py::class_<ExactSbend, elements::mixin::Named, elements::mixin::Thick, elements::mixin::Alignment, elements::mixin::PipeAperture> py_ExactSbend(me, "ExactSbend");
     py_ExactSbend
         .def("__repr__",

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -956,6 +956,7 @@ void init_elements(py::module& m)
                 amrex::ParticleReal,
                 int,
                 int,
+                int,
                 std::optional<std::string>
              >(),
              py::arg("ds"),
@@ -966,6 +967,7 @@ void init_elements(py::module& m)
              py::arg("rotation") = 0,
              py::arg("aperture_x") = 0,
              py::arg("aperture_y") = 0,
+             py::arg("int_order") = 2,
              py::arg("mapsteps") = 1,
              py::arg("nslice") = 1,
              py::arg("name") = py::none(),
@@ -981,10 +983,15 @@ void init_elements(py::module& m)
             [](ExactQuad & exact_quad, int unit) { exact_quad.m_unit = unit; },
             "unit specification for quad strength"
         )
+        .def_property("int_order",
+            [](ExactQuad & exact_quad) { return exact_quad.m_int_order; },
+            [](ExactQuad & exact_quad, int int_order) { exact_quad.m_int_order = int_order; },
+            "order of symplectic integration used for particle push in applied fields"
+        )
         .def_property("mapsteps",
             [](ExactQuad & exact_quad) { return exact_quad.m_mapsteps; },
             [](ExactQuad & exact_quad, int mapsteps) { exact_quad.m_mapsteps = mapsteps; },
-            "number of integration steps per slice used for map and reference particle push in applied fields"
+            "number of integration steps per slice used for particle push in the applied fields"
         )
     ;
     register_push(py_ExactQuad);


### PR DESCRIPTION
This PR implements a quadrupole model called `ExactQuad` that is based on the exact nonlinear Hamiltonian of an ideal hard-edge quadrupole.  It is needed for beams with a large energy spread and transverse divergence, and correctly handles relativistic kinematic effects.  It is analogous to the Elegant element `KQUAD`.  Symplectic integration is used to push between space charge kicks.

- [x] add basic element structure, parameters and user inputs
- [x] add support for symplectic integration of particle 6-vector
- [x] implement push for map1 (identical to a linear quadrupole)
- [x] implement push for map2 (the nonlinear kinematic correction terms)
- [x] add user option for integration order (2 / 4)
- [x] add Python bindings
- [x] add benchmark examples:  FODO with exact nonlinear elements, quad with H invariance
- [x] update documentation
- [x] add citation(s)

Follow-up:  a general combined-function multipole addressing Issue #929 .
