### PR TITLE
Dashboard Tests: Add lattice statistics coverage to `test_dashboard.py`

### DIFF
--- a/src/python/impactx/dashboard/Input/visualization/lattice/statistics.py
+++ b/src/python/impactx/dashboard/Input/visualization/lattice/statistics.py
@@ -67,11 +67,11 @@ class LatticeVisualizerStatisticUtils:
             state.length_stats_content = []
 
     @staticmethod
-    def update_element_counts() -> list[tuple[str, int]]:
+    def update_element_counts() -> dict[str, int]:
         """
         Computes the element counts in the lattice list.
 
-        :return: List of (element name, count) tuples, sorted by count descending.
+        :return: Dictionary of element names and their counts, sorted by count descending.
         """
         counts = {}
         for element in state.selected_lattice_list:
@@ -81,7 +81,10 @@ class LatticeVisualizerStatisticUtils:
 
         state.lattice_is_empty = len(counts) == 0
         # sort from desc. so we see top elements left to right
-        return sorted(counts.items(), key=lambda item: item[1], reverse=True)
+        sorted_counts = dict(sorted(counts.items(), key=lambda item: item[1], reverse=True))
+
+        state.element_counts = sorted_counts
+        return sorted_counts
 
     @staticmethod
     def update_total_steps() -> int:
@@ -155,7 +158,7 @@ class LatticeVisualizerStatisticComponents:
                     with vuetify.Template(v_else=True):
                         with vuetify.VChipGroup():
                             with vuetify.Template(
-                                v_for="[name, count] in element_counts", key="name"
+                                v_for="(count, name) in element_counts", key="name"
                             ):
                                 vuetify.VChip(
                                     "{{ name.charAt(0).toUpperCase() + name.slice(1) }}: {{ count }}",

--- a/src/python/impactx/dashboard/Input/visualization/lattice/statistics.py
+++ b/src/python/impactx/dashboard/Input/visualization/lattice/statistics.py
@@ -81,7 +81,9 @@ class LatticeVisualizerStatisticUtils:
 
         state.lattice_is_empty = len(counts) == 0
         # sort from desc. so we see top elements left to right
-        sorted_counts = dict(sorted(counts.items(), key=lambda item: item[1], reverse=True))
+        sorted_counts = dict(
+            sorted(counts.items(), key=lambda item: item[1], reverse=True)
+        )
 
         state.element_counts = sorted_counts
         return sorted_counts

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -73,11 +73,11 @@ def test_dashboard(dashboard):
         "total_elements": 5,
         "total_length": "3.0m",
         "max_length": "1.0m",
-        "avg_length" : "0.6m",
+        "avg_length": "0.6m",
         "min_length": "0.25m",
         "total_steps": 125,
         "periods": 1,
-        "element_counts": {'drift': 3, 'quad': 2}
+        "element_counts": {"drift": 3, "quad": 2},
     }
 
     for state_name, expected_value in EXPECTED_LATTICE_STATS.items():

--- a/tests/python/dashboard/test_dashboard.py
+++ b/tests/python/dashboard/test_dashboard.py
@@ -8,6 +8,7 @@ def test_dashboard(dashboard):
     - Configuring the lattice
         - Through direct numeric input
         - Through the variable configuration
+    - Checking if the lattice statistics update correctly
     - Running the simulation
     - Checking if the simulation completes successfully
     """
@@ -66,6 +67,21 @@ def test_dashboard(dashboard):
     VARIABLES = {"variable_name_1": "ns", "variable_value_1": 25}
     for param_id, value in VARIABLES.items():
         dashboard.set_input(param_id, value)
+
+    # Check if the lattice statistics update correctly
+    EXPECTED_LATTICE_STATS = {
+        "total_elements": 5,
+        "total_length": "3.0m",
+        "max_length": "1.0m",
+        "avg_length" : "0.6m",
+        "min_length": "0.25m",
+        "total_steps": 125,
+        "periods": 1,
+        "element_counts": {'drift': 3, 'quad': 2}
+    }
+
+    for state_name, expected_value in EXPECTED_LATTICE_STATS.items():
+        dashboard.assert_state(state_name, expected_value)
 
     # Run simulation
     dashboard.sb.click("#Run_route")

--- a/tests/python/dashboard/utils.py
+++ b/tests/python/dashboard/utils.py
@@ -219,7 +219,7 @@ class DashboardTester:
                 return
 
             print(
-                f"Waiting for state['{state_name}'] to become '{expected_input}' - ({i + 1}s elapsed)"
+                f"Waiting for state['{state_name}'] to become '{expected_input}' - (current value: '{value}') - ({i + 1}s elapsed)"
             )
             time.sleep(1)
 


### PR DESCRIPTION
Just making sure it works while testing. I don't think an extensive test is needed (ie importing a large lattice configuration and then testing stats).


Also updated a print statement inside of `tests/python/dashboard/utils.py` to help with debugging.