### PR TITLE
Python: `sim.omp_threads`

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -237,6 +237,12 @@ Collective Effects & Overall Simulation Parameters
 
       The number of periods to repeat the lattice.
 
+   .. py:property:: omp_threads
+
+      Controls the number of OpenMP threads to use (ImpactX default: "nosmt").
+
+      See the detailed `AMReX docs <https://amrex-codes.github.io/amrex/docs_html/InputsComputeBackends.html>`__ for details in the accepted values.
+
    .. py:property:: abort_on_warning_threshold
 
       (optional) Set to "low", "medium" or "high".

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -429,6 +429,20 @@ void init_ImpactX (py::module& m)
             "if there are unused parameters in the input."
         )
 
+        .def_property("omp_threads",
+            [](ImpactX & /* ix */){
+                return detail::get_or_throw<std::string>("amrex", "omp_threads");
+            },
+            [](ImpactX & /* ix */, std::variant<int, std::string> omp_threads_var) {
+                std::visit([&]( auto && omp_threads) {
+                    amrex::ParmParse pp_amrex("amrex");
+                pp_amrex.add("omp_threads", omp_threads);
+                }, omp_threads_var);
+            },
+            "Controls the number of OpenMP threads to use (ImpactX default: \"nosmt\").\n"
+            "https://amrex-codes.github.io/amrex/docs_html/InputsComputeBackends.html."
+        )
+
         .def_property("verbose",
             [](ImpactX & /* ix */){
                 return detail::get_or_throw<int>("impactx", "verbose");

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -81,6 +81,11 @@ def test_impactx_nofile():
     """
     sim = ImpactX()
 
+    # various ways to change OMP threads from the default "nosmt"
+    sim.omp_threads = 1
+    sim.omp_threads = "1"
+    sim.omp_threads = "nosmt"
+
     sim.particle_shape = 2
     sim.slice_step_diagnostics = True
     sim.init_grids()


### PR DESCRIPTION
Expose `amrex.omp_threads` (ParmParse) via a `ImpactX::omp_threads` attribute in Python.