### PR TITLE
PyTest Conftest: Set Tiling

### DIFF
--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -130,6 +130,12 @@ namespace impactx
         nthreads = omp_get_max_threads();
 #endif
 
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            nthreads == 1 || this->do_tiling == true,
+            "OpenMP threads are used for parallelism but particles.do_tiling is set to false. "
+            "This would create invalid particle data."
+        );
+
         // When running without space charge and OpenMP parallelization,
         // we need to make sure we have enough tiles on level 0, grid 0
         // to thread over the available tiles. We try to set the tile_size

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -21,6 +21,7 @@ basepath = os.getcwd()
 @pytest.fixture(autouse=True, scope="function")
 def amrex_init(tmpdir):
     with tmpdir.as_cwd():
+        # warning: with an external AMReX initialize, our ImpactX overwrite_amrex_parser_defaults is never called!
         amr.initialize(
             [
                 # print AMReX status messages
@@ -39,6 +40,9 @@ def amrex_init(tmpdir):
                 # to enable parallel test runs on the same GPU
                 # https://amrex-codes.github.io/amrex/docs_html/RuntimeParameters.html?highlight=arena#memory
                 "amrex.the_arena_init_size=0",
+                # We override the default tiling option for particles, which is always
+                # "false" in AMReX, to "false" if running on GPU and "true" on CPU.
+                f"particles.do_tiling={0 if impactx.Config.have_gpu else 1}",
             ]
         )
         yield

--- a/tests/python/test_benchmark_elements.py
+++ b/tests/python/test_benchmark_elements.py
@@ -72,9 +72,6 @@ def sim():
             self.sim.add_particles(bunch_charge_C, distr, npart)
             assert self.sim.particle_container().total_number_of_particles() == npart
 
-            # work-around, see https://github.com/AMReX-Codes/amrex/issues/4498
-            self.sim.particle_container().redistribute()
-
             self.sim.backup_beam = self.sim.particle_container().make_alike()
             assert self.sim.backup_beam.total_number_of_particles() == 0
 


### PR DESCRIPTION
In our pytests, we externally initialize AMReX, where we forgot to set the `particles.do_tiling` option on CPU. Externally initializing AMReX on CPU with threads, but not tiling, creates invalid particle data structures (i.e., that do not
get copied correctly).

Fix https://github.com/AMReX-Codes/amrex/issues/4498

Now, our `pytest-benchmark` element test properly speeds up with OpenMP threads.

This did not affect any other inputs-file based runs or Python-based runs, as long as they did not externally init AMReX. This also adds a new check/assert, to avoid that people that externally init AMReX and use OpenMP threads run into the issue again.