### PR TITLE
Ubuntu CI: Pre-Clean Disk Space

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -16,6 +16,17 @@ jobs:
       CXXFLAGS: "-Werror"
       OMP_NUM_THREADS: 2
     steps:
+    - name: Free More Disk Space
+      uses: ax3l/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false  # apt takes ~1:30min
+        docker-images: true
+        swap-storage: false
+
     - uses: actions/checkout@v4
 
     - name: install dependencies
@@ -87,6 +98,17 @@ jobs:
       CXXFLAGS: "-Werror"
       OMP_NUM_THREADS: 2
     steps:
+    - name: Free More Disk Space
+      uses: ax3l/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false  # apt takes ~1:30min
+        docker-images: true
+        swap-storage: false
+
     - uses: actions/checkout@v4
 
     - name: install dependencies


### PR DESCRIPTION
We run large debug builds on the Ubuntu runners, for which we are starting to get tight in disk space. [This action](https://github.com/ax3l/free-disk-space) (quickly) frees up a lot of disk space by (quickly) removing a lot of pre-installed software that we do not need on Ubuntu runners.