### PR TITLE
Dashboard: Disable “Add” Button for Invalid Lattice Elements

### DIFF
--- a/src/python/impactx/dashboard/Input/components/input.py
+++ b/src/python/impactx/dashboard/Input/components/input.py
@@ -116,14 +116,14 @@ class InputComponents:
         )
 
     @staticmethod
-    def combobox(
+    def autocomplete(
         label: str,
         v_model_name: Optional[str] = None,
         items: Optional[list] = None,
         **kwargs,
-    ) -> vuetify.VCombobox:
+    ) -> vuetify.VAutocomplete:
         """
-        Creates a Vuetify VCombobox component with default properties.
+        Creates a Vuetify VAutocomplete component with default properties.
 
         :param label: The label to display.
         :param v_model_name: Optional binding name for v_model. Defaults to a lowercase version
@@ -133,5 +133,5 @@ class InputComponents:
         """
 
         InputComponents._build_component(
-            vuetify.VCombobox, label, v_model_name, items=items, **kwargs
+            vuetify.VAutocomplete, label, v_model_name, items=items, **kwargs
         )

--- a/src/python/impactx/dashboard/Input/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/lattice/ui.py
@@ -21,7 +21,7 @@ from .utils import LatticeConfigurationHelper
 from .variable_handler import LatticeVariableHandler
 
 state.lattice_elements_using_variables = {}
-
+state.is_selected_element_invalid = True
 # -----------------------------------------------------------------------------
 # Helpful
 # -----------------------------------------------------------------------------
@@ -119,21 +119,14 @@ def on_selected_lattice_list_change(selected_lattice_list, **kwargs):
 
 @state.change("selected_lattice")
 def on_lattice_element_name_change(selected_lattice, **kwargs):
-    return
+    lattice_list = DashboardDefaults.LISTS["lattice_list"]
+    state.is_selected_element_invalid = selected_lattice not in lattice_list
 
 
 @ctrl.add("add_latticeElement")
 def on_add_lattice_element_click():
-    lattice_list = DashboardDefaults.LISTS["lattice_list"]
-    selected_lattice = state.selected_lattice
-
-    if selected_lattice not in lattice_list:
-        state.isSelectedLatticeListEmpty = (
-            f"Lattice element '{selected_lattice}' does not exist."
-        )
-    else:
-        add_lattice_element()
-        state.dirty("selected_lattice_list")
+    add_lattice_element()
+    state.dirty("selected_lattice_list")
 
 
 def process_if_variable(index, parameter_name, ui_input, parameter_type):
@@ -291,6 +284,7 @@ class LatticeConfiguration(CardBase):
                             color="primary",
                             dense=True,
                             click=ctrl.add_latticeElement,
+                            disabled=("is_selected_element_invalid",),
                         )
                 with vuetify.VRow(
                     **self.ROW_STYLE,

--- a/src/python/impactx/dashboard/Input/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/lattice/ui.py
@@ -278,7 +278,7 @@ class LatticeConfiguration(CardBase):
                         )
                     vuetify.VDivider(vertical=True)
                     with vuetify.VCol(cols=True):
-                        InputComponents.combobox(
+                        InputComponents.autocomplete(
                             label="Select Accelerator Lattice",
                             v_model_name="selected_lattice",
                             items=("lattice_list",),


### PR DESCRIPTION
Before:
Selecting an invalid element popped up an error message.

After:
The “Add” button is grayed-out until a valid element is chosen.

Before:

https://github.com/user-attachments/assets/3f62da16-e153-4cee-8358-a7f503ed42e1


After:

https://github.com/user-attachments/assets/35e35fde-77f4-424c-bcc4-e05a2befd51a

