### PR TITLE
Div 2 is * 0.5

### DIFF
--- a/src/diagnostics/CovarianceMatrixMath.H
+++ b/src/diagnostics/CovarianceMatrixMath.H
@@ -124,41 +124,41 @@ namespace impactx::diagnostics
         using Complex = amrex::GpuComplex<amrex::ParticleReal>;
 
         std::tuple<amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal> roots;
-        amrex::ParticleReal x1 = 0.0_prt;
-        amrex::ParticleReal x2 = 0.0_prt;
-        amrex::ParticleReal x3 = 0.0_prt;
+        amrex::ParticleReal x1 = 0_prt;
+        amrex::ParticleReal x2 = 0_prt;
+        amrex::ParticleReal x3 = 0_prt;
 
-        amrex::ParticleReal Q = (3.0_prt*a*c - powi<2>(b))/(9.0_prt * powi<2>(a));
-        amrex::ParticleReal R = (9.0_prt*a*b*c - 27_prt*powi<2>(a)*d - 2.0_prt*powi<3>(b))/(54.0_prt*powi<3>(a));
+        amrex::ParticleReal Q = (3_prt*a*c - powi<2>(b))/(9_prt * powi<2>(a));
+        amrex::ParticleReal R = (9_prt*a*b*c - 27_prt*powi<2>(a)*d - 2_prt*powi<3>(b))/(54_prt*powi<3>(a));
         amrex::ParticleReal discriminant = powi<3>(Q) + powi<2>(R);
 
         // Define complex variable C
-        Complex Qc(Q,0.0_prt);
-        Complex Rc(R,0.0_prt);
-        Complex Dc(discriminant,0.0_prt);
-        Complex C = amrex::pow(-Rc + amrex::sqrt(Dc),1.0/3.0);
+        Complex Qc(Q,0_prt);
+        Complex Rc(R,0_prt);
+        Complex Dc(discriminant,0_prt);
+        Complex C = amrex::pow(-Rc + amrex::sqrt(Dc),1_prt/3_prt);
 
         // Define a cubic root of unity xi
-        amrex::ParticleReal xire = -1.0/2.0;
-        amrex::ParticleReal xiim = std::sqrt(3.0)/2.0;
+        amrex::ParticleReal xire = -0.5_prt;
+        amrex::ParticleReal xiim = std::sqrt(3_prt)*0.5_prt;
         Complex xi(xire,xiim);
 
         //Three roots in algebraic form.
 
-        if (C.m_real == 0.0_prt && C.m_imag == 0.0_prt) {  // Special case of a triple root
+        if (C.m_real == 0_prt && C.m_imag == 0_prt) {  // Special case of a triple root
 
-           x1 = - b/(3.0_prt*a);
-           x2 = - b/(3.0_prt*a);
-           x3 = - b/(3.0_prt*a);
+           x1 = - b/(3_prt*a);
+           x2 = - b/(3_prt*a);
+           x3 = - b/(3_prt*a);
 
         } else {
 
            Complex z1 = Qc/C - C;
            Complex z2 = Qc/(xi*C) - xi*C;
            Complex z3 = Qc/(powi<2>(xi)*C) - powi<2>(xi)*C;
-           x1 = z2.m_real - b/(3.0*a);
-           x2 = z1.m_real - b/(3.0*a);
-           x3 = z3.m_real - b/(3.0*a);
+           x1 = z2.m_real - b/(3_prt*a);
+           x2 = z1.m_real - b/(3_prt*a);
+           x3 = z3.m_real - b/(3_prt*a);
         }
 
         roots = std::make_tuple(x1,x2,x3);

--- a/src/diagnostics/EmittanceInvariants.cpp
+++ b/src/diagnostics/EmittanceInvariants.cpp
@@ -68,9 +68,9 @@ namespace impactx::diagnostics
         auto const S6 = S2 * S4;
 
         // Define the three kinematic invariants (should be nonnegative).
-        amrex::ParticleReal const I2 = -S2.trace() / 2.0_prt;
-        amrex::ParticleReal const I4 = +S4.trace() / 2.0_prt;
-        amrex::ParticleReal const I6 = -S6.trace() / 2.0_prt;
+        amrex::ParticleReal const I2 = -S2.trace() * 0.5_prt;
+        amrex::ParticleReal const I4 = +S4.trace() * 0.5_prt;
+        amrex::ParticleReal const I6 = -S6.trace() * 0.5_prt;
 
 
         std::tuple<amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal> invariants = std::make_tuple(I2, I4, I6);
@@ -118,8 +118,8 @@ namespace impactx::diagnostics
         // doi:10.48550/arXiv.1305.1532.
         amrex::ParticleReal a = 1.0_prt;
         amrex::ParticleReal b = -I2;
-        amrex::ParticleReal c = (powi<2>(I2) - I4) / 2.0_prt;
-        amrex::ParticleReal d = -powi<3>(I2) / 6.0_prt + I2 * I4 / 2.0_prt - I6 / 3.0_prt;
+        amrex::ParticleReal c = (powi<2>(I2) - I4) * 0.5_prt;
+        amrex::ParticleReal d = -powi<3>(I2) / 6.0_prt + I2 * I4 * 0.5_prt - I6 / 3.0_prt;
 
         // Return the cubic coefficients
         //std::cout << "Return a,b,c,d " << a << " " << b << " " << c << " " << d << "\n";

--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -151,8 +151,8 @@ namespace impactx::elements
             // define intermediate variables
             amrex::ParticleReal u;
             amrex::ParticleReal v;
-            amrex::ParticleReal dx = m_repeat_x/2.0;
-            amrex::ParticleReal dy = m_repeat_y/2.0;
+            amrex::ParticleReal dx = m_repeat_x * 0.5_prt;
+            amrex::ParticleReal dy = m_repeat_y * 0.5_prt;
 
             // if the aperture is periodic, shift x,y coordinates to the fundamental domain
             u = (m_repeat_x==0.0) ? x : (std::fmod(std::abs(x)+dx,m_repeat_x)-dx);

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -106,7 +106,7 @@ namespace impactx::elements
             m_bgi = std::sqrt(powi<2>(m_pti_ref) - 1.0_prt);
 
             // compute focusing constant (1/m) and rotation angle (in rad)
-            m_alpha = m_bz / 2.0_prt;
+            m_alpha = m_bz * 0.5_prt;
             m_alpha_iez = m_alpha / m_ez;
         }
 

--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -378,7 +378,7 @@ namespace RFCavityData
             // specify constants
             using ablastr::constant::math::pi;
             amrex::ParticleReal const zlen = m_ds;
-            amrex::ParticleReal const zmid = zlen / 2.0_prt;
+            amrex::ParticleReal const zmid = zlen * 0.5_prt;
 
             // compute on-axis electric field (z is relative to cavity midpoint)
             amrex::ParticleReal efield = 0.0;
@@ -473,8 +473,8 @@ namespace RFCavityData
             // Define parameters and intermediate constants
             using ablastr::constant::math::pi;
             using ablastr::constant::SI::c;
-            amrex::ParticleReal const k = (2.0_prt*pi/c)*m_freq;
-            amrex::ParticleReal const phi = m_phase*(pi/180.0_prt);
+            amrex::ParticleReal const k = (2_prt*pi/c)*m_freq;
+            amrex::ParticleReal const phi = m_phase*(pi/180_prt);
             amrex::ParticleReal const E0 = m_escale;
 
             // push the reference particle
@@ -487,17 +487,17 @@ namespace RFCavityData
             // push the linear map equations
             amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
             amrex::ParticleReal const s = tau/refpart.beta_gamma();
-            amrex::ParticleReal const L = E0*ezp * std::sin(k*t+phi)/(2.0_prt*k);
+            amrex::ParticleReal const L = E0*ezp * std::sin(k*t+phi)/(2_prt*k);
 
-            refpart.map(1,1) = (1.0_prt-s*L)*R(1,1) + s*R(2,1);
-            refpart.map(1,2) = (1.0_prt-s*L)*R(1,2) + s*R(2,2);
-            refpart.map(2,1) = -s * powi<2>(L)*R(1,1) + (1.0_prt+s*L)*R(2,1);
-            refpart.map(2,2) = -s * powi<2>(L)*R(1,2) + (1.0_prt+s*L)*R(2,2);
+            refpart.map(1,1) = (1_prt-s*L)*R(1,1) + s*R(2,1);
+            refpart.map(1,2) = (1_prt-s*L)*R(1,2) + s*R(2,2);
+            refpart.map(2,1) = -s * powi<2>(L)*R(1,1) + (1_prt+s*L)*R(2,1);
+            refpart.map(2,2) = -s * powi<2>(L)*R(1,2) + (1_prt+s*L)*R(2,2);
 
-            refpart.map(3,3) = (1.0_prt-s*L)*R(3,3) + s*R(4,3);
-            refpart.map(3,4) = (1.0_prt-s*L)*R(3,4) + s*R(4,4);
-            refpart.map(4,3) = -s * powi<2>(L)*R(3,3) + (1.0_prt+s*L)*R(4,3);
-            refpart.map(4,4) = -s * powi<2>(L)*R(3,4) + (1.0_prt+s*L)*R(4,4);
+            refpart.map(3,3) = (1_prt-s*L)*R(3,3) + s*R(4,3);
+            refpart.map(3,4) = (1_prt-s*L)*R(3,4) + s*R(4,4);
+            refpart.map(4,3) = -s * powi<2>(L)*R(3,3) + (1_prt+s*L)*R(4,3);
+            refpart.map(4,4) = -s * powi<2>(L)*R(3,4) + (1_prt+s*L)*R(4,4);
         }
 
         /** This pushes the reference particle and the linear map matrix
@@ -522,8 +522,8 @@ namespace RFCavityData
             // Define parameters and intermediate constants
             using ablastr::constant::math::pi;
             using ablastr::constant::SI::c;
-            amrex::ParticleReal const k = (2.0_prt*pi/c)*m_freq;
-            amrex::ParticleReal const phi = m_phase*(pi/180.0_prt);
+            amrex::ParticleReal const k = (2_prt*pi/c)*m_freq;
+            amrex::ParticleReal const phi = m_phase*(pi/180_prt);
             amrex::ParticleReal const E0 = m_escale;
 
             // push the reference particle
@@ -539,7 +539,7 @@ namespace RFCavityData
             // push the linear map equations
             amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
             amrex::ParticleReal const M = E0*(ezintf-ezint)*k * std::sin(k*t+phi);
-            amrex::ParticleReal const L = E0*(ezpf-ezp) * std::sin(k*t+phi)/(2.0_prt*k)+M/2.0_prt;
+            amrex::ParticleReal const L = E0*(ezpf-ezp) * std::sin(k*t+phi)/(2_prt*k)+M*0.5_prt;
 
             refpart.map(2,1) = L*R(1,1) + R(2,1);
             refpart.map(2,2) = L*R(1,2) + R(2,2);

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -376,7 +376,7 @@ namespace SoftQuadrupoleData
             // specify constants
             using ablastr::constant::math::pi;
             amrex::ParticleReal const zlen = m_ds;
-            amrex::ParticleReal const zmid = zlen / 2.0_prt;
+            amrex::ParticleReal const zmid = zlen * 0.5_prt;
 
             // compute on-axis magnetic field (z is relative to quadrupole midpoint)
             amrex::ParticleReal bfield = 0.0;

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -385,7 +385,7 @@ namespace SoftSolenoidData
             // specify constants
             using ablastr::constant::math::pi;
             amrex::ParticleReal const zlen = m_ds;
-            amrex::ParticleReal const zmid = zlen / 2.0_prt;
+            amrex::ParticleReal const zmid = zlen * 0.5_prt;
 
             // compute on-axis magnetic field (z is relative to solenoid midpoint)
             amrex::ParticleReal bfield = 0.0;
@@ -495,7 +495,7 @@ namespace SoftSolenoidData
 
             // push the linear map equations
             amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
-            amrex::ParticleReal const alpha = B0*bz/2.0_prt;
+            amrex::ParticleReal const alpha = B0*bz*0.5_prt;
             amrex::ParticleReal const alpha2 = powi<2>(alpha);
 
             refpart.map(2,1) = R(2,1) - tau*alpha2*R(1,1);
@@ -544,7 +544,7 @@ namespace SoftSolenoidData
 
             // push the linear map equations
             amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
-            amrex::ParticleReal const theta = tau*B0*bz/2.0_prt;
+            amrex::ParticleReal const theta = tau*B0*bz*0.5_prt;
             amrex::ParticleReal const cs = std::cos(theta);
             amrex::ParticleReal const sn = std::sin(theta);
 

--- a/src/elements/Sol.H
+++ b/src/elements/Sol.H
@@ -98,7 +98,7 @@ namespace impactx::elements
 
             // compute phase advance per unit length (in rad/m) and
             // rotation angle (in rad)
-            amrex::ParticleReal const alpha = m_ks / 2.0_prt;
+            amrex::ParticleReal const alpha = m_ks * 0.5_prt;
             amrex::ParticleReal const theta = alpha*slice_ds;
             auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
 
@@ -257,7 +257,7 @@ namespace impactx::elements
 
             // compute phase advance per unit length (in rad/m) and
             // rotation angle (in rad)
-            amrex::ParticleReal const alpha = m_ks / 2.0_prt;
+            amrex::ParticleReal const alpha = m_ks * 0.5_prt;
             amrex::ParticleReal const theta = alpha*slice_ds;
             auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
 

--- a/src/initialization/AmrCoreData.cpp
+++ b/src/initialization/AmrCoreData.cpp
@@ -79,8 +79,8 @@ namespace impactx::initialization
                                            * prob_relative[lev+1] / prob_relative[0];
         amrex::RealVect const n_cell_diff = (r_cell_n - n_cell_nup / r_ref_ratio);
 
-        amrex::RealVect const r_fine_tag_lo = amrex::RealVect(dom.smallEnd()) + n_cell_diff / 2.0;
-        amrex::RealVect const r_fine_tag_hi = amrex::RealVect(dom.bigEnd())   - n_cell_diff / 2.0;
+        amrex::RealVect const r_fine_tag_lo = amrex::RealVect(dom.smallEnd()) + n_cell_diff * 0.5;
+        amrex::RealVect const r_fine_tag_hi = amrex::RealVect(dom.bigEnd())   - n_cell_diff * 0.5;
 
         amrex::IntVect const fine_tag_lo = {
                 AMREX_D_DECL((int)std::ceil(r_fine_tag_lo[0]), (int)std::ceil(r_fine_tag_lo[1]), (int)std::ceil(r_fine_tag_lo[2]))

--- a/src/initialization/InitMeshRefinement.cpp
+++ b/src/initialization/InitMeshRefinement.cpp
@@ -82,6 +82,8 @@ namespace detail
     {
         BL_PROFILE("ImpactX::ResizeMesh");
 
+        using namespace amrex::literals; // for _rt and _prt
+
         {
             auto space_charge = get_space_charge_algo();
             if (space_charge == SpaceChargeAlgo::False)
@@ -117,7 +119,7 @@ namespace detail
             amrex::RealVect const beam_max(x_max, y_max, z_max);
             amrex::RealVect const beam_width(beam_max - beam_min);
 
-            amrex::RealVect const beam_padding = beam_width * (frac - 1.0) / 2.0;
+            amrex::RealVect const beam_padding = beam_width * (frac - 1_rt) * 0.5_rt;
             //                           added to the beam extent --^         ^-- box half above/below the beam
 
             // In AMReX, all levels have the same problem domain, that of the

--- a/src/particles/distribution/Thermal.H
+++ b/src/particles/distribution/Thermal.H
@@ -162,9 +162,9 @@ namespace distribution
             using namespace ablastr::constant::math;  // for pi
 
             amrex::ParticleReal k = m_k;
-            amrex::ParticleReal kT = (1.0_prt - m_w) * m_T1 + m_w * m_T2;
-            amrex::ParticleReal a = m_Cintensity/(4.0_prt*pi*5.0_prt*std::sqrt(5.0_prt));
-            amrex::ParticleReal rscale = std::sqrt(kT + std::pow(a*k,2.0/3.0))/k;
+            amrex::ParticleReal kT = (1_prt - m_w) * m_T1 + m_w * m_T2;
+            amrex::ParticleReal a = m_Cintensity/(4_prt*pi*5_prt*std::sqrt(5_prt));
+            amrex::ParticleReal rscale = std::sqrt(kT + std::pow(a*k,2_prt/3_prt))/k;
 
             return rscale;
         }
@@ -180,7 +180,7 @@ namespace distribution
 
             // initialize numerical integration parameters
             amrex::ParticleReal const tau = (out-in)/steps;
-            amrex::ParticleReal const half = tau/2.0_prt;
+            amrex::ParticleReal const half = tau*0.5_prt;
 
             // initialize the value of the independent variable
             amrex::ParticleReal reval = in;
@@ -249,12 +249,12 @@ namespace distribution
             amrex::ParticleReal const T2 = m_T2;
 
             // Define space charge intensity parameters
-            amrex::ParticleReal const c1 = (1.0_prt-w) * m_Cintensity;
+            amrex::ParticleReal const c1 = (1_prt-w) * m_Cintensity;
             amrex::ParticleReal const c2 = w * m_Cintensity;
 
             // Define intermediate quantities
-            amrex::ParticleReal potential = 0.0_prt;
-            potential = std::pow(k*r,2.0)/2.0_prt + c1*phi1 + c2*phi2;
+            amrex::ParticleReal potential = 0_prt;
+            potential = std::pow(k*r,2)*0.5_prt + c1*phi1 + c2*phi2;
             amrex::ParticleReal Pdensity1 = m_p1 * std::exp(-potential/T1);
             amrex::ParticleReal Pdensity2 = m_p2 * std::exp(-potential/T2);
             // amrex::ParticleReal Pdensity_tot = (1.0_prt-w)*Pdensity1 + w*Pdensity2;
@@ -263,8 +263,8 @@ namespace distribution
             // Apply map to update f1 and f2:
             m_phi1 = phi1;
             m_phi2 = phi2;
-            m_f1 = f1 + tau*4.0_prt*pi * std::pow(r,2.0)*Pdensity1;
-            m_f2 = f2 + tau*4.0_prt*pi * std::pow(r,2.0)*Pdensity2;
+            m_f1 = f1 + tau*4_prt*pi * std::pow(r,2)*Pdensity1;
+            m_f2 = f2 + tau*4_prt*pi * std::pow(r,2)*Pdensity2;
             reval = r;
         }
     };

--- a/src/particles/integrators/Integrators.H
+++ b/src/particles/integrators/Integrators.H
@@ -45,7 +45,7 @@ namespace impactx::integrators
 
         // initialize numerical integration parameters
         amrex::ParticleReal const dz = (zout-zin)/nsteps;
-        amrex::ParticleReal const tau1 = dz/2.0_prt;
+        amrex::ParticleReal const tau1 = dz*0.5_prt;
         amrex::ParticleReal const tau2 = dz;
 
         // initialize the value of the independent variable
@@ -88,8 +88,8 @@ namespace impactx::integrators
 
         // initialize numerical integration parameters
         amrex::ParticleReal const dz = (zout-zin)/nsteps;
-        amrex::ParticleReal const tau1 = dz/2.0_prt;
-        amrex::ParticleReal const tau2 = dz/2.0_prt;
+        amrex::ParticleReal const tau1 = dz*0.5_prt;
+        amrex::ParticleReal const tau2 = dz*0.5_prt;
         amrex::ParticleReal const tau3 = dz;
 
         // initialize the value of the independent variable
@@ -137,11 +137,11 @@ namespace impactx::integrators
 
         // initialize numerical integration parameters
         amrex::ParticleReal const dz = (zout-zin)/nsteps;
-        amrex::ParticleReal const alpha = 1.0_prt - std::pow(2.0_prt,1.0/3.0);
-        amrex::ParticleReal const tau2 = dz/(1.0_prt + alpha);
-        amrex::ParticleReal const tau1 = tau2/2.0_prt;
+        amrex::ParticleReal const alpha = 1_prt - std::pow(2_prt,1_prt/3_prt);
+        amrex::ParticleReal const tau2 = dz/(1_prt + alpha);
+        amrex::ParticleReal const tau1 = tau2*0.5_prt;
         amrex::ParticleReal const tau3 = alpha*tau1;
-        amrex::ParticleReal const tau4 = (alpha - 1.0_prt)*tau2;
+        amrex::ParticleReal const tau4 = (alpha - 1_prt)*tau2;
 
         // initialize the value of the independent variable
         amrex::ParticleReal zeval = zin;
@@ -187,7 +187,7 @@ namespace impactx::integrators
 
         // initialize numerical integration parameters
         amrex::ParticleReal const dz = (zout-zin)/nsteps;
-        amrex::ParticleReal const tau1 = dz/2.0_prt;
+        amrex::ParticleReal const tau1 = dz*0.5_prt;
         amrex::ParticleReal const tau2 = dz;
 
         // initialize the value of the independent variable
@@ -234,11 +234,11 @@ namespace impactx::integrators
 
         // initialize numerical integration parameters
         amrex::ParticleReal const dz = (zout-zin)/nsteps;
-        amrex::ParticleReal const alpha = 1.0_prt - std::pow(2.0_prt,1.0/3.0);
-        amrex::ParticleReal const tau2 = dz/(1.0_prt + alpha);
-        amrex::ParticleReal const tau1 = tau2/2.0_prt;
+        amrex::ParticleReal const alpha = 1_prt - std::pow(2_prt,1_prt/3_prt);
+        amrex::ParticleReal const tau2 = dz/(1_prt + alpha);
+        amrex::ParticleReal const tau1 = tau2*0.5_prt;
         amrex::ParticleReal const tau3 = alpha*tau1;
-        amrex::ParticleReal const tau4 = (alpha - 1.0_prt)*tau2;
+        amrex::ParticleReal const tau4 = (alpha - 1_prt)*tau2;
 
         // initialize the value of the independent variable
         amrex::ParticleReal zeval = zin;

--- a/src/particles/wakefields/WakePush.cpp
+++ b/src/particles/wakefields/WakePush.cpp
@@ -59,7 +59,7 @@ namespace impactx::particles::wakefields
                 amrex::ParticleReal* const AMREX_RESTRICT part_pt = soa_real[RealSoA::pt].dataPtr();
 
                 // Obtain constants for force normalization
-                amrex::ParticleReal const push_consts = 1.0 / ((ablastr::constant::SI::c) * pz_ref_SI);
+                amrex::ParticleReal const push_consts = 1_prt / ((ablastr::constant::SI::c) * pz_ref_SI);
 
                 // Gather particles and push momentum
                 const amrex::Real* wakefield_ptr = convolved_wakefield.data();


### PR DESCRIPTION
- `/2.0 == *0.5`: making a few constants a bit faster, even without fast-math.
- add missing floating point literal suffixes (to avoid implicit upcasting in single precision)
- remove unnecessary `.0` with we add literal suffices