### PR TITLE
Dashboard: add simple fix for type extraction

### DIFF
--- a/src/python/impactx/dashboard/Input/defaults_helper.py
+++ b/src/python/impactx/dashboard/Input/defaults_helper.py
@@ -159,8 +159,16 @@ class InputDefaultsHelper:
                 else:
                     parameter_type = type_and_default
 
-            if "Optional" in parameter_type:
-                parameter_type = parameter_type[len("Optional[") : -1]
+            match parameter_type:
+                case optional_type if "Optional" in optional_type:
+                    parameter_type = parameter_type[len("Optional[") : -1]
+                case "typing.SupportsFloat":
+                    parameter_type = "float"
+                case "typing.SupportsInt":
+                    parameter_type = "int"
+                case "str | None":
+                    parameter_type = "str"
+
             parameters.append((name, default, parameter_type))
 
         return parameters


### PR DESCRIPTION
Error first noted in https://github.com/BLAST-ImpactX/impactx/issues/1081 — the **lattice configuration** section of the dashboard wasn’t pulling the correct type values for each parameter after the change in https://github.com/BLAST-ImpactX/impactx/commit/be9e504b3977864d0485bd1090f700706166d5e2 to `src/python/impactx/elements/__init__.pyi`. Instead of returning `int`, `float`, or `str` for each element parameter, it was returning `SupportInt` or `SupportFloat`.

This PR adds a simple hardcoded fix to correct the type values on the dashboard.
