### PR TITLE
Dashboard: Add inputs for `tracking modes` and space charge dropdown for `2D/3D`

### DIFF
--- a/src/python/impactx/dashboard/Input/components/input.py
+++ b/src/python/impactx/dashboard/Input/components/input.py
@@ -114,7 +114,7 @@ class InputComponents:
         """
 
         InputComponents._build_component(
-            vuetify.VCheckbox, label, v_model_name, **kwargs
+            vuetify.VCheckbox, label, v_model_name, color="primary", **kwargs
         )
 
     @staticmethod

--- a/src/python/impactx/dashboard/Input/defaults.py
+++ b/src/python/impactx/dashboard/Input/defaults.py
@@ -6,12 +6,32 @@ Authors: Parthib Roy
 License: BSD-3-Clause-LBNL
 """
 
+from typing import Any
+
 from impactx.impactx_pybind import ImpactX, RefPart
 
-from .. import setup_server
 from .defaults_helper import InputDefaultsHelper
 
-server, state, ctrl = setup_server()
+TRACKING_MODE_PROPERTIES: dict[str, dict[str, Any]] = {
+    "Reference Tracking": {
+        "space_charge": False,
+        "csr": False,
+        "disable_space_charge": True,
+        "disable_csr": True,
+        "space_charge_list": ["false"],
+    },
+    "Envelope Tracking": {
+        "csr": False,
+        "disable_space_charge": False,
+        "disable_csr": True,
+        "space_charge_list": ["false", "2D", "3D"],
+    },
+    "Particle Tracking": {
+        "disable_space_charge": False,
+        "disable_csr": False,
+        "space_charge_list": ["false", "3D"],
+    },
+}
 
 
 class DashboardDefaults:
@@ -31,7 +51,7 @@ class DashboardDefaults:
     # -------------------------------------------------------------------------
 
     SELECTION = {
-        "space_charge": False,
+        "space_charge": "false",
         "csr": False,
     }
 
@@ -81,7 +101,11 @@ class DashboardDefaults:
     }
 
     LISTS = {
-        "tracking_mode_list": ["Particle Tracking", "Envelope Tracking", "Reference Tracking"],
+        "tracking_mode_list": [
+            "Particle Tracking",
+            "Envelope Tracking",
+            "Reference Tracking",
+        ],
         "kin_energy_unit_list": ["meV", "eV", "keV", "MeV", "GeV", "TeV"],
         "distribution_type_list": ["Twiss", "Quadratic"],
         "poisson_solver_list": ["fft", "multigrid"],

--- a/src/python/impactx/dashboard/Input/defaults.py
+++ b/src/python/impactx/dashboard/Input/defaults.py
@@ -36,6 +36,7 @@ class DashboardDefaults:
     }
 
     INPUT_PARAMETERS = {
+        "tracking_mode": "Particle Tracking",
         "charge_qe": -1,
         "mass_MeV": 0.51099895,
         "npart": 1000,
@@ -80,6 +81,7 @@ class DashboardDefaults:
     }
 
     LISTS = {
+        "tracking_mode_list": ["Particle Tracking", "Envelope Tracking", "Reference Tracking"],
         "kin_energy_unit_list": ["meV", "eV", "keV", "MeV", "GeV", "TeV"],
         "distribution_type_list": ["Twiss", "Quadratic"],
         "poisson_solver_list": ["fft", "multigrid"],

--- a/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
@@ -13,6 +13,24 @@ from . import InputFunctions
 server, state, ctrl = setup_server()
 
 
+TRACKING_MODE_UI_PROPERTIES: dict[str, dict[str, bool]] = {
+    "Reference Tracking": {
+        "space_charge":        False,
+        "csr":                 False,
+        "disable_space_charge": True,
+        "disable_csr":          True,
+    },
+    "Envelope Tracking": {
+        "csr":                 False,
+        "disable_space_charge": False,
+        "disable_csr":          True,
+    },
+    "Particle Tracking": {
+        "disable_space_charge": False,
+        "disable_csr":          False,
+    },
+}
+
 class InputParameters(CardBase):
     """
     User-Input section for beam properties.
@@ -28,18 +46,34 @@ class InputParameters(CardBase):
         if state.kin_energy_on_ui != 0:
             InputFunctions.update_kin_energy_sim_value()
 
+    @state.change("tracking_mode")
+    def on_tracking_mode_change(**kwargs) -> None:
+        """
+        Sync the relevant UI components whenever
+        the user selects a new tracking mode.
+        """
+        ui_props = TRACKING_MODE_UI_PROPERTIES[state.tracking_mode]
+        for prop_name, prop in ui_props.items():
+            setattr(state, prop_name, prop)
+
     def card_content(self):
         with vuetify.VCard(**self.card_props):
             CardComponents.input_header(self.HEADER_NAME)
             with vuetify.VCardText(**self.CARD_TEXT_OVERFLOW):
                 with vuetify.VRow(**self.ROW_STYLE):
-                    with vuetify.VCol(cols="auto"):
-                        InputComponents.checkbox(
-                            label="Space Charge",
+                    with vuetify.VCol(md=6, sm=12):
+                        InputComponents.select(
+                            label="Tracking Mode",
                         )
-                    with vuetify.VCol(cols="auto"):
+                    with vuetify.VCol(classes="ga-4 py-0 d-flex align-center"):
+                        InputComponents.checkbox(
+                            label="SC",
+                            v_model_name="space_charge",
+                            disabled=("disable_space_charge",),
+                        )
                         InputComponents.checkbox(
                             label="CSR",
+                            disabled=("disable_csr",),
                         )
                 with vuetify.VRow(**self.ROW_STYLE):
                     with vuetify.VCol(cols=6):

--- a/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
+++ b/src/python/impactx/dashboard/Input/inputParameters/inputMain.py
@@ -7,29 +7,12 @@ License: BSD-3-Clause-LBNL
 """
 
 from ... import setup_server, vuetify
-from .. import CardBase, CardComponents, InputComponents
+from .. import CardBase, CardComponents, InputComponents, generalFunctions
 from . import InputFunctions
 
 server, state, ctrl = setup_server()
+from ..defaults import TRACKING_MODE_PROPERTIES
 
-
-TRACKING_MODE_UI_PROPERTIES: dict[str, dict[str, bool]] = {
-    "Reference Tracking": {
-        "space_charge":        False,
-        "csr":                 False,
-        "disable_space_charge": True,
-        "disable_csr":          True,
-    },
-    "Envelope Tracking": {
-        "csr":                 False,
-        "disable_space_charge": False,
-        "disable_csr":          True,
-    },
-    "Particle Tracking": {
-        "disable_space_charge": False,
-        "disable_csr":          False,
-    },
-}
 
 class InputParameters(CardBase):
     """
@@ -52,9 +35,14 @@ class InputParameters(CardBase):
         Sync the relevant UI components whenever
         the user selects a new tracking mode.
         """
-        ui_props = TRACKING_MODE_UI_PROPERTIES[state.tracking_mode]
+        ui_props = TRACKING_MODE_PROPERTIES[state.tracking_mode]
         for prop_name, prop in ui_props.items():
             setattr(state, prop_name, prop)
+
+        current_sc_list = ui_props.get("space_charge_list", [])
+        if state.space_charge not in current_sc_list:
+            state.space_charge = current_sc_list[0]
+        generalFunctions.update_simulation_validation_status()
 
     def card_content(self):
         with vuetify.VCard(**self.card_props):
@@ -66,9 +54,9 @@ class InputParameters(CardBase):
                             label="Tracking Mode",
                         )
                     with vuetify.VCol(classes="ga-4 py-0 d-flex align-center"):
-                        InputComponents.checkbox(
-                            label="SC",
-                            v_model_name="space_charge",
+                        InputComponents.select(
+                            label="Space Charge",
+                            items=("space_charge_list",),
                             disabled=("disable_space_charge",),
                         )
                         InputComponents.checkbox(

--- a/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeMain.py
+++ b/src/python/impactx/dashboard/Input/space_charge_configuration/spaceChargeMain.py
@@ -112,7 +112,7 @@ def on_poisson_solver_change(poisson_solver, **kwargs):
 
 @state.change("space_charge")
 def on_space_charge_change(space_charge, **kwargs):
-    state.dynamic_size = space_charge
+    state.dynamic_size = space_charge != "false"
     generalFunctions.update_simulation_validation_status()
 
 

--- a/src/python/impactx/dashboard/Run/simulation.py
+++ b/src/python/impactx/dashboard/Run/simulation.py
@@ -82,7 +82,7 @@ def build_space_charge_or_csr():
 
     if state.space_charge:
         content += f"""# Space Charge
-sim.space_charge = {state.space_charge}
+sim.space_charge = "{state.space_charge}"
 sim.dynamic_size = {state.dynamic_size}
 sim.poisson_solver = '{state.poisson_solver}'
 sim.particle_shape = {state.particle_shape}
@@ -124,6 +124,7 @@ def build_tracking_commands() -> str:
     return the corresponding ImpactX sim command block.
     """
     return TRACKING_MODE_COMMANDS[state.tracking_mode]
+
 
 # -----------------------------------------------------------------------------
 # Trame setup

--- a/src/python/impactx/dashboard/Run/simulation.py
+++ b/src/python/impactx/dashboard/Run/simulation.py
@@ -12,6 +12,16 @@ from ..Input.latticeConfiguration.latticeMain import parameter_input_checker_for
 
 server, state, ctrl = setup_server()
 
+TRACKING_MODE_COMMANDS = {
+    "Particle Tracking": """\
+sim.add_particles(bunch_charge_C, distr, npart)
+sim.track_particles()""",
+    "Envelope Tracking": """\
+sim.init_envelope(ref, distr)
+sim.track_envelope()""",
+    "Reference Tracking": "sim.track_reference(ref)",
+}
+
 # -----------------------------------------------------------------------------
 # Helper Functions
 # -----------------------------------------------------------------------------
@@ -108,6 +118,13 @@ sim.particle_shape = {state.particle_shape}
     return content
 
 
+def build_tracking_commands() -> str:
+    """
+    Read the user's choice from state.tracking_mode and
+    return the corresponding ImpactX sim command block.
+    """
+    return TRACKING_MODE_COMMANDS[state.tracking_mode]
+
 # -----------------------------------------------------------------------------
 # Trame setup
 # -----------------------------------------------------------------------------
@@ -117,7 +134,7 @@ def generate_phase_space(is_exporting: bool) -> str:
     or an empty string if the script is being exported.
     """
 
-    if is_exporting:
+    if is_exporting or state.tracking_mode != "particle tracking":
         return ""
     return (
         "import matplotlib.pyplot as plt\n"
@@ -154,13 +171,12 @@ ref = pc.ref_particle()
 ref.set_charge_qe({state.charge_qe}).set_mass_MeV({state.mass_MeV}).set_kin_energy_MeV(kin_energy_MeV)
 
 {build_distribution_list()}
-sim.add_particles(bunch_charge_C, distr, npart)
 
 {build_lattice_list()}
 sim.lattice.extend(lattice_configuration)
 
 # Simulate
-sim.track_particles()
+{build_tracking_commands()}
 
 {generate_phase_space(is_exporting)}
 # Clean Shutdown

--- a/src/python/impactx/dashboard/__main__.py
+++ b/src/python/impactx/dashboard/__main__.py
@@ -62,7 +62,7 @@ with RouterViewLayout(server, "/Input"):
                         inputParameters.card()
                     with vuetify.VCol(
                         **{**card_breakpoints, **card_column_padding},
-                        v_show="space_charge",
+                        v_show="space_charge !== 'false'",
                     ):
                         space_charge.card()
                     with vuetify.VCol(**{**card_breakpoints, **card_column_padding}):


### PR DESCRIPTION
Add new `tracking_mode` dropdown with following options:
- Particle Tracking (**default**) (user can also select `space charge` or `csr`)
- Envelope Tracking (user can select `space charge` while `csr` is disabled)
- Reference Tracking (both `space charge` and `csr` are disabled)

Additionally, the selection for space charge has changed from a checkbox to a dropdown, with the options depending on the users selection of `tracking mode`.:
- In particle tracking, the options for `space charge` are `off`, `3D`
- In envelope tracking, the options for `space charge` are `off`, `2D`, `3D`
- In reference tracking, `space charge` defaults to `false` and is set to `readonly`

Demo:
https://github.com/user-attachments/assets/8ec7f597-4dfe-44ab-b2c4-2e9e47e750c0







