### PR TITLE
Doc: Particle Theory Clarification/Cross-Link

### DIFF
--- a/docs/source/theory/assumptions.rst
+++ b/docs/source/theory/assumptions.rst
@@ -5,11 +5,13 @@ Assumptions
 
 This is an overview of physical assumptions implemented in the numerics of ImpactX.
 
+ImpactX supports multiple :ref:`tracking modes <usage_run-tracking-mode>`.
+This section focuses on *particle tracking*.
 
-Tracking and Lattice Optics
----------------------------
+Particle Tracking and Lattice Optics
+------------------------------------
 
-Tracking through lattice optics in ImpactX is performed by updating the canonical phase space variables (x,px,y,py,t,pt) using symplectic transport.
+Particle tracking through lattice optics in ImpactX is performed by updating the canonical phase space variables (x,px,y,py,t,pt) using symplectic transport.
 The elements supported currently fall into one of the following categories:
 
 * **zero-length (thin) elements**, such as multipole kicks and coordinate transformations
@@ -17,7 +19,7 @@ The elements supported currently fall into one of the following categories:
 * **soft-edge elements** described by :math:`s`-dependent, user-provided field data, such as RF cavities
 * **ML surrogate models** using a trained neural network (not necessarily symplectic)
 
-Transport may be performed using one of three possible levels of approximation to the underlying Hamiltonian:
+Particle tracking may be performed using one of three possible levels of approximation to the underlying Hamiltonian:
 
 ================================== ==================== =================================================
 Model                              Use Case             Notes


### PR DESCRIPTION
Update the theory/assumption section on particle tracking a little, to avoid confusion with other tracking modes that we now provide.

Preview: https://impactx--1074.org.readthedocs.build/en/1074/theory/assumptions.html