### PR TITLE
[WIP] Dashboard: update UI interactions

### DIFF
--- a/src/python/impactx/dashboard/Input/defaults.py
+++ b/src/python/impactx/dashboard/Input/defaults.py
@@ -222,6 +222,7 @@ class UIDefaults:
             "flex": "1",
             "overflow-y": "auto",
             "overflow-x": "auto",
+            "max-height": "50vh",
         },
     }
 

--- a/src/python/impactx/dashboard/Run/utils.py
+++ b/src/python/impactx/dashboard/Run/utils.py
@@ -49,6 +49,7 @@ class SimulationHelper:
         state.sims[state.sim_index]["status"] = "Completed"
         state.sim_is_generating_plots = False
         state.dirty("filtered_sims")
+        state.active_plot = state.plot_options[0]
         state.flush()
         SimulationHistory.save_view_details_log()
 

--- a/src/python/impactx/dashboard/Run/utils.py
+++ b/src/python/impactx/dashboard/Run/utils.py
@@ -86,6 +86,7 @@ class SimulationHelper:
 
     @staticmethod
     def reset():
+        ctrl.terminal_clear()
         state.sim_is_cancelled = False
         state.sim_is_running = True
         state.sim_progress = 0

--- a/src/python/impactx/dashboard/__main__.py
+++ b/src/python/impactx/dashboard/__main__.py
@@ -100,7 +100,6 @@ def init_terminal():
 
 
 def application():
-    init_terminal()
     with SinglePageWithDrawerLayout(server) as layout:
         layout.title.hide()
         with layout:

--- a/src/python/impactx/dashboard/__main__.py
+++ b/src/python/impactx/dashboard/__main__.py
@@ -94,8 +94,9 @@ with RouterViewLayout(server, "/Analyze"):
 # GUI
 # -----------------------------------------------------------------------------
 def init_terminal():
-    with xterm.XTerm(v_if="$route.path == '/Run'") as term:
+    with xterm.XTerm(v_show="$route.path == '/Run'") as term:
         ctrl.terminal_print = term.writeln
+        ctrl.terminal_clear = term.clear
 
 
 def application():


### PR DESCRIPTION
This PR updates/improves various UI interactions across the dashboard.

**Changes:**
1.) keep xterm output persistent across tabs. The terminal now only clears when a new simulation runs.

Additionally removed redundant call to initializing the terminal that is shown on the `Run` page.

**Before:**
`Run a simulation -> switch tabs -> return -> terminal is blank`
https://github.com/user-attachments/assets/f603930d-4018-4091-8d5f-530bd3055895

**After:**
`Run a simulation -> switch tabs -> return -> output is still there. 
Clears only when a new simulation starts`
https://github.com/user-attachments/assets/1c90d27c-7b79-4c52-a02b-95ede0ec96cc

2.) Correctly display a scroll bar for the lattice configuration after a certain height
     - Previously had the issue where after X elements, the card would not expand and the rest of the remaining elements would not display and disable the user from modifying parameters
3.) Display plot by default after a sim completes



TODO
- [ ] Provide  user with an alert to have the proper builds on the selection of `space charge` and `csr`
- [ ] Add remaining time under progress bar when running a simulation
- [x] Add default `BeamMonitor` name if not given
- [ ] Change default `name` parameter to not be `None` for elements != `BeamMonitor`
- [X] Correctly disable the correct index of `view_details` and `delete_sim` in the simulation history when a simulation is in progress.