### PR TITLE
Dashboard: Record failed sims

### DIFF
--- a/src/python/impactx/dashboard/Run/executor.py
+++ b/src/python/impactx/dashboard/Run/executor.py
@@ -13,7 +13,6 @@ state.sim_is_running = False
 state.sim_current_step = 0
 state.sim_total_steps = 0
 state.sim_progress = 0
-start_timer = 0
 
 
 def run_execute_impactx_sim():
@@ -33,6 +32,9 @@ async def execute_impactx_sim() -> None:
     """
     SimulationHelper.reset()
 
+    start_timer = None
+    sim_failed = False
+
     simulation_contents = dashboard_sim_inputs()
     state.sim_total_steps = SimulationProgress.determine_sim_total_steps(
         simulation_contents
@@ -49,6 +51,9 @@ async def execute_impactx_sim() -> None:
         if not sim_output_line:
             break
 
+        if "Traceback" in sim_output_line_decoded:
+            sim_failed = True
+
         if "Initializing AMReX" in sim_output_line_decoded:
             start_timer = asyncio.create_task(SimulationProgress.dashboard_timer())
         if "++++ Starting step=" in sim_output_line_decoded:
@@ -63,6 +68,13 @@ async def execute_impactx_sim() -> None:
         SimulationHistory.add_to_view_details_log(sim_output_line_decoded)
 
     await simulation_process.wait()
+
+    if start_timer is not None:
+        start_timer.cancel()
+
+    if sim_failed:
+        SimulationHelper.fail_simulation()
+        return
+
     SimulationHelper.display_phase_space_plots()
-    start_timer.cancel()
     SimulationHelper.complete_simulation()

--- a/src/python/impactx/dashboard/Run/utils.py
+++ b/src/python/impactx/dashboard/Run/utils.py
@@ -52,6 +52,20 @@ class SimulationHelper:
         SimulationHistory.save_view_details_log()
 
     @staticmethod
+    def fail_simulation() -> None:
+        """
+        Updates the UI and simulation history to reflect a failed simulation.
+        """
+        state.sim_is_running = False
+        state.sim_progress_status = "Failed"
+        state.sim_status_color = "error"
+        state.sims[state.sim_index]["status"] = "Failed"
+        state.dirty("filtered_sims")
+        state.flush()
+        ctrl.terminal_print("Simulation failed due to the above error.")
+        SimulationHistory.save_view_details_log()
+
+    @staticmethod
     def reset():
         state.sim_is_running = True
         state.sim_progress = 0

--- a/src/python/impactx/dashboard/Toolbar/sim_history/custom.js
+++ b/src/python/impactx/dashboard/Toolbar/sim_history/custom.js
@@ -1,6 +1,7 @@
 window.getSimStatusColor = function(status) {
     if (status === 'Completed') return 'success';
     if (status === 'In Progress') return 'info';
+    if (status === 'Failed') return 'error';
     return 'default';
 }
 

--- a/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
+++ b/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
@@ -257,7 +257,7 @@ class SimulationHistory:
                             label="Status",
                             v_model=("selected_sim_search_status", None),
                             update_modelValue=(ctrl.update_status, "[$event]"),
-                            items=(["All", "Completed", "In Progress"],),
+                            items=(["All", "Completed", "In Progress", "Failed"],),
                             clearable=True,
                             density="comfortable",
                             hide_details=True,
@@ -295,6 +295,10 @@ class SimulationHistory:
                                         "{{ window.formatTime(item.created_at_time) }}",
                                         classes="text-caption",
                                     )
+                            with SimulationHistory._access_sim_history_slot(
+                                "time_elapsed"
+                            ):
+                                html.Span("{{ item.time_elapsed || '—' }}")
                             with SimulationHistory._access_sim_history_slot("status"):
                                 SimulationHistoryComponents.status_chip("item")
                             with SimulationHistory._access_sim_history_slot("actions"):
@@ -303,7 +307,7 @@ class SimulationHistory:
                                     classes="mr-1",
                                     click=(ctrl.open_view_details, "[item]"),
                                     description="View Details",
-                                    disabled=("item.status !== 'Completed'", True),
+                                    disabled=("sim_is_running",),
                                 )
                                 SimulationHistoryComponents.icon_button(
                                     icon_name="mdi-download",
@@ -327,5 +331,5 @@ class SimulationHistory:
                                     color="error",
                                     click=(ctrl.delete_sim, "[item]"),
                                     description="Delete",
-                                    disabled=("item.status !== 'Completed'", True),
+                                    disabled=("sim_is_running",),
                                 )


### PR DESCRIPTION
This PR introduces initial support for tracking failed simulations in the dashboard.

If a simulation ends with a Python `Traceback` error, the dashboard now updates the progress status to indicate a failure. This failure is also logged in the Simulation History view.

Previously, when a simulation failed, users were blocked from launching a new one unless they restarted the dashboard. 