### PR TITLE
Dashboard: Correct import path for CLI entry point

### DIFF
--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -8,7 +8,7 @@ License: BSD-3-Clause-LBNL
 
 import inspect
 
-from distribution_input_helpers import twiss
+from impactx.distribution_input_helpers import twiss
 
 from impactx import distribution
 

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -8,9 +8,8 @@ License: BSD-3-Clause-LBNL
 
 import inspect
 
-from impactx.distribution_input_helpers import twiss
-
 from impactx import distribution
+from impactx.distribution_input_helpers import twiss
 
 from ... import setup_server, vuetify
 from .. import (


### PR DESCRIPTION
I noticed that the dashboard would not load properly when using the CLI entry point (`impactx-dashboard`) from the base directory. It failed with the following error:

```
ModuleNotFoundError: No module named 'distribution_input_helpers'
```

After testing in GitHub Codespaces, I found that adding the `impactx.` prefix resolved the issue on my end:

```python
from impactx.distribution_input_helpers import twiss
```

This change would allow the dashboard to run correctly when launched from the command line.
