### PR TITLE
Documentation: Change lambda to sigma in example README docs.

### DIFF
--- a/examples/cfbend/README.rst
+++ b/examples/cfbend/README.rst
@@ -11,7 +11,7 @@ C. Steier et al, "Status of the Conceptual Design of ALS-U", IPAC2017, WEPAB104,
 
 A 2 GeV electron bunch with normalized transverse rms emittance of 50 pm undergoes a 3.76 deg bend.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run

--- a/examples/chicane/README.rst
+++ b/examples/chicane/README.rst
@@ -10,7 +10,7 @@ A 5 GeV electron bunch with normalized transverse rms emittance of 1 um undergoe
 
 The emittances should be preserved, and the rms pulse length should decrease by the compression factor (10).
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 We also have :ref:`a variation of this test that includes CSR effects in the bending magnets <examples-chicane-csr>`.
 

--- a/examples/chicane/README_csr.rst
+++ b/examples/chicane/README_csr.rst
@@ -11,7 +11,7 @@ The rms pulse length should decrease by the compression factor (10).
 
 An ultrarelativistic model of steady-state CSR in the bending dipoles is included, resulting in a horizontal emittance growth of 19%.  Note that this value is smaller than the horizontal emittance growth of 57% that is obtained when transient (bend-entry and -exit) effects are included.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run

--- a/examples/chicane/README_isr.rst
+++ b/examples/chicane/README_isr.rst
@@ -10,7 +10,7 @@ Coherent synchrotron radiation (CSR) is turned off.
 A 5 GeV electron bunch with normalized transverse rms emittance of 1 um undergoes longitudinal compression by a factor of 10 in a standard 4-bend chicane.
 The rms pulse length should decrease by the compression factor (10).
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run

--- a/examples/coupled_optics/README.rst
+++ b/examples/coupled_optics/README.rst
@@ -8,7 +8,7 @@ The solenoid is identical to that found in the example "solenoid".
 
 Its primary purpose is to benchmark the calculation of the three beam eigenemittances (mode emittances).
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must
 agree with nominal values.
 
 In addition, the initial and final values of :math:`emittance_1`, :math:`emittance_2`, :math:`emittance_3` must coincide.

--- a/examples/distgen/README.rst
+++ b/examples/distgen/README.rst
@@ -26,7 +26,7 @@ The matched Twiss parameters are the same as those used in the FODO example:
 
 The second moments of the particle distribution after the FODO cell should coincide with the second moments of the particle distribution before the FODO cell, to within the level expected due to noise due to statistical sampling.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 .. _examples-distgen-gaussian:
@@ -36,7 +36,7 @@ A 6d Gaussian distribution from Twiss functions
 
 A Gaussian distribution in all 6 phase space variables, initialized using Courant-Snyder (Twiss) functions.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run
@@ -83,7 +83,7 @@ A K-V distribution initialized from Twiss functions
 
 This example is initialized using Courant-Snyder (Twiss) functions.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run
@@ -133,7 +133,7 @@ A 4D Kurth Distribution
 A 4D Kurth distribution in the transverse phase space variables ( + a longitudinally uniform distribution in :math:`t` + a Gaussian distribution in :math:`p_t` ).
 
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 Run
 ---
@@ -181,7 +181,7 @@ A Semigaussian distribution
 
 A 6D semigaussian distribution (uniform in position, Gaussian in momentum).
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run

--- a/examples/dogleg/README.rst
+++ b/examples/dogleg/README.rst
@@ -12,7 +12,7 @@ All parameters can be found online.  A 5 GeV electron bunch with normalized tran
 
 The final expected dispersion is 267 mm.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must
 agree with nominal values.
 
 In addition, the initial and final values of :math:`\alpha_x`, :math:`\alpha_y`, :math:`\beta_x`, :math:`\beta_y`, :math:`\dispersion_x`, and :math:`\dispersion_px` must

--- a/examples/fodo/README.rst
+++ b/examples/fodo/README.rst
@@ -16,7 +16,7 @@ We use a 2 GeV electron beam with initial unnormalized rms emittance of 2 nm.
 
 The second moments of the particle distribution after the FODO cell should coincide with the second moments of the particle distribution before the FODO cell, to within the level expected due to noise due to statistical sampling.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run
@@ -99,7 +99,7 @@ We use a 2 GeV electron beam with initial unnormalized rms emittance of 2 nm.
 The second moments of the particle distribution after the FODO cell should coincide with the second moments of the particle distribution before the FODO cell, to within the level expected
 due to$
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run
@@ -151,7 +151,7 @@ The kinematic nonlinear effects are essentially negligible, so this is primarily
 The second moments of the particle distribution after the FODO cell should coincide with the second moments of the particle distribution before the FODO cell, to within the level expected due to
 noise due to the finite particle population.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run

--- a/examples/fodo_rf/README.rst
+++ b/examples/fodo_rf/README.rst
@@ -21,7 +21,7 @@ mm-mrad in all three phase planes.
 
 The second moments of the particle distribution after the FODO cell should coincide with the second moments of the particle distribution before the FODO cell, to within the level expected due to noise due to statistical sampling.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run

--- a/examples/fodo_space_charge/README.rst
+++ b/examples/fodo_space_charge/README.rst
@@ -13,7 +13,7 @@ The purpose of this example is to illustrate the use of envelope tracking mode w
 
 The second moments of the particle distribution after the FODO cell should coincide with the second moments of the particle distribution before the FODO cell, to within the level expected due to noise due to statistical sampling.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run

--- a/examples/fodo_userdef/README.rst
+++ b/examples/fodo_userdef/README.rst
@@ -23,7 +23,7 @@ We use a 2 GeV electron beam with initial unnormalized rms emittance of 2 nm.
 
 The second moments of the particle distribution after the FODO cell should coincide with the second moments of the particle distribution before the FODO cell, to within the level expected due to noise due to statistical sampling.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run

--- a/examples/iota_lens/README.rst
+++ b/examples/iota_lens/README.rst
@@ -124,7 +124,7 @@ ideal map associated with the remainder of the lattice.
 
 We use a 2.5 MeV proton beam, corresponding to the nominal IOTA proton energy.  The beam is transported over 3 periods.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 The fraction of charge lost after 3 periods of transport must agree with the nominal value obtained from high-resolution simulation.
 

--- a/examples/kicker/README.rst
+++ b/examples/kicker/README.rst
@@ -9,7 +9,7 @@ We use a 2 GeV electron beam.
 
 The second beam moments should be unchanged, but the first beam moments corresponding to :math:`p_x` and :math:`p_y` should change according to the size of the kick.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run

--- a/examples/kurth/README.rst
+++ b/examples/kurth/README.rst
@@ -14,7 +14,7 @@ in all three phase planes.
 The particle distribution should remain unchanged, to within the level expected due to numerical particle noise.
 This is tested using the second moments of the distribution.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run
@@ -71,7 +71,7 @@ phase advance from 121 degrees to 74 degrees.
 The particle distribution should remain unchanged, to within the level expected due to numerical particle noise.
 This is tested using the second moments of the distribution.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run

--- a/examples/rfcavity/README.rst
+++ b/examples/rfcavity/README.rst
@@ -14,7 +14,7 @@ https://github.com/impact-lbl/IMPACT-Z/tree/master/examples/Example2
 The final target beam energy and beam moments are based on simulation in
 IMPACT-Z, without space charge.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 
 Run

--- a/examples/symplectic_integration/README.rst
+++ b/examples/symplectic_integration/README.rst
@@ -8,7 +8,7 @@ This benchmark tests the use of the ExactQuad (quadrupole_exact) element for int
 A 25 pC electron bunch with 100 MeV total energy, a small initial rms beam size of (3.9, 3.9, 1.0) microns, 2 mrad transverse divergence and 2.5% energy spread undergoes rapid expansion followed
 by transverse focusing in a quadrupole doublet.  The parameters are chosen such that chromatic focusing effects are important.
 
-In this test, the initial and final values of :math:`\lambda_x`, :math:`\lambda_y`, :math:`\lambda_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
 In addition, the Hamiltonian value is computed for each particle at the entrance and exit of the final quadrupole.  The change in the Hamiltonian value, taken relative to the standard deviation
 :math:`\sigma_H` over particles, must be smaller than the allowed tolerance (here, taken to be 0.1%).


### PR DESCRIPTION
Some of the examples contain `\lambda_x`, etc. instead of `\sigma_x`, etc. in the documentation README, due to a previous update of an internal variable label.  This should read `\sigma_x`, etc. as corrected here.