### PR TITLE
`sim.verbose` also AMReX

### DIFF
--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -436,6 +436,9 @@ void init_ImpactX (py::module& m)
             [](ImpactX & /* ix */, int const verbose) {
                 amrex::ParmParse pp_impactx("impactx");
                 pp_impactx.add("verbose", verbose);
+                // AMReX init/finalize
+                amrex::ParmParse pp_amrex("amrex");
+                pp_amrex.add("verbose", verbose);
             },
             "Controls how much information is printed to the terminal, when running ImpactX.\n"
             "``0`` for silent, higher is more verbose. Default is ``1``."


### PR DESCRIPTION
While technically two options, we usually need this to set `sim.verbose = 0`. We now also set the AMReX verbose level to the same number, which ensures that init/finalize messages are also not printed, e.g.,
```
Initializing AMReX (25.05)...
OMP initialized with 14 OMP threads
AMReX (25.05) initialized
AMReX (25.05) finalized
```