### PR TITLE
PipeAperture Mix-In w/o Divisions

### DIFF
--- a/src/elements/mixin/pipeaperture.H
+++ b/src/elements/mixin/pipeaperture.H
@@ -4,7 +4,7 @@
  *
  * This file is part of ImpactX.
  *
- * Authors: Axel Huebl, Chad Mitchell
+ * Authors: Axel Huebl, Chad Mitchell, Alexander Sinn
  * License: BSD-3-Clause-LBNL
  */
 #ifndef IMPACTX_ELEMENTS_MIXIN_PIPE_APERTURE_H
@@ -23,18 +23,20 @@ namespace impactx::elements::mixin
      */
     struct PipeAperture
     {
-
         /** A finite-length element with a constant elliptical aperture over s.
          *
-         * @param aperture_x horizontal half-aperture size in m
-         * @param aperture_y vertical half-aperture size in m
+         * @param aperture_x horizontal half-aperture size [m]
+         * @param aperture_y vertical half-aperture size [m]
          */
         PipeAperture (
             amrex::ParticleReal aperture_x,
             amrex::ParticleReal aperture_y
         )
-        : m_aperture_x(aperture_x), m_aperture_y(aperture_y)
         {
+            using namespace amrex::literals;  // for _prt
+
+            m_inv_aperture_x = aperture_x > 0_prt ? 1_prt / aperture_x : 0_prt;
+            m_inv_aperture_y = aperture_y > 0_prt ? 1_prt / aperture_y : 0_prt;
         }
 
         PipeAperture () = default;
@@ -60,42 +62,43 @@ namespace impactx::elements::mixin
             using namespace amrex::literals; // for _rt and _prt
 
             // skip aperture application if aperture_x <= 0 or aperture_y <= 0
-            if (m_aperture_x > 0 && m_aperture_y > 0) {
+            if (m_inv_aperture_x > 0_prt && m_inv_aperture_y > 0_prt) {
 
                // scale horizontal and vertical coordinates
-               amrex::ParticleReal const u = x / m_aperture_x;
-               amrex::ParticleReal const v = y / m_aperture_y;
+               amrex::ParticleReal const u = x * m_inv_aperture_x;
+               amrex::ParticleReal const v = y * m_inv_aperture_y;
 
                // compare against the aperture boundary
                if (amrex::Math::powi<2>(u) + amrex::Math::powi<2>(v) > 1_prt) {
                   amrex::ParticleIDWrapper{idcpu}.make_invalid();
                }
-
             }
         }
 
         /** Horizontal aperture size
          *
-         * @return horizontal aperture size in m
+         * @return horizontal aperture size [m]
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         amrex::ParticleReal aperture_x () const
         {
-            return m_aperture_x;
+            using namespace amrex::literals; // for _prt
+            return 1_prt / m_inv_aperture_x;
         }
 
         /** Vertical aperture size
          *
-         * @return vertical aperture size in m
+         * @return vertical aperture size [m]
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         amrex::ParticleReal aperture_y () const
         {
-            return m_aperture_y;
+            using namespace amrex::literals; // for _prt
+            return 1_prt / m_inv_aperture_y;
         }
 
-        amrex::ParticleReal m_aperture_x = 0; //! horizontal aperture size [m]
-        amrex::ParticleReal m_aperture_y = 0; //! vertical aperture size [m]
+        amrex::ParticleReal m_inv_aperture_x = 0; //! inverse of the horizontal aperture size [1/m]
+        amrex::ParticleReal m_inv_aperture_y = 0; //! inverse of the vertical aperture size [1/m]
     };
 
 } // namespace impactx::elements::mixin

--- a/src/elements/mixin/pipeaperture.H
+++ b/src/elements/mixin/pipeaperture.H
@@ -65,6 +65,9 @@ namespace impactx::elements::mixin
             if (m_inv_aperture_x > 0_prt && m_inv_aperture_y > 0_prt) {
 
                // scale horizontal and vertical coordinates
+               // performance optimization: we intentionally store the inverse of
+               //   the aperture, so we can do a quick multiplication (instead of a
+               //   costly division) here.
                amrex::ParticleReal const u = x * m_inv_aperture_x;
                amrex::ParticleReal const v = y * m_inv_aperture_y;
 
@@ -97,6 +100,9 @@ namespace impactx::elements::mixin
             return 1_prt / m_inv_aperture_y;
         }
 
+        // performance optimization: we intentionally store the inverse of
+        //   the aperture, so we can do a quick multiplication instead of a costly
+        //   division in the comparison operation per particle
         amrex::ParticleReal m_inv_aperture_x = 0; //! inverse of the horizontal aperture size [1/m]
         amrex::ParticleReal m_inv_aperture_y = 0; //! inverse of the vertical aperture size [1/m]
     };


### PR DESCRIPTION
The `PipeAperture` class is a mixin class used in all thick elements and always checked and potentially applied for on the critical path of the computation.

A small optimization we can apply is to pre-compute the inverse of the pipe aperture in x and y, so that we can do a simple multiplication to calculate aperture horizontal and vertical comparison instead of a (way more) costly division _per particle_.

First spotted by @AlexanderSinn :+1: 