### PR TITLE
`Aperture`: Hexagonal Mask Patterns

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -177,6 +177,7 @@ This requires these additional parameters:
 * ``<element_name>.aperture_y`` (``float``, in meters) vertical half-aperture (elliptical or rectangular)
 * ``<element_name>.repeat_x`` (``float``, in meters) horizontal period for repeated aperture masking (inactive by default)
 * ``<element_name>.repeat_y`` (``float``, in meters) vertical period for repeated aperture masking (inactive by default)
+* ``<element_name>.shift_odd_x`` (``bool``) for hexagonal/triangular mask patterns: horizontal shift of every 2nd (odd) vertical period by repeat_x / 2. Use alignment offsets dx,dy to move whole mask as needed.
 * ``<element_name>.shape`` (``string``) shape of the aperture boundary: ``rectangular`` (default) or ``elliptical``
 * ``<element_name>.action`` (``string``) action of the aperture domain: ``transmit`` (default) or ``absorb``
 * ``<element_name>.dx`` (``float``, in meters) horizontal translation error

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1222,7 +1222,7 @@ This module provides elements and methods for the accelerator lattice.
    :param rotation: rotation error in the transverse plane [degrees]
    :param name: an optional name for the element
 
-.. py:class:: impactx.elements.Aperture(aperture_x, aperture_y, shape="rectangular", dx=0, dy=0, rotation=0, name=None)
+.. py:class:: impactx.elements.Aperture(aperture_x, aperture_y, repeat_x, repeat_y, shift_odd_x, shape="rectangular", dx=0, dy=0, rotation=0, name=None)
 
    A thin collimator element, applying a transverse aperture boundary.
 
@@ -1230,6 +1230,7 @@ This module provides elements and methods for the accelerator lattice.
    :param aperture_y: vertical half-aperture (rectangular or elliptical) in m
    :param repeat_x: horizontal period for repeated aperture masking (inactive by default) (meter)
    :param repeat_y: vertical period for repeated aperture masking (inactive by default) (meter)
+   :param shift_odd_x: for hexagonal/triangular mask patterns: horizontal shift of every 2nd (odd) vertical period by repeat_x / 2. Use alignment offsets dx,dy to move whole mask as needed.
    :param shape: aperture boundary shape: ``"rectangular"`` (default) or ``"elliptical"``
    :param action: aperture domain action: ``"transmit"`` (default) or ``"absorb"``
    :param dx: horizontal translation error in m

--- a/examples/aperture/README.rst
+++ b/examples/aperture/README.rst
@@ -55,13 +55,14 @@ We run the following script to analyze correctness:
 .. _examples-aperture-periodic:
 
 Aperture Collimation with Periodic Masking
-===========================================
+==========================================
 
 Proton beam undergoing collimation by a periodic array of rectangular apertures, such as those used in a pepperpot emittance measurement.
 
 We use a 250 MeV proton beam with a horizontal rms beam size of 1.56 mm and a vertical rms beam size of 2.21 mm.
 
 After a short drift of 0.123 m, the beam intercepts a periodic array of apertures of period 1 mm (in the horizontal and vertical), each of which is 0.15 mm x 0.1 mm in size.
+Every 2nd row of the aperture pattern (rows -3, -1, 1, 3, ...) is shifted horizontally by half the horizontal period, creating a `hexagonal / triangular pattern <https://github.com/BLAST-ImpactX/impactx/pull/1019>`__.
 
 In this test, the initial values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 The test fails if:

--- a/examples/aperture/analysis_aperture_periodic.py
+++ b/examples/aperture/analysis_aperture_periodic.py
@@ -84,6 +84,11 @@ repeat_y = 1.0e-3
 # kept particles, shifted to the fundamental domain
 xshifted = abs(final["position_x"]) + xmax
 yshifted = abs(final["position_y"]) + ymax
+
+dx = repeat_x * 0.5
+dy = repeat_y * 0.5
+xshifted[np.fmod(np.floor((yshifted + dy) / repeat_y), 2) == 1] += dx
+
 u = np.fmod(xshifted, repeat_x) - xmax
 v = np.fmod(yshifted, repeat_y) - ymax
 

--- a/examples/aperture/input_aperture_periodic.in
+++ b/examples/aperture/input_aperture_periodic.in
@@ -36,6 +36,7 @@ pepperpot.aperture_x = 1.5e-4
 pepperpot.aperture_y = 1.0e-4
 pepperpot.repeat_x = 1.0e-3
 pepperpot.repeat_y = 1.0e-3
+pepperpot.shift_odd_x = true
 
 
 ###############################################################################

--- a/examples/aperture/run_aperture_periodic.py
+++ b/examples/aperture/run_aperture_periodic.py
@@ -56,6 +56,7 @@ sim.lattice.extend(
             aperture_y=1.0e-4,
             repeat_x=1.0e-3,
             repeat_y=1.0e-3,
+            shift_odd_x=True,
             shape="rectangular",
         ),
         monitor,

--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -67,6 +67,7 @@ namespace impactx::elements
          * @param aperture_y vertical half-aperture (m)
          * @param repeat_x horizontal period for repeated masking, optional (m)
          * @param repeat_y vertical period for repeated masking, optional (m)
+         * @param shift_odd_x for hexagonal/triangular mask patterns: horizontal shift of every 2nd (odd) vertical period by repeat_x / 2. Use alignment offsets dx,dy to move whole mask as needed.
          * @param dx horizontal translation error in m
          * @param dy vertical translation error in m
          * @param rotation_degree rotation error in the transverse plane [degrees]
@@ -77,6 +78,7 @@ namespace impactx::elements
             amrex::ParticleReal aperture_y,
             amrex::ParticleReal repeat_x,
             amrex::ParticleReal repeat_y,
+            bool shift_odd_x,
             Shape shape,
             Action action,
             amrex::ParticleReal dx = 0,
@@ -86,7 +88,7 @@ namespace impactx::elements
         )
         : Named(std::move(name)),
           Alignment(dx, dy, rotation_degree),
-          m_shape(shape), m_action(action), m_repeat_x(repeat_x), m_repeat_y(repeat_y)
+          m_shape(shape), m_action(action), m_repeat_x(repeat_x), m_repeat_y(repeat_y), m_shift_odd_x(shift_odd_x)
         {
             using namespace amrex::literals; // for _rt and _prt
 
@@ -100,6 +102,10 @@ namespace impactx::elements
                 m_inv_aperture_y = 1_prt / aperture_y;
             } else {
                 throw std::runtime_error("Aperture: aperture_y must be > 0!");
+            }
+
+            if (m_repeat_y == 0_prt && m_shift_odd_x) {
+                throw std::runtime_error("Aperture: shift_odd_x can only be used if repeat_y is set, too!");
             }
         }
 
@@ -149,14 +155,16 @@ namespace impactx::elements
             shift_in(x, y, px, py);
 
             // define intermediate variables
-            amrex::ParticleReal u;
-            amrex::ParticleReal v;
-            amrex::ParticleReal dx = m_repeat_x * 0.5_prt;
-            amrex::ParticleReal dy = m_repeat_y * 0.5_prt;
+            amrex::ParticleReal const dx = m_repeat_x * 0.5_prt;
+            amrex::ParticleReal const dy = m_repeat_y * 0.5_prt;
 
-            // if the aperture is periodic, shift x,y coordinates to the fundamental domain
-            u = (m_repeat_x==0.0) ? x : (std::fmod(std::abs(x)+dx,m_repeat_x)-dx);
-            v = (m_repeat_y==0.0) ? y : (std::fmod(std::abs(y)+dy,m_repeat_y)-dy);
+            // shift every 2nd row by half of m_repeat_x
+            amrex::ParticleReal const sx = (!m_shift_odd_x || std::fmod(std::floor((y+dy)/m_repeat_y), 2) == 0_prt) ? x : x + dx;
+            amrex::ParticleReal const sy = y;
+
+            // if the aperture is periodic, shift sx,sy coordinates to the fundamental domain
+            amrex::ParticleReal u = (m_repeat_x==0.0_prt) ? sx : (std::fmod(std::abs(sx)+dx,m_repeat_x)-dx);
+            amrex::ParticleReal v = (m_repeat_y==0.0_prt) ? sy : (std::fmod(std::abs(sy)+dy,m_repeat_y)-dy);
 
             // scale horizontal and vertical coordinates
             // performance optimization: we intentionally store the inverse of
@@ -218,6 +226,7 @@ namespace impactx::elements
         amrex::ParticleReal m_inv_aperture_y; //! maximum vertical coordinate
         amrex::ParticleReal m_repeat_x; //! horizontal period for repeated masking
         amrex::ParticleReal m_repeat_y; //! vertical period for repeated masking
+        bool m_shift_odd_x; //! for hexagonal/triangular mask patterns: horizontal shift of every 2nd (odd) vertical period by m_repeat_x / 2. Use Alignment offsets to move whole mask as needed.
 
     };
 

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -481,6 +481,7 @@ element_name) );
             amrex::Real aperture_x, aperture_y;
             amrex::ParticleReal repeat_x = 0.0;
             amrex::ParticleReal repeat_y = 0.0;
+            bool shift_odd_x = false;
             std::string shape_str = "rectangular";
             std::string action_str = "transmit";
 
@@ -511,9 +512,9 @@ element_name) );
                 pp_element.getWithParser("aperture_y", aperture_y);
             }
 
-            pp_element.queryAddWithParser("repeat_y", repeat_y);
             pp_element.queryAddWithParser("repeat_x", repeat_x);
             pp_element.queryAddWithParser("repeat_y", repeat_y);
+            pp_element.queryAdd("shift_odd_x", shift_odd_x);  // https://github.com/AMReX-Codes/amrex/issues/4535
             pp_element.queryAdd("shape", shape_str);
             pp_element.queryAdd("action", action_str);
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(shape_str == "rectangular" || shape_str == "elliptical",
@@ -527,7 +528,7 @@ element_name) );
                                         Aperture::Action::transmit :
                                         Aperture::Action::absorb;
 
-            m_lattice.emplace_back( Aperture(aperture_x, aperture_y, repeat_x, repeat_y, shape, action, a["dx"], a["dy"], a["rotation_degree"], element_name) );
+            m_lattice.emplace_back( Aperture(aperture_x, aperture_y, repeat_x, repeat_y, shift_odd_x, shape, action, a["dx"], a["dy"], a["rotation_degree"], element_name) );
         } else if (element_type == "beam_monitor")
         {
             std::string openpmd_name = element_name;

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -421,7 +421,8 @@ void init_elements(py::module& m)
                     std::make_pair("aperture_x", 1_prt / ap.m_inv_aperture_x),
                     std::make_pair("aperture_y", 1_prt / ap.m_inv_aperture_y),
                     std::make_pair("repeat_x", ap.m_repeat_x),
-                    std::make_pair("repeat_y", ap.m_repeat_y)
+                    std::make_pair("repeat_y", ap.m_repeat_y),
+                    std::make_pair("shift_odd_x", ap.m_shift_odd_x)
                 );
             }
         )
@@ -430,6 +431,7 @@ void init_elements(py::module& m)
                  amrex::ParticleReal aperture_y,
                  amrex::ParticleReal repeat_x,
                  amrex::ParticleReal repeat_y,
+                 bool shift_odd_x,
                  std::string const & shape,
                  std::string const & action,
                  amrex::ParticleReal dx,
@@ -450,12 +452,13 @@ void init_elements(py::module& m)
                  Aperture::Action const a = action == "transmit" ?
                      Aperture::Action::transmit :
                      Aperture::Action::absorb;
-                 return new Aperture(aperture_x, aperture_y, repeat_x, repeat_y, s, a, dx, dy, rotation_degree, name);
+                 return new Aperture(aperture_x, aperture_y, repeat_x, repeat_y, shift_odd_x, s, a, dx, dy, rotation_degree, name);
              }),
              py::arg("aperture_x"),
              py::arg("aperture_y"),
              py::arg("repeat_x") = 0,
              py::arg("repeat_y") = 0,
+             py::arg("shift_odd_x") = false,
              py::arg("shape") = "rectangular",
              py::arg("action") = "transmit",
              py::arg("dx") = 0,
@@ -515,6 +518,12 @@ void init_elements(py::module& m)
             [](Aperture & ap) { return ap.m_repeat_y; },
             [](Aperture & ap, amrex::ParticleReal repeat_y) { ap.m_repeat_y = repeat_y; },
             "vertical period for repeated aperture masking"
+        )
+        .def_property("shift_odd_x",
+            [](Aperture & ap) { return ap.m_shift_odd_x; },
+            [](Aperture & ap, bool shift_odd_x) { ap.m_shift_odd_x = shift_odd_x; },
+            "for hexagonal/triangular mask patterns: horizontal shift of every 2nd (odd) vertical period by repeat_x / 2. "
+            "Use alignment offsets dx,dy to move whole mask as needed."
         )
     ;
     register_push(py_Aperture);


### PR DESCRIPTION
Support hexagonal mask patterns by adding an option to shift every other (odd) vertical period by a horizontal half-period. Alignment can be used to move the whole mask as needed.

Enhances #739
Close #931


## Visually

Default repeating pattern so far:
![default](https://github.com/user-attachments/assets/ce2c3013-7ed3-4d78-8043-fa426ab993e9)

With this PR, one can shift every other line:
![shift](https://github.com/user-attachments/assets/8b2f981a-c8ad-4a37-9728-948c353404ab)


## Checklist

- [x] [Notebook draft: Mask.zip](https://github.com/user-attachments/files/20970578/Mask.zip)
- [x] C++ implementation
- [x] Python bindings
- [x] docs: inputs & python
- [x] Test case: similar to existing one, reproduce the aperture in Python