### PR TITLE
pybind11: 3.0.0

### DIFF
--- a/.github/ci/sanitizer/clang/Leak.supp
+++ b/.github/ci/sanitizer/clang/Leak.supp
@@ -5,7 +5,7 @@ leak:libopen-pal*
 leak:libopen-rte*
 leak:libmpi*
 leak:libevent*
-# CPython 3.7.1 and pybind11 2.3.0
+# CPython 3.7.1 and pybind11 3.0.0
 leak:*py*
 # 10 byte memleak in main of "make" 4.1
 leak:/usr/bin/make*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,7 @@ if(ImpactX_PYTHON)
             impactx_enable_IPO(pyImpactX)
         else()
             # conditionally defined target in pybind11
-            # https://github.com/pybind/pybind11/blob/v2.13.0/tools/pybind11Common.cmake#L407-L413
+            # https://github.com/pybind/pybind11/blob/v3.0.0/tools/pybind11Common.cmake#L420-L426
             target_link_libraries(pyImpactX PRIVATE pybind11::lto)
         endif()
     endif()

--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -173,7 +173,7 @@ set(ImpactX_openpmd_src ""
 set(ImpactX_ablastr_repo "https://github.com/BLAST-WarpX/warpx.git"
     CACHE STRING
     "Repository URI to pull and build ABLASTR from if(ImpactX_ablastr_internal)")
-set(ImpactX_ablastr_branch "25.07"
+set(ImpactX_ablastr_branch "06feda8131de7b97f2cc16a6e244d1d4f9874c3b"
     CACHE STRING
     "Repository branch for ImpactX_ablastr_repo if(ImpactX_ablastr_internal)")
 

--- a/cmake/dependencies/pyAMReX.cmake
+++ b/cmake/dependencies/pyAMReX.cmake
@@ -74,7 +74,7 @@ option(ImpactX_pyamrex_internal "Download & build pyAMReX" ON)
 set(ImpactX_pyamrex_repo "https://github.com/AMReX-Codes/pyamrex.git"
     CACHE STRING
     "Repository URI to pull and build pyamrex from if(ImpactX_pyamrex_internal)")
-set(ImpactX_pyamrex_branch "25.07"
+set(ImpactX_pyamrex_branch "f884dda4beebdd955aaba8f82a8a9530b8185bb5"
     CACHE STRING
     "Repository branch for ImpactX_pyamrex_repo if(ImpactX_pyamrex_internal)")
 

--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -37,7 +37,7 @@ function(find_pybind11)
             mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDpybind11)
         endif()
     else()
-        find_package(pybind11 2.13.0 CONFIG REQUIRED)
+        find_package(pybind11 3.0.0 CONFIG REQUIRED)
         message(STATUS "pybind11: Found version '${pybind11_VERSION}'")
     endif()
 endfunction()
@@ -52,7 +52,7 @@ option(ImpactX_pybind11_internal "Download & build pybind11" ON)
 set(ImpactX_pybind11_repo "https://github.com/pybind/pybind11.git"
     CACHE STRING
     "Repository URI to pull and build pybind11 from if(ImpactX_pybind11_internal)")
-set(ImpactX_pybind11_branch "v2.13.6"
+set(ImpactX_pybind11_branch "v3.0.0"
     CACHE STRING
     "Repository branch for ImpactX_pybind11_repo if(ImpactX_pybind11_internal)")
 

--- a/src/python/Iterator.H
+++ b/src/python/Iterator.H
@@ -27,7 +27,7 @@ namespace pyImpactX
      * explicitly, otherwise we will jump directly to the 2nd element. We do
      * this the same way as pybind11 does this, via a little state:
      *   https://github.com/AMReX-Codes/pyamrex/pull/50
-     *   https://github.com/pybind/pybind11/blob/v2.10.0/include/pybind11/pybind11.h#L2269-L2282
+     *   https://github.com/pybind/pybind11/blob/v3.0.0/include/pybind11/pybind11.h#L2954-L2967
      *
      * To avoid unnecessary (and expensive) copies, remember to only call this
      * helper always with py::return_value_policy::reference_internal!


### PR DESCRIPTION
Update to pybind11 v3.0.0, following:
- [x] https://github.com/AMReX-Codes/pyamrex/pull/455
- [x] https://github.com/BLAST-WarpX/warpx/pull/6043

To-do:
- [x] Update ABLASTR branch after https://github.com/BLAST-WarpX/warpx/pull/6043 is merged.