### PR TITLE
Remove unneeded assignment in ChrQuad, fix spelling error

### DIFF
--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -165,7 +165,7 @@ namespace impactx::elements
             T_Real pyout = py;
             T_Real const ptout = pt;
 
-            // paceholder variables
+            // placeholder variables
             T_Real q1 = xout;
             T_Real q2 = yout;
             T_Real p1 = px;
@@ -193,10 +193,6 @@ namespace impactx::elements
                    sin(omega*m_slice_ds) / (omega*delta1) * py;
                pyout = -omega * delta1 * sin(omega*m_slice_ds) * yout + cos(omega * m_slice_ds) * py;
 
-               q1 = yout;
-               q2 = xout;
-               p1 = py;
-               p2 = px;
             } else
             {
                // advance transverse position and momentum (zero focusing strength = drift)


### PR DESCRIPTION
While reading the code of ChrQuad, I noticed a little block of assignments that doesn't change anything.
This PR removes it.