### PR TITLE
Fix multislice t-update in ExactSbend.

### DIFF
--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -223,7 +223,7 @@ namespace impactx::elements
                        // update position coordinates
                        x = -m_rc + rho*m_cos_phi + m_rc*(pzf + px*m_sin_phi - pzi*m_cos_phi);
                        y = yout + theta * m_rc * py;
-                       t = tout - theta * m_rc * (pt - 1.0_prt * m_ibeta) - m_phi * m_rc * m_ibeta;
+                       t = tout - theta * m_rc * (pt - 1.0_prt * m_ibeta) - m_slice_phi * m_rc * m_ibeta;
 
                        // assign updated momenta
                        px = pxout;


### PR DESCRIPTION
This PR addresses a bug observed in the update to the t-variable in the element ExactSbend.  This bug does not affect the other 5 phase space variables, and is observable only when nslice > 1.

The map updating t contains a term that previously scaled with the total element length, while this term should scale with the slice length.