### PR TITLE
[WIP] CI: `pip` -> `uv`

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,18 +37,14 @@ jobs:
 
       - name: Install Packages
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes cmake openmpi-bin libfftw3-dev libfftw3-mpi-dev libopenmpi-dev libhdf5-openmpi-dev
+          sudo apt update
+          sudo apt install --yes cmake openmpi-bin libfftw3-dev libfftw3-mpi-dev libopenmpi-dev libhdf5-openmpi-dev
 
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade pipx
-          python -m pip install --upgrade wheel
-          python -m pip install --upgrade numpy
-          python -m pip install --upgrade mpi4py
-          python -m pip install --upgrade pytest
-          python -m pip install --upgrade pytest-benchmark
-          python -m pip install --upgrade cmake
-          python -m pipx install cmake
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          export PATH=$HOME/.local/bin:$PATH
+
+          uv pip install --system --upgrade cmake mpi4py numpy pytest pytest-benchmark wheel
+          uvx pip install cmake
 
       - name: Configure (C++)
         if: ${{ matrix.language == 'cpp' }}

--- a/.github/workflows/dependencies/clang-san-openmpi.sh
+++ b/.github/workflows/dependencies/clang-san-openmpi.sh
@@ -7,8 +7,8 @@
 
 set -eu -o pipefail
 
-sudo apt-get -qqq update
-sudo apt-get install -y \
+sudo apt -qqq update
+sudo apt install -y     \
     build-essential     \
     ca-certificates     \
     ccache              \
@@ -28,13 +28,14 @@ sudo apt-get install -y \
     python3-pip         \
     wget
 
-python3 -m pip install -U pip
-python3 -m pip install -U build packaging setuptools[core] wheel
-python3 -m pip install -U cmake
-python3 -m pip install -U -r requirements_mpi.txt
-python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt
-python3 -m pip install -U -r examples/requirements.txt
-python3 -m pip install -U -r tests/python/requirements.txt
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH=$HOME/.local/bin:$PATH
+
+sudo uv pip install --system -U build cmake packaging setuptools[core] wheel
+sudo uv pip install --system -U -r requirements_mpi.txt
+sudo uv pip install --system -U -r src/python/impactx/dashboard/requirements.txt
+sudo uv pip install --system -U -r examples/requirements.txt
+sudo uv pip install --system -U -r tests/python/requirements.txt
 
 # cmake-easyinstall
 #

--- a/.github/workflows/dependencies/clang-tidy.sh
+++ b/.github/workflows/dependencies/clang-tidy.sh
@@ -7,8 +7,8 @@
 
 set -eu -o pipefail
 
-sudo apt-get -qqq update
-sudo apt-get install -y \
+sudo apt -qqq update
+sudo apt install -y     \
     build-essential     \
     ca-certificates     \
     ccache              \
@@ -27,13 +27,14 @@ sudo apt-get install -y \
     python3-pip         \
     wget
 
-python3 -m pip install -U pip
-python3 -m pip install -U build packaging setuptools[core] wheel
-python3 -m pip install -U cmake
-python3 -m pip install -U -r requirements_mpi.txt
-python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt
-python3 -m pip install -U -r examples/requirements.txt
-python3 -m pip install -U -r tests/python/requirements.txt
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH=$HOME/.local/bin:$PATH
+
+sudo uv pip install --system -U build cmake packaging setuptools[core] wheel
+sudo uv pip install --system -U -r requirements_mpi.txt
+sudo uv pip install --system -U -r src/python/impactx/dashboard/requirements.txt
+sudo uv pip install --system -U -r examples/requirements.txt
+sudo uv pip install --system -U -r tests/python/requirements.txt
 
 # cmake-easyinstall
 #

--- a/.github/workflows/dependencies/gcc-openmpi.sh
+++ b/.github/workflows/dependencies/gcc-openmpi.sh
@@ -7,8 +7,8 @@
 
 set -eu -o pipefail
 
-sudo apt-get -qqq update
-sudo apt-get install -y \
+sudo apt -qqq update
+sudo apt install -y     \
     build-essential     \
     ca-certificates     \
     ccache              \
@@ -24,14 +24,14 @@ sudo apt-get install -y \
     python3-pip         \
     wget
 
-python3 -m pip install -U pip
-python3 -m pip install -U build packaging setuptools[core] wheel
-python3 -m pip install -U cmake
-python3 -m pip install -U -r requirements_mpi.txt
-python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt
-python3 -m pip install -U -r examples/requirements.txt
-python3 -m pip install -U -r tests/python/requirements.txt
+python3 -m pip install -U pip pipx uv
+
+uv pip install --system -U build cmake packaging setuptools[core] wheel
+uv pip install --system -U -r requirements_mpi.txt
+uv pip install --system -U -r src/python/impactx/dashboard/requirements.txt
+uv pip install --system -U -r examples/requirements.txt
+uv pip install --system -U -r tests/python/requirements.txt
 
 # extra tests
-python3 -m pip install -U -r examples/requirements_torch_cpu.txt
-python3 -m pip install -U openPMD-validator
+uv pip install --system -U -r examples/requirements_torch_cpu.txt
+uv pip install --system -U openPMD-validator

--- a/.github/workflows/dependencies/gcc.sh
+++ b/.github/workflows/dependencies/gcc.sh
@@ -7,8 +7,8 @@
 
 set -eu -o pipefail
 
-sudo apt-get -qqq update
-sudo apt-get install -y \
+sudo apt -qqq update
+sudo apt install -y     \
     build-essential     \
     ca-certificates     \
     ccache              \
@@ -22,14 +22,14 @@ sudo apt-get install -y \
     python3-pip         \
     wget
 
-python3 -m pip install -U pip
-python3 -m pip install -U build packaging setuptools[core] wheel
-python3 -m pip install -U cmake
-python3 -m pip install -U -r requirements.txt
-python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt
-python3 -m pip install -U -r examples/requirements.txt
-python3 -m pip install -U -r tests/python/requirements.txt
+python3 -m pip install -U pip pipx uv
+
+uv pip install --system -U build cmake packaging setuptools[core] wheel
+uv pip install --system -U -r requirements.txt
+uv pip install --system -U -r src/python/impactx/dashboard/requirements.txt
+uv pip install --system -U -r examples/requirements.txt
+uv pip install --system -U -r tests/python/requirements.txt
 
 # extra tests
-python3 -m pip install -U -r examples/requirements_torch_cpu.txt
-python3 -m pip install -U openPMD-validator
+uv pip install --system -U -r examples/requirements_torch_cpu.txt
+uv pip install --system -U openPMD-validator

--- a/.github/workflows/dependencies/hip-openmpi.sh
+++ b/.github/workflows/dependencies/hip-openmpi.sh
@@ -36,13 +36,13 @@ echo 'export PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/r
   | sudo tee -a /etc/profile.d/rocm.sh
 # we should not need to export HIP_PATH=/opt/rocm/hip with those installs
 
-sudo apt-get update
+sudo apt update
 
 # Ref.: https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html#installing-development-packages-for-cross-compilation
 # meta-package: rocm-dkms
 # OpenCL: rocm-opencl
 # other: rocm-dev rocm-utils
-sudo apt-get install -y --no-install-recommends \
+sudo apt install -y --no-install-recommends \
     build-essential \
     gfortran        \
     libhdf5-openmpi-dev \
@@ -59,7 +59,7 @@ sudo apt-get install -y --no-install-recommends \
     rocsparse-dev${VERSION}
 
 # hiprand-dev is a new package that does not exist in old versions
-sudo apt-get install -y --no-install-recommends hiprand-dev${VERSION} || true
+sudo apt install -y --no-install-recommends hiprand-dev${VERSION} || true
 
 # activate
 #
@@ -67,6 +67,10 @@ source /etc/profile.d/rocm.sh
 hipcc --version
 which clang
 which clang++
+
+# uv
+#
+curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # cmake-easyinstall
 #

--- a/.github/workflows/dependencies/nvcc11-openmpi.sh
+++ b/.github/workflows/dependencies/nvcc11-openmpi.sh
@@ -7,8 +7,8 @@
 
 set -eu -o pipefail
 
-sudo apt-get -qqq update
-sudo apt-get install -y \
+sudo apt -qqq update
+sudo apt install -y     \
     build-essential     \
     ca-certificates     \
     cmake               \
@@ -26,8 +26,8 @@ sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda
 echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64 /" \
     | sudo tee /etc/apt/sources.list.d/cuda.list
 
-sudo apt-get update
-sudo apt-get install -y          \
+sudo apt update
+sudo apt install -y              \
     cuda-command-line-tools-11-7 \
     cuda-compiler-11-7           \
     cuda-cupti-dev-11-7          \
@@ -38,6 +38,10 @@ sudo apt-get install -y          \
     libcurand-dev-11-7           \
     libcusparse-dev-11-7
 sudo ln -s cuda-11.7 /usr/local/cuda
+
+# uv
+#
+curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # cmake-easyinstall
 #

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,14 +37,16 @@ jobs:
         set -e
     - name: install pip dependencies
       run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade build packaging setuptools[core] wheel pytest pytest-benchmark
-        python3 -m pip install --upgrade -r requirements_mpi.txt
-        python3 -m pip install --upgrade -r src/python/impactx/dashboard/requirements.txt
-        python3 -m pip install --upgrade -r examples/requirements.txt
-        python3 -m pip install --upgrade -r tests/python/requirements.txt
-        python3 -m pip install --upgrade pipx
-        python3 -m pipx install openPMD-validator
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+
+        uv pip install --system --upgrade pip
+        uv pip install --system --upgrade build packaging setuptools[core] wheel pytest pytest-benchmark
+        uv pip install --system --upgrade -r requirements_mpi.txt
+        uv pip install --system --upgrade -r src/python/impactx/dashboard/requirements.txt
+        uv pip install --system --upgrade -r examples/requirements.txt
+        uv pip install --system --upgrade -r tests/python/requirements.txt
+        uv pip install --system --upgrade pipx
+        uvx pip install openPMD-validator
     - name: CCache Cache
       uses: actions/cache@v4
       # - once stored under a key, they become immutable (even if local cache path content changes)

--- a/.github/workflows/stubs.yml
+++ b/.github/workflows/stubs.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Dependencies
       run: |
         .github/workflows/dependencies/gcc-openmpi.sh
-        python3 -m pip install -U pybind11-stubgen pre-commit
+        sudo uv pip install --system -U pybind11-stubgen pre-commit
 
     - name: Set Up Cache
       uses: actions/cache@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,6 +38,8 @@ jobs:
         Invoke-WebRequest https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_12_2.tar.gz -OutFile hdf5-1_12_2.tar.gz
         7z.exe x -r hdf5-1_12_2.tar.gz
         7z.exe x -r hdf5-1_12_2.tar
+
+        powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
     - name: Install Dependencies
       env:
         # Work-around for windows-latest GH runner issue, see
@@ -80,13 +82,14 @@ jobs:
         $env:HDF5_DIR = "C:/Program Files/HDF_Group/HDF5/1.12.2/cmake/"
         $env:HDF5_USE_STATIC_LIBRARIES = "ON"
 
-        python3 -m pip install -U pip
-        python3 -m pip install -U build packaging setuptools[core] wheel
-        python3 -m pip install -U -r requirements.txt
-        python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt
-        python3 -m pip install -U -r examples/requirements.txt
-        python3 -m pip install -U -r tests/python/requirements.txt
-        python3 -m pip install -U openPMD-validator
+        uv venv
+        uv pip install --system -U pip
+        uv pip install --system -U build packaging setuptools[core] wheel
+        uv pip install --system -U -r requirements.txt
+        uv pip install --system -U -r src/python/impactx/dashboard/requirements.txt
+        uv pip install --system -U -r examples/requirements.txt
+        uv pip install --system -U -r tests/python/requirements.txt
+        uv pip install --system -U openPMD-validator
     - name: Build
       env:
         # Work-around for windows-latest GH runner issue, see
@@ -157,6 +160,8 @@ jobs:
         Invoke-WebRequest https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_12_2.tar.gz -OutFile hdf5-1_12_2.tar.gz
         7z.exe x -r hdf5-1_12_2.tar.gz
         7z.exe x -r hdf5-1_12_2.tar
+
+        powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
     - name: Install Dependencies
       shell: cmd
       run: |
@@ -201,13 +206,13 @@ jobs:
         set "HDF5_DIR=C:/Program Files/HDF_Group/HDF5/1.12.2/cmake/"
         set "HDF5_USE_STATIC_LIBRARIES=ON"
 
-        python3 -m pip install -U pip
-        python3 -m pip install -U build packaging setuptools[core] wheel
-        python3 -m pip install -U -r requirements.txt
-        python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt
-        python3 -m pip install -U -r examples/requirements.txt
-        python3 -m pip install -U -r tests/python/requirements.txt
-        python3 -m pip install -U openPMD-validator
+        uv pip install --system -U pip
+        uv pip install --system -U build packaging setuptools[core] wheel
+        uv pip install --system -U -r requirements.txt
+        uv pip install --system -U -r src/python/impactx/dashboard/requirements.txt
+        uv pip install --system -U -r examples/requirements.txt
+        uv pip install --system -U -r tests/python/requirements.txt
+        uv pip install --system -U openPMD-validator
     - name: Build
       shell: cmd
       env:


### PR DESCRIPTION
There are central Python tools being rewritten in performant, compiled rust via [the astral.sh project](https://astral.sh/). `uv` as a drop-in replacement of `pip` is one of them, another one, `ruff`, we are already using.

Speed up CI time by ditching slow Python tools accordingly.