### PR TITLE
Dashboard: Add tooltips for Twiss distribution parameters

### DIFF
--- a/src/python/impactx/dashboard/Input/components/input.py
+++ b/src/python/impactx/dashboard/Input/components/input.py
@@ -43,7 +43,7 @@ class InputComponents:
         props = {**common_props, **component_kwargs}
 
         with vuetify.VTooltip(
-            location="bottom", text=TooltipDefaults.TOOLTIP.get(v_model_name)
+            location="bottom", text=(f"all_tooltips['{v_model_name}']",),
         ):
             with vuetify.Template(v_slot_activator="{ props }"):
                 vuetify_component(**props)

--- a/src/python/impactx/dashboard/Input/components/input.py
+++ b/src/python/impactx/dashboard/Input/components/input.py
@@ -42,7 +42,7 @@ class InputComponents:
         props = {**common_props, **component_kwargs}
 
         with vuetify.VTooltip(
-            location="bottom",
+            location="top",
             text=(f"all_tooltips['{v_model_name}']",),
         ):
             with vuetify.Template(v_slot_activator="{ props }"):

--- a/src/python/impactx/dashboard/Input/components/input.py
+++ b/src/python/impactx/dashboard/Input/components/input.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from ... import setup_server, vuetify
-from ..defaults import TooltipDefaults
 from ..generalFunctions import generalFunctions
 
 server, state, ctrl = setup_server()
@@ -43,7 +42,8 @@ class InputComponents:
         props = {**common_props, **component_kwargs}
 
         with vuetify.VTooltip(
-            location="bottom", text=(f"all_tooltips['{v_model_name}']",),
+            location="bottom",
+            text=(f"all_tooltips['{v_model_name}']",),
         ):
             with vuetify.Template(v_slot_activator="{ props }"):
                 vuetify_component(**props)

--- a/src/python/impactx/dashboard/Input/defaults.py
+++ b/src/python/impactx/dashboard/Input/defaults.py
@@ -10,9 +10,9 @@ from typing import Any
 
 from impactx.impactx_pybind import ImpactX, RefPart
 
+from .. import setup_server
 from .defaults_helper import InputDefaultsHelper
 
-from .. import setup_server
 server, state, ctrl = setup_server()
 
 TRACKING_MODE_PROPERTIES: dict[str, dict[str, Any]] = {

--- a/src/python/impactx/dashboard/Input/defaults.py
+++ b/src/python/impactx/dashboard/Input/defaults.py
@@ -12,6 +12,9 @@ from impactx.impactx_pybind import ImpactX, RefPart
 
 from .defaults_helper import InputDefaultsHelper
 
+from .. import setup_server
+server, state, ctrl = setup_server()
+
 TRACKING_MODE_PROPERTIES: dict[str, dict[str, Any]] = {
     "Reference Tracking": {
         "space_charge": False,
@@ -177,7 +180,7 @@ class TooltipDefaults:
     Defaults for input toolips in the ImpactX dashboard.
     """
 
-    TOOLTIP = InputDefaultsHelper.get_docstrings(
+    state.all_tooltips = InputDefaultsHelper.get_docstrings(
         [RefPart, ImpactX], DashboardDefaults.DEFAULT_VALUES
     )
 

--- a/src/python/impactx/dashboard/Input/defaults_helper.py
+++ b/src/python/impactx/dashboard/Input/defaults_helper.py
@@ -51,24 +51,36 @@ class InputDefaultsHelper:
         return docstrings
 
     @staticmethod
-    def get_tooltips_from_param(func: Callable) -> Dict[str, str]:
+    def get_tooltips_from_param(function: Callable) -> Dict[str, str]:
         """
         Extract all ':param name: description' entries from a function's docstring.
 
-        :param func: The function whose docstring you want to parse.
+        Example:
+            :param beta_x: Beta function value in the x dimension.
+            :param emitt_x: Emittance function value in the x dimension.
+
+        This will produce:
+            {
+                "beta_x": "Beta function value in the x dimension.",
+                "emitt_x": "Emittance function value in the x dimension."
+            }
+
+        :param function: The function whose docstring you want to parse.
         :return: A dict mapping each parameter name to its description.
         """
-        tooltips = {}
-        doc = inspect.getdoc(func) or ""
+        tooltip_results = {}
+        docstring = inspect.getdoc(function) or ""
         pattern = re.compile(r"^\s*:param\s+(\w+)\s*:\s*(.+)$", re.MULTILINE)
-        pattern_matches = list(pattern.finditer(doc))
+        pattern_matches = list(pattern.finditer(docstring))
 
         if not pattern_matches:
-            raise ValueError(f"Found no docstrings to parse in function {func.__name__}")
+            raise ValueError(
+                f"Found no docstrings to parse in function {function.__name__}"
+            )
 
         for match in pattern_matches:
             param_name = match.group(1)
-            description = match.group(2)
-            tooltips[param_name] = description
+            param_description = match.group(2)
+            tooltip_results[param_name] = param_description
 
-        return tooltips
+        return tooltip_results

--- a/src/python/impactx/dashboard/Input/defaults_helper.py
+++ b/src/python/impactx/dashboard/Input/defaults_helper.py
@@ -7,7 +7,10 @@ License: BSD-3-Clause-LBNL
 """
 
 import inspect
-from typing import Dict, List, Type
+import re
+from typing import Callable, Dict, List, Type
+
+from impactx.distribution_input_helpers import twiss
 
 
 class InputDefaultsHelper:
@@ -42,4 +45,25 @@ class InputDefaultsHelper:
                     docstring = inspect.getdoc(attribute) or ""
                     docstrings[name] = docstring
 
+        distribution_tooltips = InputDefaultsHelper.get_tooltips_from_param(twiss)
+        docstrings.update(distribution_tooltips)
+
         return docstrings
+
+    def get_tooltips_from_param(func: Callable) -> Dict[str, str]:
+        """
+        Extract all ':param name: description' entries from a function's docstring.
+
+        :param func: The function whose docstring you want to parse.
+        :return: A dict mapping each parameter name to its description.
+        """
+        tooltips = {}
+        doc = inspect.getdoc(func) or ""
+        pattern = re.compile(r"^\s*:param\s+(\w+)\s*:\s*(.+)$", re.MULTILINE)
+
+        for match in pattern.finditer(doc):
+            param_name = match.group(1)
+            description = match.group(2)
+            tooltips[param_name] = description
+
+        return tooltips

--- a/src/python/impactx/dashboard/Input/defaults_helper.py
+++ b/src/python/impactx/dashboard/Input/defaults_helper.py
@@ -50,6 +50,7 @@ class InputDefaultsHelper:
 
         return docstrings
 
+    @staticmethod
     def get_tooltips_from_param(func: Callable) -> Dict[str, str]:
         """
         Extract all ':param name: description' entries from a function's docstring.

--- a/src/python/impactx/dashboard/Input/defaults_helper.py
+++ b/src/python/impactx/dashboard/Input/defaults_helper.py
@@ -61,8 +61,12 @@ class InputDefaultsHelper:
         tooltips = {}
         doc = inspect.getdoc(func) or ""
         pattern = re.compile(r"^\s*:param\s+(\w+)\s*:\s*(.+)$", re.MULTILINE)
+        pattern_matches = list(pattern.finditer(doc))
 
-        for match in pattern.finditer(doc):
+        if not pattern_matches:
+            raise ValueError(f"Found no docstrings to parse in function {func.__name__}")
+
+        for match in pattern_matches:
             param_name = match.group(1)
             description = match.group(2)
             tooltips[param_name] = description

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -177,19 +177,27 @@ class DistributionParameters(CardBase):
                         v_for="(parameter, index) in selected_distribution_parameters",
                         cols=4,
                     ):
-                        vuetify.VTextField(
-                            label=("parameter.parameter_name",),
-                            v_model=("parameter.parameter_default_value",),
-                            suffix=("parameter.parameter_units",),
-                            update_modelValue=(
-                                ctrl.updateDistributionParameters,
-                                "[parameter.parameter_name, $event, parameter.parameter_type]",
-                            ),
-                            error_messages=("parameter.parameter_error_message",),
-                            type="number",
-                            step=("parameter.parameter_step",),
-                            __properties=["step"],
-                            density="compact",
-                            variant="underlined",
-                            hide_details="auto",
-                        )
+                        with vuetify.VTooltip(
+                            location="bottom",
+                            text=("all_tooltips[parameter.parameter_name]",),
+                        ):
+                            with vuetify.Template(v_slot_activator="{ props }"):
+                                vuetify.VTextField(
+                                    label=("parameter.parameter_name",),
+                                    v_model=("parameter.parameter_default_value",),
+                                    suffix=("parameter.parameter_units",),
+                                    update_modelValue=(
+                                        ctrl.updateDistributionParameters,
+                                        "[parameter.parameter_name, $event, parameter.parameter_type]",
+                                    ),
+                                    error_messages=(
+                                        "parameter.parameter_error_message",
+                                    ),
+                                    type="number",
+                                    step=("parameter.parameter_step",),
+                                    __properties=["step"],
+                                    density="compact",
+                                    variant="underlined",
+                                    hide_details="auto",
+                                    v_bind="props",
+                                )

--- a/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
+++ b/src/python/impactx/dashboard/Input/distributionParameters/distributionMain.py
@@ -178,7 +178,7 @@ class DistributionParameters(CardBase):
                         cols=4,
                     ):
                         with vuetify.VTooltip(
-                            location="bottom",
+                            location="top",
                             text=("all_tooltips[parameter.parameter_name]",),
                         ):
                             with vuetify.Template(v_slot_activator="{ props }"):


### PR DESCRIPTION
The PR adds the tooltips for the twiss distribution parameters on the dashboard.

This is done by adding a helper function `get_tooltips_from_param`  in `Input/defaults_helper.py` which looks at a given function (in this case, `twiss` from`src\python\impactx\distribution_input_helpers.py`) and properly parses through the docstring by looking at each `:param` and its description to retrieve the tooltip.