### PR TITLE
Re-Enable Element Benchmarks

### DIFF
--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -181,7 +181,7 @@ set(ImpactX_ablastr_branch "25.06"
 set(ImpactX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(ImpactX_amrex_internal)")
-set(ImpactX_amrex_branch ""
+set(ImpactX_amrex_branch "e0f31edabcc2a8f245e1efa247e85fe9c7574cc2"
     CACHE STRING
     "Repository branch for ImpactX_amrex_repo if(ImpactX_amrex_internal)")
 

--- a/cmake/dependencies/pyAMReX.cmake
+++ b/cmake/dependencies/pyAMReX.cmake
@@ -74,7 +74,7 @@ option(ImpactX_pyamrex_internal "Download & build pyAMReX" ON)
 set(ImpactX_pyamrex_repo "https://github.com/AMReX-Codes/pyamrex.git"
     CACHE STRING
     "Repository URI to pull and build pyamrex from if(ImpactX_pyamrex_internal)")
-set(ImpactX_pyamrex_branch "25.06"
+set(ImpactX_pyamrex_branch "5042df9cd6cbb9d0f0952fd47dd238357321e010"
     CACHE STRING
     "Repository branch for ImpactX_pyamrex_repo if(ImpactX_pyamrex_internal)")
 

--- a/tests/python/test_benchmark_elements.py
+++ b/tests/python/test_benchmark_elements.py
@@ -18,12 +18,6 @@ import pytest
 
 from impactx import ImpactX, Map6x6, distribution, elements, twiss
 
-#################################################
-# TEMPORARY UNTIL 25.06 was released
-# this tests needs AMReX/pyAMReX 25.07 features
-pytest.skip(allow_module_level=True)
-#################################################
-
 # benchmark config
 rounds = 5
 npart = 1_000_000  # increase this to >10M or even 100M to avoid L1/L2/L3 cache effects on some hardware.


### PR DESCRIPTION
Had to temporarily disable the new benchmark tests (#993 #987) for the release (#1008) due to post-25.06 AMReX/pyAMReX features it uses.