### PR TITLE
Python: Load Arbitrary Particle Weight

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -379,7 +379,7 @@ Particles
       :param pt: momentum in t
       :param qm: charge over mass in 1/eV
       :param bunch_charge: total charge within a bunch in C
-      :param w: weight of each particle: how many real particles to represent
+      :param w: weight of each particle: the macroparticle charge in units of the elementary charge `e` (i.e., how many real particles to represent)
 
    .. py:method:: ref_particle()
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -360,9 +360,12 @@ Particles
       :param keep_mass: do not reset the reference particle mass
       :param keep_charge: do not reset the reference particle charge
 
-   .. py:method:: add_n_particles(x, y, t, px, py, pt, qm, bchchg)
+   .. py:method:: add_n_particles(x, y, t, px, py, pt, qm, bunch_charge=None, w=None)
 
       Add new particles to the container for fixed s.
+
+      Either the total charge (bunch_charge) or the weight of each
+      particle (w) must be provided.
 
       Note: This can only be used *after* the initialization (grids) have
             been created, meaning after the call to :py:meth:`ImpactX.init_grids`
@@ -375,7 +378,8 @@ Particles
       :param py: momentum in y
       :param pt: momentum in t
       :param qm: charge over mass in 1/eV
-      :param bchchg: total charge within a bunch in C
+      :param bunch_charge: total charge within a bunch in C
+      :param w: weight of each particle: how many real particles to represent
 
    .. py:method:: ref_particle()
 

--- a/examples/initialize_from_array/analyze_from_array.py
+++ b/examples/initialize_from_array/analyze_from_array.py
@@ -36,6 +36,7 @@ dt = beam_at_step["position_t"]
 dpx_s = beam_at_step["momentum_x"]
 dpy_s = beam_at_step["momentum_y"]
 dpt = beam_at_step["momentum_t"]
+w = beam_at_step["weighting"]
 
 dx_t, dy_t, dz, dpx_t, dpy_t, dpz = coord.to_t_from_s(
     ref_part, dx_s, dy_s, dt, dpx_s, dpy_s, dpt
@@ -50,16 +51,18 @@ sigz = z1.std()
 sigpx = px1.std()
 sigpy = py1.std()
 sigpz = pz1.std()
+N = np.sum(w)
 print(f"sig x={sigx:.2e}, sig y={sigy:.2e}, sig z={sigz:.2e}")
 print(f"sig px={sigpx:.2e}, sig py={sigpy:.2e}, sig pz={sigpz:.2e}")
+print(f"N={N:.2e}")
 
 atol = 0.0  # ignored
 rtol = 2.5 * num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
-    [sigx, sigy, sigz, sigpx, sigpy, sigpz],
-    [1.46e-3, 1.46e-3, 1.0e-3, 10, 10, 200],
+    [sigx, sigy, sigz, sigpx, sigpy, sigpz, N],
+    [1.46e-3, 1.46e-3, 1.0e-3, 10, 10, 200, 62415090.90043337],
     rtol=rtol,
     atol=atol,
 )

--- a/examples/initialize_from_array/run_from_array.py
+++ b/examples/initialize_from_array/run_from_array.py
@@ -46,7 +46,8 @@ sim.init_grids()
 
 energy_gamma = np.sqrt(1 + pz_mean**2)
 energy_MeV = 0.510998950 * energy_gamma  # reference energy
-bunch_charge_C = 10.0e-15  # used with space charge
+bunch_charge_C = 10.0e-12  # used with space charge
+q_e_C = 1.60217663e-19
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
@@ -61,6 +62,9 @@ dx, dy, dz, dpx, dpy, dpz = pycoord.to_ref_part_t_from_global_t(
 )
 dx, dy, dt, dpx, dpy, dpt = pycoord.to_s_from_t(ref, dx, dy, dz, dpx, dpy, dpz)
 
+# here we use equal particle weighting, but you can assign any weight to each particle
+w = np.ones_like(dx) * (bunch_charge_C / q_e_C / N_part)
+
 if not Config.have_gpu:  # initialize using cpu-based PODVectors
     dx_podv = amr.PODVector_real_std()
     dy_podv = amr.PODVector_real_std()
@@ -68,6 +72,7 @@ if not Config.have_gpu:  # initialize using cpu-based PODVectors
     dpx_podv = amr.PODVector_real_std()
     dpy_podv = amr.PODVector_real_std()
     dpt_podv = amr.PODVector_real_std()
+    w_podv = amr.PODVector_real_std()
 else:  # initialize on device using arena/gpu-based PODVectors
     dx_podv = amr.PODVector_real_arena()
     dy_podv = amr.PODVector_real_arena()
@@ -75,6 +80,7 @@ else:  # initialize on device using arena/gpu-based PODVectors
     dpx_podv = amr.PODVector_real_arena()
     dpy_podv = amr.PODVector_real_arena()
     dpt_podv = amr.PODVector_real_arena()
+    w_podv = amr.PODVector_real_arena()
 
 for p_dx in dx:
     dx_podv.push_back(p_dx)
@@ -88,11 +94,30 @@ for p_dpy in dpy:
     dpy_podv.push_back(p_dpy)
 for p_dpt in dpt:
     dpt_podv.push_back(p_dpt)
+for p_w in w:
+    w_podv.push_back(p_w)
+
+# This call has two options:
+# A) reassign equal weighting according to bunch_charge_C
+# B) use the particle weighting from the input array w
+pc.add_n_particles(
+    dx_podv,
+    dy_podv,
+    dt_podv,
+    dpx_podv,
+    dpy_podv,
+    dpt_podv,
+    qm_eev,
+    bunch_charge=bunch_charge_C,
+)
+# ok, let's clear all particles and do option B
+pc.clear_particles()
 
 pc.add_n_particles(
-    dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, bunch_charge_C
+    dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, w=w_podv
 )
 
+# build the accelerator lattice
 monitor = elements.BeamMonitor("monitor", backend="h5")
 sim.lattice.extend(
     [

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -160,6 +160,9 @@ namespace impactx
 
         /** Add new particles to the container for fixed s.
          *
+         * Either the total charge (bunch_charge) or the weight of each
+         * particle (w) must be provided.
+         *
          * Note: This can only be used *after* the initialization (grids) have
          *       been created, meaning after the call to AmrCore::InitFromScratch
          *       or AmrCore::InitFromCheckpoint has been made in the ImpactX
@@ -172,7 +175,8 @@ namespace impactx
          * @param py momentum in y
          * @param pt momentum in t
          * @param qm charge over mass in 1/eV
-         * @param bchchg total charge within a bunch in C
+         * @param bunch_charge total charge within a bunch in C
+         * @param w weight of each particle: how many real particles to represent
          */
         void
         AddNParticles (
@@ -183,7 +187,8 @@ namespace impactx
             amrex::Gpu::DeviceVector<amrex::ParticleReal> const & py,
             amrex::Gpu::DeviceVector<amrex::ParticleReal> const & pt,
             amrex::ParticleReal qm,
-            amrex::ParticleReal bchchg
+            std::optional<amrex::ParticleReal> bunch_charge = std::nullopt,
+            std::optional<amrex::Gpu::DeviceVector<amrex::ParticleReal>> w = std::nullopt
         );
 
         /** Register storage for lost particles

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -198,16 +198,26 @@ namespace impactx
         amrex::Gpu::DeviceVector<amrex::ParticleReal> const & py,
         amrex::Gpu::DeviceVector<amrex::ParticleReal> const & pt,
         amrex::ParticleReal qm,
-        amrex::ParticleReal bchchg
+        std::optional<amrex::ParticleReal> bunch_charge,
+        std::optional<amrex::Gpu::DeviceVector<amrex::ParticleReal>> w
     )
     {
         BL_PROFILE("ImpactX::AddNParticles");
+
+        using namespace amrex::literals;  // for _rt and _prt
+
+        bool const has_w = w.has_value();
+        if (!(bunch_charge.has_value() ^ has_w))
+        {
+            throw std::runtime_error("AddNParticles: Exactly one of bunch_charge or w must be provided!");
+        }
 
         AMREX_ALWAYS_ASSERT(x.size() == y.size());
         AMREX_ALWAYS_ASSERT(x.size() == t.size());
         AMREX_ALWAYS_ASSERT(x.size() == px.size());
         AMREX_ALWAYS_ASSERT(x.size() == py.size());
         AMREX_ALWAYS_ASSERT(x.size() == pt.size());
+        if (has_w) { AMREX_ALWAYS_ASSERT(x.size() == w->size()); }
 
         // number of particles to add
         amrex::Long const np = x.size();
@@ -218,7 +228,7 @@ namespace impactx
             const auto& pmap = ParticleDistributionMap(lid).ProcessorMap();
             auto it = std::find(pmap.begin(), pmap.end(), amrex::ParallelDescriptor::MyProc());
             if (it == std::end(pmap)) {
-                amrex::Abort("Attempting to add particles to box that does not exist.");
+                throw std::runtime_error("AddNParticles: Attempting to add particles to box that does not exist.");
             } else {
                 gid = *it;
             }
@@ -289,6 +299,8 @@ namespace impactx
             amrex::ParticleReal const * const AMREX_RESTRICT px_ptr = px.data();
             amrex::ParticleReal const * const AMREX_RESTRICT py_ptr = py.data();
             amrex::ParticleReal const * const AMREX_RESTRICT pt_ptr = pt.data();
+            amrex::ParticleReal const * const AMREX_RESTRICT w_ptr = has_w ? w->data() : nullptr;
+            amrex::ParticleReal const bunch_charge_value = has_w ? 0_prt : bunch_charge.value();
 
             amrex::ParallelFor(num_to_add,
                 [=] AMREX_GPU_DEVICE (amrex::Long i) noexcept
@@ -304,7 +316,7 @@ namespace impactx
                 pt_arr[old_np+i] = pt_ptr[my_offset+i];
 
                 qm_arr[old_np+i] = qm;
-                w_arr[old_np+i]  = bchchg/ablastr::constant::SI::q_e/np;
+                w_arr[old_np+i]  = has_w ? w_ptr[my_offset+i] : bunch_charge_value / ablastr::constant::SI::q_e/np;
             });
         }
 

--- a/src/python/ImpactXParticleContainer.cpp
+++ b/src/python/ImpactXParticleContainer.cpp
@@ -83,8 +83,10 @@ void init_impactxparticlecontainer(py::module& m)
              &ImpactXParticleContainer::AddNParticles,
              py::arg("x"), py::arg("y"), py::arg("t"),
              py::arg("px"), py::arg("py"), py::arg("pt"),
-             py::arg("qm"), py::arg("bchchg"),
+             py::arg("qm"), py::arg("bunch_charge")=py::none(), py::arg("w")=py::none(),
              "Add new particles to the container for fixed s.\n\n"
+             "Either the total charge (bunch_charge) or the weight of each\n"
+             "particle (w) must be provided.\n\n"
              "Note: This can only be used *after* the initialization (grids) have\n"
              "      been created, meaning after the call to ImpactX.init_grids\n"
              "      has been made in the ImpactX class.\n\n"
@@ -95,7 +97,8 @@ void init_impactxparticlecontainer(py::module& m)
              ":param py: momentum in y\n"
              ":param pt: momentum in t\n"
              ":param qm: charge over mass in 1/eV\n"
-             ":param bchchg: total charge within a bunch in C"
+             ":param bunch_charge: total charge within a bunch in C"
+             ":param w: weight of each particle: how many real particles to represent"
         )
         .def("ref_particle",
             py::overload_cast<>(&ImpactXParticleContainer::GetRefParticle),


### PR DESCRIPTION
Enhance the Python `add_n_particles` method to support loading particles of non-uniform particle weights. This is typically needed when loading from t-based PIC codes (EM/ES), like WarpX, which often modify particle weights for injection, ionization and density profile purposes.

X-ref: https://github.com/orgs/BLAST-ImpactX/discussions/1031 (ping Xuan Zhang @Xuan0533, Stony Brook University :) )

Check-list:
- [x] implement
- [x] document
- [x] test