### PR TITLE
Reuse Particle Chunking Logic

### DIFF
--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -87,7 +87,7 @@ namespace impactx
         add_particles (
             amrex::ParticleReal bunch_charge,
             distribution::KnownDistributions distr,
-            int npart
+            amrex::Long npart
         );
 
         /** Validate the simulation is ready to run the particle tracking loop via @see track_particles

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -278,7 +278,7 @@ namespace impactx
     ImpactX::add_particles (
         amrex::ParticleReal bunch_charge,
         distribution::KnownDistributions distr,
-        int npart
+        amrex::Long npart
     )
     {
         BL_PROFILE("ImpactX::add_particles");
@@ -313,7 +313,7 @@ namespace impactx
             amrex::ParallelDescriptor::MyProc(),
             amrex::ParallelDescriptor::NProcs()
         );
-        int const npart_this_proc = proc_chunk.size;
+        amrex::Long const npart_this_proc = proc_chunk.size;
         auto const rel_part_this_proc =
             amrex::ParticleReal(npart_this_proc) / amrex::ParticleReal(npart);
 
@@ -344,8 +344,8 @@ namespace impactx
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             {
-                int npart_this_thread = npart_this_proc;
-                int my_offset = 0;  // offset into global arrays x, y, etc. for this thread
+                amrex::Long npart_this_thread = npart_this_proc;
+                amrex::Long my_offset = 0;  // offset into global arrays x, y, etc. for this thread
 #ifdef AMREX_USE_OMP
                 ParticleChunk thread_chunk = split_equally(
                     npart_this_proc,
@@ -530,7 +530,7 @@ namespace impactx
             std::string distribution;
             pp_dist.get("distribution", distribution);
 
-            int npart = 0;  // Number of simulation particles
+            amrex::Long npart = 0;  // Number of simulation particles
             if (distribution != "empty")
             {
                 pp_dist.getWithParser("npart", npart);

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -14,6 +14,7 @@
 #include "particles/CovarianceMatrix.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/distribution/All.H"
+#include "particles/SplitEqually.H"
 
 #include <ablastr/constant.H>
 #include <ablastr/warn_manager/WarnManager.H>
@@ -307,11 +308,12 @@ namespace impactx
         // position, per MPI rank. We then measure the distribution's spatial
         // extent, create a grid, resize it to fit the beam, and then
         // redistribute particles so that they reside on the correct MPI rank.
-        int const myproc = amrex::ParallelDescriptor::MyProc();
-        int const nprocs = amrex::ParallelDescriptor::NProcs();
-        int const navg = npart / nprocs;  // note: integer division
-        int const nleft = npart - navg * nprocs;
-        int const npart_this_proc = (myproc < nleft) ? navg+1 : navg;  // add 1 to each proc until distributed
+        ParticleChunk proc_chunk = split_equally(
+            npart,
+            amrex::ParallelDescriptor::MyProc(),
+            amrex::ParallelDescriptor::NProcs()
+        );
+        int const npart_this_proc = proc_chunk.size;
         auto const rel_part_this_proc =
             amrex::ParticleReal(npart_this_proc) / amrex::ParticleReal(npart);
 
@@ -342,24 +344,16 @@ namespace impactx
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             {
+                int npart_this_thread = npart_this_proc;
                 int my_offset = 0;  // offset into global arrays x, y, etc. for this thread
-
 #ifdef AMREX_USE_OMP
-                int const nthreads = omp_get_max_threads();
-                int const tid = omp_get_thread_num();
-
-                int const navg_thread = npart_this_proc / nthreads;  // note: integer division
-                int const nleft_thread = npart_this_proc - navg_thread * nthreads;
-                int const npart_this_thread = (tid < nleft_thread) ? navg_thread+1 : navg_thread;  // add 1 to each thread until distributed
-
-                if (tid < nleft_thread) { // get navg_thread+1 items
-                    my_offset = tid * (navg_thread + 1);
-                } else {                  // get navg_thread items
-                    my_offset = tid * navg_thread + nleft_thread;
-                }
-
-#else
-                int const npart_this_thread = npart_this_proc;
+                ParticleChunk thread_chunk = split_equally(
+                    npart_this_proc,
+                    omp_get_thread_num(),
+                    omp_get_max_threads()
+                );
+                my_offset = thread_chunk.offset;
+                npart_this_thread = thread_chunk.size;
 #endif
 
                 initialization::InitSingleParticleData<Distribution> const init_single_particle_data(

--- a/src/particles/CMakeLists.txt
+++ b/src/particles/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(lib
     CollectLost.cpp
     ImpactXParticleContainer.cpp
     Push.cpp
+    SplitEqually.cpp
 )
 
 add_subdirectory(spacecharge)

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -210,7 +210,7 @@ namespace impactx
         AMREX_ALWAYS_ASSERT(x.size() == pt.size());
 
         // number of particles to add
-        int const np = x.size();
+        amrex::Long const np = x.size();
 
         // we add particles to lev 0, grid 0
         int lid = 0, gid = 0;
@@ -235,10 +235,10 @@ namespace impactx
             DefineAndReturnParticleTile(lid, gid, ithr);
         }
 
-        int pid = ParticleType::NextID();
+        amrex::Long pid = ParticleType::NextID();
         ParticleType::NextID(pid + np);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-            static_cast<amrex::Long>(pid) + static_cast<amrex::Long>(np) < amrex::LongParticleIds::LastParticleID,
+            pid + np < amrex::LongParticleIds::LastParticleID,
             "ERROR: overflow on particle id numbers"
         );
 
@@ -261,15 +261,15 @@ namespace impactx
                 tid,
                 nthreads
             );
-            int const my_offset = thread_chunk.offset;
-            int const num_to_add = thread_chunk.size;
+            amrex::Long const my_offset = thread_chunk.offset;
+            amrex::Long const num_to_add = thread_chunk.size;
 
             auto& particle_tile = ParticlesAt(lid, gid, tid);
             auto old_np = particle_tile.numParticles();
             auto new_np = old_np + num_to_add;
             particle_tile.resize(new_np);
 
-            const int cpuid = amrex::ParallelDescriptor::MyProc();
+            const amrex::Long cpuid = amrex::ParallelDescriptor::MyProc();
 
             auto & soa = particle_tile.GetStructOfArrays().GetRealData();
             amrex::ParticleReal * const AMREX_RESTRICT x_arr = soa[RealSoA::x].dataPtr();
@@ -291,7 +291,7 @@ namespace impactx
             amrex::ParticleReal const * const AMREX_RESTRICT pt_ptr = pt.data();
 
             amrex::ParallelFor(num_to_add,
-                [=] AMREX_GPU_DEVICE (int i) noexcept
+                [=] AMREX_GPU_DEVICE (amrex::Long i) noexcept
             {
                 idcpu_arr[old_np+i] = amrex::SetParticleIDandCPU(pid + my_offset + i, cpuid);
 

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -12,6 +12,7 @@
 #include "initialization/AmrCoreData.H"
 #include "initialization/Algorithms.H"
 #include "diagnostics/ReducedBeamCharacteristics.H"
+#include "particles/SplitEqually.H"
 
 #include <ablastr/constant.H>
 #include <ablastr/particles/ParticleMoments.H>
@@ -255,19 +256,13 @@ namespace impactx
             // get get n_regular particles. If there are some
             // leftovers, however, the first n_leftover threads
             // will get one extra
-            int n_regular  = np / nthreads;
-            int n_leftover = np - n_regular*nthreads;
-
-            int num_to_add = 0; /* how many particles this tile will get*/
-            int my_offset = 0; /*  offset into global arrays x, y, etc. for this thread*/
-
-            if (tid < n_leftover) { // get n_regular+1 items
-                my_offset = tid * (n_regular + 1);
-                num_to_add = n_regular + 1;
-            } else {         // get n_regular items
-                my_offset = tid * n_regular + n_leftover;
-                num_to_add = n_regular;
-            }
+            ParticleChunk thread_chunk = split_equally(
+                np,
+                tid,
+                nthreads
+            );
+            int const my_offset = thread_chunk.offset;
+            int const num_to_add = thread_chunk.size;
 
             auto& particle_tile = ParticlesAt(lid, gid, tid);
             auto old_np = particle_tile.numParticles();

--- a/src/particles/SplitEqually.H
+++ b/src/particles/SplitEqually.H
@@ -10,13 +10,15 @@
 #ifndef IMPACTX_SPLIT_EQUALLY_H
 #define IMPACTX_SPLIT_EQUALLY_H
 
+#include <AMReX_INT.H>
+
 namespace impactx
 {
     /** Offset and size of a chunk in a contigous array (e.g., of particle properties) */
     struct ParticleChunk
     {
-        int offset = 0;  //! where to start in the array, in elements
-        int size = 0;    //! how large is my chunk, counted from offset, in elements
+        amrex::Long offset = 0;  //! where to start in the array, in elements
+        amrex::Long size = 0;    //! how large is my chunk, counted from offset, in elements
     };
 
     /** Split an array of contiguous elements into well-balanched chunks.
@@ -33,7 +35,7 @@ namespace impactx
      * @return offset and size of the chunk for a specific index
      */
     ParticleChunk
-    split_equally (int npart, int index, int size);
+    split_equally (amrex::Long npart, amrex::Long index, amrex::Long size);
 
 } // namespace impactx
 

--- a/src/particles/SplitEqually.H
+++ b/src/particles/SplitEqually.H
@@ -1,0 +1,40 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl, Chad Mitchell
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_SPLIT_EQUALLY_H
+#define IMPACTX_SPLIT_EQUALLY_H
+
+namespace impactx
+{
+    /** Offset and size of a chunk in a contigous array (e.g., of particle properties) */
+    struct ParticleChunk
+    {
+        int offset = 0;  //! where to start in the array, in elements
+        int size = 0;    //! how large is my chunk, counted from offset, in elements
+    };
+
+    /** Split an array of contiguous elements into well-balanched chunks.
+     *
+     * This function contains the auxiliary math to split npart contiguous particles into
+     * contiguous chunks of size, returning the individual starting offset and chunk size.
+     * It also deals with distributing remainders well.
+     *
+     * This can be used for distributed logic for MPI and OpenMP parallelism alike.
+     *
+     * @param npart total number of elements/particles
+     * @param index my index in parallelization, e.g., MPI rank or OpenMP thread id
+     * @param size the parallelization space, e.g., MPI size or OpenMP max threads
+     * @return offset and size of the chunk for a specific index
+     */
+    ParticleChunk
+    split_equally (int npart, int index, int size);
+
+} // namespace impactx
+
+#endif // IMPACTX_SPLIT_EQUALLY_H

--- a/src/particles/SplitEqually.cpp
+++ b/src/particles/SplitEqually.cpp
@@ -1,0 +1,32 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl, Chad Mitchell
+ * License: BSD-3-Clause-LBNL
+ */
+#include "SplitEqually.H"
+
+namespace impactx
+{
+    ParticleChunk
+    split_equally (int npart, int index, int size)
+    {
+        ParticleChunk my_chunk;
+
+        int const navg = npart / size;  // note: integer division
+        int const nleft = npart - navg * size;
+        my_chunk.size = (index < nleft) ? navg+1 : navg;  // add 1 to each chunk (proc/thread) until distributed
+
+        if (index < nleft) { // get navg+1 items
+            my_chunk.offset = index * (navg + 1);
+        } else {                  // get navg items
+            my_chunk.offset = index * navg + nleft;
+        }
+
+        return my_chunk;
+    }
+
+} // namespace impactx

--- a/src/particles/SplitEqually.cpp
+++ b/src/particles/SplitEqually.cpp
@@ -12,12 +12,12 @@
 namespace impactx
 {
     ParticleChunk
-    split_equally (int npart, int index, int size)
+    split_equally (amrex::Long npart, amrex::Long index, amrex::Long size)
     {
         ParticleChunk my_chunk;
 
-        int const navg = npart / size;  // note: integer division
-        int const nleft = npart - navg * size;
+        amrex::Long const navg = npart / size;  // note: integer division
+        amrex::Long const nleft = npart - navg * size;
         my_chunk.size = (index < nleft) ? navg+1 : navg;  // add 1 to each chunk (proc/thread) until distributed
 
         if (index < nleft) { // get navg+1 items


### PR DESCRIPTION
Write a common function to partition/chunk the particle array for MPI and OpenMP parallelization.

- [x] rebase after #1070 was merged
- [x] `int`/`amrex::Long`

Close #1071

This function might also be a good candidate for ABLASTR or even AMReX.