### PR TITLE
Change the default 3D Poisson solver to FFT.

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -821,7 +821,7 @@ See there ``nslice`` option on lattice elements for slicing.
   High-order shape factors are computationally more expensive, but may increase the overall accuracy of the results.
   For production runs it is generally safer to use high-order shape factors, such as cubic order.
 
-* ``algo.poisson_solver`` (``string``, optional, default: ``"multigrid"``)
+* ``algo.poisson_solver`` (``string``, optional, default: ``"fft"``)
 
   The numerical solver to solve the Poisson equation when calculating space charge effects.
   Currently, this is a 3D solver.

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -79,7 +79,7 @@ Collective Effects & Overall Simulation Parameters
    .. py:property:: poisson_solver
 
       The numerical solver to solve the Poisson equation when calculating space charge effects.
-      Either ``"multigrid"`` (default) or ``"fft"``.
+      Either ``"fft"`` (default) or ``"multigrid"``.
 
       Currently, this is a 3D solver.
       An additional `2D/2.5D solver <https://github.com/BLAST-ImpactX/impactx/issues/401>`__ will be added in the near future.

--- a/examples/cfchannel/input_cfchannel_10nC_mlmg.in
+++ b/examples/cfchannel/input_cfchannel_10nC_mlmg.in
@@ -38,6 +38,7 @@ constf1.kt = 1.0
 ###############################################################################
 algo.particle_shape = 2
 algo.space_charge = 3D
+algo.poisson_solver = "multigrid"
 
 amr.n_cell = 48 48 40
 #amr.n_cell = 72 72 64  # optional for increased precision

--- a/examples/cfchannel/run_cfchannel_10nC_mlmg.py
+++ b/examples/cfchannel/run_cfchannel_10nC_mlmg.py
@@ -14,6 +14,7 @@ sim = ImpactX()
 sim.n_cell = [48, 48, 40]  # [72, 72, 64] for increased precision
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "3D"
+sim.poisson_solver = "multigrid"
 sim.prob_relative = [3.0]
 # sim.diagnostics = False  # benchmarking
 sim.slice_step_diagnostics = True

--- a/examples/epac2004_benchmarks/input_fodo_rf_SC.in
+++ b/examples/epac2004_benchmarks/input_fodo_rf_SC.in
@@ -118,6 +118,7 @@ gapb1.sin_coefficients = 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0  \
 ###############################################################################
 algo.particle_shape = 2
 algo.space_charge = 3D
+algo.poisson_solver = "multigrid"
 
 amr.n_cell = 56 56 64
 geometry.prob_relative = 4.0

--- a/examples/epac2004_benchmarks/run_fodo_rf_SC.py
+++ b/examples/epac2004_benchmarks/run_fodo_rf_SC.py
@@ -14,6 +14,7 @@ sim = ImpactX()
 sim.n_cell = [56, 56, 64]
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "3D"
+sim.poisson_solver = "multigrid"
 sim.dynamic_size = True
 sim.prob_relative = [4.0]
 

--- a/examples/expanding_beam/input_expanding_mlmg.in
+++ b/examples/expanding_beam/input_expanding_mlmg.in
@@ -33,6 +33,7 @@ monitor.backend = h5
 ###############################################################################
 algo.particle_shape = 2
 algo.space_charge = 3D
+algo.poisson_solver = "multigrid"
 
 # Space charge solver with one MR level
 amr.max_level = 1

--- a/examples/expanding_beam/run_expanding_mlmg.py
+++ b/examples/expanding_beam/run_expanding_mlmg.py
@@ -19,6 +19,7 @@ sim.blocking_factor_z = [4]
 
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "3D"
+sim.poisson_solver = "multigrid"
 sim.dynamic_size = True
 sim.prob_relative = [3.0, 1.1]
 

--- a/examples/kurth/input_kurth_10nC_periodic.in
+++ b/examples/kurth/input_kurth_10nC_periodic.in
@@ -41,6 +41,7 @@ constf1.kt = 0.7
 ###############################################################################
 algo.particle_shape = 2
 algo.space_charge = 3D
+algo.poisson_solver = "multigrid"
 
 amr.n_cell = 48 48 40
 #amr.n_cell = 72 72 72  # optional for increased precision

--- a/examples/kurth/run_kurth_10nC_periodic.py
+++ b/examples/kurth/run_kurth_10nC_periodic.py
@@ -14,6 +14,7 @@ sim = ImpactX()
 sim.n_cell = [48, 48, 40]  # use [72, 72, 72] for increased precision
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "3D"
+sim.poisson_solver = "multigrid"
 # sim.diagnostics = False  # benchmarking
 sim.slice_step_diagnostics = True
 

--- a/src/initialization/InitMeshRefinement.H
+++ b/src/initialization/InitMeshRefinement.H
@@ -36,7 +36,7 @@ namespace impactx::initialization
 
         auto space_charge = get_space_charge_algo();
 
-        std::string poisson_solver = "multigrid";
+        std::string poisson_solver = "fft";
         pp_algo.queryAdd("poisson_solver", poisson_solver);
 
         int max_level = 0;

--- a/src/initialization/InitMeshRefinement.cpp
+++ b/src/initialization/InitMeshRefinement.cpp
@@ -40,7 +40,7 @@ namespace detail
         int max_level = 0;
         pp_amr.queryWithParser("max_level", max_level);
 
-        std::string poisson_solver = "multigrid";
+        std::string poisson_solver = "fft";
         pp_algo.queryAdd("poisson_solver", poisson_solver);
 
         // The box is expanded beyond the min and max of the particle beam.


### PR DESCRIPTION
The 3D FFT-based Poisson solver based on an Integrated Green Function approach (with open boundary conditions) is robust and efficient.  Following a prior discussion with ax3l, this PR updates this Poisson solver to serve as default, with the MLMG solver as a user option.