### PR TITLE
Python: Interactive/In Situ Beam History

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -390,6 +390,17 @@ Particles
       :return: beam properties with string keywords
       :rtype: dict
 
+   .. py::property:: enable_beam_history
+
+      In situ record and store the beam history for every simulation step (default: ``False``).
+
+   .. py:method:: beam_history()
+
+      Return the history of the beam as calculated by the reduced beam characteristics on every step.
+
+      :return: Pandas Dataframe of beam properties, including the global reference position s
+      :rtype: Pandas Dataframe
+
    .. py:method:: min_and_max_positions()
 
       Compute the min and max of the particle position in each dimension.

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -24,6 +24,7 @@
 #include <AMReX_IntVect.H>
 #include <AMReX_Vector.H>
 
+#include <list>
 #include <optional>
 #include <tuple>
 #include <unordered_map>
@@ -281,6 +282,21 @@ namespace impactx
         void
         SetCoordSystem (CoordSystem coord_system);
 
+        /** In situ record and store the beam history for every simulation step */
+        bool enable_beam_history = false;
+
+        /** Record the reduced beam diagnostics */
+        void
+        RecordRBC ();
+
+        /** Get the history of reduced beam diagnostics */
+        std::list<std::unordered_map<std::string, amrex::ParticleReal> >
+        GetRBCHistory () { return m_rbc_history; }
+
+        /** Reset the history of the reduced beam diagnostics */
+        void
+        ResetRBCHistory () { m_rbc_history.clear(); }
+
       private:
 
         //! the reference particle for the beam in the particle container
@@ -294,6 +310,9 @@ namespace impactx
 
         //! the current coordinate system of particles in this container
         CoordSystem m_coordsystem = CoordSystem::s;
+
+        //! history of the reduced beam diagnostics over s
+        std::list<std::unordered_map<std::string, amrex::ParticleReal> > m_rbc_history;
 
     }; // ImpactXParticleContainer
 

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -10,6 +10,7 @@
 #include "ImpactXParticleContainer.H"
 
 #include "initialization/AmrCoreData.H"
+#include "diagnostics/ReducedBeamCharacteristics.H"
 
 #include <ablastr/constant.H>
 #include <ablastr/particles/ParticleMoments.H>
@@ -355,5 +356,17 @@ namespace impactx
     ImpactXParticleContainer::SetCoordSystem (CoordSystem coord_system)
     {
         m_coordsystem = coord_system;
+    }
+
+    void
+    ImpactXParticleContainer::RecordRBC ()
+    {
+        BL_PROFILE("ImpactXParticleContainer::RecordRBC");
+
+        auto rbc = diagnostics::reduced_beam_characteristics(*this);
+        amrex::ParticleReal const s = this->GetRefParticle().s;
+        rbc["s"] = s;
+
+        m_rbc_history.push_back(rbc);
     }
 } // namespace impactx

--- a/src/python/ImpactXParticleContainer.cpp
+++ b/src/python/ImpactXParticleContainer.cpp
@@ -117,6 +117,23 @@ void init_impactxparticlecontainer(py::module& m)
              },
              "Compute reduced beam characteristics like the position and momentum moments of the particle distribution, as well as emittance and Twiss parameters."
         )
+        .def("beam_history_list",
+             [](ImpactXParticleContainer & pc) {
+                 return pc.GetRBCHistory();
+             },
+             "Return the history of the beam as calculated by the reduced beam characteristics on every step."
+        )
+        .def("reset_beam_history",
+             [](ImpactXParticleContainer & pc) {
+                 return pc.ResetRBCHistory();
+             },
+             "Reset the history of the reduced beam diagnostics with the current global simulation step."
+        )
+        .def_property("enable_beam_history",
+            [](ImpactXParticleContainer & pc){ return pc.enable_beam_history; },
+            [](ImpactXParticleContainer & pc, bool record){ pc.enable_beam_history = record; },
+            "In situ record and store the beam history for every simulation step."
+        )
 
         // TODO: cleverly pass the list of rho multifabs as references
         /*

--- a/src/python/impactx/extensions/ImpactXParticleContainer.py
+++ b/src/python/impactx/extensions/ImpactXParticleContainer.py
@@ -287,7 +287,17 @@ def ix_pc_plot_mpl_phasespace(self, num_bins=50, root_rank=0):
     return fig
 
 
+def ix_beam_history(self):
+    """
+    Return the history of the beam as calculated by the reduced beam characteristics on every step.
+    """
+    import pandas as pd
+
+    return pd.DataFrame(self.beam_history_list())
+
+
 def register_ImpactXParticleContainer_extension(ixpc):
     """ImpactXParticleContainer helper methods"""
     # register member functions for ImpactXParticleContainer
     ixpc.plot_phasespace = ix_pc_plot_mpl_phasespace
+    ixpc.beam_history = ix_beam_history

--- a/src/tracking/particles.cpp
+++ b/src/tracking/particles.cpp
@@ -47,12 +47,18 @@ namespace impactx
         // check typos in inputs after step 1
         bool early_params_checked = false;
 
+        // shortcuts
+        auto & pc = amr_data->track_particles.m_particle_container;
+
+        // diags
         amrex::ParmParse pp_diag("diag");
         bool diag_enable = true;
         pp_diag.queryAdd("enable", diag_enable);
         if (verbose > 0) {
             amrex::Print() << " Diagnostics: " << diag_enable << "\n";
         }
+
+        pc->ResetRBCHistory();
 
         if (diag_enable)
         {
@@ -140,6 +146,10 @@ namespace impactx
                     // slice-step diagnostics
                     bool slice_step_diagnostics = false;
                     pp_diag.queryAdd("slice_step_diagnostics", slice_step_diagnostics);
+
+                    if (amr_data->track_particles.m_particle_container->enable_beam_history) {
+                        amr_data->track_particles.m_particle_container->RecordRBC();
+                    }
 
                     if (diag_enable && slice_step_diagnostics) {
                         // print slice step reference particle to file

--- a/tests/python/test_dataframe.py
+++ b/tests/python/test_dataframe.py
@@ -24,7 +24,9 @@ def test_df_pandas(save_png=True):
     """
     sim = ImpactX()
 
+    sim.verbose = 0  # quiet
     sim.particle_shape = 2
+    sim.diagnostics = False  # no files
     sim.space_charge = False
     sim.slice_step_diagnostics = False
     sim.init_grids()
@@ -55,6 +57,9 @@ def test_df_pandas(save_png=True):
 
     assert pc.total_number_of_particles() == npart
 
+    # record purely in memory
+    sim.particle_container().enable_beam_history = True
+
     # init accelerator lattice
     fodo = [
         elements.Drift(name="d1", ds=0.25),
@@ -67,6 +72,17 @@ def test_df_pandas(save_png=True):
 
     # simulate
     sim.track_particles()
+
+    # look at beam history (reduced beam diagnostics)
+    beam_history = sim.particle_container().beam_history()
+
+    if amr.ParallelDescriptor.IOProcessor():
+        print(beam_history)
+        plt.plot(beam_history.s, beam_history.beta_x)
+        if save_png:
+            plt.savefig("beam_history.png")
+        else:
+            plt.show()
 
     # check local particles
     df = pc.to_df(local=True)


### PR DESCRIPTION
Add support to in situ store the reduced beam history with a beam instead of writing it to file. This is useful for interactive use of the simulation and to avoid writing files.

Before that, we had access to this information only through text files and we could access already this information, but only for the very last step or by writing our own push/tracker loop in Python.

Useful for the notebook in https://github.com/BLAST-ImpactX/2025_pilot_digital_twin_LDRD/pull/37