### PR TITLE
Explicit Power 2 & 3

### DIFF
--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -155,13 +155,13 @@ namespace impactx::elements
                   switch (m_shape)
                   {
                       case Shape::rectangular :  // default shape
-                        if (std::pow(u,2)>1 || std::pow(v,2) > 1_prt) {
+                        if (u * u > 1_prt || v * v > 1_prt) {
                             amrex::ParticleIDWrapper{idcpu}.make_invalid();
                         }
                         break;
 
                       case Shape::elliptical :
-                        if (std::pow(u,2) + std::pow(v,2) > 1_prt) {
+                        if (u * u + v * v > 1_prt) {
                             amrex::ParticleIDWrapper{idcpu}.make_invalid();
                         }
                         break;
@@ -173,13 +173,13 @@ namespace impactx::elements
                   switch (m_shape)
                   {
                       case Shape::rectangular :  // default
-                        if (std::pow(u,2) < 1 && std::pow(v,2) < 1_prt) {
+                        if (u * u < 1 && v * v < 1_prt) {
                             amrex::ParticleIDWrapper{idcpu}.make_invalid();
                         }
                         break;
 
                      case Shape::elliptical :
-                        if (std::pow(u,2) + std::pow(v,2) < 1_prt) {
+                        if (u * u + v * v < 1_prt) {
                             amrex::ParticleIDWrapper{idcpu}.make_invalid();
                         }
                         break;

--- a/src/elements/Buncher.H
+++ b/src/elements/Buncher.H
@@ -78,7 +78,7 @@ namespace impactx::elements
             Alignment::compute_constants(refpart);
 
             // find beta*gamma^2
-            amrex::ParticleReal const betgam2 = std::pow(refpart.pt, 2) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = refpart.pt * refpart.pt - 1.0_prt;
 
             m_neg_kV = -m_k * m_V;
             m_kV_r2bg2 = -m_neg_kV / (2.0_prt * betgam2);
@@ -152,7 +152,7 @@ namespace impactx::elements
             using namespace amrex::literals; // for _rt and _prt
 
             // find beta*gamma^2
-            amrex::ParticleReal const betgam2 = std::pow(refpart.pt, 2) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = (refpart.pt * refpart.pt) - 1.0_prt;
 
             amrex::ParticleReal const neg_kV = -m_k * m_V;
             amrex::ParticleReal const kV_r2bg2 = -neg_kV / (2.0_prt * betgam2);

--- a/src/elements/CFbend.H
+++ b/src/elements/CFbend.H
@@ -98,13 +98,13 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // find beta*gamma^2, beta
-            amrex::ParticleReal const betgam2 = std::pow(refpart.pt, 2) - 1_prt;
+            amrex::ParticleReal const betgam2 = refpart.pt*refpart.pt - 1_prt;
             amrex::ParticleReal const bet = refpart.beta();
             amrex::ParticleReal const ibetgam2 = 1_prt / betgam2;
-            amrex::ParticleReal const b2rc2 = std::pow(bet, 2) * std::pow(m_rc, 2);
+            amrex::ParticleReal const b2rc2 = bet*bet * m_rc*m_rc;
 
             // update horizontal and longitudinal phase space variables
-            amrex::ParticleReal const gx = m_k + std::pow(m_rc,-2);
+            amrex::ParticleReal const gx = m_k + 1_prt / (m_rc*m_rc);
             amrex::ParticleReal const omega_x = std::sqrt(std::abs(gx));
 
             // update vertical phase space variables

--- a/src/elements/ChrDrift.H
+++ b/src/elements/ChrDrift.H
@@ -94,7 +94,7 @@ namespace impactx::elements
             m_beta = refpart.beta();
             m_gamma = refpart.gamma();
 
-            m_const1 = 1_prt / (2_prt * std::pow(m_beta,3) * std::pow(m_gamma, 2));
+            m_const1 = 1_prt / (2_prt * m_beta*m_beta*m_beta * m_gamma*m_gamma);
         }
 
         /** This is a chrdrift functor, so that a variable of this type can be used like a chrdrift function.
@@ -136,7 +136,7 @@ namespace impactx::elements
             amrex::ParticleReal const ptout = pt;
 
             // compute particle momentum deviation delta + 1
-            amrex::ParticleReal const idelta1 = 1_prt / std::sqrt(1_prt - 2_prt*pt/m_beta + std::pow(pt,2));
+            amrex::ParticleReal const idelta1 = 1_prt / std::sqrt(1_prt - 2_prt*pt/m_beta + pt*pt);
 
             // advance transverse position and momentum (drift)
             x = xout + m_slice_ds * px * idelta1;
@@ -145,12 +145,12 @@ namespace impactx::elements
             // pyout = py;
 
             // the corresponding symplectic update to t
-            amrex::ParticleReal term = 2_prt * std::pow(pt,2) + std::pow(px,2) + std::pow(py,2);
-            term = 2_prt - 4_prt*m_beta*pt + std::pow(m_beta,2)*term;
-            term = -2_prt + std::pow(m_gamma, 2)*term;
+            amrex::ParticleReal term = 2_prt * pt*pt + px*px + py*py;
+            term = 2_prt - 4_prt*m_beta*pt + m_beta*m_beta*term;
+            term = -2_prt + m_gamma*m_gamma*term;
             term = (-1_prt+m_beta*pt)*term;
             term = term * m_const1;
-            t = tout - m_slice_ds * (1_prt / m_beta + term * std::pow(idelta1, 3));
+            t = tout - m_slice_ds * (1_prt / m_beta + term * idelta1*idelta1*idelta1);
             // ptout = pt;
 
             // assign updated momenta
@@ -189,7 +189,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds /std::sqrt(std::pow(pt,2)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds / std::sqrt(pt*pt - 1.0_prt);
 
             // advance position and momentum (drift)
             refpart.x = x + step*px;

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -109,7 +109,7 @@ namespace impactx::elements
             // normalize quad units to MAD-X convention if needed
             m_g = m_unit == 1 ? m_k / refpart.rigidity_Tm() : m_k;
 
-            m_const1 = 1_prt / (2_prt * std::pow(m_beta, 3) * std::pow(m_gamma, 2));
+            m_const1 = 1_prt / (2_prt * m_beta * m_beta * m_beta * m_gamma * m_gamma);
         }
 
         /** This is a chrquad functor, so that a variable of this type can be used like a chrquad function.
@@ -146,7 +146,7 @@ namespace impactx::elements
             amrex::ParticleReal const tout = t;
 
             // compute particle momentum deviation delta + 1
-            amrex::ParticleReal const delta1 = std::sqrt(1_prt - 2_prt*pt/m_beta + std::pow(pt,2));
+            amrex::ParticleReal const delta1 = std::sqrt(1_prt - 2_prt*pt/m_beta + pt*pt);
             amrex::ParticleReal const delta = delta1 - 1_prt;
 
             // compute phase advance per unit length in s (in rad/m)
@@ -205,12 +205,12 @@ namespace impactx::elements
             if (m_g == 0.0)
             {
                // the corresponding symplectic update to t (zero strength = drift)
-               amrex::ParticleReal term = 2_prt * std::pow(pt,2) + std::pow(px,2) + std::pow(py,2);
-               term = 2_prt - 4_prt * m_beta * pt + std::pow(m_beta,2) * term;
-               term = -2_prt + std::pow(m_gamma, 2)*term;
+               amrex::ParticleReal term = 2_prt * pt*pt + px*px + py*py;
+               term = 2_prt - 4_prt * m_beta * pt + m_beta * m_beta * term;
+               term = -2_prt + m_gamma*m_gamma*term;
                term = (-1_prt + m_beta * pt) * term;
                term = term * m_const1;
-               t = tout - m_slice_ds * (1_prt / m_beta + term / std::pow(delta1, 3));
+               t = tout - m_slice_ds * (1_prt / m_beta + term / (delta1 * delta1 * delta1));
                // ptout = pt;
 
             } else
@@ -220,14 +220,14 @@ namespace impactx::elements
                 amrex::ParticleReal const t0 = tout - term * m_slice_ds / delta1;
 
                 amrex::ParticleReal const w = omega * delta1;
-                amrex::ParticleReal const term1 = -(std::pow(p2,2) + std::pow(q2,2) * std::pow(w,2)) * std::sinh(2_prt*m_slice_ds*omega);
-                amrex::ParticleReal const term2 = -(std::pow(p1,2) - std::pow(q1,2) * std::pow(w,2)) * std::sin(2_prt*m_slice_ds*omega);
+                amrex::ParticleReal const term1 = -(p2*p2 + q2*q2 * w*w) * std::sinh(2_prt*m_slice_ds*omega);
+                amrex::ParticleReal const term2 = -(p1*p1 - q1*q1 * w*w) * std::sin(2_prt*m_slice_ds*omega);
                 amrex::ParticleReal const term3 = -2_prt * q2 * p2 * w * std::cosh(2_prt*m_slice_ds*omega);
                 amrex::ParticleReal const term4 = -2_prt * q1 * p1 * w * std::cos(2_prt*m_slice_ds*omega);
                 amrex::ParticleReal const term5 =  2_prt * omega * (q1*p1*delta1 + q2*p2*delta1
-                    -(std::pow(p1,2) + std::pow(p2,2))*m_slice_ds - (std::pow(q1,2)-std::pow(q2,2)) * std::pow(w,2)*m_slice_ds);
+                    -(p1*p1 + p2*p2)*m_slice_ds - (q1*q1 - q2*q2) * w*w*m_slice_ds);
                 t = t0 + (-1_prt+m_beta*pt)
-                       / (8_prt*m_beta * std::pow(delta1,3)*omega)
+                       / (8_prt*m_beta * delta1*delta1*delta1*omega)
                        * (term1+term2+term3+term4+term5);
                // ptout = pt;
              }

--- a/src/elements/DipEdge.H
+++ b/src/elements/DipEdge.H
@@ -93,9 +93,9 @@ namespace impactx::elements
 
             // first-order effect of nonzero gap
             auto const [sin_psi, cos_psi] = amrex::Math::sincos(m_psi);
-            amrex::ParticleReal const vf = (1.0_prt + std::pow(sin_psi, 2))
-                / std::pow(cos_psi, 3)
-                * m_g * m_K2 / std::pow(m_rc, 2);
+            amrex::ParticleReal const vf = (1.0_prt + sin_psi*sin_psi)
+                / (cos_psi * cos_psi * cos_psi)
+                * m_g * m_K2 / (m_rc * m_rc);
 
             m_R43 = vf - m_R21;
         }
@@ -165,9 +165,9 @@ namespace impactx::elements
 
             // first-order effect of nonzero gap
             auto const [sin_psi, cos_psi] = amrex::Math::sincos(m_psi);
-            amrex::ParticleReal const vf = (1.0_prt + std::pow(sin_psi, 2))
-                / std::pow(cos_psi, 3)
-                * m_g * m_K2 / std::pow(m_rc, 2);
+            amrex::ParticleReal const vf = (1.0_prt + sin_psi*sin_psi)
+                / (cos_psi * cos_psi * cos_psi)
+                * m_g * m_K2 / (m_rc * m_rc);
 
             amrex::ParticleReal const R43 = vf - R21;
 

--- a/src/elements/Drift.H
+++ b/src/elements/Drift.H
@@ -89,7 +89,7 @@ namespace impactx::elements
             m_slice_ds = m_ds / nslice();
 
             // find beta*gamma^2
-            m_betgam2 = std::pow(refpart.pt, 2) - 1.0_prt;
+            m_betgam2 = refpart.pt*refpart.pt - 1.0_prt;
 
             m_slice_bg = m_slice_ds / m_betgam2;
         }
@@ -179,7 +179,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds /std::sqrt(std::pow(pt,2)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds / std::sqrt(pt*pt - 1.0_prt);
 
             // advance position and momentum (drift)
             refpart.x = x + step*px;
@@ -209,7 +209,7 @@ namespace impactx::elements
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = pt_ref * pt_ref - 1.0_prt;
 
             // assign linear map matrix elements
             Map6x6 R = Map6x6::Identity();

--- a/src/elements/LinearMap.H
+++ b/src/elements/LinearMap.H
@@ -140,7 +140,7 @@ namespace impactx::elements
                 amrex::ParticleReal const slice_ds = m_ds / nslice();
 
                 // assign intermediate parameter
-                amrex::ParticleReal const step = slice_ds /std::sqrt(std::pow(pt,2)-1.0_prt);
+                amrex::ParticleReal const step = slice_ds /std::sqrt(pt*pt-1.0_prt);
 
                 // advance position and momentum (drift)
                 refpart.x = x + step*px;

--- a/src/elements/Quad.H
+++ b/src/elements/Quad.H
@@ -94,7 +94,7 @@ namespace impactx::elements
 
             amrex::ParticleReal const pt_ref = refpart.pt;
             // find beta*gamma^2
-            m_betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
+            m_betgam2 = pt_ref * pt_ref - 1.0_prt;
             m_slice_bg = m_slice_ds / m_betgam2;
 
             // compute phase advance per unit length in s (in rad/m)

--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -287,7 +287,7 @@ namespace RFCavityData
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // compute intial value of beta*gamma
-            amrex::ParticleReal const bgi = std::sqrt(std::pow(pt, 2) - 1.0_prt);
+            amrex::ParticleReal const bgi = std::sqrt(pt*pt - 1.0_prt);
 
             // call integrator to advance (t,pt)
             amrex::ParticleReal const zin = s - sedge;
@@ -303,7 +303,7 @@ namespace RFCavityData
             refpart.z = z + slice_ds*pz/bgi;
 
             // compute final value of beta*gamma
-            amrex::ParticleReal const bgf = std::sqrt(std::pow(ptf, 2) - 1.0_prt);
+            amrex::ParticleReal const bgf = std::sqrt(ptf*ptf - 1.0_prt);
 
             // advance momentum (px,py,pz)
             refpart.px = px*bgf/bgi;

--- a/src/elements/Sbend.H
+++ b/src/elements/Sbend.H
@@ -92,7 +92,8 @@ namespace impactx::elements
 
             // access reference particle values
             amrex::ParticleReal const ibet = 1.0_prt / refpart.beta();
-            amrex::ParticleReal const ibetagam2 = 1_prt / std::pow(refpart.beta_gamma(), 2);
+            amrex::ParticleReal const betgam = refpart.beta_gamma();
+            amrex::ParticleReal const ibetagam2 = 1_prt / (betgam * betgam);
 
             // treat the special case of zero field (equivalent to a drift)
             if (m_rc==0_prt) {

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -303,7 +303,7 @@ namespace SoftSolenoidData
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // compute intial value of beta*gamma
-            amrex::ParticleReal const bgi = std::sqrt(std::pow(pt, 2) - 1.0_prt);
+            amrex::ParticleReal const bgi = std::sqrt(pt*pt - 1.0_prt);
 
             // call integrator to advance (t,pt)
             amrex::ParticleReal const zin = s - sedge;

--- a/src/elements/TaperedPL.H
+++ b/src/elements/TaperedPL.H
@@ -117,7 +117,7 @@ namespace impactx::elements
 
             // advance position and momentum
             xout = x;
-            pxout = px - g * ( x + m_taper*0.5_prt * (std::pow(x, 2) + std::pow(y, 2)) );
+            pxout = px - g * ( x + m_taper * 0.5_prt * (x*x + y*y) );
 
             yout = y;
             pyout = py - g * ( y + m_taper * x * y );

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -135,12 +135,12 @@ namespace impactx::elements
             amrex::ParticleReal ptout = pt;
 
             // compute the function expressing dp/p in terms of pt (labeled f in Ripken etc.)
-            amrex::ParticleReal const f = -1.0_prt + std::sqrt(1.0_prt - 2.0_prt * pt / m_beta + std::pow(pt, 2));
+            amrex::ParticleReal const f = -1.0_prt + std::sqrt(1.0_prt - 2.0_prt * pt / m_beta + pt*pt);
             amrex::ParticleReal const fprime = (1.0_prt - m_beta*pt) / (m_beta * (1.0_prt + f));
 
             // advance position and momentum
             x = xout;
-            pxout = px - std::pow(m_kx, 2) * m_ds * xout + m_kx * m_ds * f; //eq (3.2b)
+            pxout = px - m_kx * m_kx * m_ds * xout + m_kx * m_ds * f; //eq (3.2b)
 
             y = yout;
             pyout = py;

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -371,8 +371,10 @@ namespace impactx
 
         // calculate Twiss / Courant-Snyder gammas
         amrex::Vector<amrex::ParticleReal> gammas;
-        for (size_t i = 0; i < alphas.size(); i++)
-            gammas.push_back((1.0 + std::pow(alphas.at(i), 2)) / betas.at(i));
+        for (size_t i = 0; i < alphas.size(); i++) {
+            amrex::ParticleReal const alpha = alphas.at(i);
+            gammas.push_back((1_prt + alpha*alpha) / betas.at(i));
+        }
 
         amrex::Vector<amrex::ParticleReal> lambdas_pos;
         amrex::Vector<amrex::ParticleReal> lambdas_mom;


### PR DESCRIPTION
@AlexanderSinn reminded me, that pow is really slow, e.g., on GPU. After a few experiments with Godbolt, it seems that indeed modern compilers do not replace powers of 2 and 3 with a (fast) multiplication unless fast-math is used. We currently only use fast-math on GPU, not CPU.

Thus, simple instances of `std::pow(..., 2)` and `std::pow(..., 3)` are replaced now with explict multiplications.

In many cases, writing power ^2 and ^3 is also shorter without `std::pow`.

- [ ] finalize all occurances

Tests:
- `-O3` on CPU https://godbolt.org/z/E951Gs9eW (current AMReX default)
- `-O3` on GPU https://godbolt.org/z/35TroGaTY
- `-O3` fast-math on CPU https://godbolt.org/z/31sonob91
- `-O3` fast-math on GPU https://godbolt.org/z/Yozdrcoa3 (current AMReX default)