### PR TITLE
fix documentation for ExactCFbend

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -786,7 +786,7 @@ This module provides elements and methods for the accelerator lattice.
    :param rotation: rotation error in the transverse plane [degrees]
    :param name: an optional name for the element
 
-.. py:class:: impactx.elements.ExactCFbend(ds, K_normal, K_skew, unit=0, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, int_order=2, mapsteps=5, nslice=1, name=None)
+.. py:class:: impactx.elements.ExactCFbend(ds, k_normal, k_skew, unit=0, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, int_order=2, mapsteps=5, nslice=1, name=None)
 
    A thick combined-function dipole magnet using the exact relativistic Hamiltonian, including all kinematic nonlinearities.
    The user must provide arrays containing normal and skew multipole coefficients, which can be specified up to decapole order.
@@ -806,8 +806,11 @@ This module provides elements and methods for the accelerator lattice.
    The vector potential is obtained from Table XI of the above-cited reference.
 
    :param ds: Segment length in m.
-   :param K_normal: Array of normal multipole coefficients (in meter^(-m) OR in T/meter^(m-1) for m=1,2,3,..)
-   :param K_skew: Array of skew multipole coefficients (in meter^(-m) OR in T/meter^(m-1) for m=1,2,3,...)
+   :param k_normal: Array of normal multipole coefficients (in meter^(-m) OR in T/meter^(m-1) for m=1,2,3,..)
+   :param k_skew: Array of skew multipole coefficients (in meter^(-m) OR in T/meter^(m-1) for m=1,2,3,...)
+
+      The arrays k_normal and k_skew must have the same number of elements.
+
    :param unit: specification of units for multipole coefficients (by default, these are normalized by magnetic rigidity)
    :param dx: horizontal translation error in m
    :param dy: vertical translation error in m

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -808,9 +808,6 @@ This module provides elements and methods for the accelerator lattice.
    :param ds: Segment length in m.
    :param k_normal: Array of normal multipole coefficients (in meter^(-m) OR in T/meter^(m-1) for m=1,2,3,..)
    :param k_skew: Array of skew multipole coefficients (in meter^(-m) OR in T/meter^(m-1) for m=1,2,3,...)
-
-   The arrays k_normal and k_skew must have the same number of elements.
-
    :param unit: specification of units for multipole coefficients (by default, these are normalized by magnetic rigidity)
    :param dx: horizontal translation error in m
    :param dy: vertical translation error in m
@@ -821,6 +818,8 @@ This module provides elements and methods for the accelerator lattice.
    :param mapsteps: number of integration steps per slice used for symplectic integration
    :param nslice: number of slices used for the application of space charge
    :param name: an optional name for the element
+
+   The arrays k_normal and k_skew must have the same number of elements.
 
    .. py:property:: unit
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -809,7 +809,7 @@ This module provides elements and methods for the accelerator lattice.
    :param k_normal: Array of normal multipole coefficients (in meter^(-m) OR in T/meter^(m-1) for m=1,2,3,..)
    :param k_skew: Array of skew multipole coefficients (in meter^(-m) OR in T/meter^(m-1) for m=1,2,3,...)
 
-      The arrays k_normal and k_skew must have the same number of elements.
+   The arrays k_normal and k_skew must have the same number of elements.
 
    :param unit: specification of units for multipole coefficients (by default, these are normalized by magnetic rigidity)
    :param dx: horizontal translation error in m


### PR DESCRIPTION
The documentation for the ExactCFbend used K_normal and K_skew (capitalized) for parameter names of the function  call but the actual code needs them to be all lower case.