### PR TITLE
Make `powi<N>(...)` Readable

### DIFF
--- a/src/diagnostics/CovarianceMatrixMath.H
+++ b/src/diagnostics/CovarianceMatrixMath.H
@@ -48,6 +48,7 @@ namespace impactx::diagnostics
     )
     {
         using namespace amrex::literals;
+        using amrex::Math::powi;
         using ablastr::constant::math::pi;
 
         std::tuple<amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal> roots;
@@ -55,9 +56,9 @@ namespace impactx::diagnostics
         amrex::ParticleReal x2 = 0.0_prt;
         amrex::ParticleReal x3 = 0.0_prt;
 
-        amrex::ParticleReal Q = (3.0_prt*a*c - amrex::Math::powi<2>(b))/(9.0_prt * amrex::Math::powi<2>(a));
-        amrex::ParticleReal R = (9.0_prt*a*b*c - 27_prt*amrex::Math::powi<2>(a)*d - 2.0_prt*amrex::Math::powi<3>(b))/(54.0_prt*amrex::Math::powi<3>(a));
-        amrex::ParticleReal discriminant = amrex::Math::powi<3>(Q) + amrex::Math::powi<2>(R);
+        amrex::ParticleReal Q = (3.0_prt*a*c - powi<2>(b))/(9.0_prt * powi<2>(a));
+        amrex::ParticleReal R = (9.0_prt*a*b*c - 27_prt*powi<2>(a)*d - 2.0_prt*powi<3>(b))/(54.0_prt*powi<3>(a));
+        amrex::ParticleReal discriminant = powi<3>(Q) + powi<2>(R);
 
         // Discriminant should be < 0.  Otherwise, keep theta at default and throw an error.
         amrex::ParticleReal tol = 1.0e-12;  //allow for roundoff error
@@ -83,7 +84,7 @@ namespace impactx::diagnostics
         } else {
 
            //Three real roots in trigonometric form.
-           amrex::ParticleReal theta = std::acos(R/std::sqrt(-amrex::Math::powi<3>(Q)));
+           amrex::ParticleReal theta = std::acos(R/std::sqrt(-powi<3>(Q)));
            x1 = 2.0_prt*std::sqrt(-Q)*std::cos(theta/3.0_prt) - b/(3.0_prt*a);
            x2 = 2.0_prt*std::sqrt(-Q)*std::cos(theta/3.0_prt + 2.0_prt*pi/3.0_prt) - b/(3.0_prt*a);
            x3 = 2.0_prt*std::sqrt(-Q)*std::cos(theta/3.0_prt + 4.0_prt*pi/3.0_prt) - b/(3.0_prt*a);
@@ -119,6 +120,7 @@ namespace impactx::diagnostics
     )
     {
         using namespace amrex::literals;
+        using amrex::Math::powi;
         using Complex = amrex::GpuComplex<amrex::ParticleReal>;
 
         std::tuple<amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal> roots;
@@ -126,9 +128,9 @@ namespace impactx::diagnostics
         amrex::ParticleReal x2 = 0.0_prt;
         amrex::ParticleReal x3 = 0.0_prt;
 
-        amrex::ParticleReal Q = (3.0_prt*a*c - amrex::Math::powi<2>(b))/(9.0_prt * amrex::Math::powi<2>(a));
-        amrex::ParticleReal R = (9.0_prt*a*b*c - 27_prt*amrex::Math::powi<2>(a)*d - 2.0_prt*amrex::Math::powi<3>(b))/(54.0_prt*amrex::Math::powi<3>(a));
-        amrex::ParticleReal discriminant = amrex::Math::powi<3>(Q) + amrex::Math::powi<2>(R);
+        amrex::ParticleReal Q = (3.0_prt*a*c - powi<2>(b))/(9.0_prt * powi<2>(a));
+        amrex::ParticleReal R = (9.0_prt*a*b*c - 27_prt*powi<2>(a)*d - 2.0_prt*powi<3>(b))/(54.0_prt*powi<3>(a));
+        amrex::ParticleReal discriminant = powi<3>(Q) + powi<2>(R);
 
         // Define complex variable C
         Complex Qc(Q,0.0_prt);
@@ -153,7 +155,7 @@ namespace impactx::diagnostics
 
            Complex z1 = Qc/C - C;
            Complex z2 = Qc/(xi*C) - xi*C;
-           Complex z3 = Qc/(amrex::Math::powi<2>(xi)*C) - amrex::Math::powi<2>(xi)*C;
+           Complex z3 = Qc/(powi<2>(xi)*C) - powi<2>(xi)*C;
            x1 = z2.m_real - b/(3.0*a);
            x2 = z1.m_real - b/(3.0*a);
            x3 = z3.m_real - b/(3.0*a);

--- a/src/diagnostics/EmittanceInvariants.cpp
+++ b/src/diagnostics/EmittanceInvariants.cpp
@@ -99,6 +99,7 @@ namespace impactx::diagnostics
         BL_PROFILE("impactx::diagnostics::Eigenemittances");
 
         using namespace amrex::literals;
+        using amrex::Math::powi;
 
         std::tuple<amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal> invariants;
         std::tuple<amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal> roots;
@@ -117,8 +118,8 @@ namespace impactx::diagnostics
         // doi:10.48550/arXiv.1305.1532.
         amrex::ParticleReal a = 1.0_prt;
         amrex::ParticleReal b = -I2;
-        amrex::ParticleReal c = (amrex::Math::powi<2>(I2) - I4) / 2.0_prt;
-        amrex::ParticleReal d = -amrex::Math::powi<3>(I2) / 6.0_prt + I2 * I4 / 2.0_prt - I6 / 3.0_prt;
+        amrex::ParticleReal c = (powi<2>(I2) - I4) / 2.0_prt;
+        amrex::ParticleReal d = -powi<3>(I2) / 6.0_prt + I2 * I4 / 2.0_prt - I6 / 3.0_prt;
 
         // Return the cubic coefficients
         //std::cout << "Return a,b,c,d " << a << " " << b << " " << c << " " << d << "\n";

--- a/src/diagnostics/NonlinearLensInvariants.H
+++ b/src/diagnostics/NonlinearLensInvariants.H
@@ -77,6 +77,7 @@ namespace impactx::diagnostics
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // a complex type with two amrex::ParticleReal
             using Complex = amrex::GpuComplex<amrex::ParticleReal>;
@@ -94,7 +95,7 @@ namespace impactx::diagnostics
             Complex const im1(0.0_prt, 1.0_prt);
 
             // compute croot = sqrt(1-zeta**2)
-            Complex croot = amrex::Math::powi<2>(zeta);
+            Complex croot = powi<2>(zeta);
             croot = re1 - croot;
             croot = amrex::sqrt(croot);
 
@@ -116,9 +117,9 @@ namespace impactx::diagnostics
 
             // compute invariants H and I
             amrex::ParticleReal const Jz = xn*pyn - yn*pxn;
-            Hinv = (amrex::Math::powi<2>(xn) + amrex::Math::powi<2>(yn) + amrex::Math::powi<2>(pxn) + amrex::Math::powi<2>(pyn))/2
+            Hinv = (powi<2>(xn) + powi<2>(yn) + powi<2>(pxn) + powi<2>(pyn))/2
                  + m_tn*Hinv;
-            Iinv = amrex::Math::powi<2>(Jz) + amrex::Math::powi<2>(pxn) + amrex::Math::powi<2>(xn) + m_tn*Iinv;
+            Iinv = powi<2>(Jz) + powi<2>(pxn) + powi<2>(xn) + m_tn*Iinv;
 
             return {Hinv, Iinv};
 

--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -143,6 +143,7 @@ namespace impactx::elements
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
@@ -170,11 +171,11 @@ namespace impactx::elements
             switch (m_shape)
             {
                 case Shape::rectangular:  // default
-                    inside_aperture = (amrex::Math::powi<2>(u) <= 1_prt && amrex::Math::powi<2>(v) <= 1_prt);
+                    inside_aperture = (powi<2>(u) <= 1_prt && powi<2>(v) <= 1_prt);
                     break;
 
                 case Shape::elliptical:
-                    inside_aperture = (amrex::Math::powi<2>(u) + amrex::Math::powi<2>(v) <= 1_prt);
+                    inside_aperture = (powi<2>(u) + powi<2>(v) <= 1_prt);
                     break;
             }
 

--- a/src/elements/Buncher.H
+++ b/src/elements/Buncher.H
@@ -75,11 +75,12 @@ namespace impactx::elements
         void compute_constants (RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
             // find beta*gamma^2
-            amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(refpart.pt) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(refpart.pt) - 1.0_prt;
 
             m_neg_kV = -m_k * m_V;
             m_kV_r2bg2 = -m_neg_kV / (2.0_prt * betgam2);
@@ -151,9 +152,10 @@ namespace impactx::elements
         transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // find beta*gamma^2
-            amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(refpart.pt) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(refpart.pt) - 1.0_prt;
 
             amrex::ParticleReal const neg_kV = -m_k * m_V;
             amrex::ParticleReal const kV_r2bg2 = -neg_kV / (2.0_prt * betgam2);

--- a/src/elements/CFbend.H
+++ b/src/elements/CFbend.H
@@ -91,6 +91,7 @@ namespace impactx::elements
         void compute_constants (RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
@@ -98,13 +99,13 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // find beta*gamma^2, beta
-            amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(refpart.pt) - 1_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(refpart.pt) - 1_prt;
             amrex::ParticleReal const bet = refpart.beta();
             amrex::ParticleReal const ibetgam2 = 1_prt / betgam2;
-            amrex::ParticleReal const b2rc2 = amrex::Math::powi<2>(bet) * amrex::Math::powi<2>(m_rc);
+            amrex::ParticleReal const b2rc2 = powi<2>(bet) * powi<2>(m_rc);
 
             // update horizontal and longitudinal phase space variables
-            amrex::ParticleReal const gx = m_k + amrex::Math::powi<-2>(m_rc);
+            amrex::ParticleReal const gx = m_k + powi<-2>(m_rc);
             amrex::ParticleReal const omega_x = std::sqrt(std::abs(gx));
 
             // update vertical phase space variables
@@ -212,6 +213,7 @@ namespace impactx::elements
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -229,7 +231,7 @@ namespace impactx::elements
 
             // assign intermediate parameter
             amrex::ParticleReal const theta = slice_ds/m_rc;
-            amrex::ParticleReal const B = std::sqrt(amrex::Math::powi<2>(pt)-1.0_prt)/m_rc;
+            amrex::ParticleReal const B = std::sqrt(powi<2>(pt)-1.0_prt)/m_rc;
 
             // calculate expensive terms once
             auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
@@ -262,18 +264,19 @@ namespace impactx::elements
         transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // find beta*gamma^2, beta
-            amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(refpart.pt) - 1_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(refpart.pt) - 1_prt;
             amrex::ParticleReal const bet = refpart.beta();
             amrex::ParticleReal const ibetgam2 = 1_prt / betgam2;
-            amrex::ParticleReal const b2rc2 = amrex::Math::powi<2>(bet) * amrex::Math::powi<2>(m_rc);
+            amrex::ParticleReal const b2rc2 = powi<2>(bet) * powi<2>(m_rc);
 
             // update horizontal and longitudinal phase space variables
-            amrex::ParticleReal const gx = m_k + amrex::Math::powi<-2>(m_rc);
+            amrex::ParticleReal const gx = m_k + powi<-2>(m_rc);
             amrex::ParticleReal const omega_x = std::sqrt(std::abs(gx));
 
             // update vertical phase space variables

--- a/src/elements/ChrDrift.H
+++ b/src/elements/ChrDrift.H
@@ -85,6 +85,7 @@ namespace impactx::elements
         void compute_constants (RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
@@ -95,7 +96,7 @@ namespace impactx::elements
             m_beta = refpart.beta();
             m_gamma = refpart.gamma();
 
-            m_const1 = 1_prt / (2_prt * amrex::Math::powi<3>(m_beta) * amrex::Math::powi<2>(m_gamma));
+            m_const1 = 1_prt / (2_prt * powi<3>(m_beta) * powi<2>(m_gamma));
         }
 
         /** This is a chrdrift functor, so that a variable of this type can be used like a chrdrift function.
@@ -122,6 +123,7 @@ namespace impactx::elements
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
@@ -137,7 +139,7 @@ namespace impactx::elements
             amrex::ParticleReal const ptout = pt;
 
             // compute particle momentum deviation delta + 1
-            amrex::ParticleReal const idelta1 = 1_prt / std::sqrt(1_prt - 2_prt*pt/m_beta + amrex::Math::powi<2>(pt));
+            amrex::ParticleReal const idelta1 = 1_prt / std::sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
 
             // advance transverse position and momentum (drift)
             x = xout + m_slice_ds * px * idelta1;
@@ -146,12 +148,12 @@ namespace impactx::elements
             // pyout = py;
 
             // the corresponding symplectic update to t
-            amrex::ParticleReal term = 2_prt * amrex::Math::powi<2>(pt) + amrex::Math::powi<2>(px) + amrex::Math::powi<2>(py);
-            term = 2_prt - 4_prt*m_beta*pt + amrex::Math::powi<2>(m_beta)*term;
-            term = -2_prt + amrex::Math::powi<2>(m_gamma)*term;
+            amrex::ParticleReal term = 2_prt * powi<2>(pt) + powi<2>(px) + powi<2>(py);
+            term = 2_prt - 4_prt*m_beta*pt + powi<2>(m_beta)*term;
+            term = -2_prt + powi<2>(m_gamma)*term;
             term = (-1_prt+m_beta*pt)*term;
             term = term * m_const1;
-            t = tout - m_slice_ds * (1_prt / m_beta + term * amrex::Math::powi<3>(idelta1));
+            t = tout - m_slice_ds * (1_prt / m_beta + term * powi<3>(idelta1));
             // ptout = pt;
 
             // assign updated momenta
@@ -174,6 +176,7 @@ namespace impactx::elements
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -190,7 +193,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds /std::sqrt(amrex::Math::powi<2>(pt)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds /std::sqrt(powi<2>(pt)-1.0_prt);
 
             // advance position and momentum (drift)
             refpart.x = x + step*px;

--- a/src/elements/ChrPlasmaLens.H
+++ b/src/elements/ChrPlasmaLens.H
@@ -131,12 +131,13 @@ namespace impactx::elements
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
 
             // compute particle momentum deviation delta + 1
-            amrex::ParticleReal const delta1 = std::sqrt(1_prt - 2_prt*pt/m_beta + amrex::Math::powi<2>(pt));
+            amrex::ParticleReal const delta1 = std::sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
             amrex::ParticleReal const delta = delta1 - 1_prt;
 
             // compute phase advance per unit length in s (in rad/m)
@@ -174,13 +175,13 @@ namespace impactx::elements
             amrex::ParticleReal const t0 = t - term*m_slice_ds/delta1;
 
             amrex::ParticleReal const w = omega*delta1;
-            amrex::ParticleReal const term1 = -(amrex::Math::powi<2>(p2)-amrex::Math::powi<2>(q2) * amrex::Math::powi<2>(w)) * std::sin(2_prt*m_slice_ds*omega);
-            amrex::ParticleReal const term2 = -(amrex::Math::powi<2>(p1)-amrex::Math::powi<2>(q1) * amrex::Math::powi<2>(w)) * std::sin(2_prt*m_slice_ds*omega);
+            amrex::ParticleReal const term1 = -(powi<2>(p2)-powi<2>(q2) * powi<2>(w)) * std::sin(2_prt*m_slice_ds*omega);
+            amrex::ParticleReal const term2 = -(powi<2>(p1)-powi<2>(q1) * powi<2>(w)) * std::sin(2_prt*m_slice_ds*omega);
             amrex::ParticleReal const term3 = -2_prt*q2*p2*w * std::cos(2_prt*m_slice_ds*omega);
             amrex::ParticleReal const term4 = -2_prt*q1*p1*w * std::cos(2_prt*m_slice_ds*omega);
             amrex::ParticleReal const term5 = 2_prt*omega*(q1*p1*delta1 + q2*p2*delta1
-                                        -(amrex::Math::powi<2>(p1) + amrex::Math::powi<2>(p2))*m_slice_ds - (amrex::Math::powi<2>(q1) + amrex::Math::powi<2>(q2)) * amrex::Math::powi<2>(w)*m_slice_ds);
-            t = t0 + (-1_prt+m_beta*pt)/(8_prt*m_beta * amrex::Math::powi<3>(delta1)*omega)
+                                        -(powi<2>(p1) + powi<2>(p2))*m_slice_ds - (powi<2>(q1) + powi<2>(q2)) * powi<2>(w)*m_slice_ds);
+            t = t0 + (-1_prt+m_beta*pt)/(8_prt*m_beta * powi<3>(delta1)*omega)
                      *(term1+term2+term3+term4+term5);
 
             // ptout = pt;
@@ -207,6 +208,7 @@ namespace impactx::elements
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -223,7 +225,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds /std::sqrt(amrex::Math::powi<2>(pt)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds /std::sqrt(powi<2>(pt)-1.0_prt);
 
             // advance position and momentum (straight element)
             refpart.x = x + step*px;

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -97,6 +97,7 @@ namespace impactx::elements
         void compute_constants (RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
@@ -110,7 +111,7 @@ namespace impactx::elements
             // normalize quad units to MAD-X convention if needed
             m_g = m_unit == 1 ? m_k / refpart.rigidity_Tm() : m_k;
 
-            m_const1 = 1_prt / (2_prt * amrex::Math::powi<3>(m_beta) * amrex::Math::powi<2>(m_gamma));
+            m_const1 = 1_prt / (2_prt * powi<3>(m_beta) * powi<2>(m_gamma));
         }
 
         /** This is a chrquad functor, so that a variable of this type can be used like a chrquad function.
@@ -137,6 +138,7 @@ namespace impactx::elements
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
@@ -147,7 +149,7 @@ namespace impactx::elements
             amrex::ParticleReal const tout = t;
 
             // compute particle momentum deviation delta + 1
-            amrex::ParticleReal const delta1 = std::sqrt(1_prt - 2_prt*pt/m_beta + amrex::Math::powi<2>(pt));
+            amrex::ParticleReal const delta1 = std::sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
             amrex::ParticleReal const delta = delta1 - 1_prt;
 
             // compute phase advance per unit length in s (in rad/m)
@@ -206,12 +208,12 @@ namespace impactx::elements
             if (m_g == 0.0)
             {
                // the corresponding symplectic update to t (zero strength = drift)
-               amrex::ParticleReal term = 2_prt * amrex::Math::powi<2>(pt) + amrex::Math::powi<2>(px) + amrex::Math::powi<2>(py);
-               term = 2_prt - 4_prt * m_beta * pt + amrex::Math::powi<2>(m_beta) * term;
-               term = -2_prt + amrex::Math::powi<2>(m_gamma)*term;
+               amrex::ParticleReal term = 2_prt * powi<2>(pt) + powi<2>(px) + powi<2>(py);
+               term = 2_prt - 4_prt * m_beta * pt + powi<2>(m_beta) * term;
+               term = -2_prt + powi<2>(m_gamma)*term;
                term = (-1_prt + m_beta * pt) * term;
                term = term * m_const1;
-               t = tout - m_slice_ds * (1_prt / m_beta + term / amrex::Math::powi<3>(delta1));
+               t = tout - m_slice_ds * (1_prt / m_beta + term / powi<3>(delta1));
                // ptout = pt;
 
             } else
@@ -221,14 +223,14 @@ namespace impactx::elements
                 amrex::ParticleReal const t0 = tout - term * m_slice_ds / delta1;
 
                 amrex::ParticleReal const w = omega * delta1;
-                amrex::ParticleReal const term1 = -(amrex::Math::powi<2>(p2) + amrex::Math::powi<2>(q2) * amrex::Math::powi<2>(w)) * std::sinh(2_prt*m_slice_ds*omega);
-                amrex::ParticleReal const term2 = -(amrex::Math::powi<2>(p1) - amrex::Math::powi<2>(q1) * amrex::Math::powi<2>(w)) * std::sin(2_prt*m_slice_ds*omega);
+                amrex::ParticleReal const term1 = -(powi<2>(p2) + powi<2>(q2) * powi<2>(w)) * std::sinh(2_prt*m_slice_ds*omega);
+                amrex::ParticleReal const term2 = -(powi<2>(p1) - powi<2>(q1) * powi<2>(w)) * std::sin(2_prt*m_slice_ds*omega);
                 amrex::ParticleReal const term3 = -2_prt * q2 * p2 * w * std::cosh(2_prt*m_slice_ds*omega);
                 amrex::ParticleReal const term4 = -2_prt * q1 * p1 * w * std::cos(2_prt*m_slice_ds*omega);
                 amrex::ParticleReal const term5 =  2_prt * omega * (q1*p1*delta1 + q2*p2*delta1
-                    -(amrex::Math::powi<2>(p1) + amrex::Math::powi<2>(p2))*m_slice_ds - (amrex::Math::powi<2>(q1)-amrex::Math::powi<2>(q2)) * amrex::Math::powi<2>(w)*m_slice_ds);
+                    -(powi<2>(p1) + powi<2>(p2))*m_slice_ds - (powi<2>(q1)-powi<2>(q2)) * powi<2>(w)*m_slice_ds);
                 t = t0 + (-1_prt+m_beta*pt)
-                       / (8_prt*m_beta * amrex::Math::powi<3>(delta1)*omega)
+                       / (8_prt*m_beta * powi<3>(delta1)*omega)
                        * (term1+term2+term3+term4+term5);
                // ptout = pt;
              }
@@ -253,6 +255,7 @@ namespace impactx::elements
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -269,7 +272,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds / std::sqrt(amrex::Math::powi<2>(pt)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds / std::sqrt(powi<2>(pt)-1.0_prt);
 
             // advance position and momentum (straight element)
             refpart.x = x + step*px;

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -92,6 +92,7 @@ namespace impactx::elements
         void compute_constants (RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
@@ -101,8 +102,8 @@ namespace impactx::elements
             // access reference particle values (final, initial):
             m_ptf_ref = refpart.pt;
             m_pti_ref = m_ptf_ref + m_ez * m_slice_ds;
-            m_bgf = std::sqrt(amrex::Math::powi<2>(m_ptf_ref) - 1.0_prt);
-            m_bgi = std::sqrt(amrex::Math::powi<2>(m_pti_ref) - 1.0_prt);
+            m_bgf = std::sqrt(powi<2>(m_ptf_ref) - 1.0_prt);
+            m_bgi = std::sqrt(powi<2>(m_pti_ref) - 1.0_prt);
 
             // compute focusing constant (1/m) and rotation angle (in rad)
             m_alpha = m_bz / 2.0_prt;
@@ -135,6 +136,7 @@ namespace impactx::elements
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
@@ -147,17 +149,17 @@ namespace impactx::elements
             // compute intermediate quantities related to acceleration
             amrex::ParticleReal const pti_tot = m_pti_ref + pt;
             amrex::ParticleReal const ptf_tot = m_ptf_ref + pt;
-            amrex::ParticleReal const pti_tot2 = amrex::Math::powi<2>(pti_tot);
-            amrex::ParticleReal const ptf_tot2 = amrex::Math::powi<2>(ptf_tot);
+            amrex::ParticleReal const pti_tot2 = powi<2>(pti_tot);
+            amrex::ParticleReal const ptf_tot2 = powi<2>(ptf_tot);
 
             // check whether particle lies within the domain of map definition
             if (pti_tot2 <= 1_prt || ptf_tot2 <= 1_prt) {
                 amrex::ParticleIDWrapper{idcpu}.make_invalid();
             } else {
-                amrex::ParticleReal const pzi_tot = std::sqrt(amrex::Math::powi<2>(pti_tot) - 1_prt);
-                amrex::ParticleReal const pzf_tot = std::sqrt(amrex::Math::powi<2>(ptf_tot) - 1_prt);
-                amrex::ParticleReal const pzi_ref = std::sqrt(amrex::Math::powi<2>(m_pti_ref) - 1_prt);
-                amrex::ParticleReal const pzf_ref = std::sqrt(amrex::Math::powi<2>(m_ptf_ref) - 1_prt);
+                amrex::ParticleReal const pzi_tot = std::sqrt(powi<2>(pti_tot) - 1_prt);
+                amrex::ParticleReal const pzf_tot = std::sqrt(powi<2>(ptf_tot) - 1_prt);
+                amrex::ParticleReal const pzi_ref = std::sqrt(powi<2>(m_pti_ref) - 1_prt);
+                amrex::ParticleReal const pzf_ref = std::sqrt(powi<2>(m_ptf_ref) - 1_prt);
 
                 amrex::ParticleReal const numer = -ptf_tot + pzf_tot;
                 amrex::ParticleReal const denom = -pti_tot + pzi_tot;
@@ -184,8 +186,8 @@ namespace impactx::elements
                 // the correct symplectic update for t
                 tout = t + (pzf_tot - pzf_ref - pzi_tot + pzi_ref) / m_ez;
                 tout += (1_prt/pzi_tot - 1_prt/pzf_tot)
-                      * (amrex::Math::powi<2>(py - m_alpha * x) +
-                         amrex::Math::powi<2>(px + m_alpha * y))
+                      * (powi<2>(py - m_alpha * x) +
+                         powi<2>(px + m_alpha * y))
                       / (2_prt * m_ez);
                 ptout = pt;
 
@@ -231,6 +233,7 @@ namespace impactx::elements
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -247,14 +250,14 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // compute initial value of beta*gamma
-            amrex::ParticleReal const bgi = std::sqrt(amrex::Math::powi<2>(pt) - 1.0_prt);
+            amrex::ParticleReal const bgi = std::sqrt(powi<2>(pt) - 1.0_prt);
 
             // advance pt (uniform acceleration)
             refpart.pt = pt - m_ez*slice_ds;
 
             // compute final value of beta*gamma
             amrex::ParticleReal const ptf = refpart.pt;
-            amrex::ParticleReal const bgf = std::sqrt(amrex::Math::powi<2>(ptf) - 1.0_prt);
+            amrex::ParticleReal const bgf = std::sqrt(powi<2>(ptf) - 1.0_prt);
 
             // update t
             refpart.t = t + (bgf - bgi)/m_ez;

--- a/src/elements/ConstF.H
+++ b/src/elements/ConstF.H
@@ -89,6 +89,7 @@ namespace impactx::elements
         void compute_constants (RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
@@ -96,7 +97,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // find beta*gamma^2
-            amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(refpart.pt) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(refpart.pt) - 1.0_prt;
 
             // trigo
             auto const [sin_kxds, cos_kxds] = amrex::Math::sincos(m_kx * slice_ds);
@@ -187,6 +188,7 @@ namespace impactx::elements
         void operator() (RefPart & AMREX_RESTRICT refpart) const {
 
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -203,7 +205,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds / std::sqrt(amrex::Math::powi<2>(pt) - 1.0_prt);
+            amrex::ParticleReal const step = slice_ds / std::sqrt(powi<2>(pt) - 1.0_prt);
 
             // advance position and momentum (straight element)
             refpart.x = x + step*px;
@@ -227,14 +229,14 @@ namespace impactx::elements
         Map6x6
         transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
-
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // find beta*gamma^2
-            amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(refpart.pt) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(refpart.pt) - 1.0_prt;
 
             // trigo
             auto const [sin_kxds, cos_kxds] = amrex::Math::sincos(m_kx * slice_ds);

--- a/src/elements/DipEdge.H
+++ b/src/elements/DipEdge.H
@@ -86,6 +86,7 @@ namespace impactx::elements
         void compute_constants ([[maybe_unused]] RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
@@ -94,9 +95,9 @@ namespace impactx::elements
 
             // first-order effect of nonzero gap
             auto const [sin_psi, cos_psi] = amrex::Math::sincos(m_psi);
-            amrex::ParticleReal const vf = (1.0_prt + amrex::Math::powi<2>(sin_psi))
-                / amrex::Math::powi<3>(cos_psi)
-                * m_g * m_K2 / amrex::Math::powi<2>(m_rc);
+            amrex::ParticleReal const vf = (1.0_prt + powi<2>(sin_psi))
+                / powi<3>(cos_psi)
+                * m_g * m_K2 / powi<2>(m_rc);
 
             m_R43 = vf - m_R21;
         }
@@ -157,6 +158,7 @@ namespace impactx::elements
         transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // initialize linear map matrix elements
             Map6x6 R = Map6x6::Identity();
@@ -166,9 +168,9 @@ namespace impactx::elements
 
             // first-order effect of nonzero gap
             auto const [sin_psi, cos_psi] = amrex::Math::sincos(m_psi);
-            amrex::ParticleReal const vf = (1.0_prt + amrex::Math::powi<2>(sin_psi))
-                / amrex::Math::powi<3>(cos_psi)
-                * m_g * m_K2 / amrex::Math::powi<2>(m_rc);
+            amrex::ParticleReal const vf = (1.0_prt + powi<2>(sin_psi))
+                / powi<3>(cos_psi)
+                * m_g * m_K2 / powi<2>(m_rc);
 
             amrex::ParticleReal const R43 = vf - R21;
 

--- a/src/elements/Drift.H
+++ b/src/elements/Drift.H
@@ -83,6 +83,7 @@ namespace impactx::elements
         void compute_constants (RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
@@ -90,7 +91,7 @@ namespace impactx::elements
             m_slice_ds = m_ds / nslice();
 
             // find beta*gamma^2
-            m_betgam2 = amrex::Math::powi<2>(refpart.pt) - 1.0_prt;
+            m_betgam2 = powi<2>(refpart.pt) - 1.0_prt;
 
             m_slice_bg = m_slice_ds / m_betgam2;
         }
@@ -164,6 +165,7 @@ namespace impactx::elements
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -180,7 +182,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds /std::sqrt(amrex::Math::powi<2>(pt)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds /std::sqrt(powi<2>(pt)-1.0_prt);
 
             // advance position and momentum (drift)
             refpart.x = x + step*px;
@@ -204,13 +206,14 @@ namespace impactx::elements
         transport_map (RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(pt_ref) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
 
             // assign linear map matrix elements
             Map6x6 R = Map6x6::Identity();

--- a/src/elements/ExactDrift.H
+++ b/src/elements/ExactDrift.H
@@ -82,6 +82,7 @@ namespace impactx::elements
         void compute_constants (RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
@@ -90,7 +91,7 @@ namespace impactx::elements
 
             // access reference particle values to find beta, 1/(beta*gamma)**2
             m_ibeta = 1_prt / refpart.beta();
-            m_ibetagam2 = 1_prt / amrex::Math::powi<2>(refpart.beta_gamma());
+            m_ibetagam2 = 1_prt / powi<2>(refpart.beta_gamma());
         }
 
         /** This is an exactdrift functor, so that a variable of this type can be used like
@@ -120,6 +121,7 @@ namespace impactx::elements
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
@@ -136,10 +138,10 @@ namespace impactx::elements
 
             // compute the radical in the denominator (= pz):
             amrex::ParticleReal const inv_pzden = 1_prt / std::sqrt(
-                amrex::Math::powi<2>(pt - m_ibeta) -
+                powi<2>(pt - m_ibeta) -
                 m_ibetagam2 -
-                amrex::Math::powi<2>(px) -
-                amrex::Math::powi<2>(py)
+                powi<2>(px) -
+                powi<2>(py)
             );
 
             // advance position and momentum (exact drift)
@@ -170,6 +172,7 @@ namespace impactx::elements
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -186,7 +189,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds /std::sqrt(amrex::Math::powi<2>(pt)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds /std::sqrt(powi<2>(pt)-1.0_prt);
 
             // advance position and momentum (drift)
             refpart.x = x + step*px;

--- a/src/elements/ExactMultipole.H
+++ b/src/elements/ExactMultipole.H
@@ -159,6 +159,7 @@ namespace impactx::elements
         void compute_constants (RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
@@ -167,7 +168,7 @@ namespace impactx::elements
 
             // find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            m_betgam2 = amrex::Math::powi<2>(pt_ref) - 1.0_prt;
+            m_betgam2 = powi<2>(pt_ref) - 1.0_prt;
             m_ibetgam2 = 1_prt / m_betgam2;
             m_beta = refpart.beta();
             m_ibeta = 1_prt / m_beta;
@@ -259,6 +260,7 @@ namespace impactx::elements
                    amrex::ParticleReal & zeval) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             amrex::ParticleReal const x = particle(1);
             amrex::ParticleReal const px = particle(2);
@@ -276,10 +278,10 @@ namespace impactx::elements
 
             // compute the radical in the denominator (= pz):
             amrex::ParticleReal const inv_pzden = 1_prt / std::sqrt(
-                amrex::Math::powi<2>(pt - m_ibeta) -
+                powi<2>(pt - m_ibeta) -
                 m_ibetgam2 -
-                amrex::Math::powi<2>(px) -
-                amrex::Math::powi<2>(py)
+                powi<2>(px) -
+                powi<2>(py)
             );
 
             // advance position and momentum (exact drift)
@@ -392,6 +394,7 @@ namespace impactx::elements
         void operator() (RefPart & AMREX_RESTRICT refpart) const {  // TODO: update as well, but needs more careful placement of calc_constants
 
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -408,7 +411,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds / std::sqrt(amrex::Math::powi<2>(pt)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds / std::sqrt(powi<2>(pt)-1.0_prt);
 
             // advance position and momentum (straight element)
             refpart.x = x + step*px;
@@ -429,13 +432,14 @@ namespace impactx::elements
         transport_map (RefPart const & AMREX_RESTRICT refpart) const  // TODO: update as well, but needs more careful placement of calc_constants
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(pt_ref) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
 
             // pick the right data depending if we are on the host side
             // (reference particle push) or device side (particles):
@@ -451,7 +455,7 @@ namespace impactx::elements
             amrex::ParticleReal const kn = m_unit == 1 ? k_normal[1] / refpart.rigidity_Tm() : k_normal[1];
             amrex::ParticleReal const ks = m_unit == 1 ? k_skew[1] / refpart.rigidity_Tm() : k_skew[1];
 
-            amrex::ParticleReal const kabs = std::sqrt(amrex::Math::powi<2>(kn) + amrex::Math::powi<2>(ks));
+            amrex::ParticleReal const kabs = std::sqrt(powi<2>(kn) + powi<2>(ks));
             amrex::ParticleReal const kplus = kn + kabs;
             amrex::ParticleReal const kminus = kn - kabs;
 

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -103,6 +103,7 @@ namespace impactx::elements
         void compute_constants (RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
@@ -111,7 +112,7 @@ namespace impactx::elements
 
             // find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            m_betgam2 = amrex::Math::powi<2>(pt_ref) - 1.0_prt;
+            m_betgam2 = powi<2>(pt_ref) - 1.0_prt;
             m_ibetgam2 = 1_prt / m_betgam2;
             m_beta = refpart.beta();
             m_ibeta = 1_prt / m_beta;
@@ -287,6 +288,7 @@ namespace impactx::elements
                    amrex::ParticleReal & zeval) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             amrex::ParticleReal const x = particle(1);
             amrex::ParticleReal const px = particle(2);
@@ -297,10 +299,10 @@ namespace impactx::elements
 
             // compute the radical in the denominator (= pz):
             amrex::ParticleReal const inv_pzden = 1_prt / std::sqrt(
-                amrex::Math::powi<2>(pt - m_ibeta) -
+                powi<2>(pt - m_ibeta) -
                 m_ibetgam2 -
-                amrex::Math::powi<2>(px) -
-                amrex::Math::powi<2>(py)
+                powi<2>(px) -
+                powi<2>(py)
             );
 
             // The momenta are not affected.
@@ -323,6 +325,7 @@ namespace impactx::elements
         void operator() (RefPart & AMREX_RESTRICT refpart) const {  // TODO: update as well, but needs more careful placement of calc_constants
 
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -339,7 +342,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds / std::sqrt(amrex::Math::powi<2>(pt)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds / std::sqrt(powi<2>(pt)-1.0_prt);
 
             // advance position and momentum (straight element)
             refpart.x = x + step*px;
@@ -360,13 +363,14 @@ namespace impactx::elements
         transport_map (RefPart const & AMREX_RESTRICT refpart) const  // TODO: update as well, but needs more careful placement of calc_constants
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(pt_ref) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
 
             // compute phase advance per unit length in s (in rad/m)
             amrex::ParticleReal const omega = std::sqrt(std::abs(m_k));

--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -108,6 +108,7 @@ namespace impactx::elements
         void compute_constants (RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
@@ -126,7 +127,7 @@ namespace impactx::elements
 
             // access reference particle values to find relativistic factors
             m_ibeta = 1_prt / refpart.beta();
-            m_ibetagam2 = 1_prt / amrex::Math::powi<2>(refpart.beta_gamma());
+            m_ibetagam2 = 1_prt / powi<2>(refpart.beta_gamma());
 
         }
 
@@ -154,6 +155,7 @@ namespace impactx::elements
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
@@ -172,10 +174,10 @@ namespace impactx::elements
             if (m_phi==0_prt && m_B==0_prt) {
                // compute the radical in the denominator (= pz):
                amrex::ParticleReal const inv_pzden = 1_prt / std::sqrt(
-                   amrex::Math::powi<2>(pt - m_ibeta) -
+                   powi<2>(pt - m_ibeta) -
                    m_ibetagam2 -
-                   amrex::Math::powi<2>(px) -
-                   amrex::Math::powi<2>(py)
+                   powi<2>(px) -
+                   powi<2>(py)
                );
 
                // advance position and momentum (exact drift)
@@ -194,8 +196,8 @@ namespace impactx::elements
             } else {
 
                // assign intermediate quantities
-               amrex::ParticleReal const pperp2 = amrex::Math::powi<2>(pt)-2.0_prt * m_ibeta * pt - amrex::Math::powi<2>(py)+1.0_prt;
-               amrex::ParticleReal const px2 = amrex::Math::powi<2>(px);
+               amrex::ParticleReal const pperp2 = powi<2>(pt)-2.0_prt * m_ibeta * pt - powi<2>(py)+1.0_prt;
+               amrex::ParticleReal const px2 = powi<2>(px);
                // determine if particle lies within the domain of map definition
                if (pperp2 <= px2)
                {
@@ -203,7 +205,7 @@ namespace impactx::elements
                } else
                {
                    amrex::ParticleReal const pperp = std::sqrt(pperp2);
-                   amrex::ParticleReal const pzi = std::sqrt(amrex::Math::powi<2>(pperp) - amrex::Math::powi<2>(px));
+                   amrex::ParticleReal const pzi = std::sqrt(powi<2>(pperp) - powi<2>(px));
                    amrex::ParticleReal const rho = m_rc + xout;
 
                    // update momenta
@@ -212,14 +214,14 @@ namespace impactx::elements
                    ptout = pt;
 
                    // angle of momentum rotation
-                   amrex::ParticleReal const px2f = amrex::Math::powi<2>(pxout);
+                   amrex::ParticleReal const px2f = powi<2>(pxout);
                    // determine if particle lies within domain of map definition
                    if (pperp2 <= px2f)
                    {
                        amrex::ParticleIDWrapper{idcpu}.make_invalid();
                    } else
                    {
-                       amrex::ParticleReal const pzf = std::sqrt(amrex::Math::powi<2>(pperp)-amrex::Math::powi<2>(pxout));
+                       amrex::ParticleReal const pzf = std::sqrt(powi<2>(pperp)-powi<2>(pxout));
                        amrex::ParticleReal const theta = m_slice_phi + std::asin(px/pperp) - std::asin(pxout/pperp);
 
                        // update position coordinates
@@ -250,6 +252,7 @@ namespace impactx::elements
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -268,7 +271,7 @@ namespace impactx::elements
             // special case of zero field = an exact drift
             if (m_phi==0_prt && m_B==0_prt) {
                // advance position and momentum (drift)
-               amrex::ParticleReal const step = slice_ds /std::sqrt(amrex::Math::powi<2>(pt)-1.0_prt);
+               amrex::ParticleReal const step = slice_ds /std::sqrt(powi<2>(pt)-1.0_prt);
                refpart.x = x + step*px;
                refpart.y = y + step*py;
                refpart.z = z + step*pz;

--- a/src/elements/LinearMap.H
+++ b/src/elements/LinearMap.H
@@ -125,6 +125,7 @@ namespace impactx::elements
             if (m_ds > 0)  // Drift
             {
                 using namespace amrex::literals; // for _rt and _prt
+                using amrex::Math::powi;
 
                 // assign input reference particle values
                 amrex::ParticleReal const x = refpart.x;
@@ -141,7 +142,7 @@ namespace impactx::elements
                 amrex::ParticleReal const slice_ds = m_ds / nslice();
 
                 // assign intermediate parameter
-                amrex::ParticleReal const step = slice_ds /std::sqrt(amrex::Math::powi<2>(pt)-1.0_prt);
+                amrex::ParticleReal const step = slice_ds / std::sqrt(powi<2>(pt)-1.0_prt);
 
                 // advance position and momentum (drift)
                 refpart.x = x + step*px;

--- a/src/elements/Multipole.H
+++ b/src/elements/Multipole.H
@@ -138,7 +138,7 @@ namespace impactx::elements
 
             // access reference particle values to find (beta*gamma)^2
             //amrex::ParticleReal const pt_ref = refpart.pt;
-            //amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(pt_ref) - 1.0_prt;
+            //amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
 
             // initialize output values
             amrex::ParticleReal xout = x;

--- a/src/elements/NonlinearLens.H
+++ b/src/elements/NonlinearLens.H
@@ -115,6 +115,7 @@ namespace impactx::elements
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // a complex type with two amrex::ParticleReal
             using Complex = amrex::GpuComplex<amrex::ParticleReal>;
@@ -124,7 +125,7 @@ namespace impactx::elements
 
             // access reference particle values to find (beta*gamma)^2
             //amrex::ParticleReal const pt_ref = refpart.pt;
-            //amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(pt_ref) - 1.0_prt;
+            //amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
 
             // initialize output values
             amrex::ParticleReal xout = x;
@@ -141,7 +142,7 @@ namespace impactx::elements
             Complex const im1(0.0_prt, 1.0_prt);
 
             // compute croot = sqrt(1-zeta**2)
-            Complex croot = amrex::Math::powi<2>(zeta);
+            Complex croot = powi<2>(zeta);
             croot = re1 - croot;
             croot = amrex::sqrt(croot);
 
@@ -150,8 +151,8 @@ namespace impactx::elements
             carcsin = -im1 * amrex::log(carcsin);
 
             // compute complex function F'(zeta)
-            Complex dF = zeta / amrex::Math::powi<2>(croot);
-            dF = dF + carcsin / amrex::Math::powi<3>(croot);
+            Complex dF = zeta / powi<2>(croot);
+            dF = dF + carcsin / powi<3>(croot);
 
             // compute momentum kick
             amrex::ParticleReal const dpx = +m_kick * dF.m_real;

--- a/src/elements/PRot.H
+++ b/src/elements/PRot.H
@@ -115,6 +115,7 @@ namespace impactx::elements
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // initialize output values
             amrex::ParticleReal xout = x;
@@ -127,9 +128,9 @@ namespace impactx::elements
             amrex::ParticleReal const pz = std::sqrt(
                 1.0_prt -
                 2.0_prt * pt * m_inv_beta +
-                amrex::Math::powi<2>(pt) -
-                amrex::Math::powi<2>(py) -
-                amrex::Math::powi<2>(px + m_sin_phi_in)
+                powi<2>(pt) -
+                powi<2>(py) -
+                powi<2>(px + m_sin_phi_in)
             );
             amrex::ParticleReal const pzf = pz * m_cos_theta - (px + m_sin_phi_in) * m_sin_theta;
 

--- a/src/elements/Quad.H
+++ b/src/elements/Quad.H
@@ -87,6 +87,7 @@ namespace impactx::elements
         void compute_constants (RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
@@ -95,7 +96,7 @@ namespace impactx::elements
 
             amrex::ParticleReal const pt_ref = refpart.pt;
             // find beta*gamma^2
-            m_betgam2 = amrex::Math::powi<2>(pt_ref) - 1.0_prt;
+            m_betgam2 = powi<2>(pt_ref) - 1.0_prt;
             m_slice_bg = m_slice_ds / m_betgam2;
 
             // compute phase advance per unit length in s (in rad/m)
@@ -199,6 +200,7 @@ namespace impactx::elements
         void operator() (RefPart & AMREX_RESTRICT refpart) const {  // TODO: update as well, but needs more careful placement of calc_constants
 
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -215,7 +217,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds / std::sqrt(amrex::Math::powi<2>(pt)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds / std::sqrt(powi<2>(pt)-1.0_prt);
 
             // advance position and momentum (straight element)
             refpart.x = x + step*px;
@@ -236,13 +238,14 @@ namespace impactx::elements
         transport_map (RefPart const & AMREX_RESTRICT refpart) const  // TODO: update as well, but needs more careful placement of calc_constants
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(pt_ref) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
 
             // compute phase advance per unit length in s (in rad/m)
             amrex::ParticleReal const omega = std::sqrt(std::abs(m_k));

--- a/src/elements/QuadEdge.H
+++ b/src/elements/QuadEdge.H
@@ -139,12 +139,13 @@ namespace impactx::elements
         {
 
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
 
             // compute particle momentum deviation delta + 1
-            amrex::ParticleReal const delta1 = std::sqrt(1_prt - 2_prt*pt/m_beta + amrex::Math::powi<2>(pt));
+            amrex::ParticleReal const delta1 = std::sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
             amrex::ParticleReal a = m_a / delta1;
 
             // initialize output values
@@ -157,19 +158,19 @@ namespace impactx::elements
             // intermediate quantities to be used below
             amrex::ParticleReal x2my2 = x*x - y*y;
             amrex::ParticleReal x2py2 = x*x + y*y;
-            amrex::ParticleReal denominator = 1_prt - 9_prt*amrex::Math::powi<2>(a)*amrex::Math::powi<2>(x2my2);
+            amrex::ParticleReal denominator = 1_prt - 9_prt*powi<2>(a)*powi<2>(x2my2);
 
             // apply edge focusing (transverse phase space)
-            xout = x - a * (amrex::Math::powi<3>(x) + 3_prt * x * amrex::Math::powi<2>(y));
-            yout = y + a * (3_prt * amrex::Math::powi<2>(x) * y + amrex::Math::powi<3>(y));
+            xout = x - a * (powi<3>(x) + 3_prt * x * powi<2>(y));
+            yout = y + a * (3_prt * powi<2>(x) * y + powi<3>(y));
 
             pxout = (px + 3_prt*a*px*x2py2 - 6_prt*a*py*x*y) / denominator;
             pyout = (py - 3_prt*a*py*x2py2 + 6_prt*a*px*x*y) / denominator;
 
             // apply edge focusing (longitudinal phase space)
-            amrex::ParticleReal f4 = a * ( pxout * (amrex::Math::powi<3>(x) + 3_prt*x*amrex::Math::powi<2>(y))
-                                         - pyout * (amrex::Math::powi<3>(y) + 3_prt*y*amrex::Math::powi<2>(x)) );
-            tout = t + f4 * (pt - 1_prt/m_beta) / amrex::Math::powi<2>(delta1);
+            amrex::ParticleReal f4 = a * ( pxout * (powi<3>(x) + 3_prt*x*powi<2>(y))
+                                         - pyout * (powi<3>(y) + 3_prt*y*powi<2>(x)) );
+            tout = t + f4 * (pt - 1_prt/m_beta) / powi<2>(delta1);
 
             // update output values
             x = xout;

--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -269,6 +269,7 @@ namespace RFCavityData
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -288,7 +289,7 @@ namespace RFCavityData
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // compute initial value of beta*gamma
-            amrex::ParticleReal const bgi = std::sqrt(amrex::Math::powi<2>(pt) - 1.0_prt);
+            amrex::ParticleReal const bgi = std::sqrt(powi<2>(pt) - 1.0_prt);
 
             // call integrator to advance (t,pt)
             amrex::ParticleReal const zin = s - sedge;
@@ -304,7 +305,7 @@ namespace RFCavityData
             refpart.z = z + slice_ds*pz/bgi;
 
             // compute final value of beta*gamma
-            amrex::ParticleReal const bgf = std::sqrt(amrex::Math::powi<2>(ptf) - 1.0_prt);
+            amrex::ParticleReal const bgf = std::sqrt(powi<2>(ptf) - 1.0_prt);
 
             // advance momentum (px,py,pz)
             refpart.px = px*bgf/bgi;
@@ -362,6 +363,7 @@ namespace RFCavityData
         RF_Efield (amrex::ParticleReal const zeval) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // pick the right data depending if we are on the host side
             // (reference particle push) or device side (particles):
@@ -395,8 +397,8 @@ namespace RFCavityData
                      sin_data[j] * std::sin(j*2*pi*z/zlen);
                  efieldp = efieldp-j*2*pi*cos_data[j] * std::sin(j*2*pi*z/zlen)/zlen +
                       j*2*pi*sin_data[j] * std::cos(j*2*pi*z/zlen)/zlen;
-                 efieldpp = efieldpp- amrex::Math::powi<2>(j*2*pi*cos_data[j]/zlen)  * std::cos(j*2*pi*z/zlen) -
-                     amrex::Math::powi<2>(j*2*pi*sin_data[j]/zlen)  * std::sin(j*2*pi*z/zlen);
+                 efieldpp = efieldpp- powi<2>(j*2*pi*cos_data[j]/zlen)  * std::cos(j*2*pi*z/zlen) -
+                     powi<2>(j*2*pi*sin_data[j]/zlen)  * std::sin(j*2*pi*z/zlen);
                  efieldint = efieldint + zlen*cos_data[j] * std::sin(j*2*pi*z/zlen)/(j*2*pi) -
                       zlen*sin_data[j] * std::cos(j*2*pi*z/zlen)/(j*2*pi);
                }
@@ -426,13 +428,14 @@ namespace RFCavityData
                    [[maybe_unused]] amrex::ParticleReal & zeval) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // push the reference particle
             amrex::ParticleReal const t = refpart.t;
             amrex::ParticleReal const pt = refpart.pt;
 
             if (pt < -1.0_prt) {
-                refpart.t = t + tau/std::sqrt(1.0_prt - amrex::Math::powi<-2>(pt));
+                refpart.t = t + tau/std::sqrt(1.0_prt - powi<-2>(pt));
                 refpart.pt = pt;
             }
             else {
@@ -444,8 +447,8 @@ namespace RFCavityData
             amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
             amrex::ParticleReal const betgam = refpart.beta_gamma();
 
-            refpart.map(5,5) = R(5,5) + tau*R(6,5)/amrex::Math::powi<3>(betgam);
-            refpart.map(5,6) = R(5,6) + tau*R(6,6)/amrex::Math::powi<3>(betgam);
+            refpart.map(5,5) = R(5,5) + tau*R(6,5)/powi<3>(betgam);
+            refpart.map(5,6) = R(5,6) + tau*R(6,6)/powi<3>(betgam);
         }
 
         /** This pushes the reference particle and the linear map matrix
@@ -462,6 +465,7 @@ namespace RFCavityData
                    amrex::ParticleReal & zeval) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             amrex::ParticleReal const t = refpart.t;
             amrex::ParticleReal const pt = refpart.pt;
@@ -487,13 +491,13 @@ namespace RFCavityData
 
             refpart.map(1,1) = (1.0_prt-s*L)*R(1,1) + s*R(2,1);
             refpart.map(1,2) = (1.0_prt-s*L)*R(1,2) + s*R(2,2);
-            refpart.map(2,1) = -s * amrex::Math::powi<2>(L)*R(1,1) + (1.0_prt+s*L)*R(2,1);
-            refpart.map(2,2) = -s * amrex::Math::powi<2>(L)*R(1,2) + (1.0_prt+s*L)*R(2,2);
+            refpart.map(2,1) = -s * powi<2>(L)*R(1,1) + (1.0_prt+s*L)*R(2,1);
+            refpart.map(2,2) = -s * powi<2>(L)*R(1,2) + (1.0_prt+s*L)*R(2,2);
 
             refpart.map(3,3) = (1.0_prt-s*L)*R(3,3) + s*R(4,3);
             refpart.map(3,4) = (1.0_prt-s*L)*R(3,4) + s*R(4,4);
-            refpart.map(4,3) = -s * amrex::Math::powi<2>(L)*R(3,3) + (1.0_prt+s*L)*R(4,3);
-            refpart.map(4,4) = -s * amrex::Math::powi<2>(L)*R(3,4) + (1.0_prt+s*L)*R(4,4);
+            refpart.map(4,3) = -s * powi<2>(L)*R(3,3) + (1.0_prt+s*L)*R(4,3);
+            refpart.map(4,4) = -s * powi<2>(L)*R(3,4) + (1.0_prt+s*L)*R(4,4);
         }
 
         /** This pushes the reference particle and the linear map matrix

--- a/src/elements/Sbend.H
+++ b/src/elements/Sbend.H
@@ -84,6 +84,7 @@ namespace impactx::elements
         void compute_constants (RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
@@ -92,7 +93,7 @@ namespace impactx::elements
 
             // access reference particle values
             amrex::ParticleReal const ibet = 1.0_prt / refpart.beta();
-            amrex::ParticleReal const ibetagam2 = 1_prt / amrex::Math::powi<2>(refpart.beta_gamma());
+            amrex::ParticleReal const ibetagam2 = 1_prt / powi<2>(refpart.beta_gamma());
 
             // treat the special case of zero field (equivalent to a drift)
             if (m_rc==0_prt) {
@@ -211,6 +212,7 @@ namespace impactx::elements
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -229,7 +231,7 @@ namespace impactx::elements
             // treat the special case of zero field (drift)
             if (m_rc == 0.0_prt) {
                // advance position and momentum (drift)
-               amrex::ParticleReal const step = slice_ds /std::sqrt(amrex::Math::powi<2>(pt)-1.0_prt);
+               amrex::ParticleReal const step = slice_ds /std::sqrt(powi<2>(pt)-1.0_prt);
                refpart.x = x + step*px;
                refpart.y = y + step*py;
                refpart.z = z + step*pz;
@@ -239,7 +241,7 @@ namespace impactx::elements
 
                // assign intermediate parameter
                amrex::ParticleReal const theta = slice_ds/m_rc;
-               amrex::ParticleReal const B = std::sqrt(amrex::Math::powi<2>(pt)-1.0_prt)/m_rc;
+               amrex::ParticleReal const B = std::sqrt(powi<2>(pt)-1.0_prt)/m_rc;
 
                // calculate expensive terms once
                auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
@@ -274,13 +276,14 @@ namespace impactx::elements
         transport_map (RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(pt_ref) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
             amrex::ParticleReal const bet = std::sqrt(betgam2/(1.0_prt + betgam2));
 
             // initialize linear map matrix elements

--- a/src/elements/ShortRF.H
+++ b/src/elements/ShortRF.H
@@ -79,6 +79,7 @@ namespace impactx::elements
         void compute_constants (RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
@@ -92,8 +93,8 @@ namespace impactx::elements
             amrex::ParticleReal const ptf_ref = refpart.pt;
             m_V_cos_phi = m_V * std::cos(m_phi);
             amrex::ParticleReal const pti_ref = ptf_ref + m_V_cos_phi;
-            m_bgf = std::sqrt(amrex::Math::powi<2>(ptf_ref) - 1.0_prt);
-            m_bgi = std::sqrt(amrex::Math::powi<2>(pti_ref) - 1.0_prt);
+            m_bgf = std::sqrt(powi<2>(ptf_ref) - 1.0_prt);
+            m_bgi = std::sqrt(powi<2>(pti_ref) - 1.0_prt);
         }
 
         /** This is a shortrf functor, so that a variable of this type can be used like a
@@ -179,6 +180,7 @@ namespace impactx::elements
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -195,14 +197,14 @@ namespace impactx::elements
             amrex::ParticleReal const phi = m_phase*(pi/180.0_prt);
 
             // compute initial value of beta*gamma
-            amrex::ParticleReal const bgi = std::sqrt(amrex::Math::powi<2>(pt) - 1.0_prt);
+            amrex::ParticleReal const bgi = std::sqrt(powi<2>(pt) - 1.0_prt);
 
             // advance pt
             refpart.pt = pt - m_V * std::cos(phi);
 
             // compute final value of beta*gamma
             amrex::ParticleReal const ptf = refpart.pt;
-            amrex::ParticleReal const bgf = std::sqrt(amrex::Math::powi<2>(ptf) - 1.0_prt);
+            amrex::ParticleReal const bgf = std::sqrt(powi<2>(ptf) - 1.0_prt);
 
             // advance position (x,y,z,t)
             refpart.x = x;
@@ -230,6 +232,7 @@ namespace impactx::elements
         transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // Define parameters and intermediate constants
             using ablastr::constant::math::pi;
@@ -240,8 +243,8 @@ namespace impactx::elements
             // access reference particle values (final, initial):
             amrex::ParticleReal const ptf_ref = refpart.pt;
             amrex::ParticleReal const pti_ref = ptf_ref + m_V * std::cos(phi);
-            amrex::ParticleReal const bgf = std::sqrt(amrex::Math::powi<2>(ptf_ref) - 1.0_prt);
-            amrex::ParticleReal const bgi = std::sqrt(amrex::Math::powi<2>(pti_ref) - 1.0_prt);
+            amrex::ParticleReal const bgf = std::sqrt(powi<2>(ptf_ref) - 1.0_prt);
+            amrex::ParticleReal const bgi = std::sqrt(powi<2>(pti_ref) - 1.0_prt);
 
             // initialize transport matrix
             Map6x6 R = Map6x6::Identity();

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -274,6 +274,7 @@ namespace SoftQuadrupoleData
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -293,7 +294,7 @@ namespace SoftQuadrupoleData
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // compute initial value of beta*gamma
-            amrex::ParticleReal const bgi = std::sqrt(amrex::Math::powi<2>(pt) - 1.0_prt);
+            amrex::ParticleReal const bgi = std::sqrt(powi<2>(pt) - 1.0_prt);
 
             // call integrator to advance (t,pt)
             amrex::ParticleReal const zin = s - sedge;
@@ -320,7 +321,7 @@ namespace SoftQuadrupoleData
             refpart.z = z + slice_ds*pz/bgi;
 
             // compute final value of beta*gamma
-            amrex::ParticleReal const bgf = std::sqrt(amrex::Math::powi<2>(ptf) - 1.0_prt);
+            amrex::ParticleReal const bgf = std::sqrt(powi<2>(ptf) - 1.0_prt);
 
             // advance momentum (px,py,pz)
             refpart.px = px*bgf/bgi;
@@ -414,6 +415,7 @@ namespace SoftQuadrupoleData
                    [[maybe_unused]] amrex::ParticleReal & zeval) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // push the reference particle
             amrex::ParticleReal const t = refpart.t;
@@ -421,7 +423,7 @@ namespace SoftQuadrupoleData
             amrex::ParticleReal const z = zeval;
 
             if (pt < -1.0_prt) {
-                refpart.t = t + tau/std::sqrt(1.0_prt - amrex::Math::powi<-2>(pt));
+                refpart.t = t + tau/std::sqrt(1.0_prt - powi<-2>(pt));
                 refpart.pt = pt;
             }
             else {
@@ -445,8 +447,8 @@ namespace SoftQuadrupoleData
             refpart.map(3,3) = R(3,3) + tau*R(4,3);
             refpart.map(3,4) = R(3,4) + tau*R(4,4);
 
-            refpart.map(5,5) = R(5,5) + tau*R(6,5)/amrex::Math::powi<2>(betgam);
-            refpart.map(5,6) = R(5,6) + tau*R(6,6)/amrex::Math::powi<2>(betgam);
+            refpart.map(5,5) = R(5,5) + tau*R(6,5)/powi<2>(betgam);
+            refpart.map(5,6) = R(5,6) + tau*R(6,6)/powi<2>(betgam);
 
         }
 

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -285,6 +285,7 @@ namespace SoftSolenoidData
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -304,7 +305,7 @@ namespace SoftSolenoidData
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // compute initial value of beta*gamma
-            amrex::ParticleReal const bgi = std::sqrt(amrex::Math::powi<2>(pt) - 1.0_prt);
+            amrex::ParticleReal const bgi = std::sqrt(powi<2>(pt) - 1.0_prt);
 
             // call integrator to advance (t,pt)
             amrex::ParticleReal const zin = s - sedge;
@@ -329,7 +330,7 @@ namespace SoftSolenoidData
             refpart.z = z + slice_ds*pz/bgi;
 
             // compute final value of beta*gamma
-            amrex::ParticleReal const bgf = std::sqrt(amrex::Math::powi<2>(ptf) - 1.0_prt);
+            amrex::ParticleReal const bgf = std::sqrt(powi<2>(ptf) - 1.0_prt);
 
             // advance momentum (px,py,pz)
             refpart.px = px*bgf/bgi;
@@ -423,6 +424,7 @@ namespace SoftSolenoidData
                    [[maybe_unused]] amrex::ParticleReal & zeval) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // push the reference particle
             amrex::ParticleReal const t = refpart.t;
@@ -430,7 +432,7 @@ namespace SoftSolenoidData
             amrex::ParticleReal const z = zeval;
 
             if (pt < -1.0_prt) {
-                refpart.t = t + tau/std::sqrt(1.0_prt - amrex::Math::powi<-2>(pt));
+                refpart.t = t + tau/std::sqrt(1.0_prt - powi<-2>(pt));
                 refpart.pt = pt;
             }
             else {
@@ -454,8 +456,8 @@ namespace SoftSolenoidData
             refpart.map(3,3) = R(3,3) + tau*R(4,3);
             refpart.map(3,4) = R(3,4) + tau*R(4,4);
 
-            refpart.map(5,5) = R(5,5) + tau*R(6,5)/amrex::Math::powi<2>(betgam);
-            refpart.map(5,6) = R(5,6) + tau*R(6,6)/amrex::Math::powi<2>(betgam);
+            refpart.map(5,5) = R(5,5) + tau*R(6,5)/powi<2>(betgam);
+            refpart.map(5,6) = R(5,6) + tau*R(6,6)/powi<2>(betgam);
 
         }
 
@@ -473,6 +475,7 @@ namespace SoftSolenoidData
                    amrex::ParticleReal & zeval) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             amrex::ParticleReal const t = refpart.t;
             amrex::ParticleReal const pt = refpart.pt;
@@ -493,7 +496,7 @@ namespace SoftSolenoidData
             // push the linear map equations
             amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
             amrex::ParticleReal const alpha = B0*bz/2.0_prt;
-            amrex::ParticleReal const alpha2 = amrex::Math::powi<2>(alpha);
+            amrex::ParticleReal const alpha2 = powi<2>(alpha);
 
             refpart.map(2,1) = R(2,1) - tau*alpha2*R(1,1);
             refpart.map(2,2) = R(2,2) - tau*alpha2*R(1,2);

--- a/src/elements/Sol.H
+++ b/src/elements/Sol.H
@@ -86,6 +86,7 @@ namespace impactx::elements
         void compute_constants (RefPart const & refpart)
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
 
@@ -93,7 +94,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // access reference particle values to find beta*gamma^2
-            amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(refpart.pt) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(refpart.pt) - 1.0_prt;
 
             // compute phase advance per unit length (in rad/m) and
             // rotation angle (in rad)
@@ -199,6 +200,7 @@ namespace impactx::elements
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // assign input reference particle values
             amrex::ParticleReal const x = refpart.x;
@@ -215,7 +217,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds / std::sqrt(amrex::Math::powi<2>(pt) - 1.0_prt);
+            amrex::ParticleReal const step = slice_ds / std::sqrt(powi<2>(pt) - 1.0_prt);
 
             // advance position and momentum (straight element)
             refpart.x = x + step*px;
@@ -240,6 +242,7 @@ namespace impactx::elements
         transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
@@ -250,7 +253,7 @@ namespace impactx::elements
             Map6x6 Rfocusing = Map6x6::Identity();
 
             // access reference particle values to find beta*gamma^2
-            amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(refpart.pt) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(refpart.pt) - 1.0_prt;
 
             // compute phase advance per unit length (in rad/m) and
             // rotation angle (in rad)

--- a/src/elements/TaperedPL.H
+++ b/src/elements/TaperedPL.H
@@ -96,8 +96,8 @@ namespace impactx::elements
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {
-
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
@@ -118,7 +118,7 @@ namespace impactx::elements
 
             // advance position and momentum
             xout = x;
-            pxout = px - g * ( x + m_taper*0.5_prt * (amrex::Math::powi<2>(x) + amrex::Math::powi<2>(y)) );
+            pxout = px - g * ( x + m_taper*0.5_prt * (powi<2>(x) + powi<2>(y)) );
 
             yout = y;
             pyout = py - g * ( y + m_taper * x * y );

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -121,6 +121,7 @@ namespace impactx::elements
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
@@ -136,12 +137,12 @@ namespace impactx::elements
             amrex::ParticleReal ptout = pt;
 
             // compute the function expressing dp/p in terms of pt (labeled f in Ripken etc.)
-            amrex::ParticleReal const f = -1.0_prt + std::sqrt(1.0_prt - 2.0_prt * pt / m_beta + amrex::Math::powi<2>(pt));
+            amrex::ParticleReal const f = -1.0_prt + std::sqrt(1.0_prt - 2.0_prt * pt / m_beta + powi<2>(pt));
             amrex::ParticleReal const fprime = (1.0_prt - m_beta*pt) / (m_beta * (1.0_prt + f));
 
             // advance position and momentum
             x = xout;
-            pxout = px - amrex::Math::powi<2>(m_kx) * m_ds * xout + m_kx * m_ds * f; //eq (3.2b)
+            pxout = px - powi<2>(m_kx) * m_ds * xout + m_kx * m_ds * f; //eq (3.2b)
 
             y = yout;
             pyout = py;

--- a/src/elements/mixin/pipeaperture.H
+++ b/src/elements/mixin/pipeaperture.H
@@ -58,8 +58,10 @@ namespace impactx::elements::mixin
             amrex::ParticleReal & AMREX_RESTRICT x,
             amrex::ParticleReal & AMREX_RESTRICT y,
             uint64_t & AMREX_RESTRICT idcpu
-        ) const {
+        ) const
+        {
             using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
 
             // skip aperture application if aperture_x <= 0 or aperture_y <= 0
             if (m_inv_aperture_x > 0_prt && m_inv_aperture_y > 0_prt) {
@@ -72,7 +74,7 @@ namespace impactx::elements::mixin
                amrex::ParticleReal const v = y * m_inv_aperture_y;
 
                // compare against the aperture boundary
-               if (amrex::Math::powi<2>(u) + amrex::Math::powi<2>(v) > 1_prt) {
+               if (powi<2>(u) + powi<2>(v) > 1_prt) {
                   amrex::ParticleIDWrapper{idcpu}.make_invalid();
                }
             }

--- a/src/envelope/spacecharge/EnvelopeSpaceChargePush.cpp
+++ b/src/envelope/spacecharge/EnvelopeSpaceChargePush.cpp
@@ -31,6 +31,7 @@ namespace impactx::envelope::spacecharge
     )
     {
         using namespace amrex::literals;
+        using amrex::Math::powi;
 
         // skip calculations for trivial case
         if (current == 0_prt) { return; }
@@ -45,12 +46,12 @@ namespace impactx::envelope::spacecharge
         amrex::ParticleReal const mass = refpart.mass;
         amrex::ParticleReal const charge = refpart.charge;
         amrex::ParticleReal const pt_ref = refpart.pt;
-        amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(pt_ref) - 1_prt;
+        amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1_prt;
         amrex::ParticleReal const betgam = std::sqrt(betgam2);
-        amrex::ParticleReal const betgam3 = amrex::Math::powi<3>(betgam);
+        amrex::ParticleReal const betgam3 = powi<3>(betgam);
 
         // evaluate the beam space charge perveance from current
-        amrex::ParticleReal const IA = 4_prt * pi * ep0 * mass * amrex::Math::powi<3>(c) / charge;
+        amrex::ParticleReal const IA = 4_prt * pi * ep0 * mass * powi<3>(c) / charge;
         amrex::ParticleReal const Kpv = std::abs(current / IA) * 2_prt / betgam3;
 
         // evaluate the linear transfer map
@@ -78,6 +79,7 @@ namespace impactx::envelope::spacecharge
     )
     {
         using namespace amrex::literals;
+        using amrex::Math::powi;
 
         // skip calculations for trivial case
         if (bunch_charge == 0_prt) { return; }
@@ -92,10 +94,10 @@ namespace impactx::envelope::spacecharge
         amrex::ParticleReal const mass = refpart.mass;
         amrex::ParticleReal const charge = refpart.charge;
         amrex::ParticleReal const pt_ref = refpart.pt;
-        amrex::ParticleReal const betgam2 = amrex::Math::powi<2>(pt_ref) - 1_prt;
+        amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1_prt;
 
         // evaluate the 3D space charge intensity parameter from bunch charge
-        amrex::ParticleReal const rcN = std::abs(charge * bunch_charge) / (4_prt * pi * ep0 * mass * amrex::Math::powi<2>(c));
+        amrex::ParticleReal const rcN = std::abs(charge * bunch_charge) / (4_prt * pi * ep0 * mass * powi<2>(c));
         amrex::ParticleReal const coeff = ds * rcN / betgam2 * (1_prt/(5_prt * std::sqrt(5_prt)));
 
         // set parameters for elliptic integrals

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -375,6 +375,7 @@ namespace impactx
     )
     {
         using namespace amrex::literals; // for _rt and _prt
+        using amrex::Math::powi;
 
         // Values to be read from input
         amrex::ParticleReal betax, betay, betat, emittx, emitty, emittt;
@@ -417,7 +418,7 @@ namespace impactx
         // calculate Twiss / Courant-Snyder gammas
         amrex::Vector<amrex::ParticleReal> gammas;
         for (size_t i = 0; i < alphas.size(); i++)
-            gammas.push_back((1.0 + amrex::Math::powi<2>(alphas.at(i))) / betas.at(i));
+            gammas.push_back((1.0 + powi<2>(alphas.at(i))) / betas.at(i));
 
         amrex::Vector<amrex::ParticleReal> lambdas_pos;
         amrex::Vector<amrex::ParticleReal> lambdas_mom;

--- a/src/particles/ReferenceParticle.H
+++ b/src/particles/ReferenceParticle.H
@@ -83,9 +83,10 @@ namespace impactx
         beta () const
         {
             using namespace amrex::literals;
+            using amrex::Math::powi;
 
             amrex::ParticleReal const ref_gamma = -pt;
-            amrex::ParticleReal const ref_beta = std::sqrt(1.0_prt - 1.0_prt / amrex::Math::powi<2>(ref_gamma));
+            amrex::ParticleReal const ref_beta = std::sqrt(1.0_prt - 1.0_prt / powi<2>(ref_gamma));
             return ref_beta;
         }
 
@@ -98,9 +99,10 @@ namespace impactx
         beta_gamma () const
         {
             using namespace amrex::literals;
+            using amrex::Math::powi;
 
             amrex::ParticleReal const ref_gamma = -pt;
-            amrex::ParticleReal const ref_betagamma = std::sqrt(amrex::Math::powi<2>(ref_gamma) - 1.0_prt);
+            amrex::ParticleReal const ref_betagamma = std::sqrt(powi<2>(ref_gamma) - 1.0_prt);
             return ref_betagamma;
         }
 
@@ -127,6 +129,7 @@ namespace impactx
         set_mass_MeV (amrex::ParticleReal const massE)
         {
             using namespace amrex::literals;
+            using amrex::Math::powi;
 
             AMREX_ASSERT_WITH_MESSAGE(massE != 0.0_prt,
                                       "set_mass_MeV: Mass cannot be zero!");
@@ -137,7 +140,7 @@ namespace impactx
             if (pt != 0.0_prt)
             {
                 pt = -kin_energy_MeV() / massE - 1.0_prt;
-                pz = std::sqrt(amrex::Math::powi<2>(pt) - 1.0_prt);
+                pz = std::sqrt(powi<2>(pt) - 1.0_prt);
             }
 
             return *this;
@@ -167,6 +170,7 @@ namespace impactx
         set_kin_energy_MeV (amrex::ParticleReal const kin_energy)
         {
             using namespace amrex::literals;
+            using amrex::Math::powi;
 
             AMREX_ASSERT_WITH_MESSAGE(mass != 0.0_prt,
                                       "set_kin_energy_MeV: Set mass first!");
@@ -174,7 +178,7 @@ namespace impactx
             px = 0.0;
             py = 0.0;
             pt = -kin_energy / mass_MeV() - 1.0_prt;
-            pz = std::sqrt(amrex::Math::powi<2>(pt) - 1.0_prt);
+            pz = std::sqrt(powi<2>(pt) - 1.0_prt);
 
             return *this;
         }
@@ -188,9 +192,10 @@ namespace impactx
         rigidity_Tm () const
         {
             using namespace amrex::literals;
+            using amrex::Math::powi;
 
             amrex::ParticleReal const ref_gamma = -pt;
-            amrex::ParticleReal const ref_betagamma = std::sqrt(amrex::Math::powi<2>(ref_gamma) - 1.0_prt);
+            amrex::ParticleReal const ref_betagamma = std::sqrt(powi<2>(ref_gamma) - 1.0_prt);
             amrex::ParticleReal const ref_rigidity = mass*ref_betagamma*(ablastr::constant::SI::c)/charge;
             return ref_rigidity;
         }

--- a/src/particles/distribution/KVdist.H
+++ b/src/particles/distribution/KVdist.H
@@ -108,6 +108,7 @@ namespace impactx::distribution
         ) const
         {
             using namespace amrex::literals;
+            using amrex::Math::powi;
             using ablastr::constant::math::pi;
 
             amrex::ParticleReal v,phi,r,beta,p,u1,u2,ln1;
@@ -124,7 +125,7 @@ namespace impactx::distribution
             // Sample and transform to define (px,py):
             beta = amrex::Random(engine);
             beta = 2_prt*pi*beta;
-            p = std::sqrt(1_prt-amrex::Math::powi<2>(r));
+            p = std::sqrt(1_prt-powi<2>(r));
             px = p * std::cos(beta);
             py = p * std::sin(beta);
 

--- a/src/particles/distribution/Kurth4D.H
+++ b/src/particles/distribution/Kurth4D.H
@@ -108,6 +108,7 @@ namespace impactx::distribution
         ) const
         {
             using namespace amrex::literals;
+            using amrex::Math::powi;
             using ablastr::constant::math::pi;
 
             amrex::ParticleReal v,phi,r,u1,u2,ln1;
@@ -129,7 +130,7 @@ namespace impactx::distribution
             // Random samples used to define pr:
             alpha = amrex::Random(engine);
             alpha = pi*alpha;
-            pmax = 1.0_prt - amrex::Math::powi<2>((Lz/r)) - amrex::Math::powi<2>(r) + amrex::Math::powi<2>(Lz);
+            pmax = 1.0_prt - powi<2>((Lz/r)) - powi<2>(r) + powi<2>(Lz);
             pmax = std::sqrt(pmax);
             pr = pmax * std::cos(alpha);
             pphi = Lz/r;

--- a/src/particles/distribution/Kurth6D.H
+++ b/src/particles/distribution/Kurth6D.H
@@ -110,6 +110,7 @@ namespace impactx::distribution
         ) const
         {
             using namespace amrex::literals;
+            using amrex::Math::powi;
             using ablastr::constant::math::pi;
 
             amrex::ParticleReal v,costheta,sintheta,phi,r;
@@ -120,7 +121,7 @@ namespace impactx::distribution
             v = amrex::Random(engine);
             costheta = amrex::Random(engine);
             costheta = 2_prt*(costheta-0.5_prt);
-            sintheta = std::sqrt(1_prt-amrex::Math::powi<2>(costheta));
+            sintheta = std::sqrt(1_prt-powi<2>(costheta));
             phi = amrex::Random(engine);
             phi = 2_prt*pi*phi;
 
@@ -137,7 +138,7 @@ namespace impactx::distribution
             // Random samples used to define pr:
             alpha = amrex::Random(engine);
             alpha = pi*alpha;
-            pmax = 1_prt - amrex::Math::powi<2>(L/r) - amrex::Math::powi<2>(r) + amrex::Math::powi<2>(L);
+            pmax = 1_prt - powi<2>(L/r) - powi<2>(r) + powi<2>(L);
             pmax = std::sqrt(pmax);
             pr = pmax * std::cos(alpha);
 

--- a/src/particles/distribution/Thermal.H
+++ b/src/particles/distribution/Thermal.H
@@ -88,6 +88,7 @@ namespace distribution
         {
             using namespace amrex::literals;  // for _rt and _prt
             using namespace ablastr::constant::math;  // for pi
+            using amrex::Math::powi;
 
             // Get relativistic beta*gamma
             amrex::ParticleReal bg = refpart.beta_gamma();
@@ -98,7 +99,7 @@ namespace distribution
             amrex::ParticleReal q_e = refpart.charge_qe();
 
             // Set space charge intensity
-            m_Cintensity = q_e*bunch_charge/(amrex::Math::powi<2>(bg)*Erest*ablastr::constant::SI::ep0);
+            m_Cintensity = q_e*bunch_charge/(powi<2>(bg)*Erest*ablastr::constant::SI::ep0);
 
             // Set minimum and maximum radius
             amrex::ParticleReal r_scale = matched_scale_radius();
@@ -108,7 +109,7 @@ namespace distribution
 
             // Scale the parameters p1 and p2
             amrex::ParticleReal rt2pi = std::sqrt(2.0_prt*pi);
-            amrex::ParticleReal p_scale = amrex::Math::powi<-3>(r_scale*rt2pi);
+            amrex::ParticleReal p_scale = powi<-3>(r_scale*rt2pi);
             m_p1 = m_p1*p_scale;
             m_p2 = m_p2*p_scale;
 

--- a/src/particles/spacecharge/PoissonSolve.cpp
+++ b/src/particles/spacecharge/PoissonSolve.cpp
@@ -32,6 +32,7 @@ namespace impactx::particles::spacecharge
         BL_PROFILE("impactx::spacecharge::PoissonSolve");
 
         using namespace amrex::literals;
+        using amrex::Math::powi;
 
         // set space charge field to zero
         //   loop over refinement levels
@@ -45,7 +46,7 @@ namespace impactx::particles::spacecharge
         // prepare parameters of the MLMG Poisson Solver
         //   relativistic beta=v/c of the reference particle
         amrex::ParticleReal const pt_ref = pc.GetRefParticle().pt;
-        amrex::ParticleReal const beta_s = std::sqrt(1.0_prt - 1.0_prt/amrex::Math::powi<2>(pt_ref));
+        amrex::ParticleReal const beta_s = std::sqrt(1.0_prt - 1.0_prt/powi<2>(pt_ref));
         // The beam particles and the corresponding box are all given in local coordinates
         // in which z is the direction of motion - this coincides with the direction of the momentum
         // of the reference particle.

--- a/src/particles/transformation/CoordinateTransformation.cpp
+++ b/src/particles/transformation/CoordinateTransformation.cpp
@@ -28,6 +28,7 @@ namespace impactx::transformation
         BL_PROFILE("impactx::transformation::CoordinateTransformation");
 
         using namespace amrex::literals; // for _rt and _prt
+        using amrex::Math::powi;
 
         if (direction == CoordSystem::s) {
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pc.GetCoordSystem() == CoordSystem::t, "Already in fixed s coordinates!");
@@ -64,7 +65,7 @@ namespace impactx::transformation
                     amrex::ParticleReal *const AMREX_RESTRICT part_pz = soa_real[RealSoA::pz].dataPtr();
 
                     // Design value of pz/mc = beta*gamma
-                    amrex::ParticleReal const pzd = std::sqrt(amrex::Math::powi<2>(pd) - 1.0);
+                    amrex::ParticleReal const pzd = std::sqrt(powi<2>(pd) - 1.0);
 
                     ToFixedS const to_s(pzd);
                     amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE(long i) {

--- a/src/particles/transformation/ToFixedS.H
+++ b/src/particles/transformation/ToFixedS.H
@@ -57,9 +57,10 @@ namespace impactx::transformation
             amrex::ParticleReal & pz) const
         {
             using namespace amrex::literals;
+            using amrex::Math::powi;
 
             // compute value of reference ptd = -gamma
-            amrex::ParticleReal const argd = 1.0_prt + amrex::Math::powi<2>(m_pzd);
+            amrex::ParticleReal const argd = 1.0_prt + powi<2>(m_pzd);
             AMREX_ASSERT_WITH_MESSAGE(argd > 0.0_prt, "invalid ptd arg (<=0)");
             amrex::ParticleReal const ptdf = argd > 0.0_prt ? -std::sqrt(argd) : -1.0_prt;
 
@@ -70,7 +71,7 @@ namespace impactx::transformation
             pz = pz * m_pzd;
 
             // compute value of particle pt = -gamma
-            amrex::ParticleReal const arg = 1.0_prt + amrex::Math::powi<2>(m_pzd + pz) + amrex::Math::powi<2>(px) + amrex::Math::powi<2>(py);
+            amrex::ParticleReal const arg = 1.0_prt + powi<2>(m_pzd + pz) + powi<2>(px) + powi<2>(py);
             AMREX_ASSERT_WITH_MESSAGE(arg > 0.0_prt, "invalid pt arg (<=0)");
             amrex::ParticleReal const ptf = arg > 0.0_prt ? -std::sqrt(arg) : -1.0_prt;
 

--- a/src/particles/transformation/ToFixedT.H
+++ b/src/particles/transformation/ToFixedT.H
@@ -57,12 +57,13 @@ namespace impactx::transformation
             amrex::ParticleReal & pt) const
         {
             using namespace amrex::literals;
+            using amrex::Math::powi;
 
             // small tolerance to avoid NaN for pz<0:
             constexpr amrex::ParticleReal tol = 1.0e-8_prt;
 
             // compute value of reference pzd = beta*gamma
-            amrex::ParticleReal const argd = -1.0_prt + amrex::Math::powi<2>(m_ptd);
+            amrex::ParticleReal const argd = -1.0_prt + powi<2>(m_ptd);
             // AMREX_ASSERT_WITH_MESSAGE(argd > 0.0_prt, "invalid pzd arg (<=0)");
             amrex::ParticleReal const pzdf = argd > 0.0_prt ? std::sqrt(argd) : tol;
 
@@ -73,7 +74,7 @@ namespace impactx::transformation
             pt = pt * pzdf;
 
             // compute value of particle pz = beta*gamma
-            amrex::ParticleReal const arg = -1.0_prt + amrex::Math::powi<2>(m_ptd+pt) - amrex::Math::powi<2>(px) - amrex::Math::powi<2>(py);
+            amrex::ParticleReal const arg = -1.0_prt + powi<2>(m_ptd+pt) - powi<2>(px) - powi<2>(py);
             // AMREX_ASSERT_WITH_MESSAGE(arg > 0.0_prt, "invalid pz arg (<=0)");
             amrex::ParticleReal const pzf = arg > 0.0_prt ? std::sqrt(arg) : tol;
 

--- a/src/particles/wakefields/ISRPush.cpp
+++ b/src/particles/wakefields/ISRPush.cpp
@@ -30,6 +30,7 @@ namespace impactx::particles::wakefields
         BL_PROFILE("impactx::particles::wakefields::ISRPush")
 
         using namespace amrex::literals;
+        using amrex::Math::powi;
 
         // Physical constants and reference quantities
         amrex::ParticleReal const mc_SI = pc.GetRefParticle().mass * (ablastr::constant::SI::c);
@@ -41,7 +42,7 @@ namespace impactx::particles::wakefields
 
         // Obtain constants for force normalization
         amrex::ParticleReal const B_normal = bg_ref/std::abs(rc);
-        amrex::ParticleReal const c1 = 2.0_prt/3.0_prt * r_e * slice_ds * amrex::Math::powi<2>(B_normal);
+        amrex::ParticleReal const c1 = 2.0_prt/3.0_prt * r_e * slice_ds * powi<2>(B_normal);
         amrex::ParticleReal const c2 = B_normal * lambda_e;
 
         // Coefficients of the Taylor expansion of polynomials g and h
@@ -84,7 +85,7 @@ namespace impactx::particles::wakefields
 
                     // Relativistic beta*gamma for this particle
                     amrex::ParticleReal const gamma = gamma_ref - bg_ref*pt;
-                    amrex::ParticleReal const bg = std::sqrt(amrex::Math::powi<2>(gamma)-1_prt);
+                    amrex::ParticleReal const bg = std::sqrt(powi<2>(gamma)-1_prt);
 
                     // Value of ISR kick in the total momentum (normalized by mc)
                     amrex::ParticleReal const tau = c1 * bg;
@@ -98,10 +99,10 @@ namespace impactx::particles::wakefields
                        h = h1*chi;
                     } else if (isr_order == 2) {
                        g = g0 + g1*chi;
-                       h = h1*chi + h2*amrex::Math::powi<2>(chi);
+                       h = h1*chi + h2*powi<2>(chi);
                     } else if (isr_order == 3) {
-                       g = g0 + g1*chi + g2*amrex::Math::powi<2>(chi);
-                       h = h1*chi + h2*amrex::Math::powi<2>(chi) + h3*amrex::Math::powi<3>(chi);
+                       g = g0 + g1*chi + g2*powi<2>(chi);
+                       h = h1*chi + h2*powi<2>(chi) + h3*powi<3>(chi);
                     }
 
                     // Value of the ISR kick in total momentum (relative to total momentum):
@@ -109,7 +110,7 @@ namespace impactx::particles::wakefields
 
                     // Final value of updated particle gamma:
                     amrex::ParticleReal const bg_f = bg*(1_prt + dp);
-                    amrex::ParticleReal const gamma_f = std::sqrt(1_prt + amrex::Math::powi<2>(bg_f));
+                    amrex::ParticleReal const gamma_f = std::sqrt(1_prt + powi<2>(bg_f));
 
                     // Update momentum
                     px = px * (1_prt + dp);

--- a/src/particles/wakefields/WakeConvolution.H
+++ b/src/particles/wakefields/WakeConvolution.H
@@ -110,9 +110,10 @@ namespace impactx::particles::wakefields
     )
     {
         using namespace amrex::literals;
+        using amrex::Math::powi;
 
-        amrex::Real const rc = amrex::Math::powi<2>(ablastr::constant::SI::q_e) / (4_rt * amrex::Real(M_PI) * ablastr::constant::SI::ep0 * ablastr::constant::SI::m_e * amrex::Math::powi<2>(ablastr::constant::SI::c));
-        amrex::Real const kappa = (2_rt * rc * ablastr::constant::SI::m_e * amrex::Math::powi<2>(ablastr::constant::SI::c)) / std::pow(3_rt, 1_rt/3_rt) / std::pow(R, 2_rt/3_rt);
+        amrex::Real const rc = powi<2>(ablastr::constant::SI::q_e) / (4_rt * amrex::Real(M_PI) * ablastr::constant::SI::ep0 * ablastr::constant::SI::m_e * powi<2>(ablastr::constant::SI::c));
+        amrex::Real const kappa = (2_rt * rc * ablastr::constant::SI::m_e * powi<2>(ablastr::constant::SI::c)) / std::pow(3_rt, 1_rt/3_rt) / std::pow(R, 2_rt/3_rt);
 
         return -3_rt/2_rt * kappa / bin_size * (unit_step(s + bin_size / 2_rt) * std::pow(std::abs(s + bin_size / 2_rt), 2_rt/3_rt) - unit_step(s - bin_size / 2_rt) * std::pow(std::abs(s - bin_size / 2_rt), 2_rt/3_rt));
     }

--- a/src/particles/wakefields/WakeConvolution.cpp
+++ b/src/particles/wakefields/WakeConvolution.cpp
@@ -41,10 +41,11 @@ namespace impactx::particles::wakefields
     )
     {
         using namespace amrex::literals;
+        using amrex::Math::powi;
 
         amrex::Real const s0 = (0.169_rt * std::pow(a, 1.79_rt) * std::pow(g, 0.38_rt)) / std::pow(L, 1.17_rt);
         amrex::Real const term = std::sqrt(std::abs(s) / s0) * std::exp(-std::sqrt(std::abs(s) / s0));
-        return (4_rt * impactx::particles::wakefields::Z0 * ablastr::constant::SI::c * s0 * unit_step(s)) / (amrex::Real(M_PI) * amrex::Math::powi<4>(a)) * term;
+        return (4_rt * impactx::particles::wakefields::Z0 * ablastr::constant::SI::c * s0 * unit_step(s)) / (amrex::Real(M_PI) * powi<4>(a)) * term;
     }
 
     amrex::Real w_l_rf (
@@ -55,9 +56,10 @@ namespace impactx::particles::wakefields
     )
     {
         using namespace amrex::literals;
+        using amrex::Math::powi;
 
-        amrex::Real const s00 = g * amrex::Math::powi<2>((a / (alpha(g / L) * L))) / 8.0_rt;
-        return (impactx::particles::wakefields::Z0 * ablastr::constant::SI::c * unit_step(s) * std::exp(-std::sqrt(std::abs(s) / s00))) / (amrex::Real(M_PI) * amrex::Math::powi<2>(a));
+        amrex::Real const s00 = g * powi<2>((a / (alpha(g / L) * L))) / 8.0_rt;
+        return (impactx::particles::wakefields::Z0 * ablastr::constant::SI::c * unit_step(s) * std::exp(-std::sqrt(std::abs(s) / s00))) / (amrex::Real(M_PI) * powi<2>(a));
     }
 
     amrex::Gpu::DeviceVector<amrex::Real>


### PR DESCRIPTION
Formulas got cluttered up a bit with the extra namespaces. Make pow(i) readable again by importing the function into the current function bodies that use it.

Follow-up to #1007