### PR TITLE
Dashboard: Add force quit

### DIFF
--- a/src/python/impactx/dashboard/Toolbar/general.py
+++ b/src/python/impactx/dashboard/Toolbar/general.py
@@ -5,8 +5,9 @@ Copyright 2024 ImpactX contributors
 Authors: Parthib Roy, Axel Huebl
 License: BSD-3-Clause-LBNL
 """
-
+import os
 from .. import setup_server, vuetify
+from ..Input import CardComponents
 from .sim_history.ui import SimulationHistory
 
 server, state, ctrl = setup_server()
@@ -17,6 +18,10 @@ from .analyze import AnalyzeToolbar
 from .input import InputToolbar
 from .run import RunToolbar
 
+
+@ctrl.trigger("force_quit")
+def _force_quit() -> None:
+    os._exit(0)
 
 class GeneralToolbar:
     """
@@ -47,16 +52,21 @@ class GeneralToolbar:
             GeneralToolbar.simulation_history_button()
             vuetify.VDivider(vertical=True, classes="mr-2")
             InputToolbar.collapse_all_sections_button()
+            GeneralToolbar.force_quit_button()
         elif toolbar_name == "run":
             (GeneralToolbar.dashboard_info(),)
             (vuetify.VSpacer(),)
             (RunToolbar.run_simulation(),)
             vuetify.VDivider(vertical=True, classes="mx-2")
             (GeneralToolbar.simulation_history_button())
+            vuetify.VDivider(vertical=True, classes="mx-2")
+            (GeneralToolbar.force_quit_button())
         elif toolbar_name == "analyze":
             (GeneralToolbar.dashboard_info(),)
             vuetify.VSpacer()
             AnalyzeToolbar.plot_options()
+            vuetify.VDivider(vertical=True, classes="mx-2")
+            GeneralToolbar.force_quit_button()
 
     @staticmethod
     def dashboard_info() -> vuetify.VAlert:
@@ -97,4 +107,16 @@ class GeneralToolbar:
             size="small",
             variant="elevated",
             disabled=("!sims.length",),
+        )
+
+    @staticmethod
+    def force_quit_button():
+        """
+        Displays a button to force quit the dashboard.
+        """
+        return CardComponents.card_button(
+            icon_name="mdi-power",
+            click="trigger('force_quit')",
+            description="Force Quit",
+            color="error",
         )

--- a/src/python/impactx/dashboard/Toolbar/general.py
+++ b/src/python/impactx/dashboard/Toolbar/general.py
@@ -5,7 +5,9 @@ Copyright 2024 ImpactX contributors
 Authors: Parthib Roy, Axel Huebl
 License: BSD-3-Clause-LBNL
 """
+
 import os
+
 from .. import setup_server, vuetify
 from ..Input import CardComponents
 from .sim_history.ui import SimulationHistory
@@ -22,6 +24,7 @@ from .run import RunToolbar
 @ctrl.trigger("force_quit")
 def _force_quit() -> None:
     os._exit(0)
+
 
 class GeneralToolbar:
     """

--- a/src/python/impactx/dashboard/Toolbar/input.py
+++ b/src/python/impactx/dashboard/Toolbar/input.py
@@ -72,6 +72,7 @@ class InputToolbar:
             click=ctrl.collapse_all_sections,
             dynamic_condition="expand_all_sections",
             description=["Minimize All", "Show All"],
+            classes="mr-2",
         )
 
     @staticmethod


### PR DESCRIPTION
Not exactly a "needed" feature, but it mimics a manual Ctrl+C in the terminal for a quick shutdown.

https://github.com/user-attachments/assets/168798fa-152f-48ab-a459-f7ff85bf61ee

