### PR TITLE
BeamMonitor: Support >2B Particles Robustly

### DIFF
--- a/src/elements/diagnostics/BeamMonitor.H
+++ b/src/elements/diagnostics/BeamMonitor.H
@@ -35,7 +35,7 @@ namespace detail
 
         ImpactXParticleCounter (ParticleContainer & pc);
 
-        unsigned long GetTotalNumParticles () { return m_Total; }
+        unsigned long long GetTotalNumParticles () { return m_Total; }
 
         std::vector<unsigned long long> m_ParticleOffsetAtRank;
         std::vector<unsigned long long> m_ParticleSizeAtRank;
@@ -46,7 +46,7 @@ namespace detail
         * @param[out] offset particle offset over all, mpi-global amrex fabs
         * @param[out] sum number of all particles from all amrex fabs
         */
-        void GetParticleOffsetOfProcessor (const long &numParticles,
+        void GetParticleOffsetOfProcessor (amrex::Long const &numParticles,
                                            unsigned long long &offset,
                                            unsigned long long &sum) const;
 

--- a/src/elements/diagnostics/BeamMonitor.cpp
+++ b/src/elements/diagnostics/BeamMonitor.cpp
@@ -47,10 +47,10 @@ namespace detail {
 
         for (auto currentLevel = 0; currentLevel <= pc.finestLevel(); currentLevel++)
         {
-            long numParticles = 0; // numParticles in this processor
+            amrex::Long numParticles = 0;  // numParticles on this MPI rank
 
             for (ParticleIter pti(pc, currentLevel); pti.isValid(); ++pti) {
-                auto numParticleOnTile = pti.numParticles();
+                amrex::Long const numParticleOnTile = pti.numParticles();
                 numParticles += numParticleOnTile;
             }
 
@@ -83,14 +83,14 @@ namespace detail {
     //
     void
     ImpactXParticleCounter::GetParticleOffsetOfProcessor (
-            const long& numParticles,
+            amrex::Long const & numParticles,
             unsigned long long& offset,
             unsigned long long& sum
     ) const
     {
         offset = 0;
 #if defined(AMREX_USE_MPI)
-        std::vector<long> result(m_MPISize, 0);
+        std::vector<amrex::Long> result(m_MPISize, 0);
     amrex::ParallelGather::Gather (numParticles, result.data(), -1, amrex::ParallelDescriptor::Communicator());
 
     sum = 0;


### PR DESCRIPTION
Robustly support more than 2 billion particles in `BeamMonitor`.

2B+ particles per AMReX particle tile or rank is a separate topic that would need changes in AMReX first, where `numParticles` et al. default to `int` today.