### PR TITLE
Python: `Marker` named `name` argument

### DIFF
--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -1336,6 +1336,7 @@ void init_elements(py::module& m)
             }
         )
         .def(py::init<std::string>(),
+             py::arg("name"),
              "This named element does nothing."
         )
     ;


### PR DESCRIPTION
Name the `name` argument and make it required when creating a Python `Marker`.