### PR TITLE
CMake: CI w/ `ImpactX_TEST_CLEANUP`

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -68,7 +68,8 @@ jobs:
         cmake -S . -B build            \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DImpactX_FFT=ON             \
-          -DImpactX_PYTHON=ON
+          -DImpactX_PYTHON=ON          \
+          -DImpactX_TEST_CLEANUP=ON
         cmake --build build -j 3
 
         du -hs ~/Library/Caches/ccache

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -49,6 +49,7 @@ jobs:
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DImpactX_FFT=ON             \
           -DImpactX_PYTHON=ON          \
+          -DImpactX_TEST_CLEANUP=ON    \
           -DImpactX_UNITY_BUILD=ON     \
           -DMPIEXEC_POSTFLAGS="--use-hwthread-cpus"
         cmake --build build -j 4
@@ -114,7 +115,8 @@ jobs:
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DImpactX_FFT=ON             \
           -DImpactX_MPI=OFF            \
-          -DImpactX_PYTHON=ON
+          -DImpactX_PYTHON=ON          \
+          -DImpactX_TEST_CLEANUP=ON
         cmake --build build -j 4
 
     - name: run tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -106,6 +106,7 @@ jobs:
               -DImpactX_FFT=ON            `
               -DImpactX_MPI=OFF           `
               -DImpactX_PYTHON=ON         `
+              -DImpactX_TEST_CLEANUP=ON   `
               -DopenPMD_USE_HDF5=ON       `
               -DPython_EXECUTABLE=python3
         if(!$?) { Exit $LASTEXITCODE }
@@ -227,6 +228,7 @@ jobs:
               -DImpactX_FFT=ON               ^
               -DImpactX_MPI=OFF              ^
               -DImpactX_PYTHON=ON            ^
+              -DImpactX_TEST_CLEANUP=ON      ^
               -DopenPMD_USE_HDF5=ON
         if errorlevel 1 exit 1
         cmake --build build --config Debug --parallel 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,10 @@ endif()
 option(ImpactX_MPI_THREAD_MULTIPLE "MPI thread-multiple support, i.e. for async_io" ON)
 mark_as_advanced(ImpactX_MPI_THREAD_MULTIPLE)
 
+# Advanced option to run tests
+option(ImpactX_TEST_CLEANUP "Clean up automated test directories" OFF)
+mark_as_advanced(ImpactX_TEST_CLEANUP)
+
 option(ImpactX_ablastr_internal                  "Download & build ABLASTR" ON)
 option(ImpactX_amrex_internal                    "Download & build AMReX" ON)
 option(ImpactX_openpmd_internal                  "Download & build openPMD-api" ON)

--- a/docs/source/install/cmake.rst
+++ b/docs/source/install/cmake.rst
@@ -148,6 +148,7 @@ CMake Option                  Default & Values                               Des
 ``ImpactX_pybind11_repo``     ``https://github.com/pybind/pybind11.git``     Repository URI to pull and build pybind11 from
 ``ImpactX_pybind11_branch``   *we set and maintain a compatible commit*      Repository branch for ``ImpactX_pybind11_repo``
 ``ImpactX_pybind11_internal`` **ON**/OFF                                     Needs a pre-installed pybind11 library if set to ``OFF``
+``ImpactX_TEST_CLEANUP``      ON/**OFF**                                     Clean up automated test directories
 ============================= ============================================== ===========================================================
 
 For example, one can also build against a local AMReX copy.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -158,6 +158,24 @@ function(add_impactx_test name input is_mpi analysis_script plot_script)
             "ValueError: No objects to concatenate"
         )
     endif()
+
+    # CI: remove test directory after run
+    if(ImpactX_TEST_CLEANUP)
+        add_test(
+            NAME ${name}.cleanup
+            COMMAND ${CMAKE_COMMAND} -P ${ImpactX_SOURCE_DIR}/examples/test_cleanup.cmake ${THIS_WORKING_DIR}
+        )
+        # test cleanup depends on test run
+        set_property(TEST ${name}.cleanup APPEND PROPERTY DEPENDS "${name}.run")
+        if(analysis_script)
+            # test cleanup depends on test analysis
+            set_property(TEST ${name}.cleanup APPEND PROPERTY DEPENDS "${name}.analysis")
+        endif()
+        if(plot_script)
+            # test cleanup depends on test analysis
+            set_property(TEST ${name}.cleanup APPEND PROPERTY DEPENDS "${name}.plot")
+        endif()
+    endif()
 endfunction()
 
 
@@ -681,6 +699,10 @@ add_impactx_test(solenoid.restart
     OFF  # no plot script yet
 )
 set_property(TEST solenoid.restart.run APPEND PROPERTY DEPENDS "solenoid.run")
+if(ImpactX_TEST_CLEANUP)
+    # do not clean up dependency test before current test is completed
+    set_property(TEST solenoid.cleanup APPEND PROPERTY DEPENDS "solenoid.restart.cleanup")
+endif()
 
 add_impactx_test(solenoid.restart.py
     examples/solenoid_restart/run_solenoid.py
@@ -690,6 +712,10 @@ add_impactx_test(solenoid.restart.py
 )
 if(ImpactX_PYTHON)
     set_property(TEST solenoid.restart.py.run APPEND PROPERTY DEPENDS "solenoid.py.run")
+endif()
+if(ImpactX_TEST_CLEANUP)
+    # do not clean up dependency test before current test is completed
+    set_property(TEST solenoid.py.cleanup APPEND PROPERTY DEPENDS "solenoid.restart.py.cleanup")
 endif()
 
 

--- a/examples/test_cleanup.cmake
+++ b/examples/test_cleanup.cmake
@@ -1,0 +1,7 @@
+# delete all test files except backtrace
+file(GLOB test_files ${CMAKE_ARGV3}/*)
+foreach(file ${test_files})
+    if(NOT ${file} MATCHES "Backtrace*")
+        execute_process(COMMAND ${CMAKE_COMMAND} -E rm -r ${file})
+    endif()
+endforeach()


### PR DESCRIPTION
Ported from WarpX: clean up the output of each test in the CI runners, to save disk space.