### PR TITLE
SIMD: No Complex on Windows - Skip Multipole

### DIFF
--- a/src/elements/ExactMultipole.H
+++ b/src/elements/ExactMultipole.H
@@ -66,8 +66,11 @@ namespace impactx::elements
       public mixin::Thick,
       public mixin::Alignment,
       public mixin::PipeAperture,
-      public mixin::NoFinalize,
-      public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
+      public mixin::NoFinalize
+#ifndef _WIN32
+      // https://github.com/AMReX-Codes/amrex/issues/4609
+      , public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
+#endif
     {
         static constexpr auto type = "ExactMultipole";
         using PType = ImpactXParticleContainer::ParticleType;

--- a/src/elements/Multipole.H
+++ b/src/elements/Multipole.H
@@ -35,8 +35,11 @@ namespace impactx::elements
       public mixin::LinearTransport<Multipole>,
       public mixin::Thin,
       public mixin::Alignment,
-      public mixin::NoFinalize,
-      public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
+      public mixin::NoFinalize
+#ifndef _WIN32
+      // https://github.com/AMReX-Codes/amrex/issues/4609
+      , public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
+#endif
     {
         static constexpr auto type = "Multipole";
         using PType = ImpactXParticleContainer::ParticleType;


### PR DESCRIPTION
Have to disable SIMD for the Multipole because our Complex SIMD implementation is still a bit wonky and has alignment errors on Windows.

https://github.com/AMReX-Codes/amrex/issues/4609