### PR TITLE
Dashboard: Set default name for BeamMonitor if name is empty

### DIFF
--- a/src/python/impactx/dashboard/Input/defaults.py
+++ b/src/python/impactx/dashboard/Input/defaults.py
@@ -38,6 +38,7 @@ TRACKING_MODE_PROPERTIES: dict[str, dict[str, Any]] = {
     },
 }
 
+BEAM_MONITOR_DEFAULT_NAME = "DefaultName"
 
 class DashboardDefaults:
     """

--- a/src/python/impactx/dashboard/Input/defaults.py
+++ b/src/python/impactx/dashboard/Input/defaults.py
@@ -40,6 +40,7 @@ TRACKING_MODE_PROPERTIES: dict[str, dict[str, Any]] = {
 
 BEAM_MONITOR_DEFAULT_NAME = "DefaultName"
 
+
 class DashboardDefaults:
     """
     Defaults for simulation parameters in the ImpactX dashboard.

--- a/src/python/impactx/dashboard/Input/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/lattice/ui.py
@@ -56,7 +56,9 @@ def add_lattice_element() -> dict:
 
     parameters = []
     for name, default_value, default_type in parameters_data:
-        value = "DefaultName" if selected_lattice == "BeamMonitor" and name == "name" else default_value
+        default_value = "" if default_value is None else str(default_value).strip()
+        value = "DefaultName" if selected_lattice == "BeamMonitor" and name == "name" and not default_value else default_value
+
 
         parameters.append({
             "parameter_name": name,

--- a/src/python/impactx/dashboard/Input/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/lattice/ui.py
@@ -16,6 +16,7 @@ from ...Input.components import (
     NavigationComponents,
 )
 from .. import DashboardDefaults, DashboardValidation, generalFunctions
+from ..defaults import BEAM_MONITOR_DEFAULT_NAME
 from ..defaults_helper import InputDefaultsHelper
 from .utils import LatticeConfigurationHelper
 from .variable_handler import LatticeVariableHandler
@@ -38,7 +39,6 @@ state.listOfLatticeElementParametersAndDefault = (
 
 state.selected_lattice_list = []
 state.nslice = ""
-BEAM_MONITOR_DEFAULT_NAME = "DefaultName"
 
 # -----------------------------------------------------------------------------
 # Main Functions

--- a/src/python/impactx/dashboard/Input/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/lattice/ui.py
@@ -57,18 +57,25 @@ def add_lattice_element() -> dict:
     parameters = []
     for name, default_value, default_type in parameters_data:
         default_value = "" if default_value is None else str(default_value).strip()
-        value = "DefaultName" if selected_lattice == "BeamMonitor" and name == "name" and not default_value else default_value
+        value = (
+            "DefaultName"
+            if selected_lattice == "BeamMonitor"
+            and name == "name"
+            and not default_value
+            else default_value
+        )
 
-
-        parameters.append({
-            "parameter_name": name,
-            "ui_input": value,
-            "sim_input": value,
-            "parameter_type": default_type,
-            "parameter_error_message": DashboardValidation.validate_against(
-                value, default_type
-            ),
-        })
+        parameters.append(
+            {
+                "parameter_name": name,
+                "ui_input": value,
+                "sim_input": value,
+                "parameter_type": default_type,
+                "parameter_error_message": DashboardValidation.validate_against(
+                    value, default_type
+                ),
+            }
+        )
 
     lattice_element = {
         "name": selected_lattice,
@@ -78,7 +85,6 @@ def add_lattice_element() -> dict:
     state.selected_lattice_list.append(lattice_element)
     DashboardValidation.update_simulation_validation_status()
     return lattice_element
-
 
 
 # -----------------------------------------------------------------------------

--- a/src/python/impactx/dashboard/Input/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/lattice/ui.py
@@ -38,6 +38,7 @@ state.listOfLatticeElementParametersAndDefault = (
 
 state.selected_lattice_list = []
 state.nslice = ""
+BEAM_MONITOR_DEFAULT_NAME = "DefaultName"
 
 # -----------------------------------------------------------------------------
 # Main Functions
@@ -56,14 +57,10 @@ def add_lattice_element() -> dict:
 
     parameters = []
     for name, default_value, default_type in parameters_data:
-        default_value = "" if default_value is None else str(default_value).strip()
-        value = (
-            "DefaultName"
-            if selected_lattice == "BeamMonitor"
-            and name == "name"
-            and not default_value
-            else default_value
-        )
+        value = default_value
+
+        if selected_lattice == "BeamMonitor" and name == "name" and not value:
+            value = BEAM_MONITOR_DEFAULT_NAME
 
         parameters.append(
             {

--- a/src/python/impactx/dashboard/Input/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/lattice/ui.py
@@ -56,13 +56,15 @@ def add_lattice_element() -> dict:
 
     parameters = []
     for name, default_value, default_type in parameters_data:
+        value = "DefaultName" if selected_lattice == "BeamMonitor" and name == "name" else default_value
+
         parameters.append({
             "parameter_name": name,
-            "ui_input": default_value,
-            "sim_input": default_value,
+            "ui_input": value,
+            "sim_input": value,
             "parameter_type": default_type,
             "parameter_error_message": DashboardValidation.validate_against(
-                default_value, default_type
+                value, default_type
             ),
         })
 
@@ -74,6 +76,7 @@ def add_lattice_element() -> dict:
     state.selected_lattice_list.append(lattice_element)
     DashboardValidation.update_simulation_validation_status()
     return lattice_element
+
 
 
 # -----------------------------------------------------------------------------

--- a/src/python/impactx/dashboard/Input/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/lattice/ui.py
@@ -52,29 +52,30 @@ def add_lattice_element():
     """
 
     selected_lattice = state.selected_lattice
-    selected_lattice_parameters = state.listOfLatticeElementParametersAndDefault.get(
+    parameters_data = state.listOfLatticeElementParametersAndDefault.get(
         selected_lattice, []
     )
 
-    selected_lattice_element = {
+    parameters = []
+    for name, default_value, default_type in parameters_data:
+        parameters.append({
+            "parameter_name": name,
+            "ui_input": default_value,
+            "sim_input": default_value,
+            "parameter_type": default_type,
+            "parameter_error_message": DashboardValidation.validate_against(
+                default_value, default_type
+            ),
+        })
+
+    lattice_element = {
         "name": selected_lattice,
-        "parameters": [
-            {
-                "parameter_name": parameter[0],
-                "ui_input": parameter[1],
-                "sim_input": parameter[1],
-                "parameter_type": parameter[2],
-                "parameter_error_message": DashboardValidation.validate_against(
-                    parameter[1], parameter[2]
-                ),
-            }
-            for parameter in selected_lattice_parameters
-        ],
+        "parameters": parameters,
     }
 
-    state.selected_lattice_list.append(selected_lattice_element)
+    state.selected_lattice_list.append(lattice_element)
     DashboardValidation.update_simulation_validation_status()
-    return selected_lattice_element
+    return lattice_element
 
 
 # -----------------------------------------------------------------------------

--- a/src/python/impactx/dashboard/Input/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/lattice/ui.py
@@ -44,11 +44,9 @@ state.nslice = ""
 # -----------------------------------------------------------------------------
 
 
-def add_lattice_element():
+def add_lattice_element() -> dict:
     """
-    Adds the selected lattice element to the list of selected
-    lattice elements along with its default parameters.
-    :return: dictionary representing the added lattice element with its parameters.
+    Appends the currently selected lattice element and its parameters to the lattice list.
     """
 
     selected_lattice = state.selected_lattice


### PR DESCRIPTION
A convenient case to cover in my usage of the dashboard. The way I’ve seen `elements.BeamMonitor` added in ImpactX examples follows this structure: `elements.BeamMonitor("monitor", backend="h5")`. The dashboard doesn’t catch "monitor" in that case because it’s passed positionally — not like `elements.BeamMonitor(name="monitor", backend="h5")`. Since the dashboard expects `name=`, it ends up empty and throws a validation error. This PR sets a default name of `"DefaultName"` if the value is missing to avoid that. To do this nicely, we also adjust the loop that adds a lattice element to make it more readable.