### PR TITLE
Dashboard: allow to load outputs from history

### DIFF
--- a/src/python/impactx/dashboard/Analyze/over_s/utils.py
+++ b/src/python/impactx/dashboard/Analyze/over_s/utils.py
@@ -12,6 +12,7 @@ import os
 import pandas as pd
 
 from ... import setup_server
+from ...Run.utils import SimulationHelper
 from .plot import over_s_plot
 
 server, state, ctrl = setup_server()
@@ -116,5 +117,6 @@ class VisualizeOverS:
         ]
         state.over_s_possible_data = data.to_dict(orient="records")
 
+        SimulationHelper.save_over_s_table_output()
 
 over_s = VisualizeOverS()

--- a/src/python/impactx/dashboard/Analyze/over_s/utils.py
+++ b/src/python/impactx/dashboard/Analyze/over_s/utils.py
@@ -119,4 +119,5 @@ class VisualizeOverS:
 
         SimulationHelper.save_over_s_table_output()
 
+
 over_s = VisualizeOverS()

--- a/src/python/impactx/dashboard/Run/utils.py
+++ b/src/python/impactx/dashboard/Run/utils.py
@@ -106,11 +106,23 @@ class SimulationHelper:
             with open("phase_space_plot.png", "rb") as f:
                 image_data = f.read()
                 image_base64 = base64.b64encode(image_data).decode()
-                state.phase_space_png = f"data:image/png;base64, {image_base64}"
+                phase_space_src = f"data:image/png;base64, {image_base64}"
+                state.phase_space_png = phase_space_src
                 state.flush()
+
+            SimulationHelper.save_phase_space_output(phase_space_src)
 
             os.remove("phase_space_plot.png")
 
+
+    @staticmethod
+    def save_phase_space_output(phase_space_src: str) -> None:
+        """
+        Saves the given phase space image into the current simulation's outputs.
+        """
+        state.sims[state.sim_index]["outputs"] = {
+            "phase_space_png": phase_space_src
+        }
 
 class SimulationProgress:
     """

--- a/src/python/impactx/dashboard/Run/utils.py
+++ b/src/python/impactx/dashboard/Run/utils.py
@@ -49,6 +49,7 @@ class SimulationHelper:
         state.sims[state.sim_index]["status"] = "Completed"
         state.sim_is_generating_plots = False
         state.dirty("filtered_sims")
+        state.selected_sim_to_analyze = state.sims[state.sim_index]
         state.flush()
         save_view_details_log()
 

--- a/src/python/impactx/dashboard/Run/utils.py
+++ b/src/python/impactx/dashboard/Run/utils.py
@@ -125,6 +125,17 @@ class SimulationHelper:
             "phase_space_png": phase_space_src
         }
 
+    @staticmethod
+    def save_over_s_table_output() -> None:
+        """
+        Saves the visualization's data table into the current simulation's
+        outputs.
+        """
+
+        current_sims_output = state.sims[state.sim_index]["outputs"]
+        current_sims_output["over_s_table_headers"] = state.over_s_possible_headers
+        current_sims_output["over_s_table_data"] = state.over_s_possible_data
+
 class SimulationProgress:
     """
     Methods which facilitate providing the dashboard user

--- a/src/python/impactx/dashboard/Run/utils.py
+++ b/src/python/impactx/dashboard/Run/utils.py
@@ -115,15 +115,12 @@ class SimulationHelper:
 
             os.remove("phase_space_plot.png")
 
-
     @staticmethod
     def save_phase_space_output(phase_space_src: str) -> None:
         """
         Saves the given phase space image into the current simulation's outputs.
         """
-        state.sims[state.sim_index]["outputs"] = {
-            "phase_space_png": phase_space_src
-        }
+        state.sims[state.sim_index]["outputs"] = {"phase_space_png": phase_space_src}
 
     @staticmethod
     def save_over_s_table_output() -> None:
@@ -135,6 +132,7 @@ class SimulationHelper:
         current_sims_output = state.sims[state.sim_index]["outputs"]
         current_sims_output["over_s_table_headers"] = state.over_s_possible_headers
         current_sims_output["over_s_table_data"] = state.over_s_possible_data
+
 
 class SimulationProgress:
     """

--- a/src/python/impactx/dashboard/Toolbar/analyze.py
+++ b/src/python/impactx/dashboard/Toolbar/analyze.py
@@ -38,7 +38,7 @@ class AnalyzeToolbar:
         """
 
         return vuetify.VChip(
-            "{{ sim_is_running ? 'Running...' : (selected_sim_to_analyze?.name || 'No simulation') }}",
+            "{{ sim_is_running ? sim_progress_status : (selected_sim_to_analyze?.name || 'No simulation') }}",
             color=("sim_is_running ? 'info' : 'green-darken-1'",),
             prepend_icon="mdi-check-circle-outline",
         )

--- a/src/python/impactx/dashboard/Toolbar/analyze.py
+++ b/src/python/impactx/dashboard/Toolbar/analyze.py
@@ -9,7 +9,7 @@ License: BSD-3-Clause-LBNL
 from .. import setup_server, vuetify
 
 server, state, ctrl = setup_server()
-
+state.selected_sim_to_analyze = None
 
 class AnalyzeToolbar:
     """
@@ -28,3 +28,18 @@ class AnalyzeToolbar:
             hide_slider=False,
             disabled=("!sims.length",),  # disabled if no sims are in the history
         )
+
+    @staticmethod
+    def simulation_selection_indicator() -> vuetify.VChip:
+        """
+        Displays the selected simulation for analysis.
+
+        By default, it shows the most recently run simulation if one is available.
+        """
+
+        return vuetify.VChip(
+            "{{ sim_is_running ? 'Running...' : (selected_sim_to_analyze?.name || 'No simulation') }}",
+            color=("sim_is_running ? 'info' : 'green-darken-1'",),
+            prepend_icon="mdi-check-circle-outline",
+        )
+

--- a/src/python/impactx/dashboard/Toolbar/analyze.py
+++ b/src/python/impactx/dashboard/Toolbar/analyze.py
@@ -11,6 +11,7 @@ from .. import setup_server, vuetify
 server, state, ctrl = setup_server()
 state.selected_sim_to_analyze = None
 
+
 class AnalyzeToolbar:
     """
     Contains toolbar components for the 'Analyze' page.
@@ -42,4 +43,3 @@ class AnalyzeToolbar:
             color=("sim_is_running ? 'info' : 'green-darken-1'",),
             prepend_icon="mdi-check-circle-outline",
         )
-

--- a/src/python/impactx/dashboard/Toolbar/file_imports/python/parser.py
+++ b/src/python/impactx/dashboard/Toolbar/file_imports/python/parser.py
@@ -17,7 +17,7 @@ state.import_file = False
 state.import_file_details = None
 state.import_file_error = False
 state.importing_file = False
-
+state.imported_file_name = None
 
 class DashboardParser:
     """

--- a/src/python/impactx/dashboard/Toolbar/file_imports/python/parser.py
+++ b/src/python/impactx/dashboard/Toolbar/file_imports/python/parser.py
@@ -17,6 +17,7 @@ state.import_file_error = False
 state.importing_file = False
 state.imported_file_name = None
 
+
 class DashboardParser:
     """
     Provides functionality to import ImpactX simulation files

--- a/src/python/impactx/dashboard/Toolbar/file_imports/python/parser.py
+++ b/src/python/impactx/dashboard/Toolbar/file_imports/python/parser.py
@@ -11,8 +11,6 @@ from .helper import DashboardParserHelper
 
 server, state, ctrl = setup_server()
 
-state.imported_file_name = None
-
 state.import_file = False
 state.import_file_details = None
 state.import_file_error = False
@@ -35,6 +33,7 @@ class DashboardParser:
         state.import_file_details = None
         state.import_file = None
         state.importing_file = False
+        state.imported_file_name = None
 
     @staticmethod
     def file_details(file) -> None:

--- a/src/python/impactx/dashboard/Toolbar/general.py
+++ b/src/python/impactx/dashboard/Toolbar/general.py
@@ -69,6 +69,8 @@ class GeneralToolbar:
             vuetify.VSpacer()
             AnalyzeToolbar.select_visualization()
             vuetify.VDivider(vertical=True, classes="mx-2")
+            AnalyzeToolbar.simulation_selection_indicator()
+            vuetify.VDivider(vertical=True, classes="mx-2")
             GeneralToolbar.simulation_history_button()
             vuetify.VDivider(vertical=True, classes="mx-2")
             GeneralToolbar.force_quit_button()

--- a/src/python/impactx/dashboard/Toolbar/general.py
+++ b/src/python/impactx/dashboard/Toolbar/general.py
@@ -69,6 +69,8 @@ class GeneralToolbar:
             vuetify.VSpacer()
             AnalyzeToolbar.select_visualization()
             vuetify.VDivider(vertical=True, classes="mx-2")
+            GeneralToolbar.simulation_history_button()
+            vuetify.VDivider(vertical=True, classes="mx-2")
             GeneralToolbar.force_quit_button()
 
     @staticmethod

--- a/src/python/impactx/dashboard/Toolbar/sim_history/dialogs.py
+++ b/src/python/impactx/dashboard/Toolbar/sim_history/dialogs.py
@@ -137,10 +137,11 @@ class SimulationHistoryDialogs:
                         prepend_icon="mdi-file-code",
                         click=(ctrl.load_selected_sim),
                     )
-                with vuetify.VList(v_show="selected_sim_to_load.status === 'Completed'"):
+                with vuetify.VList(
+                    v_show="selected_sim_to_load.status === 'Completed'"
+                ):
                     vuetify.VListItem(
                         title="Load Outputs",
                         prepend_icon="mdi-folder-open",
                         click=(ctrl.load_selected_sim_outputs),
                     )
-

--- a/src/python/impactx/dashboard/Toolbar/sim_history/dialogs.py
+++ b/src/python/impactx/dashboard/Toolbar/sim_history/dialogs.py
@@ -137,7 +137,7 @@ class SimulationHistoryDialogs:
                         prepend_icon="mdi-file-code",
                         click=(ctrl.load_selected_sim),
                     )
-                with vuetify.VList():
+                with vuetify.VList(v_show="selected_sim_to_load.status === 'Completed'"):
                     vuetify.VListItem(
                         title="Load Outputs",
                         prepend_icon="mdi-folder-open",

--- a/src/python/impactx/dashboard/Toolbar/sim_history/dialogs.py
+++ b/src/python/impactx/dashboard/Toolbar/sim_history/dialogs.py
@@ -137,3 +137,10 @@ class SimulationHistoryDialogs:
                         prepend_icon="mdi-file-code",
                         click=(ctrl.load_selected_sim),
                     )
+                with vuetify.VList():
+                    vuetify.VListItem(
+                        title="Load Outputs",
+                        prepend_icon="mdi-folder-open",
+                        click=(ctrl.load_selected_sim_outputs),
+                    )
+

--- a/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
+++ b/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
@@ -205,6 +205,7 @@ class SimulationHistory:
         SimulationHistoryDialogs.download_options_dialog()
         SimulationHistoryDialogs.load_sim_dialog()
 
+    @staticmethod
     def _ensure_unique_name(base_name: str) -> str:
         """
         Ensures the simulation name is unique by appending _1, _2, etc., if needed.

--- a/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
+++ b/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
@@ -195,6 +195,24 @@ class SimulationHistory:
         SimulationHistoryDialogs.download_options_dialog()
         SimulationHistoryDialogs.load_sim_dialog()
 
+
+    def _ensure_unique_name(base_name: str) -> str:
+        """
+        Ensures the simulation name is unique by appending _1, _2, etc., if needed.
+
+        :param base_name: The simulation name to check for uniqueness.
+        :return: Unique simulation name
+        """
+        existing_names = {sim["name"] for sim in state.sims}
+        if base_name not in existing_names:
+            return base_name
+
+        i = 1
+        while f"{base_name}_{i}" in existing_names:
+            i += 1
+
+        return f"{base_name}_{i}"
+
     @staticmethod
     def add_sim_to_history():
         """
@@ -206,6 +224,7 @@ class SimulationHistory:
         curr_num_sims = len(state.sims)
         new_sim_name = state.imported_file_name or f"Simulation_{curr_num_sims + 1}"
         current_time = datetime.utcnow().isoformat() + "Z"
+        new_sim_name = SimulationHistory._ensure_unique_name(new_sim_name)
         sim_inputs = dashboard_sim_inputs(is_exporting=True)
 
         new_sim = {

--- a/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
+++ b/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
@@ -9,13 +9,13 @@ License: BSD-3-Clause-LBNL
 from datetime import datetime
 from pathlib import Path
 
+from ..file_imports.ui_populator import populate_impactx_simulation_file_to_ui
 from ... import html, setup_server, vuetify
 from ...Run.simulation import dashboard_sim_inputs
+from ...Analyze import over_s
 from . import SimulationHistoryComponents, SimulationHistoryDialogs
 
 server, state, ctrl = setup_server()
-from ..file_imports.ui_populator import populate_impactx_simulation_file_to_ui
-
 state.curr_view_details_log = ""
 
 state.sims = []
@@ -153,10 +153,20 @@ class SimulationHistory:
     def load_sim_outputs():
         sim = state.selected_sim_to_load
         state.selected_sim_to_analyze = sim
-        state.phase_space_png = sim["outputs"]["phase_space_png"]
+
+        outputs = sim["outputs"] if "outputs" in sim else {}
+
+        # Load phase space PNG
+        state.phase_space_png = outputs.get("phase_space_png")
+        
+        # Load Over S plot data
+        state.over_s_possible_headers = outputs.get("over_s_table_headers")
+        state.over_s_possible_data = outputs.get("over_s_table_data")
+        over_s._update_table()
+        over_s._update_plot()
 
         state.load_sim_dialog = False
-        
+
     @staticmethod
     def filter_sim_history():
         """

--- a/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
+++ b/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
@@ -153,10 +153,7 @@ class SimulationHistory:
     def load_sim_outputs():
         sim = state.selected_sim_to_load
         state.selected_sim_to_analyze = sim
-        outputs = sim.get("outputs", {})
-
-        if "phase_space_png" in outputs:
-            state.phase_space_png = outputs["phase_space_png"]
+        state.phase_space_png = sim["outputs"]["phase_space_png"]
 
         state.load_sim_dialog = False
         

--- a/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
+++ b/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
@@ -149,6 +149,17 @@ class SimulationHistory:
         state.selected_sim_to_load = None
 
     @staticmethod
+    @ctrl.add("load_selected_sim_outputs")
+    def load_sim_outputs():
+        sim = state.selected_sim_to_load
+        outputs = sim.get("outputs", {})
+
+        if "phase_space_png" in outputs:
+            state.phase_space_png = outputs["phase_space_png"]
+
+        state.load_sim_dialog = False
+        
+    @staticmethod
     def filter_sim_history():
         """
         Handles the functionality to filter the sim history.
@@ -206,6 +217,7 @@ class SimulationHistory:
             "status": "In Progress",
             "inputs": sim_inputs,
             "log": "",
+            "outputs": {},
         }
 
         state.sims = state.sims + [new_sim]

--- a/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
+++ b/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
@@ -152,6 +152,7 @@ class SimulationHistory:
     @ctrl.add("load_selected_sim_outputs")
     def load_sim_outputs():
         sim = state.selected_sim_to_load
+        state.selected_sim_to_analyze = sim
         outputs = sim.get("outputs", {})
 
         if "phase_space_png" in outputs:

--- a/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
+++ b/src/python/impactx/dashboard/Toolbar/sim_history/ui.py
@@ -9,10 +9,10 @@ License: BSD-3-Clause-LBNL
 from datetime import datetime
 from pathlib import Path
 
-from ..file_imports.ui_populator import populate_impactx_simulation_file_to_ui
 from ... import html, setup_server, vuetify
-from ...Run.simulation import dashboard_sim_inputs
 from ...Analyze import over_s
+from ...Run.simulation import dashboard_sim_inputs
+from ..file_imports.ui_populator import populate_impactx_simulation_file_to_ui
 from . import SimulationHistoryComponents, SimulationHistoryDialogs
 
 server, state, ctrl = setup_server()
@@ -158,7 +158,7 @@ class SimulationHistory:
 
         # Load phase space PNG
         state.phase_space_png = outputs.get("phase_space_png")
-        
+
         # Load Over S plot data
         state.over_s_possible_headers = outputs.get("over_s_table_headers")
         state.over_s_possible_data = outputs.get("over_s_table_data")
@@ -204,7 +204,6 @@ class SimulationHistory:
         SimulationHistoryDialogs.view_details_dialog()
         SimulationHistoryDialogs.download_options_dialog()
         SimulationHistoryDialogs.load_sim_dialog()
-
 
     def _ensure_unique_name(base_name: str) -> str:
         """

--- a/tests/python/dashboard/test_lattice_variable_handler.py
+++ b/tests/python/dashboard/test_lattice_variable_handler.py
@@ -112,6 +112,7 @@ def test_lattice_variable_handler(dashboard):
 
     # Reset variables and check state
     dashboard.sb.click("#reset_variables")
+    dashboard.assert_state("is_only_variable", True)
     variables_after_reset = dashboard.get_state("variables")
     assert len(variables_after_reset) == 1, (
         "Resetting variables should leave only one variable."

--- a/tests/python/dashboard/test_lattice_variable_handler.py
+++ b/tests/python/dashboard/test_lattice_variable_handler.py
@@ -7,6 +7,7 @@ License: BSD-3-Clause-LBNL
 """
 
 import pytest
+import time
 
 
 def lattice_value(state, index: int, param_name: str) -> float:
@@ -34,6 +35,27 @@ def variable_index(variable_name: str, dashboard) -> int:
         if variable["name"] == variable_name:
             return index
     raise ValueError(f"Variable '{variable_name}' not found in dashboard state")
+
+
+def assert_lattice_param_sim_input(dashboard, lattice_index: int, param_name: str, expected_value):
+    """
+    Asserts that a lattice parameter's sim_input matches expected value, with retry logic.
+    """
+    def get_sim_input():
+        lattice_list = dashboard.get_state("selected_lattice_list")
+        for param in lattice_list[lattice_index]["parameters"]:
+            if param["parameter_name"] == param_name:
+                return param["sim_input"]
+        return None
+    
+    # Simple retry logic similar to assert_state
+    for i in range(10):
+        current_value = get_sim_input()
+        if current_value == expected_value:
+            return
+        time.sleep(1)
+    
+    raise AssertionError(f"Parameter '{param_name}' sim_input never became '{expected_value}' (got: {current_value})")
 
 
 def test_lattice_variable_handler(dashboard):
@@ -84,27 +106,28 @@ def test_lattice_variable_handler(dashboard):
     ns_var_index = variable_index("ns", dashboard)
     dashboard.sb.click(f"#delete_variable_button_{ns_var_index}")
 
-    lattice_list = dashboard.get_state("selected_lattice_list")
-    variables = dashboard.get_state("variables")
-
     # Verify the lattice element value is storing the variable value in the backend
-    assert lattice_value(lattice_list, 0, "ds") == 0.500194828041958
-    assert lattice_value(lattice_list, 0, "rc") == -10.346228368619553
+    assert_lattice_param_sim_input(dashboard, 0, "ds", 0.500194828041958)
+    assert_lattice_param_sim_input(dashboard, 0, "rc", -10.346228368619553)
+    
+    variables = dashboard.get_state("variables")
     assert all(var["name"] != "ns" for var in variables), (
         "Variable 'ns' was not deleted"
     )
 
-    # Make sure nslice parameter does not have numeric value
-    # since 'ns' is deleted
+    # Wait for nslice parameter to have 'ns' as sim_input (non-numeric after variable deletion)
+    assert_lattice_param_sim_input(dashboard, 0, "nslice", "ns")
+    
+    # Verify lattice_value function raises AssertionError for non-numeric sim_input
     with pytest.raises(AssertionError, match="'nslice'"):
-        lattice_value(lattice_list, 0, "nslice")
+        current_lattice_list = dashboard.get_state("selected_lattice_list")
+        lattice_value(current_lattice_list, 0, "nslice")
 
     # Verify that changing a variable value correctly updates the lattice element
     NEW_LB = 0.75
     lb_var_index = variable_index("lb", dashboard)
     dashboard.set_input(f"variable_value_{lb_var_index}", NEW_LB)
-    lattice_list_with_updated_lb = dashboard.get_state("selected_lattice_list")
-    assert lattice_value(lattice_list_with_updated_lb, 0, "ds") == NEW_LB
+    assert_lattice_param_sim_input(dashboard, 0, "ds", NEW_LB)
 
     # Verify that the invalid variables cannot be set on the dashboard
     for var in variables[len(VALID_VARIABLES) :]:
@@ -113,6 +136,8 @@ def test_lattice_variable_handler(dashboard):
     # Reset variables and check state
     dashboard.sb.click("#reset_variables")
     dashboard.assert_state("is_only_variable", True)
+    
+    # Retrieve variables state once the
     variables_after_reset = dashboard.get_state("variables")
     assert len(variables_after_reset) == 1, (
         "Resetting variables should leave only one variable."

--- a/tests/python/dashboard/test_lattice_variable_handler.py
+++ b/tests/python/dashboard/test_lattice_variable_handler.py
@@ -6,8 +6,9 @@ Authors: Parthib Roy
 License: BSD-3-Clause-LBNL
 """
 
-import pytest
 import time
+
+import pytest
 
 
 def lattice_value(state, index: int, param_name: str) -> float:
@@ -37,25 +38,30 @@ def variable_index(variable_name: str, dashboard) -> int:
     raise ValueError(f"Variable '{variable_name}' not found in dashboard state")
 
 
-def assert_lattice_param_sim_input(dashboard, lattice_index: int, param_name: str, expected_value):
+def assert_lattice_param_sim_input(
+    dashboard, lattice_index: int, param_name: str, expected_value
+):
     """
     Asserts that a lattice parameter's sim_input matches expected value, with retry logic.
     """
+
     def get_sim_input():
         lattice_list = dashboard.get_state("selected_lattice_list")
         for param in lattice_list[lattice_index]["parameters"]:
             if param["parameter_name"] == param_name:
                 return param["sim_input"]
         return None
-    
+
     # Simple retry logic similar to assert_state
     for i in range(10):
         current_value = get_sim_input()
         if current_value == expected_value:
             return
         time.sleep(1)
-    
-    raise AssertionError(f"Parameter '{param_name}' sim_input never became '{expected_value}' (got: {current_value})")
+
+    raise AssertionError(
+        f"Parameter '{param_name}' sim_input never became '{expected_value}' (got: {current_value})"
+    )
 
 
 def test_lattice_variable_handler(dashboard):
@@ -109,7 +115,7 @@ def test_lattice_variable_handler(dashboard):
     # Verify the lattice element value is storing the variable value in the backend
     assert_lattice_param_sim_input(dashboard, 0, "ds", 0.500194828041958)
     assert_lattice_param_sim_input(dashboard, 0, "rc", -10.346228368619553)
-    
+
     variables = dashboard.get_state("variables")
     assert all(var["name"] != "ns" for var in variables), (
         "Variable 'ns' was not deleted"
@@ -117,7 +123,7 @@ def test_lattice_variable_handler(dashboard):
 
     # Wait for nslice parameter to have 'ns' as sim_input (non-numeric after variable deletion)
     assert_lattice_param_sim_input(dashboard, 0, "nslice", "ns")
-    
+
     # Verify lattice_value function raises AssertionError for non-numeric sim_input
     with pytest.raises(AssertionError, match="'nslice'"):
         current_lattice_list = dashboard.get_state("selected_lattice_list")
@@ -136,7 +142,7 @@ def test_lattice_variable_handler(dashboard):
     # Reset variables and check state
     dashboard.sb.click("#reset_variables")
     dashboard.assert_state("is_only_variable", True)
-    
+
     # Retrieve variables state once the
     variables_after_reset = dashboard.get_state("variables")
     assert len(variables_after_reset) == 1, (


### PR DESCRIPTION
Close https://github.com/BLAST-ImpactX/impactx/issues/941

https://github.com/user-attachments/assets/cf9ecea7-4f70-4d99-91dc-a8d2f8d30a7b



Additionally changes were made to `tests/python/dashboard/test_lattice_variable_handler.py` to improve robustness. The key change includes adding a helper function that will retry an assert for ~10 seconds before deeming a fail. This should allow the UI to smoothly update its state before having to be checked.
