### PR TITLE
CI: macOS w/ `-Werror` Again

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -63,6 +63,8 @@ jobs:
         export CCACHE_SLOPPINESS=time_macros
         ccache -z
 
+        export CXXFLAGS="-Werror -Wno-error=pass-failed"
+
         cmake -S . -B build            \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DImpactX_FFT=ON             \


### PR DESCRIPTION
Add `-Werror` back to macOS CI.

- [x] after the 25.07 release #1060
- [x] Was temporarily disabled until https://github.com/AMReX-Codes/pyamrex/pull/453 landed in ImpactX.