### PR TITLE
Dashboard:  Add simple lattice statistics

### DIFF
--- a/src/python/impactx/dashboard/Input/visualization/lattice/__init__.py
+++ b/src/python/impactx/dashboard/Input/visualization/lattice/__init__.py
@@ -1,0 +1,7 @@
+from .statistics import LatticeVisualizerStatisticComponents as StatComponents
+from .statistics import LatticeVisualizerStatisticUtils as StatUtils
+
+__all__ = [
+    "StatComponents",  
+    "StatUtils",
+]

--- a/src/python/impactx/dashboard/Input/visualization/lattice/__init__.py
+++ b/src/python/impactx/dashboard/Input/visualization/lattice/__init__.py
@@ -2,6 +2,6 @@ from .statistics import LatticeVisualizerStatisticComponents as StatComponents
 from .statistics import LatticeVisualizerStatisticUtils as StatUtils
 
 __all__ = [
-    "StatComponents",  
+    "StatComponents",
     "StatUtils",
 ]

--- a/src/python/impactx/dashboard/Input/visualization/lattice/statistics.py
+++ b/src/python/impactx/dashboard/Input/visualization/lattice/statistics.py
@@ -50,16 +50,15 @@ class LatticeVisualizerStatisticUtils:
         lattice configuration. Sums all elements' 'ds' (length) parameters.
         """
         lengths = LatticeVisualizerStatisticUtils._extract_parameter_values("ds", float)
-
         if lengths:
-            state.total_length = round(sum(lengths), 2)
-            state.min_length = round(min(lengths), 3)
-            state.max_length = round(max(lengths), 3)
-            state.avg_length = round(sum(lengths) / len(lengths), 3)
+            state.total_length = f"{round(sum(lengths), 2)}m"
+            state.min_length = f"{round(min(lengths), 3)}m"
+            state.max_length = f"{round(max(lengths), 3)}m"
+            state.avg_length = f"{round(sum(lengths) / len(lengths), 3)}m"
             state.length_stats_content = [
-                f"Longest: {state.max_length} m",
-                f"Shortest: {state.min_length} m",
-                f"Average: {state.avg_length} m",
+                f"Longest: {state.max_length}",
+                f"Shortest: {state.min_length}",
+                f"Average: {state.avg_length}",
             ]
         else:
             state.total_length = None
@@ -107,14 +106,12 @@ class LatticeVisualizerStatisticComponents:
         :param title: The statistic name
         """
         title_state_name = title.lower().replace(" ", "_")
-
         is_stat_length = "length" in title.lower()
-        suffix = " m" if is_stat_length and state.total_elements > 0 else ""
 
         vuetify.VCardSubtitle(title, classes="pb-0 mb-0")
 
         with vuetify.VCardTitle(
-            f"{{{{ {title_state_name} || '-' }}}}{suffix}",
+            f"{{{{ {title_state_name} || '-' }}}}",
             classes="d-flex align-center justify-center my-0 py-0",
         ):
             if is_stat_length:

--- a/src/python/impactx/dashboard/Input/visualization/lattice/statistics.py
+++ b/src/python/impactx/dashboard/Input/visualization/lattice/statistics.py
@@ -7,6 +7,7 @@ License: BSD-3-Clause-LBNL
 """
 
 from .... import html, setup_server, vuetify
+
 server, state, ctrl = setup_server()
 
 state.total_elements = 0
@@ -19,19 +20,19 @@ state.element_counts = {}
 state.length_stats_content = ""
 state.lattice_is_empty = len(state.selected_lattice_list) == 0
 
+
 class LatticeVisualizerStatisticUtils:
-    
     @staticmethod
     def _extract_parameter_values(parameter_name: str, value_type=float):
         """
         Helper function to extract parameter values from the lattice list.
-        
+
         :param parameter_name: Name of the parameter to extract (case-insensitive)
         :param value_type: Type to convert values to (float, int, etc.)
         :return: List of extracted values
         """
         values = []
-        
+
         for element in state.selected_lattice_list:
             for param in element.get("parameters", []):
                 if param.get("parameter_name", "").lower() == parameter_name.lower():
@@ -39,9 +40,9 @@ class LatticeVisualizerStatisticUtils:
                         values.append(value_type(param.get("sim_input", 0)))
                     except (ValueError, TypeError):
                         pass
-        
+
         return values
-    
+
     @staticmethod
     def update_length_statistics() -> None:
         """
@@ -58,7 +59,7 @@ class LatticeVisualizerStatisticUtils:
             state.length_stats_content = [
                 f"Longest: {state.max_length} m",
                 f"Shortest: {state.min_length} m",
-                f"Average: {state.avg_length} m"
+                f"Average: {state.avg_length} m",
             ]
         else:
             state.total_length = None
@@ -95,6 +96,7 @@ class LatticeVisualizerStatisticUtils:
         steps = LatticeVisualizerStatisticUtils._extract_parameter_values("nslice", int)
         return sum(steps)
 
+
 class LatticeVisualizerStatisticComponents:
     @staticmethod
     def _stat(title: str) -> None:
@@ -113,7 +115,7 @@ class LatticeVisualizerStatisticComponents:
 
         with vuetify.VCardTitle(
             f"{{{{ {title_state_name} || '-' }}}}{suffix}",
-            classes="d-flex align-center justify-center my-0 py-0"
+            classes="d-flex align-center justify-center my-0 py-0",
         ):
             if is_stat_length:
                 LatticeVisualizerStatisticComponents._additional_length_stats()
@@ -156,7 +158,9 @@ class LatticeVisualizerStatisticComponents:
                         vuetify.VCardTitle("Lattice list is empty.")
                     with vuetify.Template(v_else=True):
                         with vuetify.VChipGroup():
-                            with vuetify.Template(v_for="[name, count] in element_counts", key="name"):
+                            with vuetify.Template(
+                                v_for="[name, count] in element_counts", key="name"
+                            ):
                                 vuetify.VChip(
                                     "{{ name.charAt(0).toUpperCase() + name.slice(1) }}: {{ count }}",
                                     style="font-size: 0.75rem;",

--- a/src/python/impactx/dashboard/Input/visualization/lattice/statistics.py
+++ b/src/python/impactx/dashboard/Input/visualization/lattice/statistics.py
@@ -1,0 +1,163 @@
+"""
+This file is part of ImpactX
+
+Copyright 2025 ImpactX contributors
+Authors: Parthib Roy
+License: BSD-3-Clause-LBNL
+"""
+
+from .... import html, setup_server, vuetify
+server, state, ctrl = setup_server()
+
+state.total_elements = 0
+state.total_length = 0
+state.max_length = 0
+state.min_length = 0
+state.avg_length = 0
+state.total_steps = 0
+state.element_counts = {}
+state.length_stats_content = ""
+state.lattice_is_empty = len(state.selected_lattice_list) == 0
+
+class LatticeVisualizerStatisticUtils:
+    
+    @staticmethod
+    def _extract_parameter_values(parameter_name: str, value_type=float):
+        """
+        Helper function to extract parameter values from the lattice list.
+        
+        :param parameter_name: Name of the parameter to extract (case-insensitive)
+        :param value_type: Type to convert values to (float, int, etc.)
+        :return: List of extracted values
+        """
+        values = []
+        
+        for element in state.selected_lattice_list:
+            for param in element.get("parameters", []):
+                if param.get("parameter_name", "").lower() == parameter_name.lower():
+                    try:
+                        values.append(value_type(param.get("sim_input", 0)))
+                    except (ValueError, TypeError):
+                        pass
+        
+        return values
+    
+    @staticmethod
+    def update_length_statistics() -> None:
+        """
+        Computes and return the total, min, max, and average length of the
+        lattice configuration. Sums all elements' 'ds' (length) parameters.
+        """
+        lengths = LatticeVisualizerStatisticUtils._extract_parameter_values("ds", float)
+
+        if lengths:
+            state.total_length = round(sum(lengths), 2)
+            state.min_length = round(min(lengths), 3)
+            state.max_length = round(max(lengths), 3)
+            state.avg_length = round(sum(lengths) / len(lengths), 3)
+            state.length_stats_content = [
+                f"Longest: {state.max_length} m",
+                f"Shortest: {state.min_length} m",
+                f"Average: {state.avg_length} m"
+            ]
+        else:
+            state.total_length = None
+            state.min_length = None
+            state.max_length = None
+            state.avg_length = None
+            state.length_stats_content = []
+
+    @staticmethod
+    def update_element_counts() -> list[tuple[str, int]]:
+        """
+        Computes the element counts in the lattice list.
+
+        :return: List of (element name, count) tuples, sorted by count descending.
+        """
+        counts = {}
+        for element in state.selected_lattice_list:
+            key = str(element["name"]).lower()
+            # can't do += 1 because key is not already initialized
+            counts[key] = counts.get(key, 0) + 1
+
+        state.lattice_is_empty = len(counts) == 0
+        # sort from desc. so we see top elements left to right
+        return sorted(counts.items(), key=lambda item: item[1], reverse=True)
+
+    @staticmethod
+    def update_total_steps() -> int:
+        """
+        Computes the total number of steps by summing 'nslice'
+        across all lattice elements.
+
+        :return: Total number of slices.
+        """
+        steps = LatticeVisualizerStatisticUtils._extract_parameter_values("nslice", int)
+        return sum(steps)
+
+class LatticeVisualizerStatisticComponents:
+    @staticmethod
+    def _stat(title: str) -> None:
+        """
+        Displays a statistic block for the statistics section
+        in the lattice visualizer.
+
+        :param title: The statistic name
+        """
+        title_state_name = title.lower().replace(" ", "_")
+
+        is_stat_length = "length" in title.lower()
+        suffix = " m" if is_stat_length and state.total_elements > 0 else ""
+
+        vuetify.VCardSubtitle(title, classes="pb-0 mb-0")
+
+        with vuetify.VCardTitle(
+            f"{{{{ {title_state_name} || '-' }}}}{suffix}",
+            classes="d-flex align-center justify-center my-0 py-0"
+        ):
+            if is_stat_length:
+                LatticeVisualizerStatisticComponents._additional_length_stats()
+
+    @staticmethod
+    def _additional_length_stats():
+        with vuetify.VTooltip(
+            location="bottom",
+        ):
+            with vuetify.Template(v_slot_activator="{ props }"):
+                vuetify.VIcon(
+                    "mdi-information",
+                    size="x-small",
+                    v_bind="props",
+                    disabled=("lattice_is_empty",),
+                    classes="ml-2",
+                )
+            with vuetify.Template(v_for="line in length_stats_content"):
+                html.Div("{{ line }}")
+
+    @staticmethod
+    def statistics():
+        with vuetify.VCardText():
+            # row 1: numerical stats
+            with vuetify.VRow(classes="text-center"):
+                with vuetify.VCol():
+                    LatticeVisualizerStatisticComponents._stat("Total Elements")
+                with vuetify.VCol():
+                    LatticeVisualizerStatisticComponents._stat("Total Length")
+                with vuetify.VCol():
+                    LatticeVisualizerStatisticComponents._stat("Total Steps")
+                with vuetify.VCol():
+                    LatticeVisualizerStatisticComponents._stat("Periods")
+
+            # row 2: element breakdown
+            with vuetify.VRow(classes="pt-0 mt-0"):
+                with vuetify.VCol(cols=12):
+                    vuetify.VCardSubtitle("Element Breakdown")
+                    with vuetify.Template(v_if="lattice_is_empty"):
+                        vuetify.VCardTitle("Lattice list is empty.")
+                    with vuetify.Template(v_else=True):
+                        with vuetify.VChipGroup():
+                            with vuetify.Template(v_for="[name, count] in element_counts", key="name"):
+                                vuetify.VChip(
+                                    "{{ name.charAt(0).toUpperCase() + name.slice(1) }}: {{ count }}",
+                                    style="font-size: 0.75rem;",
+                                )

--- a/src/python/impactx/dashboard/Input/visualization/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/visualization/lattice/ui.py
@@ -7,7 +7,6 @@ License: BSD-3-Clause-LBNL
 """
 
 from .... import html, setup_server, vuetify
-
 from ... import CardBase
 from . import StatComponents, StatUtils
 
@@ -28,6 +27,7 @@ def _update_statistics() -> None:
 def on_lattice_list_change(**kwargs):
     _update_statistics()
 
+
 class LatticeVisualizer(CardBase):
     """
     Displays the lattice visualizer section on the inputs page of the dashboard.
@@ -35,7 +35,7 @@ class LatticeVisualizer(CardBase):
 
     def __init__(self):
         super().__init__()
-        
+
     def card_content(self):
         """
         The content of the lattice visualizer.
@@ -53,5 +53,3 @@ class LatticeVisualizer(CardBase):
                     html.Div("Lattice Statistics")
                     vuetify.VSpacer()
                 StatComponents.statistics()
-            
-

--- a/src/python/impactx/dashboard/Input/visualization/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/visualization/lattice/ui.py
@@ -1,0 +1,57 @@
+"""
+This file is part of ImpactX
+
+Copyright 2025 ImpactX contributors
+Authors: Parthib Roy
+License: BSD-3-Clause-LBNL
+"""
+
+from .... import html, setup_server, vuetify
+
+from ... import CardBase
+from . import StatComponents, StatUtils
+
+server, state, ctrl = setup_server()
+
+
+def _update_statistics() -> None:
+    """
+    Update statistics based on the current selected lattice elements.
+    """
+    state.total_elements = len(state.selected_lattice_list)
+    state.total_steps = StatUtils.update_total_steps()
+    state.element_counts = StatUtils.update_element_counts()
+    StatUtils.update_length_statistics()
+
+
+@state.change("selected_lattice_list")
+def on_lattice_list_change(**kwargs):
+    _update_statistics()
+
+class LatticeVisualizer(CardBase):
+    """
+    Displays the lattice visualizer section on the inputs page of the dashboard.
+    """
+
+    def __init__(self):
+        super().__init__()
+        
+    def card_content(self):
+        """
+        The content of the lattice visualizer.
+        """
+
+        with vuetify.VCard():
+            with vuetify.VCard(
+                classes="d-flex flex-column",
+                style="min-height: 3.75rem; margin-bottom: 20px;",
+                color="#002949",
+                elevation=2,
+            ):
+                # create custom header over using component in CardComponents
+                with vuetify.VCardTitle(classes="d-flex align-center"):
+                    html.Div("Lattice Statistics")
+                    vuetify.VSpacer()
+                StatComponents.statistics()
+            
+

--- a/src/python/impactx/dashboard/__main__.py
+++ b/src/python/impactx/dashboard/__main__.py
@@ -12,6 +12,7 @@ from trame.ui.router import RouterViewLayout
 from trame.ui.vuetify3 import SinglePageWithDrawerLayout
 from trame.widgets import router, xterm
 
+from .Input.visualization.lattice.ui import LatticeVisualizer
 from . import (
     AnalyzeSimulation,
     DistributionParameters,
@@ -25,6 +26,7 @@ from . import (
     setup_server,
     vuetify,
 )
+
 from .start import main
 from .Toolbar.sim_history.ui import load_my_js
 
@@ -80,6 +82,10 @@ with RouterViewLayout(server, "/Input"):
                 with vuetify.VRow(**card_row_padding):
                     with vuetify.VCol(cols=12, **card_column_padding):
                         lattice_config.card()
+            with vuetify.VCol(cols=12, md=6):
+                with vuetify.VRow(**card_row_padding):
+                    with vuetify.VCol():
+                        LatticeVisualizer().card()
 
 with RouterViewLayout(server, "/Analyze"):
     with vuetify.VContainer(fluid=True):

--- a/src/python/impactx/dashboard/__main__.py
+++ b/src/python/impactx/dashboard/__main__.py
@@ -12,7 +12,6 @@ from trame.ui.router import RouterViewLayout
 from trame.ui.vuetify3 import SinglePageWithDrawerLayout
 from trame.widgets import router, xterm
 
-from .Input.visualization.lattice.ui import LatticeVisualizer
 from . import (
     AnalyzeSimulation,
     DistributionParameters,
@@ -26,7 +25,7 @@ from . import (
     setup_server,
     vuetify,
 )
-
+from .Input.visualization.lattice.ui import LatticeVisualizer
 from .start import main
 from .Toolbar.sim_history.ui import load_my_js
 


### PR DESCRIPTION
This is the first PR for the Lattice Visualizer section on the `Inputs ` page. It introduces basic lattice statistics that give users immediate feedback on their current lattice configuration. The visual representation of the lattice is intended to be added below these statistics in a future PR.

https://github.com/user-attachments/assets/28aba791-7bb2-4a85-8a94-fc069a9343ea

