### PR TITLE
Dashboard: Test python importing

### DIFF
--- a/src/python/impactx/dashboard/Toolbar/file_imports/ui_populator.py
+++ b/src/python/impactx/dashboard/Toolbar/file_imports/ui_populator.py
@@ -61,7 +61,7 @@ def _populate_distribution_inputs_to_ui(parsed_data):
     state.flush()  # force calls state.change("distribution") and state.change("distribution_type")
 
     for distr_param_name, distr_param_value in parsed_data["parameters"].items():
-        ctrl.updateDistributionParameters(distr_param_name, distr_param_value, "float")
+        ctrl.update_distribution_parameter(distr_param_name, distr_param_value, "float")
 
 
 @staticmethod

--- a/tests/python/dashboard/conftest.py
+++ b/tests/python/dashboard/conftest.py
@@ -1,0 +1,42 @@
+import pytest
+from seleniumbase import SB
+
+from .utils import (
+    DashboardTester,
+    start_dashboard,
+    wait_for_interaction_ready,
+    wait_for_server_ready,
+)
+
+
+@pytest.fixture(scope="session")
+def dashboard():
+    """
+    Sets up a single ImpactX dashboard server and headless browser for all tests in the session.
+    Automatically shuts down the server after all tests complete.
+    """
+
+    app_process = None
+
+    try:
+        app_process = start_dashboard()
+        wait_for_server_ready(app_process)
+
+        with SB(headless=True) as sb:
+            sb.open("http://localhost:8080/index.html#/Input")
+            wait_for_interaction_ready(sb)
+            yield DashboardTester(sb)
+    finally:
+        if app_process:
+            app_process.terminate()
+
+
+@pytest.fixture(autouse=True)
+def reset_dashboard_inputs(dashboard):
+    """
+    Resets the dashboard to its default state before each test.
+
+    This ensures all tests start from a clean, consistent baseline.
+    """
+    dashboard.sb.click("#Input_route")
+    dashboard.sb.click("#reset_all_inputs_button")

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -1,126 +1,73 @@
-"""
-This file is part of ImpactX
-
-Copyright 2025 ImpactX contributors
-Authors: Parthib Roy
-License: BSD-3-Clause-LBNL
-"""
-
-import importlib.util
-
-import pytest
-
-from .utils import (
-    DashboardTester,
-    start_dashboard,
-    wait_for_interaction_ready,
-    wait_for_server_ready,
-)
-
-
-@pytest.mark.skipif(
-    importlib.util.find_spec("trame") is None
-    or importlib.util.find_spec("seleniumbase") is None,
-    reason="trame and seleniumbase must be available",
-)
-def test_dashboard():
+def test_dashboard(dashboard):
     """
-    Tests the ImpactX dashboard with inputs from 'examples/fodo/run_fodo.py'.
+    End-to-end test of the ImpactX dashboard by directly setting inputs via UI,
+    instead of importing a file. Mirrors the configuration in 'examples/fodo/run_fodo.py'.
 
     The test includes:
-    - Launching the dashboard
-    - Configuring the beam properties
-    - Configuring the beam distribution
+    - Configuring the beam properties / beam distribution
     - Configuring the lattice
         - Through direct numeric input
         - Through the variable configuration
     - Running the simulation
     - Checking if the simulation completes successfully
     """
-    from seleniumbase import SB
 
-    app_process = None
+    BEAM_PROPERTIES = {
+        "tracking_mode": "Particle Tracking",
+        "space_charge": "false",
+        "csr": False,
+        "isr": False,
+        "charge_qe": -1,
+        "mass_MeV": 0.510998950,
+        "npart": 10000,
+        "bunch_charge_C": 1e-9,
+    }
 
-    try:
-        with SB(headless=True) as sb:
-            dashboard = DashboardTester(sb)
+    DISTRIBUTION_PARAMETERS = {
+        "distribution": "Waterbag",
+        "distribution_type": "Quadratic",
+        "lambdaX": 3.9984884770e-5,
+        "lambdaY": 3.9984884770e-5,
+        "lambdaT": 1.0e-3,
+        "lambdaPx": 2.6623538760e-5,
+        "lambdaPy": 2.6623538760e-5,
+        "lambdaPt": 2.0e-3,
+        "muxpx": -0.846574929020762,
+        "muypy": 0.846574929020762,
+        "mutpt": 0.0,
+    }
 
-            # Setup Dashboard
-            app_process = start_dashboard()
-            wait_for_server_ready(app_process)
-            sb.open("http://localhost:8080/index.html#/Input")
-            wait_for_interaction_ready(sb)
+    for param_id, value in {**BEAM_PROPERTIES, **DISTRIBUTION_PARAMETERS}.items():
+        dashboard.set_input(param_id, value)
 
-            # Adjust beam properties
-            BEAM_PROPERTIES = {
-                "tracking_mode": "Particle Tracking",
-                "space_charge": "false",
-                "csr": False,
-                "isr": False,
-                "charge_qe": -1,
-                "mass_MeV": 0.510998950,
-                "npart": 10000,
-                "bunch_charge_C": 1e-9,
-            }
+    # Lattice
+    for name in ["Drift", "Quad", "Drift", "Quad", "Drift"]:
+        dashboard.add_lattice_element(name)
 
-            for param_id, param_value in BEAM_PROPERTIES.items():
-                dashboard.set_input(param_id, param_value)
+    LATTICE_PARAMS = {
+        "ds1": 0.25,
+        "nslice1": "ns",
+        "ds2": 1.0,
+        "k2": 1.0,
+        "nslice2": "ns",
+        "ds3": 0.5,
+        "nslice3": "ns",
+        "ds4": 1.0,
+        "k4": -1.0,
+        "nslice4": "ns",
+        "ds5": 0.25,
+        "nslice5": "ns",
+    }
+    for param_id, value in LATTICE_PARAMS.items():
+        dashboard.set_input(param_id, value)
 
-            # Adjust beam distribution
-            DISTRIBUTION_PARAMETERS = {
-                "distribution": "Waterbag",
-                "distribution_type": "Quadratic",
-                "lambdaX": 3.9984884770e-5,
-                "lambdaY": 3.9984884770e-5,
-                "lambdaT": 1.0e-3,
-                "lambdaPx": 2.6623538760e-5,
-                "lambdaPy": 2.6623538760e-5,
-                "lambdaPt": 2.0e-3,
-                "muxpx": -0.846574929020762,
-                "muypy": 0.846574929020762,
-                "mutpt": 0.0,
-            }
+    # Variable
+    dashboard.sb.click("#lattice_settings")
+    VARIABLES = {"variable_name_1": "ns", "variable_value_1": 25}
+    for param_id, value in VARIABLES.items():
+        dashboard.set_input(param_id, value)
 
-            for param_id, param_value in DISTRIBUTION_PARAMETERS.items():
-                dashboard.set_input(param_id, param_value)
-
-            # Build lattice
-            for element_name in ["Drift", "Quad", "Drift", "Quad", "Drift"]:
-                dashboard.add_lattice_element(element_name)
-
-            LATTICE_CONFIGURATION = {
-                "ds1": 0.25,
-                "nslice1": "ns",
-                "ds2": 1.0,
-                "k2": 1.0,
-                "nslice2": "ns",
-                "ds3": 0.5,
-                "nslice3": "ns",
-                "ds4": 1.0,
-                "k4": -1.0,
-                "nslice4": "ns",
-                "ds5": 0.25,
-                "nslice5": "ns",
-            }
-
-            for param_id, param_value in LATTICE_CONFIGURATION.items():
-                dashboard.set_input(param_id, param_value)
-
-            # Add variable
-            sb.click("#lattice_settings")
-            VARIABLES = {
-                "variable_name_1": "ns",
-                "variable_value_1": 25,
-            }
-
-            for param_id, param_value in VARIABLES.items():
-                dashboard.set_input(param_id, param_value)
-
-            # Run the simulation and check if it completes successfully
-            sb.click("#Run_route")
-            sb.click("#run_simulation_button")
-            dashboard.assert_state("sim_progress_status", "Complete!")
-
-    finally:
-        if app_process is not None:
-            app_process.terminate()
+    # Run simulation
+    dashboard.sb.click("#Run_route")
+    dashboard.sb.click("#run_simulation_button")
+    dashboard.assert_state("sim_progress_status", "Complete!")

--- a/tests/python/dashboard/test_python_import.py
+++ b/tests/python/dashboard/test_python_import.py
@@ -1,0 +1,65 @@
+def test_python_import(dashboard):
+    """
+    End-to-end test of the ImpactX dashboard by importing input values from a Python file.
+
+    This test mirrors the configuration in 'testdata/example.py' and verifies:
+    - Trame state reflects the correct beam and distribution values
+    - Form fields (distribution and lattice) are populated with expected inputs
+
+    The configuration is loaded automatically from the file, unlike test_dashboard,
+    which sets values manually through direct UI interaction.
+    """
+    dashboard.load_example("testdata/example.py", manual=True)
+
+    BEAM_PARAMETERS = [
+        ("tracking_mode", "Particle Tracking"),
+        ("space_charge", "false"),
+        ("charge_qe", -1),
+        ("mass_MeV", 0.510998950),
+        ("npart", 10000),
+        ("bunch_charge_C", 1e-9),
+    ]
+
+    DISTRIBUTION_PARAMETERS = [
+        ("distribution", "Waterbag"),
+        ("distribution_type", "Quadratic"),
+    ]
+
+    LATTICE_INPUTS = [
+        ("periods", 2),
+    ]
+
+    DISTRIBUTION_VALUES = [
+        ("#lambdaX", 3.9984884770e-5),
+        ("#lambdaY", 3.9984884770e-5),
+        ("#lambdaT", 1.0e-3),
+        ("#lambdaPx", 2.6623538760e-5),
+        ("#lambdaPy", 2.6623538760e-5),
+        ("#lambdaPt", 2.0e-3),
+        ("#muxpx", -0.846574929020762),
+        ("#muypy", 0.846574929020762),
+        ("#mutpt", 0.0),
+    ]
+
+    LATTICE_CONFIGURATION = [
+        ("#ds1", 0.25),
+        ("#ds2", 1),
+        ("#k2", 1.0),
+        ("#ds3", 0.5),
+        ("#ds4", 1.0),
+        ("#k4", -1.0),
+        ("#ds5", 0.25),
+    ]
+
+    # Check state parameters
+    for param_name, expected_value in (
+        BEAM_PARAMETERS + DISTRIBUTION_PARAMETERS + LATTICE_INPUTS
+    ):
+        dashboard.assert_state(param_name, expected_value)
+
+    # Check input values
+    for element_id, expected_value in DISTRIBUTION_VALUES + LATTICE_CONFIGURATION:
+        actual_value = float(dashboard.sb.get_value(element_id))
+        assert actual_value == expected_value, (
+            f"{element_id}: expected {expected_value}, got {actual_value}"
+        )

--- a/tests/python/dashboard/testdata/example.py
+++ b/tests/python/dashboard/testdata/example.py
@@ -1,0 +1,51 @@
+from impactx import ImpactX, distribution, elements
+
+sim = ImpactX()
+
+sim.particle_shape = 2
+
+sim.slice_step_diagnostics = True
+
+sim.init_grids()
+
+# Initialize particle beam
+kin_energy_MeV = 2000.0
+bunch_charge_C = 1e-09
+npart = 10000
+
+pc = sim.particle_container()
+
+# Reference particle
+ref = pc.ref_particle()
+ref.set_charge_qe(-1).set_mass_MeV(0.51099895).set_kin_energy_MeV(kin_energy_MeV)
+
+distr = distribution.Waterbag(
+    lambdaX=3.998488477e-05,
+    lambdaY=3.998488477e-05,
+    lambdaT=0.001,
+    lambdaPx=2.662353876e-05,
+    lambdaPy=2.662353876e-05,
+    lambdaPt=0.002,
+    muxpx=-0.846574929020762,
+    muypy=0.846574929020762,
+    mutpt=0.0,
+)
+
+ns = 25
+lattice_configuration = [
+    elements.Drift(ds=0.25, nslice=ns, name="drift1"),
+    elements.Quad(ds=1.0, k=1.0, nslice=ns, name="quad1"),
+    elements.Drift(ds=0.5, nslice=ns, name="drift2"),
+    elements.Quad(ds=1.0, k=-1.0, nslice=ns, name="quad2"),
+    elements.Drift(ds=0.25, nslice=ns, name="drift3"),
+]
+
+sim.lattice.extend(lattice_configuration)
+sim.periods = 2
+
+# Simulate
+sim.add_particles(bunch_charge_C, distr, npart)
+sim.track_particles()
+
+# Clean Shutdown
+sim.finalize()

--- a/tests/python/dashboard/utils.py
+++ b/tests/python/dashboard/utils.py
@@ -94,6 +94,23 @@ class DashboardTester:
     def __init__(self, sb):
         self.sb = sb
 
+        # Set up the examples directory path once
+        impactx_directory = Path(get_impactx_root_dir())
+        self.examples_directory = impactx_directory / "examples"
+        self.testing_directory = impactx_directory / "tests" / "python" / "dashboard"
+
+    def load_example(self, example_path, manual=False):
+        """
+        Load an example file into the dashboard
+        """
+        base_dir = self.testing_directory if manual else self.examples_directory
+        full_path = base_dir / example_path
+
+        self.sb.choose_file('input[type="file"]', full_path)
+
+    def clear(self):
+        self.sb.click("#reset_all_inputs_button")
+
     def add_lattice_element(self, element_name: str) -> None:
         """
         Add a lattice element to the dashboard.


### PR DESCRIPTION
The dashboard’s `ui populator` for the python parser silently broke after #981 due to a wrong function call. Since no test existed for file imports, CI didn’t catch it. This PR fixes the bug and adds a test to add coverage to the parser.

Additionally, a `conftest.py` is added to handle dashboard setup and shared fixtures. Tests reuse a single dashboard instance and reset inputs to a clean default state before each run.

**Changes:**
- Adds a test that imports a custom ImpactX Python file (testdata/example.py) into the dashboard
    - This file is a simple example to begin with and will have to be expanded when the python parser receives an update to handle more complex lattice builds.
- Checks that all expected values are populated correctly in both the UI and backend state.
- Add `conftest.py`
