### PR TITLE
Rename to Beam Moments History

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -390,23 +390,27 @@ Particles
 
       :param impactx.RefPart refpart: a reference particle to copy all attributes from
 
-   .. py:method:: reduced_beam_characteristics()
+   .. py:method:: beam_moments()
 
-      Compute reduced beam characteristics like the position and momentum moments of the particle distribution, as well as emittance and Twiss parameters.
+      Calculate beam moments at current ``s`` like the position and momentum moments of the particle distribution, as well as emittance and Twiss parameters.
 
       :return: beam properties with string keywords
       :rtype: dict
 
-   .. py:property:: enable_beam_history
+   .. py:property:: store_beam_moments
 
-      In situ record and store the beam history for every simulation step (default: ``False``).
+      In situ calculate and store the beam moments for every simulation step (default: ``False``).
 
-   .. py:method:: beam_history()
+   .. py:method:: beam_moments_history()
 
-      Return the history of the beam as calculated by the reduced beam characteristics on every step.
+      Return the history of the beam moments on every step.
 
       :return: Pandas Dataframe of beam properties, including the global reference position s
       :rtype: Pandas Dataframe
+
+   .. py:method:: reset_beam_moments_history()
+
+      Reset the history of the beam moments
 
    .. py:method:: min_and_max_positions()
 

--- a/examples/optimize_triplet/run_triplet.py
+++ b/examples/optimize_triplet/run_triplet.py
@@ -130,7 +130,7 @@ def run(parameters: tuple, write_particles=False, write_reduced=False) -> dict:
 
     # in situ calculate the reduced beam characteristics
     beam = sim.particle_container()
-    rbc = beam.reduced_beam_characteristics()
+    rbc = beam.beam_moments()
 
     # clean shutdown
     sim.finalize()

--- a/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
+++ b/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
@@ -307,7 +307,7 @@ class UpdateConstF(elements.Programmable):
 
     def set_lens(self, pc, step, period):
         # get envelope parameters
-        rbc = pc.reduced_beam_characteristics()
+        rbc = pc.beam_moments()
         alpha = rbc[f"alpha_{self.x_or_y}"]
         beta = rbc[f"beta_{self.x_or_y}"]
         gamma = (1 + alpha**2) / beta

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -289,20 +289,24 @@ namespace impactx
         void
         SetCoordSystem (CoordSystem coord_system);
 
-        /** In situ record and store the beam history for every simulation step */
-        bool enable_beam_history = false;
+        /** In situ calculate and store the beam moments for every simulation step */
+        bool store_beam_moments = false;
 
-        /** Record the reduced beam diagnostics */
+        /** Calculate & record the beam moments at current s */
         void
-        RecordRBC ();
+        record_beam_moments ();
 
-        /** Get the history of reduced beam diagnostics */
+        /** Calculate beam moments at current s */
+        std::unordered_map<std::string, amrex::ParticleReal>
+        beam_moments ();
+
+        /** Get the history of beam moments */
         std::list<std::unordered_map<std::string, amrex::ParticleReal> >
-        GetRBCHistory () { return m_rbc_history; }
+        beam_moments_history () { return m_beam_moments; }
 
-        /** Reset the history of the reduced beam diagnostics */
+        /** Reset the history of the beam moments */
         void
-        ResetRBCHistory () { m_rbc_history.clear(); }
+        reset_beam_moments_history () { m_beam_moments.clear(); }
 
       private:
 
@@ -318,8 +322,8 @@ namespace impactx
         //! the current coordinate system of particles in this container
         CoordSystem m_coordsystem = CoordSystem::s;
 
-        //! history of the reduced beam diagnostics over s
-        std::list<std::unordered_map<std::string, amrex::ParticleReal> > m_rbc_history;
+        //! history of the beam moments over s
+        std::list<std::unordered_map<std::string, amrex::ParticleReal> > m_beam_moments;
 
     }; // ImpactXParticleContainer
 

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -366,14 +366,26 @@ namespace impactx
     }
 
     void
-    ImpactXParticleContainer::RecordRBC ()
+    ImpactXParticleContainer::record_beam_moments ()
     {
-        BL_PROFILE("ImpactXParticleContainer::RecordRBC");
+        BL_PROFILE("ImpactXParticleContainer::record_beam_moments");
 
         auto rbc = diagnostics::reduced_beam_characteristics(*this);
         amrex::ParticleReal const s = this->GetRefParticle().s;
         rbc["s"] = s;
 
-        m_rbc_history.push_back(rbc);
+        m_beam_moments.push_back(rbc);
+    }
+
+    std::unordered_map<std::string, amrex::ParticleReal>
+    ImpactXParticleContainer::beam_moments ()
+    {
+        BL_PROFILE("ImpactXParticleContainer::beam_moments");
+
+        auto rbc = diagnostics::reduced_beam_characteristics(*this);
+        amrex::ParticleReal const s = this->GetRefParticle().s;
+        rbc["s"] = s;
+
+        return rbc;
     }
 } // namespace impactx

--- a/src/python/ImpactXParticleContainer.cpp
+++ b/src/python/ImpactXParticleContainer.cpp
@@ -8,6 +8,8 @@
 #include <particles/ImpactXParticleContainer.H>
 #include <diagnostics/ReducedBeamCharacteristics.H>
 
+#include <ablastr/warn_manager/WarnManager.H>
+
 #include <AMReX.H>
 #include <AMReX_MFIter.H>
 #include <AMReX_ParticleContainer.H>
@@ -117,26 +119,45 @@ void init_impactxparticlecontainer(py::module& m)
         )
         .def("reduced_beam_characteristics",
              [](ImpactXParticleContainer & pc) {
+                 ablastr::warn_manager::WMRecordWarning(
+                    "reduced_beam_characteristics",
+                    "WARNING: reduced_beam_characteristics() is deprecated. "
+                    "Use beam_moments() instead.",
+                    ablastr::warn_manager::WarnPriority::medium
+                 );
                  return diagnostics::reduced_beam_characteristics(pc);
              },
              "Compute reduced beam characteristics like the position and momentum moments of the particle distribution, as well as emittance and Twiss parameters."
         )
-        .def("beam_history_list",
+        .def("beam_moments",
              [](ImpactXParticleContainer & pc) {
-                 return pc.GetRBCHistory();
+                 return pc.beam_moments();
              },
-             "Return the history of the beam as calculated by the reduced beam characteristics on every step."
+             "Calculate beam moments at current ``s`` like the position and momentum moments of the particle "
+             "distribution, as well as emittance and Twiss parameters."
         )
-        .def("reset_beam_history",
+        .def("beam_moments_history_list",
              [](ImpactXParticleContainer & pc) {
-                 return pc.ResetRBCHistory();
+                 return pc.beam_moments_history();
              },
-             "Reset the history of the reduced beam diagnostics with the current global simulation step."
+             "Return the history of the beam moments on every step."
         )
-        .def_property("enable_beam_history",
-            [](ImpactXParticleContainer & pc){ return pc.enable_beam_history; },
-            [](ImpactXParticleContainer & pc, bool record){ pc.enable_beam_history = record; },
-            "In situ record and store the beam history for every simulation step."
+        .def("record_beam_moments",
+             [](ImpactXParticleContainer & pc) {
+                 return pc.record_beam_moments();
+             },
+             "Calculate & record the beam moments at current s"
+        )
+        .def("reset_beam_moments_history",
+             [](ImpactXParticleContainer & pc) {
+                 return pc.reset_beam_moments_history();
+             },
+             "Reset the history of the beam moments."
+        )
+        .def_property("store_beam_moments",
+            [](ImpactXParticleContainer & pc){ return pc.store_beam_moments; },
+            [](ImpactXParticleContainer & pc, bool record){ pc.store_beam_moments = record; },
+            "In situ calculate and store the beam moments for every simulation step."
         )
 
         // TODO: cleverly pass the list of rho multifabs as references

--- a/src/python/impactx/extensions/ImpactXParticleContainer.py
+++ b/src/python/impactx/extensions/ImpactXParticleContainer.py
@@ -30,7 +30,7 @@ def ix_pc_plot_mpl_phasespace(self, num_bins=50, root_rank=0):
     from quantiphy import Quantity
 
     # Beam Characteristics
-    rbc = self.reduced_beam_characteristics()
+    rbc = self.beam_moments()
 
     # update for plot unit system
     m2mm = 1.0e3
@@ -287,17 +287,17 @@ def ix_pc_plot_mpl_phasespace(self, num_bins=50, root_rank=0):
     return fig
 
 
-def ix_beam_history(self):
+def ix_beam_moments_history(self):
     """
     Return the history of the beam as calculated by the reduced beam characteristics on every step.
     """
     import pandas as pd
 
-    return pd.DataFrame(self.beam_history_list())
+    return pd.DataFrame(self.beam_moments_history_list())
 
 
 def register_ImpactXParticleContainer_extension(ixpc):
     """ImpactXParticleContainer helper methods"""
     # register member functions for ImpactXParticleContainer
     ixpc.plot_phasespace = ix_pc_plot_mpl_phasespace
-    ixpc.beam_history = ix_beam_history
+    ixpc.beam_moments_history = ix_beam_moments_history

--- a/src/tracking/particles.cpp
+++ b/src/tracking/particles.cpp
@@ -58,7 +58,7 @@ namespace impactx
             amrex::Print() << " Diagnostics: " << diag_enable << "\n";
         }
 
-        pc->ResetRBCHistory();
+        pc->reset_beam_moments_history();
 
         if (diag_enable)
         {
@@ -147,8 +147,8 @@ namespace impactx
                     bool slice_step_diagnostics = false;
                     pp_diag.queryAdd("slice_step_diagnostics", slice_step_diagnostics);
 
-                    if (amr_data->track_particles.m_particle_container->enable_beam_history) {
-                        amr_data->track_particles.m_particle_container->RecordRBC();
+                    if (amr_data->track_particles.m_particle_container->store_beam_moments) {
+                        amr_data->track_particles.m_particle_container->record_beam_moments();
                     }
 
                     if (diag_enable && slice_step_diagnostics) {

--- a/tests/python/test_dataframe.py
+++ b/tests/python/test_dataframe.py
@@ -58,7 +58,7 @@ def test_df_pandas(save_png=True):
     assert pc.total_number_of_particles() == npart
 
     # record purely in memory
-    sim.particle_container().enable_beam_history = True
+    sim.particle_container().store_beam_moments = True
 
     # init accelerator lattice
     fodo = [
@@ -74,13 +74,13 @@ def test_df_pandas(save_png=True):
     sim.track_particles()
 
     # look at beam history (reduced beam diagnostics)
-    beam_history = sim.particle_container().beam_history()
+    beam_moments = sim.particle_container().beam_moments_history()
 
     if amr.ParallelDescriptor.IOProcessor():
-        print(beam_history)
-        plt.plot(beam_history.s, beam_history.beta_x)
+        print(beam_moments)
+        plt.plot(beam_moments.s, beam_moments.beta_x)
         if save_png:
-            plt.savefig("beam_history.png")
+            plt.savefig("beam_moments.png")
         else:
             plt.show()
 

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -30,7 +30,7 @@ def validate_fodo(beam):
     rtol = 2.2 * num_particles**-0.5  # from random sampling of a smooth distribution
 
     # in situ calculate the reduced beam characteristics
-    rbc = beam.reduced_beam_characteristics()
+    rbc = beam.beam_moments()
     ref = beam.ref_particle()
 
     print("charge=", rbc["charge_C"])

--- a/tests/python/test_transformation.py
+++ b/tests/python/test_transformation.py
@@ -53,7 +53,7 @@ def test_transformation():
         mutpt=0.8,
     )
     sim.add_particles(bunch_charge_C, distr, npart)
-    rbc_s0 = pc.reduced_beam_characteristics()
+    rbc_s0 = pc.beam_moments()
 
     # this must fail: we cannot transform from s to s
     with pytest.raises(Exception):
@@ -61,7 +61,7 @@ def test_transformation():
 
     # transform to t
     coordinate_transformation(pc, direction=CoordSystem.t)
-    rbc_t = pc.reduced_beam_characteristics()
+    rbc_t = pc.beam_moments()
 
     # this must fail: we cannot transform from t to t
     with pytest.raises(Exception):
@@ -69,7 +69,7 @@ def test_transformation():
 
     # transform back to s
     coordinate_transformation(pc, direction=CoordSystem.s)
-    rbc_s = pc.reduced_beam_characteristics()
+    rbc_s = pc.beam_moments()
 
     # finalize simulation
     sim.finalize()

--- a/tests/python/test_xopt.py
+++ b/tests/python/test_xopt.py
@@ -130,7 +130,7 @@ def run(parameters: dict, write_particles=False, write_reduced=False) -> dict:
 
     # in situ calculate the reduced beam characteristics
     beam = sim.particle_container()
-    rbc = beam.reduced_beam_characteristics()
+    rbc = beam.beam_moments()
 
     # clean shutdown
     sim.finalize()


### PR DESCRIPTION
Rename the recently introduced method to store beam moments over s to a clearer name.

Follow-up to #1025