### PR TITLE
Dashboard: add `sim.periods` to inputs

### DIFF
--- a/src/python/impactx/dashboard/Input/defaults.py
+++ b/src/python/impactx/dashboard/Input/defaults.py
@@ -83,6 +83,7 @@ class DashboardDefaults:
     LATTICE_CONFIGURATION = {
         "selected_lattice_list": [],
         "selected_lattice": None,
+        "periods": 1,
     }
 
     SPACE_CHARGE = {
@@ -153,6 +154,7 @@ class DashboardDefaults:
         "mass_MeV": "float",
         "charge_qe": "int",
         "csr_bins": "int",
+        "periods": "int",
     }
 
     VALIDATION_CONDITION = {
@@ -162,6 +164,7 @@ class DashboardDefaults:
         "charge_qe": ["non_zero"],
         "mass_MeV": ["positive"],
         "csr_bins": ["positive"],
+        "periods": ["positive"],
     }
 
     # If a parameter is not included in the dictionary, default step amount is 1.

--- a/src/python/impactx/dashboard/Input/latticeConfiguration/latticeMain.py
+++ b/src/python/impactx/dashboard/Input/latticeConfiguration/latticeMain.py
@@ -274,6 +274,11 @@ class LatticeConfiguration(CardBase):
             )
             with vuetify.VCardText(**self.CARD_TEXT_OVERFLOW):
                 with vuetify.VRow(**self.ROW_STYLE):
+                    with vuetify.VCol(cols=2):
+                        InputComponents.text_field(
+                            label="Periods",
+                        )
+                    vuetify.VDivider(vertical=True)
                     with vuetify.VCol(cols=True):
                         InputComponents.combobox(
                             label="Select Accelerator Lattice",

--- a/src/python/impactx/dashboard/Input/latticeConfiguration/variable_handler.py
+++ b/src/python/impactx/dashboard/Input/latticeConfiguration/variable_handler.py
@@ -2,9 +2,9 @@ from typing import Optional, Tuple
 
 from ... import html, setup_server, vuetify
 from .. import (
-    generalFunctions,
     CardComponents,
     DashboardValidation,
+    generalFunctions,
 )
 from .helper import LatticeConfigurationHelper
 

--- a/src/python/impactx/dashboard/Input/latticeConfiguration/variable_handler.py
+++ b/src/python/impactx/dashboard/Input/latticeConfiguration/variable_handler.py
@@ -2,6 +2,7 @@ from typing import Optional, Tuple
 
 from ... import html, setup_server, vuetify
 from .. import (
+    generalFunctions,
     CardComponents,
     DashboardValidation,
 )

--- a/src/python/impactx/dashboard/Input/shared.py
+++ b/src/python/impactx/dashboard/Input/shared.py
@@ -15,13 +15,19 @@ server, state, ctrl = setup_server()
 
 input_parameters_defaults = list(DashboardDefaults.INPUT_PARAMETERS.keys())
 space_charge_defaults = list(DashboardDefaults.CSR.keys())
-INPUT_DEFAULTS = input_parameters_defaults + space_charge_defaults
+lattice_state_defaults = ["periods"]
+INPUT_DEFAULTS = (
+    input_parameters_defaults + space_charge_defaults + lattice_state_defaults
+)
 
 
 class SharedUtilities:
     @staticmethod
     @state.change(*INPUT_DEFAULTS)
     def on_input_state_change(**_):
+        """
+        Called when any non-nested state variables are modified.
+        """
         state_changes = state.modified_keys & set(INPUT_DEFAULTS)
         for state_name in state_changes:
             if type(state[state_name]) is str:

--- a/src/python/impactx/dashboard/Input/validation.py
+++ b/src/python/impactx/dashboard/Input/validation.py
@@ -174,6 +174,8 @@ class DashboardValidation:
 
         if state.selected_lattice_list == []:
             error_details.append("LatticeListIsEmpty")
+        if state.periods_error_message:
+            error_details.append(f"Periods: {state.periods_error_message}")
 
         # Check for errors in CSR parameters
         if state.csr_bins_error_message:

--- a/src/python/impactx/dashboard/Run/simulation.py
+++ b/src/python/impactx/dashboard/Run/simulation.py
@@ -187,6 +187,7 @@ ref.set_charge_qe({state.charge_qe}).set_mass_MeV({state.mass_MeV}).set_kin_ener
 
 {build_lattice_list()}
 sim.lattice.extend(lattice_configuration)
+sim.periods = {state.periods}
 
 # Simulate
 {build_tracking_commands()}


### PR DESCRIPTION
default = `1`
type = `int`
additional conditions = `Must be positive`


TODO
- [X] add to ui
- [X] set defaults (`default value`, `default type`, `additional conditions`)
- [X] connect to simulation validation (do not allow to run simulation if `periods` input is invalid)
- [X] connect to simulation

Lattice Configuration now:
![image](https://github.com/user-attachments/assets/f764fed3-a3f9-40e6-b3a3-9043b9c22cf9)

Notes for future reference:
* Because `state.periods` matches `sim.periods`  (the naming is the same) and isn’t nested, the dashboard auto-loads tooltips from the `ImpactX` class and can parse `sim.periods` directly from `.py` files when importing.

