### PR TITLE
`Aperture`: Remove Code Duplication, Avoid Division

### DIFF
--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -86,8 +86,21 @@ namespace impactx::elements
         )
         : Named(std::move(name)),
           Alignment(dx, dy, rotation_degree),
-          m_shape(shape), m_action(action), m_aperture_x(aperture_x), m_aperture_y(aperture_y), m_repeat_x(repeat_x), m_repeat_y(repeat_y)
+          m_shape(shape), m_action(action), m_repeat_x(repeat_x), m_repeat_y(repeat_y)
         {
+            using namespace amrex::literals; // for _rt and _prt
+
+            if (aperture_x > 0_prt) {
+                m_inv_aperture_x = 1_prt / aperture_x;
+            } else {
+                throw std::runtime_error("Aperture: aperture_x must be > 0!");
+            }
+
+            if (aperture_y > 0_prt) {
+                m_inv_aperture_y = 1_prt / aperture_y;
+            } else {
+                throw std::runtime_error("Aperture: aperture_y must be > 0!");
+            }
         }
 
         /** Push all particles */
@@ -145,8 +158,11 @@ namespace impactx::elements
             v = (m_repeat_y==0.0) ? y : (std::fmod(std::abs(y)+dy,m_repeat_y)-dy);
 
             // scale horizontal and vertical coordinates
-            u = u / m_aperture_x;
-            v = v / m_aperture_y;
+            // performance optimization: we intentionally store the inverse of
+            //   the aperture, so we can do a quick multiplication (instead of a
+            //   costly division) here.
+            u = u * m_inv_aperture_x;
+            v = v * m_inv_aperture_y;
 
             // compare against the aperture boundary
             bool inside_aperture = true;
@@ -194,8 +210,11 @@ namespace impactx::elements
 
         Shape m_shape; //! aperture type (rectangular, elliptical)
         Action m_action; //! action type (transmit, absorb)
-        amrex::ParticleReal m_aperture_x; //! maximum horizontal coordinate
-        amrex::ParticleReal m_aperture_y; //! maximum vertical coordinate
+        // performance optimization: we intentionally store the inverse of
+        //   the aperture, so we can do a quick multiplication instead of a costly
+        //   division in the comparison operation per particle
+        amrex::ParticleReal m_inv_aperture_x; //! maximum horizontal coordinate
+        amrex::ParticleReal m_inv_aperture_y; //! maximum vertical coordinate
         amrex::ParticleReal m_repeat_x; //! horizontal period for repeated masking
         amrex::ParticleReal m_repeat_y; //! vertical period for repeated masking
 

--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -149,45 +149,25 @@ namespace impactx::elements
             v = v / m_aperture_y;
 
             // compare against the aperture boundary
-            switch (m_action)
+            bool inside_aperture = true;
+
+            switch (m_shape)
             {
-               case Action::transmit :  // default action
+                case Shape::rectangular:  // default
+                    inside_aperture = (amrex::Math::powi<2>(u) <= 1_prt && amrex::Math::powi<2>(v) <= 1_prt);
+                    break;
 
-                  switch (m_shape)
-                  {
-                      case Shape::rectangular :  // default shape
-                        if (amrex::Math::powi<2>(u)>1 || amrex::Math::powi<2>(v) > 1_prt) {
-                            amrex::ParticleIDWrapper{idcpu}.make_invalid();
-                        }
-                        break;
-
-                      case Shape::elliptical :
-                        if (amrex::Math::powi<2>(u) + amrex::Math::powi<2>(v) > 1_prt) {
-                            amrex::ParticleIDWrapper{idcpu}.make_invalid();
-                        }
-                        break;
-                  }
-                  break;
-
-               case Action::absorb :
-
-                  switch (m_shape)
-                  {
-                      case Shape::rectangular :  // default
-                        if (amrex::Math::powi<2>(u) < 1 && amrex::Math::powi<2>(v) < 1_prt) {
-                            amrex::ParticleIDWrapper{idcpu}.make_invalid();
-                        }
-                        break;
-
-                     case Shape::elliptical :
-                        if (amrex::Math::powi<2>(u) + amrex::Math::powi<2>(v) < 1_prt) {
-                            amrex::ParticleIDWrapper{idcpu}.make_invalid();
-                        }
-                        break;
-                  }
-                  break;
+                case Shape::elliptical:
+                    inside_aperture = (amrex::Math::powi<2>(u) + amrex::Math::powi<2>(v) <= 1_prt);
+                    break;
             }
 
+            // For transmit (default): invalidate if outside aperture
+            // For absorb: invalidate if inside aperture
+            if ((m_action == Action::transmit && !inside_aperture) ||
+                (m_action == Action::absorb && inside_aperture)) {
+                amrex::ParticleIDWrapper{idcpu}.make_invalid();
+            }
 
             // undo shift due to alignment errors of the element
             shift_out(x, y, px, py);

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -413,12 +413,13 @@ void init_elements(py::module& m)
         )
         .def("to_dict",
             [](Aperture const & ap) {
+                using namespace amrex::literals;
                 return element_dict(
                     ap,
                     std::make_pair("shape", ap.m_shape),
                     std::make_pair("action", ap.m_action),
-                    std::make_pair("aperture_x", ap.m_aperture_x),
-                    std::make_pair("aperture_y", ap.m_aperture_y),
+                    std::make_pair("aperture_x", 1_prt / ap.m_inv_aperture_x),
+                    std::make_pair("aperture_y", 1_prt / ap.m_inv_aperture_y),
                     std::make_pair("repeat_x", ap.m_repeat_x),
                     std::make_pair("repeat_y", ap.m_repeat_y)
                 );
@@ -496,13 +497,13 @@ void init_elements(py::module& m)
             "action type (transmit, absorb)"
         )
         .def_property("aperture_x",
-            [](Aperture & ap) { return ap.m_aperture_x; },
-            [](Aperture & ap, amrex::ParticleReal aperture_x) { ap.m_aperture_x = aperture_x; },
+            [](Aperture & ap) { using namespace amrex::literals; return 1_prt / ap.m_inv_aperture_x; },
+            [](Aperture & ap, amrex::ParticleReal aperture_x) { using namespace amrex::literals; ap.m_inv_aperture_x = 1_prt / aperture_x; },
             "maximum horizontal coordinate"
         )
         .def_property("aperture_y",
-            [](Aperture & ap) { return ap.m_aperture_y; },
-            [](Aperture & ap, amrex::ParticleReal aperture_y) { ap.m_aperture_y = aperture_y; },
+            [](Aperture & ap) { using namespace amrex::literals; return 1_prt / ap.m_inv_aperture_y; },
+            [](Aperture & ap, amrex::ParticleReal aperture_y) { using namespace amrex::literals; ap.m_inv_aperture_y = 1_prt / aperture_y; },
             "maximum vertical coordinate"
         )
         .def_property("repeat_x",


### PR DESCRIPTION
- [x] Refactor our duplicate code paths in `Aperture` for transmit/absorb logic.
- [x] Avoid division as in #1011