### PR TITLE
Dashboard: update dynamic tooltip messages

### DIFF
--- a/src/python/impactx/dashboard/Input/components/card.py
+++ b/src/python/impactx/dashboard/Input/components/card.py
@@ -1,7 +1,8 @@
+from typing import List, Optional, Union
+
 from ... import html, setup_server, vuetify
 from ..defaults import DashboardDefaults, UIDefaults
 from ..generalFunctions import generalFunctions
-from typing import Optional, Union, List, Tuple
 
 server, state, ctrl = setup_server()
 
@@ -99,11 +100,11 @@ class CardComponents:
     @staticmethod
     def card_button(
         icon_name: Union[str, List[str]],
-        color: str ="primary",
+        color: str = "primary",
         dynamic_condition: Optional[str] = None,
         description: Optional[Union[str, List[str]]] = None,
-        density: str ="compact",
-        variant: str ="text",
+        density: str = "compact",
+        variant: str = "text",
         **kwargs,
     ) -> vuetify.VBtn:
         """

--- a/src/python/impactx/dashboard/Input/components/card.py
+++ b/src/python/impactx/dashboard/Input/components/card.py
@@ -122,19 +122,27 @@ class CardComponents:
             Ensure dynamic_condition components are a list of exactly 2 strings for dynamic toggling (e.g., expand/collapse).
             """
 
-            if not isinstance(prop_value, list):
-                raise ValueError(f"When dynamic_condition is set, {prop_name} must be a list of exactly 2 strings")
-            if len(prop_value) != 2:
-                raise ValueError(f"When dynamic_condition is set, {prop_name} must contain exactly 2 elements")
-            if not all(isinstance(item, str) for item in prop_value):
-                raise ValueError(f"When dynamic_condition is set, all elements in {prop_name} must be strings")
+            if not isinstance(value, (list, tuple)):
+                raise ValueError(
+                    f"When dynamic_condition is True, {name} must be a list or tuple of exactly 2 strings"
+                )
+            if len(value) != 2:
+                raise ValueError(
+                    f"When dynamic_condition is True, {name} must contain exactly 2 elements"
+                )
+            if not all(isinstance(item, str) for item in value):
+                raise ValueError(
+                    f"When dynamic_condition is True, all elements in {name} must be strings"
+                )
 
         if dynamic_condition:
             validate_dynamic_condition(icon_name, "icon_name")
             validate_dynamic_condition(description, "description")
 
         if dynamic_condition:
-            tooltip_text =  (f"{dynamic_condition} ? '{description[1]}' : '{description[0]}'",)
+            tooltip_text = (
+                f"{dynamic_condition} ? '{description[1]}' : '{description[0]}'",
+            )
         else:
             tooltip_text = description
 
@@ -200,7 +208,7 @@ class CardComponents:
             ["mdi-arrow-expand", "mdi-close"],
             click=f"{expand_state} = !{expand_state}",
             dynamic_condition=expand_state,
-            description=["Expand","Close"],
+            description=["Expand", "Close"],
         )
 
     @staticmethod

--- a/src/python/impactx/dashboard/Input/components/card.py
+++ b/src/python/impactx/dashboard/Input/components/card.py
@@ -1,6 +1,7 @@
 from ... import html, setup_server, vuetify
 from ..defaults import DashboardDefaults, UIDefaults
 from ..generalFunctions import generalFunctions
+from typing import Optional, Union, List, Tuple
 
 server, state, ctrl = setup_server()
 
@@ -97,35 +98,36 @@ class CardComponents:
 
     @staticmethod
     def card_button(
-        icon_name,
-        color="primary",
-        dynamic_condition=None,
-        description=None,
-        density="compact",
-        variant="text",
+        icon_name: Union[str, List[str]],
+        color: str ="primary",
+        dynamic_condition: Optional[str] = None,
+        description: Optional[Union[str, List[str]]] = None,
+        density: str ="compact",
+        variant: str ="text",
         **kwargs,
     ) -> vuetify.VBtn:
         """
-        Create a Vuetify VBtn containing an icon.
+        Creates a Vuetify VBtn as an icon button. Can be dynamically toggled
+        between two states using 'dynamic_condition'.
 
-        :param icon_name: A string or a list/tuple of two strings for conditional rendering of the button icon.
+        :param icon_name: A string or a list of two strings for conditional rendering of the button icon.
         :param color: The button color.
-        :param dynamic_condition: A Vue boolean expression used to toggle between the two values in 'icon_name' and 'description'.
-        :param description: A string or a list/tuple of two strings for conditional tooltip text.
-        :param kwargs: Extra keyword arguments for the VBtn component.
+        :param dynamic_condition: A Vue state variable (boolean) that controls which value to show in 'icon_name' and 'description'.
+        :param description: A string or a list of two strings for conditional tooltip text.
+        :param kwargs: Extra keyword arguments for the component.
         """
 
-        def validate_dynamic_condition(value, name):
+        def validate_dynamic_condition(prop_value: List[str], prop_name: str) -> None:
             """
-            Ensure dynamic_condition components are a list/tuple with exactly 2 strings for dynamic toggling (e.g., expand/collapse).
+            Ensure dynamic_condition components are a list of exactly 2 strings for dynamic toggling (e.g., expand/collapse).
             """
 
-            if not isinstance(value, (list, tuple)):
-                raise ValueError(f"When dynamic_condition is True, {name} must be a list or tuple of exactly 2 strings")
-            if len(value) != 2:
-                raise ValueError(f"When dynamic_condition is True, {name} must contain exactly 2 elements")
-            if not all(isinstance(item, str) for item in value):
-                raise ValueError(f"When dynamic_condition is True, all elements in {name} must be strings")
+            if not isinstance(prop_value, list):
+                raise ValueError(f"When dynamic_condition is set, {prop_name} must be a list of exactly 2 strings")
+            if len(prop_value) != 2:
+                raise ValueError(f"When dynamic_condition is set, {prop_name} must contain exactly 2 elements")
+            if not all(isinstance(item, str) for item in prop_value):
+                raise ValueError(f"When dynamic_condition is set, all elements in {prop_name} must be strings")
 
         if dynamic_condition:
             validate_dynamic_condition(icon_name, "icon_name")

--- a/src/python/impactx/dashboard/Input/components/card.py
+++ b/src/python/impactx/dashboard/Input/components/card.py
@@ -122,17 +122,17 @@ class CardComponents:
             Ensure dynamic_condition components are a list of exactly 2 strings for dynamic toggling (e.g., expand/collapse).
             """
 
-            if not isinstance(value, (list, tuple)):
+            if not isinstance(prop_value, (list, tuple)):
                 raise ValueError(
-                    f"When dynamic_condition is True, {name} must be a list or tuple of exactly 2 strings"
+                    f"When dynamic_condition is set, {prop_name} must be a list of exactly 2 strings"
                 )
-            if len(value) != 2:
+            if len(prop_value) != 2:
                 raise ValueError(
-                    f"When dynamic_condition is True, {name} must contain exactly 2 elements"
+                    f"When dynamic_condition is set, {prop_name} must contain exactly 2 elements"
                 )
-            if not all(isinstance(item, str) for item in value):
+            if not all(isinstance(item, str) for item in prop_value):
                 raise ValueError(
-                    f"When dynamic_condition is True, all elements in {name} must be strings"
+                    f"When dynamic_condition is set, all elements in {prop_name} must be strings"
                 )
 
         if dynamic_condition:

--- a/src/python/impactx/dashboard/Input/components/card.py
+++ b/src/python/impactx/dashboard/Input/components/card.py
@@ -136,6 +136,10 @@ class CardComponents:
                 )
 
         if dynamic_condition:
+            if description is None:
+                raise ValueError(
+                    "When dynamic_condition is set, 'description' must be provided and cannot be None."
+                )
             validate_dynamic_condition(icon_name, "icon_name")
             validate_dynamic_condition(description, "description")
 

--- a/src/python/impactx/dashboard/Input/components/card.py
+++ b/src/python/impactx/dashboard/Input/components/card.py
@@ -114,7 +114,28 @@ class CardComponents:
         :param kwargs: Extra keyword arguments for the VBtn component.
         """
 
-        with vuetify.VTooltip(location="bottom", text=description):
+        def validate_dynamic_condition(value, name):
+            """
+            Ensure dynamic_condition components are a list/tuple with exactly 2 strings for dynamic toggling (e.g., expand/collapse).
+            """
+
+            if not isinstance(value, (list, tuple)):
+                raise ValueError(f"When dynamic_condition is True, {name} must be a list or tuple of exactly 2 strings")
+            if len(value) != 2:
+                raise ValueError(f"When dynamic_condition is True, {name} must contain exactly 2 elements")
+            if not all(isinstance(item, str) for item in value):
+                raise ValueError(f"When dynamic_condition is True, all elements in {name} must be strings")
+
+        if dynamic_condition:
+            validate_dynamic_condition(icon_name, "icon_name")
+            validate_dynamic_condition(description, "description")
+
+        if dynamic_condition:
+            tooltip_text =  (f"{dynamic_condition} ? '{description[1]}' : '{description[0]}'",)
+        else:
+            tooltip_text = description
+
+        with vuetify.VTooltip(location="bottom", text=tooltip_text):
             with vuetify.Template(v_slot_activator="{ props }"):
                 with vuetify.VBtn(
                     color=color,
@@ -124,7 +145,7 @@ class CardComponents:
                     v_bind="props",
                     **kwargs,
                 ):
-                    if isinstance(icon_name, (list, tuple)):
+                    if dynamic_condition:
                         with vuetify.Template(v_if=dynamic_condition):
                             vuetify.VIcon(icon_name[1])
                         with vuetify.Template(v_else=True):
@@ -176,7 +197,7 @@ class CardComponents:
             ["mdi-arrow-expand", "mdi-close"],
             click=f"{expand_state} = !{expand_state}",
             dynamic_condition=expand_state,
-            description="Expand",
+            description=["Expand","Close"],
         )
 
     @staticmethod
@@ -195,5 +216,5 @@ class CardComponents:
             ["mdi-chevron-up", "mdi-chevron-down"],
             click=f"{collapsed_state_name} = !{collapsed_state_name}",
             dynamic_condition=collapsed_state_name,
-            description="Collapse",
+            description=["Minimize", "Show"],
         )

--- a/src/python/impactx/dashboard/Input/components/card.py
+++ b/src/python/impactx/dashboard/Input/components/card.py
@@ -108,9 +108,10 @@ class CardComponents:
         """
         Create a Vuetify VBtn containing an icon.
 
-        :param icon_name: A string for a static icon, or a list/tuple of two strings for conditional rendering.
+        :param icon_name: A string or a list/tuple of two strings for conditional rendering of the button icon.
         :param color: The button color.
-        :param dynamic_condition: A Vue expression that determines which icon to display when `icon_name` is a list/tuple.
+        :param dynamic_condition: A Vue boolean expression used to toggle between the two values in 'icon_name' and 'description'.
+        :param description: A string or a list/tuple of two strings for conditional tooltip text.
         :param kwargs: Extra keyword arguments for the VBtn component.
         """
 

--- a/src/python/impactx/dashboard/Toolbar/controls.py
+++ b/src/python/impactx/dashboard/Toolbar/controls.py
@@ -189,7 +189,7 @@ class RunToolbar:
             ["mdi-play-circle", "mdi-close-circle"],
             color=("sim_is_running ? 'error' : sim_status_color",),
             click="sim_is_running ? trigger('cancel_sim') : trigger('begin_sim')",
-            description="Run Simulation",
+            description=["Run Simulation", "Cancel Simulation"],
             dynamic_condition="sim_is_running",
             disabled=("disableRunSimulationButton || sim_is_generating_plots", True),
         )

--- a/src/python/impactx/dashboard/Toolbar/controls.py
+++ b/src/python/impactx/dashboard/Toolbar/controls.py
@@ -92,7 +92,7 @@ class InputToolbar:
             ["mdi-collapse-all", "mdi-expand-all"],
             click=ctrl.collapse_all_sections,
             dynamic_condition="expand_all_sections",
-            description="Collapse all",
+            description=["Minimize All", "Show All"],
         )
 
     @staticmethod


### PR DESCRIPTION
This PR fixes the issue where dynamic icons did not update their tooltip messages correctly. Previously, tooltips remained unchanged even when the icon state changed—for example, the "Run Simulation" button still displayed "Run Simulation" instead of "Cancel Simulation" during an active run.

This PR ensures **all dynamic icons** update their tooltips to reflect their current states accurately. It also adds a check to maintain consistent tooltip behavior across all dynamic interactions.

------------------------------------
Ready to merge after tests pass