### PR TITLE
[WIP] Distribution Arguments: snake_case & Default to Twiss?

### DIFF
--- a/examples/dogleg/run_dogleg_reverse.py
+++ b/examples/dogleg/run_dogleg_reverse.py
@@ -40,8 +40,8 @@ distr = distribution.Waterbag(
         alpha_x=1.3385830279518021,
         alpha_y=-1.3479109197361046,
         alpha_t=92.624347459169869,
+        dispX=-0.26669723385388505,
     ),
-    dispX=-0.26669723385388505,
 )
 sim.add_particles(bunch_charge_C, distr, npart)
 

--- a/src/initialization/InitDistribution.H
+++ b/src/initialization/InitDistribution.H
@@ -133,77 +133,77 @@ namespace impactx::initialization
     /** Initialize the input parameters for all distributions that read phase space ellipse parameters from the input
      *
      * This function sets the distribution parameters based on the provided phase space inputs.
-     * The parameters include the phase space ellipse intersections for position (`lambdaX`, `lambdaY`), time (`lambdaT`),
-     * momentum (`lambdaPx`, `lambdaPy`) and energy (`lambdaPt`), as well as the correlation terms (`muxpx`, `muypy`, `mutpt`).
+     * The parameters include the phase space ellipse intersections for position (`lambda_x`, `lambda_y`), time (`lambda_t`),
+     * momentum (`lambda_px`, `lambda_py`) and energy (`lambda_pt`), as well as the correlation terms (`mu_x_px`, `mu_y_py`, `mu_t_pt`).
      *
      * @param pp_dist The parameter parser object.
-     * @param lambdax Reference to the variable storing the axis intersection of the phase space ellipse for x position.
-     * @param lambday Reference to the variable storing the axis intersection of the phase space ellipse for y position.
-     * @param lambdat Reference to the variable storing the axis intersection of the phase space ellipse for time.
-     * @param lambdapx Reference to the variable storing the axis intersection of the phase space ellipse for momentum in x direction.
-     * @param lambdapy Reference to the variable storing the axis intersection of the phase space ellipse for momentum in y direction.
-     * @param lambdapt Reference to the variable storing the axis intersection of the phase space ellipse for energy.
-     * @param muxpx Reference to the variable storing the correlation coefficient between the x position and the x momentum.
-     * @param muypy Reference to the variable storing the correlation coefficient between the y position and the y momentum.
-     * @param mutpt Reference to the variable storing the correlation coefficient between the t position and the t momentum.
-     * @param meanx Reference to the variable storing the mean for position in the x direction.
-     * @param meany Reference to the variable storing the mean for position in the y direction.
-     * @param meant Reference to the variable storing the mean for position in the t direction.
-     * @param meanpx Reference to the variable storing the mean for momentum in the x direction.
-     * @param meanpy Reference to the variable storing the mean for momentum in the y direction.
-     * @param meanpt Reference to the variable storing the mean for momentum in the t direction.
-     * @param dispx Reference to the variable storing the beam-based dispersion in the x direction.
-     * @param disppx Reference to the variable storing the derivative of the beam-based dispersion in the x direction.
-     * @param dispy Reference to the variable storing the beam-based dispersion in the y direction.
-     * @param disppy Reference to the variable storing the derivative of the beam-based dispersion in the y direction.
+     * @param lambda_x Reference to the variable storing the axis intersection of the phase space ellipse for x position.
+     * @param lambda_y Reference to the variable storing the axis intersection of the phase space ellipse for y position.
+     * @param lambda_t Reference to the variable storing the axis intersection of the phase space ellipse for time.
+     * @param lambda_px Reference to the variable storing the axis intersection of the phase space ellipse for momentum in x direction.
+     * @param lambda_py Reference to the variable storing the axis intersection of the phase space ellipse for momentum in y direction.
+     * @param lambda_pt Reference to the variable storing the axis intersection of the phase space ellipse for energy.
+     * @param mu_x_px Reference to the variable storing the correlation coefficient between the x position and the x momentum.
+     * @param mu_y_py Reference to the variable storing the correlation coefficient between the y position and the y momentum.
+     * @param mu_t_pt Reference to the variable storing the correlation coefficient between the t position and the t momentum.
+     * @param mean_x Reference to the variable storing the mean for position in the x direction.
+     * @param mean_y Reference to the variable storing the mean for position in the y direction.
+     * @param mean_t Reference to the variable storing the mean for position in the t direction.
+     * @param mean_px Reference to the variable storing the mean for momentum in the x direction.
+     * @param mean_py Reference to the variable storing the mean for momentum in the y direction.
+     * @param mean_pt Reference to the variable storing the mean for momentum in the t direction.
+     * @param dispersion_x Reference to the variable storing the beam-based dispersion in the x direction.
+     * @param dispersion_px Reference to the variable storing the derivative of the beam-based dispersion in the x direction.
+     * @param dispersion_y Reference to the variable storing the beam-based dispersion in the y direction.
+     * @param dispersion_py Reference to the variable storing the derivative of the beam-based dispersion in the y direction.
      */
     void
     set_distribution_parameters_from_phase_space_inputs (
         amrex::ParmParse const & pp_dist,
-        amrex::ParticleReal& lambdax, amrex::ParticleReal& lambday, amrex::ParticleReal& lambdat,
-        amrex::ParticleReal& lambdapx,amrex::ParticleReal& lambdapy, amrex::ParticleReal& lambdapt,
-        amrex::ParticleReal& muxpx, amrex::ParticleReal& muypy, amrex::ParticleReal& mutpt,
-        amrex::ParticleReal& meanx, amrex::ParticleReal& meany, amrex::ParticleReal& meant,
-        amrex::ParticleReal& meanpx, amrex::ParticleReal& meanpy, amrex::ParticleReal& meanpt,
-        amrex::ParticleReal& dispx, amrex::ParticleReal& disppx, amrex::ParticleReal& dispy, amrex::ParticleReal& disppy
+        amrex::ParticleReal& lambda_x, amrex::ParticleReal& lambda_y, amrex::ParticleReal& lambda_t,
+        amrex::ParticleReal& lambda_px,amrex::ParticleReal& lambda_py, amrex::ParticleReal& lambda_pt,
+        amrex::ParticleReal& mu_x_px, amrex::ParticleReal& mu_y_py, amrex::ParticleReal& mu_t_pt,
+        amrex::ParticleReal& mean_x, amrex::ParticleReal& mean_y, amrex::ParticleReal& mean_t,
+        amrex::ParticleReal& mean_px, amrex::ParticleReal& mean_py, amrex::ParticleReal& mean_pt,
+        amrex::ParticleReal& dispersion_x, amrex::ParticleReal& dispersion_px, amrex::ParticleReal& dispersion_y, amrex::ParticleReal& dispersion_py
     );
 
 
     /** Set the distribution parameters from Twiss inputs
      *
      * This function reads Courant-Snyder / Twiss parameters from the provided `ParmParse` object and calculates the distribution parameters for a particle beam.
-     * It sets the values for the axis intercepts of the phase space ellipse (`lambdaX`, `lambdaY`, `lambdaT`, and `lambdaPx`, `lambdaPy`, `lambdaPt`) and correlation terms (`muxpx`, `muypy`, `mutpt`)  normally accepted as input.
+     * It sets the values for the axis intercepts of the phase space ellipse (`lambda_x`, `lambda_y`, `lambda_t`, and `lambda_px`, `lambda_py`, `lambda_pt`) and correlation terms (`mu_x_px`, `mu_y_py`, `mu_t_pt`)  normally accepted as input.
      *
      * @param pp_dist The parameter parser object.
-     * @param lambdax Reference to the variable storing the axis intersection of the phase space ellipse for x position.
-     * @param lambday Reference to the variable storing the axis intersection of the phase space ellipse for y position.
-     * @param lambdat Reference to the variable storing the axis intersection of the phase space ellipse for time.
-     * @param lambdapx Reference to the variable storing the axis intersection of the phase space ellipse for momentum in x direction.
-     * @param lambdapy Reference to the variable storing the axis intersection of the phase space ellipse for momentum in y direction.
-     * @param lambdapt Reference to the variable storing the axis intersection of the phase space ellipse for energy.
-     * @param muxpx Reference to the variable storing the correlation coefficient between the x position and the x momentum.
-     * @param muypy Reference to the variable storing the correlation coefficient between the y position and the y momentum.
-     * @param mutpt Reference to the variable storing the correlation coefficient between the t position and the t momentum.
-     * @param meanx Reference to the variable storing the mean for position in the x direction.
-     * @param meany Reference to the variable storing the mean for position in the y direction.
-     * @param meant Reference to the variable storing the mean for position in the t direction.
-     * @param meanpx Reference to the variable storing the mean for momentum in the x direction.
-     * @param meanpy Reference to the variable storing the mean for momentum in the y direction.
-     * @param meanpt Reference to the variable storing the mean for momentum in the t direction.
-     * @param dispx Reference to the variable storing the beam-based dispersion in the x direction.
-     * @param disppx Reference to the variable storing the derivative of the beam-based dispersion in the x direction.
-     * @param dispy Reference to the variable storing the beam-based dispersion in the y direction.
-     * @param disppy Reference to the variable storing the derivative of the beam-based dispersion in the y direction.
+     * @param lambda_x Reference to the variable storing the axis intersection of the phase space ellipse for x position.
+     * @param lambda_y Reference to the variable storing the axis intersection of the phase space ellipse for y position.
+     * @param lambda_t Reference to the variable storing the axis intersection of the phase space ellipse for time.
+     * @param lambda_px Reference to the variable storing the axis intersection of the phase space ellipse for momentum in x direction.
+     * @param lambda_py Reference to the variable storing the axis intersection of the phase space ellipse for momentum in y direction.
+     * @param lambda_pt Reference to the variable storing the axis intersection of the phase space ellipse for energy.
+     * @param mu_x_px Reference to the variable storing the correlation coefficient between the x position and the x momentum.
+     * @param mu_y_py Reference to the variable storing the correlation coefficient between the y position and the y momentum.
+     * @param mu_t_pt Reference to the variable storing the correlation coefficient between the t position and the t momentum.
+     * @param mean_x Reference to the variable storing the mean for position in the x direction.
+     * @param mean_y Reference to the variable storing the mean for position in the y direction.
+     * @param mean_t Reference to the variable storing the mean for position in the t direction.
+     * @param mean_px Reference to the variable storing the mean for momentum in the x direction.
+     * @param mean_py Reference to the variable storing the mean for momentum in the y direction.
+     * @param mean_pt Reference to the variable storing the mean for momentum in the t direction.
+     * @param dispersion_x Reference to the variable storing the beam-based dispersion in the x direction.
+     * @param dispersion_px Reference to the variable storing the derivative of the beam-based dispersion in the x direction.
+     * @param dispersion_y Reference to the variable storing the beam-based dispersion in the y direction.
+     * @param dispersion_py Reference to the variable storing the derivative of the beam-based dispersion in the y direction.
      */
     void
     set_distribution_parameters_from_twiss_inputs (
         amrex::ParmParse const & pp_dist,
-        amrex::ParticleReal& lambdax, amrex::ParticleReal& lambday, amrex::ParticleReal& lambdat,
-        amrex::ParticleReal& lambdapx,amrex::ParticleReal& lambdapy, amrex::ParticleReal& lambdapt,
-        amrex::ParticleReal& muxpx, amrex::ParticleReal& muypy, amrex::ParticleReal& mutpt,
-        amrex::ParticleReal& meanx, amrex::ParticleReal& meany, amrex::ParticleReal& meant,
-        amrex::ParticleReal& meanpx, amrex::ParticleReal& meanpy, amrex::ParticleReal& meanpt,
-        amrex::ParticleReal& dispx, amrex::ParticleReal& disppx, amrex::ParticleReal& dispy, amrex::ParticleReal& disppy
+        amrex::ParticleReal& lambda_x, amrex::ParticleReal& lambda_y, amrex::ParticleReal& lambda_t,
+        amrex::ParticleReal& lambda_px,amrex::ParticleReal& lambda_py, amrex::ParticleReal& lambda_pt,
+        amrex::ParticleReal& mu_x_px, amrex::ParticleReal& mu_y_py, amrex::ParticleReal& mu_t_pt,
+        amrex::ParticleReal& mean_x, amrex::ParticleReal& mean_y, amrex::ParticleReal& mean_t,
+        amrex::ParticleReal& mean_px, amrex::ParticleReal& mean_py, amrex::ParticleReal& mean_pt,
+        amrex::ParticleReal& dispersion_x, amrex::ParticleReal& dispersion_px, amrex::ParticleReal& dispersion_y, amrex::ParticleReal& dispersion_py
     );
 
 }  // namespace impactx::initialization

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -236,15 +236,15 @@ namespace impactx
             {
                 throw std::runtime_error("Empty and Thermal type cannot create Covariance matrices!");
             } else {
-                amrex::ParticleReal lambdaX = distribution.m_lambdaX;
-                amrex::ParticleReal lambdaY = distribution.m_lambdaY;
-                amrex::ParticleReal lambdaT = distribution.m_lambdaT;
-                amrex::ParticleReal lambdaPx = distribution.m_lambdaPx;
-                amrex::ParticleReal lambdaPy = distribution.m_lambdaPy;
-                amrex::ParticleReal lambdaPt = distribution.m_lambdaPt;
-                amrex::ParticleReal muxpx = distribution.m_muxpx;
-                amrex::ParticleReal muypy = distribution.m_muypy;
-                amrex::ParticleReal mutpt = distribution.m_mutpt;
+                amrex::ParticleReal lambdaX = distribution.m_lambda_x;
+                amrex::ParticleReal lambdaY = distribution.m_lambda_y;
+                amrex::ParticleReal lambdaT = distribution.m_lambda_t;
+                amrex::ParticleReal lambdaPx = distribution.m_lambda_px;
+                amrex::ParticleReal lambdaPy = distribution.m_lambda_py;
+                amrex::ParticleReal lambdaPt = distribution.m_lambda_pt;
+                amrex::ParticleReal muxpx = distribution.m_mu_x_px;
+                amrex::ParticleReal muypy = distribution.m_mu_y_py;
+                amrex::ParticleReal mutpt = distribution.m_mu_t_pt;
 
                 // use distribution inputs to populate a 6x6 covariance matrix
                 amrex::ParticleReal denom_x = 1.0 - muxpx*muxpx;

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -67,8 +67,8 @@ namespace detail
         pp_element.getWithParser("ds", ds);
         pp_element.queryAddWithParser("nslice", nslice);
 
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nslice > 0,
-                                         pp_element.getPrefix() + ".nslice must be > 0.");
+        //AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nslice > 0,
+        //                                 pp_element.getPrefix() + ".nslice must be > 0.");
 
         return {ds, nslice};
     }

--- a/src/particles/distribution/Empty.H
+++ b/src/particles/distribution/Empty.H
@@ -22,7 +22,7 @@ namespace impactx::distribution
     {
         /** This distribution sets all values to zero.
          */
-        Empty()
+        Empty ()
         {
         }
 

--- a/src/particles/distribution/Gaussian.H
+++ b/src/particles/distribution/Gaussian.H
@@ -28,39 +28,39 @@ namespace impactx::distribution
          *
          * Return sampling from a 6D Gaussian distribution.
          *
-         * @param lambdax,lambday,lambdat phase space axis intercepts (position);
-         *                                for zero correlation, these are the related RMS sizes (in meters)
-         * @param lambdapx,lambdapy,lambdapt phase space axis intercepts (momentum)
-         * @param muxpx,muypy,mutpt correlation length-momentum
-         * @param meanx,meany,meant offsets of the mean (centroid) positions from those of the reference particle
-         * @param meanpx,meanpy,meanpt offsets of the mean (centroid) momenta from those of the reference particle
-         * @param dispx,disppx,dispy,disppy dispersion and its derivative in horizontal and vertical directions
+         * @param lambda_x,lambda_y,lambda_t phase space axis intercepts (position);
+         *                                   for zero correlation, these are the related RMS sizes (in meters)
+         * @param lambda_px,lambda_py,lambda_pt phase space axis intercepts (momentum)
+         * @param mu_x_px,mu_y_py,mu_t_pt correlation length-momentum
+         * @param mean_x,mean_y,mean_t offsets of the mean (centroid) positions from those of the reference particle
+         * @param mean_px,mean_py,mean_pt offsets of the mean (centroid) momenta from those of the reference particle
+         * @param dispersion_x,dispersion_px,dispersion_y,dispersion_py dispersion and its derivative in horizontal and vertical directions
          */
         Gaussian (
-            amrex::ParticleReal lambdax,
-            amrex::ParticleReal lambday,
-            amrex::ParticleReal lambdat,
-            amrex::ParticleReal lambdapx,
-            amrex::ParticleReal lambdapy,
-            amrex::ParticleReal lambdapt,
-            amrex::ParticleReal muxpx=0.0,
-            amrex::ParticleReal muypy=0.0,
-            amrex::ParticleReal mutpt=0.0,
-            amrex::ParticleReal meanx=0.0,
-            amrex::ParticleReal meany=0.0,
-            amrex::ParticleReal meant=0.0,
-            amrex::ParticleReal meanpx=0.0,
-            amrex::ParticleReal meanpy=0.0,
-            amrex::ParticleReal meanpt=0.0,
-            amrex::ParticleReal dispx=0.0,
-            amrex::ParticleReal disppx=0.0,
-            amrex::ParticleReal dispy=0.0,
-            amrex::ParticleReal disppy=0.0
+            amrex::ParticleReal lambda_x,
+            amrex::ParticleReal lambda_y,
+            amrex::ParticleReal lambda_t,
+            amrex::ParticleReal lambda_px,
+            amrex::ParticleReal lambda_py,
+            amrex::ParticleReal lambda_pt,
+            amrex::ParticleReal mu_x_px=0.0,
+            amrex::ParticleReal mu_y_py=0.0,
+            amrex::ParticleReal mu_t_pt=0.0,
+            amrex::ParticleReal mean_x=0.0,
+            amrex::ParticleReal mean_y=0.0,
+            amrex::ParticleReal mean_t=0.0,
+            amrex::ParticleReal mean_px=0.0,
+            amrex::ParticleReal mean_py=0.0,
+            amrex::ParticleReal mean_pt=0.0,
+            amrex::ParticleReal dispersion_x=0.0,
+            amrex::ParticleReal dispersion_px=0.0,
+            amrex::ParticleReal dispersion_y=0.0,
+            amrex::ParticleReal dispersion_py=0.0
         )
-        : m_lambdaX(lambdax), m_lambdaY(lambday), m_lambdaT(lambdat), m_lambdaPx(lambdapx), m_lambdaPy(lambdapy),
-          m_lambdaPt(lambdapt), m_muxpx(muxpx), m_muypy(muypy), m_mutpt(mutpt), m_meanx(meanx), m_meany(meany),
-          m_meant(meant), m_meanpx(meanpx), m_meanpy(meanpy), m_meanpt(meanpt), m_dispx(dispx), m_disppx(disppx),
-          m_dispy(dispy), m_disppy(disppy)
+        : m_lambda_x(lambda_x), m_lambda_y(lambda_y), m_lambda_t(lambda_t), m_lambda_px(lambda_px), m_lambda_py(lambda_py),
+          m_lambda_pt(lambda_pt), m_mu_x_px(mu_x_px), m_mu_y_py(mu_y_py), m_mu_t_pt(mu_t_pt), m_mean_x(mean_x), m_mean_y(mean_y),
+          m_mean_t(mean_t), m_mean_px(mean_px), m_mean_py(mean_py), m_mean_pt(mean_pt), m_dispersion_x(dispersion_x), m_dispersion_px(dispersion_px),
+          m_dispersion_y(dispersion_y), m_dispersion_py(dispersion_py)
         {
         }
 
@@ -132,43 +132,43 @@ namespace impactx::distribution
             pt = ln1 * std::sin(2_prt*pi*u2);
 
             // Transform to produce the desired second moments/correlations:
-            root = std::sqrt(1.0_prt-m_muxpx*m_muxpx);
-            a1 = m_lambdaX * x / root;
-            a2 = m_lambdaPx * (-m_muxpx * x / root + px);
+            root = std::sqrt(1.0_prt-m_mu_x_px*m_mu_x_px);
+            a1 = m_lambda_x * x / root;
+            a2 = m_lambda_px * (-m_mu_x_px * x / root + px);
             x = a1;
             px = a2;
-            root = std::sqrt(1.0_prt-m_muypy*m_muypy);
-            a1 = m_lambdaY * y / root;
-            a2 = m_lambdaPy * (-m_muypy * y / root + py);
+            root = std::sqrt(1.0_prt-m_mu_y_py*m_mu_y_py);
+            a1 = m_lambda_y * y / root;
+            a2 = m_lambda_py * (-m_mu_y_py * y / root + py);
             y = a1;
             py = a2;
-            root = std::sqrt(1.0_prt-m_mutpt*m_mutpt);
-            a1 = m_lambdaT * t / root;
-            a2 = m_lambdaPt * (-m_mutpt * t / root + pt);
+            root = std::sqrt(1.0_prt-m_mu_t_pt*m_mu_t_pt);
+            a1 = m_lambda_t * t / root;
+            a2 = m_lambda_pt * (-m_mu_t_pt * t / root + pt);
             t = a1;
             pt = a2;
 
             // Apply dispersive correlations
-            x = x - m_dispx * pt;
-            px = px - m_disppx * pt;
-            y = y - m_dispy * pt;
-            py = py - m_disppy * pt;
+            x = x - m_dispersion_x * pt;
+            px = px - m_dispersion_px * pt;
+            y = y - m_dispersion_y * pt;
+            py = py - m_dispersion_py * pt;
 
             // Apply centroid translation
-            x = x + m_meanx;
-            px = px + m_meanpx;
-            y = y + m_meany;
-            py = py + m_meanpy;
-            t = t + m_meant;
-            pt = pt + m_meanpt;
+            x = x + m_mean_x;
+            px = px + m_mean_px;
+            y = y + m_mean_y;
+            py = py + m_mean_py;
+            t = t + m_mean_t;
+            pt = pt + m_mean_pt;
         }
 
-        amrex::ParticleReal m_lambdaX, m_lambdaY, m_lambdaT;  //! related position axis intercepts (length) of the phase space ellipse
-        amrex::ParticleReal m_lambdaPx, m_lambdaPy, m_lambdaPt;  //! related momentum axis intercepts of the phase space ellipse
-        amrex::ParticleReal m_muxpx, m_muypy, m_mutpt;  //! correlation length-momentum
-        amrex::ParticleReal m_meanx, m_meany, m_meant;  //! spatial coordinates of centroid offset
-        amrex::ParticleReal m_meanpx, m_meanpy, m_meanpt;  //! momentum coordinates of centroid offset
-        amrex::ParticleReal m_dispx, m_disppx, m_dispy, m_disppy;  //! dispersion and its derivative
+        amrex::ParticleReal m_lambda_x, m_lambda_y, m_lambda_t;  //! related position axis intercepts (length) of the phase space ellipse
+        amrex::ParticleReal m_lambda_px, m_lambda_py, m_lambda_pt;  //! related momentum axis intercepts of the phase space ellipse
+        amrex::ParticleReal m_mu_x_px, m_mu_y_py, m_mu_t_pt;  //! correlation length-momentum
+        amrex::ParticleReal m_mean_x, m_mean_y, m_mean_t;  //! spatial coordinates of centroid offset
+        amrex::ParticleReal m_mean_px, m_mean_py, m_mean_pt;  //! momentum coordinates of centroid offset
+        amrex::ParticleReal m_dispersion_x, m_dispersion_px, m_dispersion_y, m_dispersion_py;  //! dispersion and its derivative
     };
 
 } // namespace impactx::distribution

--- a/src/particles/distribution/KVdist.H
+++ b/src/particles/distribution/KVdist.H
@@ -30,39 +30,39 @@ namespace impactx::distribution
          *
          * Return sampling from a K-V + uniform distribution.
          *
-         * @param lambdax,lambday,lambdat for zero correlation, these are the related
+         * @param lambda_x,lambda_y,lambda_t for zero correlation, these are the related
          *                                   RMS sizes (in meters)
-         * @param lambdapx,lambdapy,lambdapt RMS momentum
-         * @param muxpx,muypy,mutpt correlation length-momentum
-         * @param meanx,meany,meant offsets of the mean (centroid) positions from those of the reference particle
-         * @param meanpx,meanpy,meanpt offsets of the mean (centroid) momenta from those of the reference particle
-         * @param dispx,disppx,dispy,disppy dispersion and its derivative in horizontal and vertical directions
+         * @param lambda_px,lambda_py,lambda_pt RMS momentum
+         * @param mu_x_px,mu_y_py,mu_t_pt correlation length-momentum
+         * @param mean_x,mean_y,mean_t offsets of the mean (centroid) positions from those of the reference particle
+         * @param mean_px,mean_py,mean_pt offsets of the mean (centroid) momenta from those of the reference particle
+         * @param dispersion_x,dispersion_px,dispersion_y,dispersion_py dispersion and its derivative in horizontal and vertical directions
          */
         KVdist (
-            amrex::ParticleReal lambdax,
-            amrex::ParticleReal lambday,
-            amrex::ParticleReal lambdat,
-            amrex::ParticleReal lambdapx,
-            amrex::ParticleReal lambdapy,
-            amrex::ParticleReal lambdapt,
-            amrex::ParticleReal muxpx=0.0,
-            amrex::ParticleReal muypy=0.0,
-            amrex::ParticleReal mutpt=0.0,
-            amrex::ParticleReal meanx=0.0,
-            amrex::ParticleReal meany=0.0,
-            amrex::ParticleReal meant=0.0,
-            amrex::ParticleReal meanpx=0.0,
-            amrex::ParticleReal meanpy=0.0,
-            amrex::ParticleReal meanpt=0.0,
-            amrex::ParticleReal dispx=0.0,
-            amrex::ParticleReal disppx=0.0,
-            amrex::ParticleReal dispy=0.0,
-            amrex::ParticleReal disppy=0.0
+            amrex::ParticleReal lambda_x,
+            amrex::ParticleReal lambda_y,
+            amrex::ParticleReal lambda_t,
+            amrex::ParticleReal lambda_px,
+            amrex::ParticleReal lambda_py,
+            amrex::ParticleReal lambda_pt,
+            amrex::ParticleReal mu_x_px=0.0,
+            amrex::ParticleReal mu_y_py=0.0,
+            amrex::ParticleReal mu_t_pt=0.0,
+            amrex::ParticleReal mean_x=0.0,
+            amrex::ParticleReal mean_y=0.0,
+            amrex::ParticleReal mean_t=0.0,
+            amrex::ParticleReal mean_px=0.0,
+            amrex::ParticleReal mean_py=0.0,
+            amrex::ParticleReal mean_pt=0.0,
+            amrex::ParticleReal dispersion_x=0.0,
+            amrex::ParticleReal dispersion_px=0.0,
+            amrex::ParticleReal dispersion_y=0.0,
+            amrex::ParticleReal dispersion_py=0.0
         )
-        : m_lambdaX(lambdax), m_lambdaY(lambday), m_lambdaT(lambdat), m_lambdaPx(lambdapx), m_lambdaPy(lambdapy),
-          m_lambdaPt(lambdapt), m_muxpx(muxpx), m_muypy(muypy), m_mutpt(mutpt), m_meanx(meanx), m_meany(meany),
-          m_meant(meant), m_meanpx(meanpx), m_meanpy(meanpy), m_meanpt(meanpt), m_dispx(dispx), m_disppx(disppx),
-          m_dispy(dispy), m_disppy(disppy)
+        : m_lambda_x(lambda_x), m_lambda_y(lambda_y), m_lambda_t(lambda_t), m_lambda_px(lambda_px), m_lambda_py(lambda_py),
+          m_lambda_pt(lambda_pt), m_mu_x_px(mu_x_px), m_mu_y_py(mu_y_py), m_mu_t_pt(mu_t_pt), m_mean_x(mean_x), m_mean_y(mean_y),
+          m_mean_t(mean_t), m_mean_px(mean_px), m_mean_py(mean_py), m_mean_pt(mean_pt), m_dispersion_x(dispersion_x), m_dispersion_px(dispersion_px),
+          m_dispersion_y(dispersion_y), m_dispersion_py(dispersion_py)
         {
         }
 
@@ -147,43 +147,43 @@ namespace impactx::distribution
             // pt = pt;
 
             // Transform to produce the desired second moments/correlations:
-            root = std::sqrt(1.0_prt-m_muxpx*m_muxpx);
-            a1 = m_lambdaX * x / root;
-            a2 = m_lambdaPx * (-m_muxpx * x / root + px);
+            root = std::sqrt(1.0_prt-m_mu_x_px*m_mu_x_px);
+            a1 = m_lambda_x * x / root;
+            a2 = m_lambda_px * (-m_mu_x_px * x / root + px);
             x = a1;
             px = a2;
-            root = std::sqrt(1.0_prt-m_muypy*m_muypy);
-            a1 = m_lambdaY * y / root;
-            a2 = m_lambdaPy * (-m_muypy * y / root + py);
+            root = std::sqrt(1.0_prt-m_mu_y_py*m_mu_y_py);
+            a1 = m_lambda_y * y / root;
+            a2 = m_lambda_py * (-m_mu_y_py * y / root + py);
             y = a1;
             py = a2;
-            root = std::sqrt(1.0_prt-m_mutpt*m_mutpt);
-            a1 = m_lambdaT * t / root;
-            a2 = m_lambdaPt * (-m_mutpt * t / root + pt);
+            root = std::sqrt(1.0_prt-m_mu_t_pt*m_mu_t_pt);
+            a1 = m_lambda_t * t / root;
+            a2 = m_lambda_pt * (-m_mu_t_pt * t / root + pt);
             t = a1;
             pt = a2;
 
             // Apply dispersive correlations
-            x = x - m_dispx * pt;
-            px = px - m_disppx * pt;
-            y = y - m_dispy * pt;
-            py = py - m_disppy * pt;
+            x = x - m_dispersion_x * pt;
+            px = px - m_dispersion_px * pt;
+            y = y - m_dispersion_y * pt;
+            py = py - m_dispersion_py * pt;
 
             // Apply centroid translation
-            x = x + m_meanx;
-            px = px + m_meanpx;
-            y = y + m_meany;
-            py = py + m_meanpy;
-            t = t + m_meant;
-            pt = pt + m_meanpt;
+            x = x + m_mean_x;
+            px = px + m_mean_px;
+            y = y + m_mean_y;
+            py = py + m_mean_py;
+            t = t + m_mean_t;
+            pt = pt + m_mean_pt;
         }
 
-        amrex::ParticleReal m_lambdaX, m_lambdaY, m_lambdaT;  //! related position axis intercepts (length) of the phase space ellipse
-        amrex::ParticleReal m_lambdaPx, m_lambdaPy, m_lambdaPt;  //! related momentum axis intercepts of the phase space ellipse
-        amrex::ParticleReal m_muxpx, m_muypy, m_mutpt;  //! correlation length-momentum
-        amrex::ParticleReal m_meanx, m_meany, m_meant;  //! spatial coordinates of centroid offset
-        amrex::ParticleReal m_meanpx, m_meanpy, m_meanpt;  //! momentum coordinates of centroid offset
-        amrex::ParticleReal m_dispx, m_disppx, m_dispy, m_disppy;  //! dispersion and its derivative
+        amrex::ParticleReal m_lambda_x, m_lambda_y, m_lambda_t;  //! related position axis intercepts (length) of the phase space ellipse
+        amrex::ParticleReal m_lambda_px, m_lambda_py, m_lambda_pt;  //! related momentum axis intercepts of the phase space ellipse
+        amrex::ParticleReal m_mu_x_px, m_mu_y_py, m_mu_t_pt;  //! correlation length-momentum
+        amrex::ParticleReal m_mean_x, m_mean_y, m_mean_t;  //! spatial coordinates of centroid offset
+        amrex::ParticleReal m_mean_px, m_mean_py, m_mean_pt;  //! momentum coordinates of centroid offset
+        amrex::ParticleReal m_dispersion_x, m_dispersion_px, m_dispersion_y, m_dispersion_py;  //! dispersion and its derivative
     };
 
 } // namespace impactx::distribution

--- a/src/particles/distribution/Kurth4D.H
+++ b/src/particles/distribution/Kurth4D.H
@@ -30,39 +30,39 @@ namespace impactx::distribution
          *
          * Return sampling from a 4D Kurth + uniform distribution.
          *
-         * @param lambdax,lambday,lambdat for zero correlation, these are the related
+         * @param lambda_x,lambda_y,lambda_t for zero correlation, these are the related
          *                                   RMS sizes (in meters)
-         * @param lambdapx,lambdapy,lambdapt RMS momentum
-         * @param muxpx,muypy,mutpt correlation length-momentum
-         * @param meanx,meany,meant offsets of the mean (centroid) positions from those of the reference particle
-         * @param meanpx,meanpy,meanpt offsets of the mean (centroid) momenta from those of the reference particle
-         * @param dispx,disppx,dispy,disppy dispersion and its derivative in horizontal and vertical directions
+         * @param lambda_px,lambda_py,lambda_pt RMS momentum
+         * @param mu_x_px,mu_y_py,mu_t_pt correlation length-momentum
+         * @param mean_x,mean_y,mean_t offsets of the mean (centroid) positions from those of the reference particle
+         * @param mean_px,mean_py,mean_pt offsets of the mean (centroid) momenta from those of the reference particle
+         * @param dispersion_x,dispersion_px,dispersion_y,dispersion_py dispersion and its derivative in horizontal and vertical directions
          */
         Kurth4D (
-            amrex::ParticleReal lambdax,
-            amrex::ParticleReal lambday,
-            amrex::ParticleReal lambdat,
-            amrex::ParticleReal lambdapx,
-            amrex::ParticleReal lambdapy,
-            amrex::ParticleReal lambdapt,
-            amrex::ParticleReal muxpx=0.0,
-            amrex::ParticleReal muypy=0.0,
-            amrex::ParticleReal mutpt=0.0,
-            amrex::ParticleReal meanx=0.0,
-            amrex::ParticleReal meany=0.0,
-            amrex::ParticleReal meant=0.0,
-            amrex::ParticleReal meanpx=0.0,
-            amrex::ParticleReal meanpy=0.0,
-            amrex::ParticleReal meanpt=0.0,
-            amrex::ParticleReal dispx=0.0,
-            amrex::ParticleReal disppx=0.0,
-            amrex::ParticleReal dispy=0.0,
-            amrex::ParticleReal disppy=0.0
+            amrex::ParticleReal lambda_x,
+            amrex::ParticleReal lambda_y,
+            amrex::ParticleReal lambda_t,
+            amrex::ParticleReal lambda_px,
+            amrex::ParticleReal lambda_py,
+            amrex::ParticleReal lambda_pt,
+            amrex::ParticleReal mu_x_px=0.0,
+            amrex::ParticleReal mu_y_py=0.0,
+            amrex::ParticleReal mu_t_pt=0.0,
+            amrex::ParticleReal mean_x=0.0,
+            amrex::ParticleReal mean_y=0.0,
+            amrex::ParticleReal mean_t=0.0,
+            amrex::ParticleReal mean_px=0.0,
+            amrex::ParticleReal mean_py=0.0,
+            amrex::ParticleReal mean_pt=0.0,
+            amrex::ParticleReal dispersion_x=0.0,
+            amrex::ParticleReal dispersion_px=0.0,
+            amrex::ParticleReal dispersion_y=0.0,
+            amrex::ParticleReal dispersion_py=0.0
         )
-        : m_lambdaX(lambdax), m_lambdaY(lambday), m_lambdaT(lambdat), m_lambdaPx(lambdapx), m_lambdaPy(lambdapy),
-          m_lambdaPt(lambdapt), m_muxpx(muxpx), m_muypy(muypy), m_mutpt(mutpt), m_meanx(meanx), m_meany(meany),
-          m_meant(meant), m_meanpx(meanpx), m_meanpy(meanpy), m_meanpt(meanpt), m_dispx(dispx), m_disppx(disppx),
-          m_dispy(dispy), m_disppy(disppy)
+        : m_lambda_x(lambda_x), m_lambda_y(lambda_y), m_lambda_t(lambda_t), m_lambda_px(lambda_px), m_lambda_py(lambda_py),
+          m_lambda_pt(lambda_pt), m_mu_x_px(mu_x_px), m_mu_y_py(mu_y_py), m_mu_t_pt(mu_t_pt), m_mean_x(mean_x), m_mean_y(mean_y),
+          m_mean_t(mean_t), m_mean_px(mean_px), m_mean_py(mean_py), m_mean_pt(mean_pt), m_dispersion_x(dispersion_x), m_dispersion_px(dispersion_px),
+          m_dispersion_y(dispersion_y), m_dispersion_py(dispersion_py)
         {
         }
 
@@ -157,43 +157,43 @@ namespace impactx::distribution
             // pt = pt;
 
             // Transform to produce the desired second moments/correlations:
-            root = std::sqrt(1.0_prt-m_muxpx*m_muxpx);
-            a1 = m_lambdaX * x / root;
-            a2 = m_lambdaPx * (-m_muxpx * x / root + px);
+            root = std::sqrt(1.0_prt-m_mu_x_px*m_mu_x_px);
+            a1 = m_lambda_x * x / root;
+            a2 = m_lambda_px * (-m_mu_x_px * x / root + px);
             x = a1;
             px = a2;
-            root = std::sqrt(1.0_prt-m_muypy*m_muypy);
-            a1 = m_lambdaY * y / root;
-            a2 = m_lambdaPy * (-m_muypy * y / root + py);
+            root = std::sqrt(1.0_prt-m_mu_y_py*m_mu_y_py);
+            a1 = m_lambda_y * y / root;
+            a2 = m_lambda_py * (-m_mu_y_py * y / root + py);
             y = a1;
             py = a2;
-            root = std::sqrt(1.0_prt-m_mutpt*m_mutpt);
-            a1 = m_lambdaT * t / root;
-            a2 = m_lambdaPt * (-m_mutpt * t / root + pt);
+            root = std::sqrt(1.0_prt-m_mu_t_pt*m_mu_t_pt);
+            a1 = m_lambda_t * t / root;
+            a2 = m_lambda_pt * (-m_mu_t_pt * t / root + pt);
             t = a1;
             pt = a2;
 
             // Apply dispersive correlations
-            x = x - m_dispx * pt;
-            px = px - m_disppx * pt;
-            y = y - m_dispy * pt;
-            py = py - m_disppy * pt;
+            x = x - m_dispersion_x * pt;
+            px = px - m_dispersion_px * pt;
+            y = y - m_dispersion_y * pt;
+            py = py - m_dispersion_py * pt;
 
             // Apply centroid translation
-            x = x + m_meanx;
-            px = px + m_meanpx;
-            y = y + m_meany;
-            py = py + m_meanpy;
-            t = t + m_meant;
-            pt = pt + m_meanpt;
+            x = x + m_mean_x;
+            px = px + m_mean_px;
+            y = y + m_mean_y;
+            py = py + m_mean_py;
+            t = t + m_mean_t;
+            pt = pt + m_mean_pt;
         }
 
-        amrex::ParticleReal m_lambdaX, m_lambdaY, m_lambdaT;  //! related position axis intercepts (length) of the phase space ellipse
-        amrex::ParticleReal m_lambdaPx, m_lambdaPy, m_lambdaPt;  //! related momentum axis intercepts of the phase space ellipse
-        amrex::ParticleReal m_muxpx, m_muypy, m_mutpt;  //! correlation length-momentum
-        amrex::ParticleReal m_meanx, m_meany, m_meant;  //! spatial coordinates of centroid offset
-        amrex::ParticleReal m_meanpx, m_meanpy, m_meanpt;  //! momentum coordinates of centroid offset
-        amrex::ParticleReal m_dispx, m_disppx, m_dispy, m_disppy;  //! dispersion and its derivative
+        amrex::ParticleReal m_lambda_x, m_lambda_y, m_lambda_t;  //! related position axis intercepts (length) of the phase space ellipse
+        amrex::ParticleReal m_lambda_px, m_lambda_py, m_lambda_pt;  //! related momentum axis intercepts of the phase space ellipse
+        amrex::ParticleReal m_mu_x_px, m_mu_y_py, m_mu_t_pt;  //! correlation length-momentum
+        amrex::ParticleReal m_mean_x, m_mean_y, m_mean_t;  //! spatial coordinates of centroid offset
+        amrex::ParticleReal m_mean_px, m_mean_py, m_mean_pt;  //! momentum coordinates of centroid offset
+        amrex::ParticleReal m_dispersion_x, m_dispersion_px, m_dispersion_y, m_dispersion_py;  //! dispersion and its derivative
     };
 
 } // namespace impactx::distribution

--- a/src/particles/distribution/Kurth6D.H
+++ b/src/particles/distribution/Kurth6D.H
@@ -32,39 +32,39 @@ namespace impactx::distribution
          * R. Kurth, Quarterly of Applied Mathematics vol. 32, pp. 325-329 (1978)
          * C. Mitchell, K. Hwang and R. D. Ryne, IPAC2021, WEPAB248 (2021)
          *
-         * @param lambdax,lambday,lambdat for zero correlation, these are the related
+         * @param lambda_x,lambda_y,lambda_t for zero correlation, these are the related
          *                                   RMS sizes (in meters)
-         * @param lambdapx,lambdapy,lambdapt RMS momentum
-         * @param muxpx,muypy,mutpt correlation length-momentum
-         * @param meanx,meany,meant offsets of the mean (centroid) positions from those of the reference particle
-         * @param meanpx,meanpy,meanpt offsets of the mean (centroid) momenta from those of the reference particle
-         * @param dispx,disppx,dispy,disppy dispersion and its derivative in horizontal and vertical directions
+         * @param lambda_px,lambda_py,lambda_pt RMS momentum
+         * @param mu_x_px,mu_y_py,mu_t_pt correlation length-momentum
+         * @param mean_x,mean_y,mean_t offsets of the mean (centroid) positions from those of the reference particle
+         * @param mean_px,mean_py,mean_pt offsets of the mean (centroid) momenta from those of the reference particle
+         * @param dispersion_x,dispersion_px,dispersion_y,dispersion_py dispersion and its derivative in horizontal and vertical directions
          */
         Kurth6D (
-            amrex::ParticleReal lambdax,
-            amrex::ParticleReal lambday,
-            amrex::ParticleReal lambdat,
-            amrex::ParticleReal lambdapx,
-            amrex::ParticleReal lambdapy,
-            amrex::ParticleReal lambdapt,
-            amrex::ParticleReal muxpx=0.0,
-            amrex::ParticleReal muypy=0.0,
-            amrex::ParticleReal mutpt=0.0,
-            amrex::ParticleReal meanx=0.0,
-            amrex::ParticleReal meany=0.0,
-            amrex::ParticleReal meant=0.0,
-            amrex::ParticleReal meanpx=0.0,
-            amrex::ParticleReal meanpy=0.0,
-            amrex::ParticleReal meanpt=0.0,
-            amrex::ParticleReal dispx=0.0,
-            amrex::ParticleReal disppx=0.0,
-            amrex::ParticleReal dispy=0.0,
-            amrex::ParticleReal disppy=0.0
+            amrex::ParticleReal lambda_x,
+            amrex::ParticleReal lambda_y,
+            amrex::ParticleReal lambda_t,
+            amrex::ParticleReal lambda_px,
+            amrex::ParticleReal lambda_py,
+            amrex::ParticleReal lambda_pt,
+            amrex::ParticleReal mu_x_px=0.0,
+            amrex::ParticleReal mu_y_py=0.0,
+            amrex::ParticleReal mu_t_pt=0.0,
+            amrex::ParticleReal mean_x=0.0,
+            amrex::ParticleReal mean_y=0.0,
+            amrex::ParticleReal mean_t=0.0,
+            amrex::ParticleReal mean_px=0.0,
+            amrex::ParticleReal mean_py=0.0,
+            amrex::ParticleReal mean_pt=0.0,
+            amrex::ParticleReal dispersion_x=0.0,
+            amrex::ParticleReal dispersion_px=0.0,
+            amrex::ParticleReal dispersion_y=0.0,
+            amrex::ParticleReal dispersion_py=0.0
         )
-        : m_lambdaX(lambdax), m_lambdaY(lambday), m_lambdaT(lambdat), m_lambdaPx(lambdapx), m_lambdaPy(lambdapy),
-          m_lambdaPt(lambdapt), m_muxpx(muxpx), m_muypy(muypy), m_mutpt(mutpt), m_meanx(meanx), m_meany(meany),
-          m_meant(meant), m_meanpx(meanpx), m_meanpy(meanpy), m_meanpt(meanpt), m_dispx(dispx), m_disppx(disppx),
-          m_dispy(dispy), m_disppy(disppy)
+        : m_lambda_x(lambda_x), m_lambda_y(lambda_y), m_lambda_t(lambda_t), m_lambda_px(lambda_px), m_lambda_py(lambda_py),
+          m_lambda_pt(lambda_pt), m_mu_x_px(mu_x_px), m_mu_y_py(mu_y_py), m_mu_t_pt(mu_t_pt), m_mean_x(mean_x), m_mean_y(mean_y),
+          m_mean_t(mean_t), m_mean_px(mean_px), m_mean_py(mean_py), m_mean_pt(mean_pt), m_dispersion_x(dispersion_x), m_dispersion_px(dispersion_px),
+          m_dispersion_y(dispersion_y), m_dispersion_py(dispersion_py)
         {
         }
 
@@ -163,43 +163,43 @@ namespace impactx::distribution
             pt = c*pt;
 
             // Transform to produce the desired second moments/correlations:
-            root = std::sqrt(1.0_prt-m_muxpx*m_muxpx);
-            a1 = m_lambdaX * x / root;
-            a2 = m_lambdaPx * (-m_muxpx * x / root + px);
+            root = std::sqrt(1.0_prt-m_mu_x_px*m_mu_x_px);
+            a1 = m_lambda_x * x / root;
+            a2 = m_lambda_px * (-m_mu_x_px * x / root + px);
             x = a1;
             px = a2;
-            root = std::sqrt(1.0_prt-m_muypy*m_muypy);
-            a1 = m_lambdaY * y / root;
-            a2 = m_lambdaPy * (-m_muypy * y / root + py);
+            root = std::sqrt(1.0_prt-m_mu_y_py*m_mu_y_py);
+            a1 = m_lambda_y * y / root;
+            a2 = m_lambda_py * (-m_mu_y_py * y / root + py);
             y = a1;
             py = a2;
-            root = std::sqrt(1.0_prt-m_mutpt*m_mutpt);
-            a1 = m_lambdaT * t / root;
-            a2 = m_lambdaPt * (-m_mutpt * t / root + pt);
+            root = std::sqrt(1.0_prt-m_mu_t_pt*m_mu_t_pt);
+            a1 = m_lambda_t * t / root;
+            a2 = m_lambda_pt * (-m_mu_t_pt * t / root + pt);
             t = a1;
             pt = a2;
 
             // Apply dispersive correlations
-            x = x - m_dispx * pt;
-            px = px - m_disppx * pt;
-            y = y - m_dispy * pt;
-            py = py - m_disppy * pt;
+            x = x - m_dispersion_x * pt;
+            px = px - m_dispersion_px * pt;
+            y = y - m_dispersion_y * pt;
+            py = py - m_dispersion_py * pt;
 
             // Apply centroid translation
-            x = x + m_meanx;
-            px = px + m_meanpx;
-            y = y + m_meany;
-            py = py + m_meanpy;
-            t = t + m_meant;
-            pt = pt + m_meanpt;
+            x = x + m_mean_x;
+            px = px + m_mean_px;
+            y = y + m_mean_y;
+            py = py + m_mean_py;
+            t = t + m_mean_t;
+            pt = pt + m_mean_pt;
         }
 
-        amrex::ParticleReal m_lambdaX, m_lambdaY, m_lambdaT;  //! related position axis intercepts (length) of the phase space ellipse
-        amrex::ParticleReal m_lambdaPx, m_lambdaPy, m_lambdaPt;  //! related momentum axis intercepts of the phase space ellipse
-        amrex::ParticleReal m_muxpx, m_muypy, m_mutpt;  //! correlation length-momentum
-        amrex::ParticleReal m_meanx, m_meany, m_meant;  //! spatial coordinates of centroid offset
-        amrex::ParticleReal m_meanpx, m_meanpy, m_meanpt;  //! momentum coordinates of centroid offset
-        amrex::ParticleReal m_dispx, m_disppx, m_dispy, m_disppy;  //! dispersion and its derivative
+        amrex::ParticleReal m_lambda_x, m_lambda_y, m_lambda_t;  //! related position axis intercepts (length) of the phase space ellipse
+        amrex::ParticleReal m_lambda_px, m_lambda_py, m_lambda_pt;  //! related momentum axis intercepts of the phase space ellipse
+        amrex::ParticleReal m_mu_x_px, m_mu_y_py, m_mu_t_pt;  //! correlation length-momentum
+        amrex::ParticleReal m_mean_x, m_mean_y, m_mean_t;  //! spatial coordinates of centroid offset
+        amrex::ParticleReal m_mean_px, m_mean_py, m_mean_pt;  //! momentum coordinates of centroid offset
+        amrex::ParticleReal m_dispersion_x, m_dispersion_px, m_dispersion_y, m_dispersion_py;  //! dispersion and its derivative
     };
 
 } // namespace impactx::distribution

--- a/src/particles/distribution/Semigaussian.H
+++ b/src/particles/distribution/Semigaussian.H
@@ -29,39 +29,39 @@ namespace impactx::distribution
          * Return sampling from a 6D Semi-Gaussian distribution (uniform in
          * position, Gaussian in momentum).
          *
-         * @param lambdax,lambday,lambdat for zero correlation, these are the related
+         * @param lambda_x,lambda_y,lambda_t for zero correlation, these are the related
          *                                   RMS sizes (in meters)
-         * @param lambdapx,lambdapy,lambdapt RMS momentum
-         * @param muxpx,muypy,mutpt correlation length-momentum
-         * @param meanx,meany,meant offsets of the mean (centroid) positions from those of the reference particle
-         * @param meanpx,meanpy,meanpt offsets of the mean (centroid) momenta from those of the reference particle
-         * @param dispx,disppx,dispy,disppy dispersion and its derivative in horizontal and vertical directions
+         * @param lambda_px,lambda_py,lambda_pt RMS momentum
+         * @param mu_x_px,mu_y_py,mu_t_pt correlation length-momentum
+         * @param mean_x,mean_y,mean_t offsets of the mean (centroid) positions from those of the reference particle
+         * @param mean_px,mean_py,mean_pt offsets of the mean (centroid) momenta from those of the reference particle
+         * @param dispersion_x,dispersion_px,dispersion_y,dispersion_py dispersion and its derivative in horizontal and vertical directions
          */
         Semigaussian (
-            amrex::ParticleReal lambdax,
-            amrex::ParticleReal lambday,
-            amrex::ParticleReal lambdat,
-            amrex::ParticleReal lambdapx,
-            amrex::ParticleReal lambdapy,
-            amrex::ParticleReal lambdapt,
-            amrex::ParticleReal muxpx=0.0,
-            amrex::ParticleReal muypy=0.0,
-            amrex::ParticleReal mutpt=0.0,
-            amrex::ParticleReal meanx=0.0,
-            amrex::ParticleReal meany=0.0,
-            amrex::ParticleReal meant=0.0,
-            amrex::ParticleReal meanpx=0.0,
-            amrex::ParticleReal meanpy=0.0,
-            amrex::ParticleReal meanpt=0.0,
-            amrex::ParticleReal dispx=0.0,
-            amrex::ParticleReal disppx=0.0,
-            amrex::ParticleReal dispy=0.0,
-            amrex::ParticleReal disppy=0.0
+            amrex::ParticleReal lambda_x,
+            amrex::ParticleReal lambda_y,
+            amrex::ParticleReal lambda_t,
+            amrex::ParticleReal lambda_px,
+            amrex::ParticleReal lambda_py,
+            amrex::ParticleReal lambda_pt,
+            amrex::ParticleReal mu_x_px=0.0,
+            amrex::ParticleReal mu_y_py=0.0,
+            amrex::ParticleReal mu_t_pt=0.0,
+            amrex::ParticleReal mean_x=0.0,
+            amrex::ParticleReal mean_y=0.0,
+            amrex::ParticleReal mean_t=0.0,
+            amrex::ParticleReal mean_px=0.0,
+            amrex::ParticleReal mean_py=0.0,
+            amrex::ParticleReal mean_pt=0.0,
+            amrex::ParticleReal dispersion_x=0.0,
+            amrex::ParticleReal dispersion_px=0.0,
+            amrex::ParticleReal dispersion_y=0.0,
+            amrex::ParticleReal dispersion_py=0.0
         )
-        : m_lambdaX(lambdax), m_lambdaY(lambday), m_lambdaT(lambdat), m_lambdaPx(lambdapx), m_lambdaPy(lambdapy),
-          m_lambdaPt(lambdapt), m_muxpx(muxpx), m_muypy(muypy), m_mutpt(mutpt), m_meanx(meanx), m_meany(meany),
-          m_meant(meant), m_meanpx(meanpx), m_meanpy(meanpy), m_meanpt(meanpt), m_dispx(dispx), m_disppx(disppx),
-          m_dispy(dispy), m_disppy(disppy)
+        : m_lambda_x(lambda_x), m_lambda_y(lambda_y), m_lambda_t(lambda_t), m_lambda_px(lambda_px), m_lambda_py(lambda_py),
+          m_lambda_pt(lambda_pt), m_mu_x_px(mu_x_px), m_mu_y_py(mu_y_py), m_mu_t_pt(mu_t_pt), m_mean_x(mean_x), m_mean_y(mean_y),
+          m_mean_t(mean_t), m_mean_px(mean_px), m_mean_py(mean_py), m_mean_pt(mean_pt), m_dispersion_x(dispersion_x), m_dispersion_px(dispersion_px),
+          m_dispersion_y(dispersion_y), m_dispersion_py(dispersion_py)
         {
         }
 
@@ -144,43 +144,43 @@ namespace impactx::distribution
             pt = ln1 * std::cos(2_prt*pi*u2);
 
             // Transform to produce the desired second moments/correlations:
-            root = std::sqrt(1.0_prt-m_muxpx*m_muxpx);
-            a1 = m_lambdaX * x / root;
-            a2 = m_lambdaPx * (-m_muxpx * x / root + px);
+            root = std::sqrt(1.0_prt-m_mu_x_px*m_mu_x_px);
+            a1 = m_lambda_x * x / root;
+            a2 = m_lambda_px * (-m_mu_x_px * x / root + px);
             x = a1;
             px = a2;
-            root = std::sqrt(1.0_prt-m_muypy*m_muypy);
-            a1 = m_lambdaY * y / root;
-            a2 = m_lambdaPy * (-m_muypy * y / root + py);
+            root = std::sqrt(1.0_prt-m_mu_y_py*m_mu_y_py);
+            a1 = m_lambda_y * y / root;
+            a2 = m_lambda_py * (-m_mu_y_py * y / root + py);
             y = a1;
             py = a2;
-            root = std::sqrt(1.0_prt-m_mutpt*m_mutpt);
-            a1 = m_lambdaT * t / root;
-            a2 = m_lambdaPt * (-m_mutpt * t / root + pt);
+            root = std::sqrt(1.0_prt-m_mu_t_pt*m_mu_t_pt);
+            a1 = m_lambda_t * t / root;
+            a2 = m_lambda_pt * (-m_mu_t_pt * t / root + pt);
             t = a1;
             pt = a2;
 
             // Apply dispersive correlations
-            x = x - m_dispx * pt;
-            px = px - m_disppx * pt;
-            y = y - m_dispy * pt;
-            py = py - m_disppy * pt;
+            x = x - m_dispersion_x * pt;
+            px = px - m_dispersion_px * pt;
+            y = y - m_dispersion_y * pt;
+            py = py - m_dispersion_py * pt;
 
             // Apply centroid translation
-            x = x + m_meanx;
-            px = px + m_meanpx;
-            y = y + m_meany;
-            py = py + m_meanpy;
-            t = t + m_meant;
-            pt = pt + m_meanpt;
+            x = x + m_mean_x;
+            px = px + m_mean_px;
+            y = y + m_mean_y;
+            py = py + m_mean_py;
+            t = t + m_mean_t;
+            pt = pt + m_mean_pt;
         }
 
-        amrex::ParticleReal m_lambdaX, m_lambdaY, m_lambdaT;  //! related position axis intercepts (length) of the phase space ellipse
-        amrex::ParticleReal m_lambdaPx, m_lambdaPy, m_lambdaPt;  //! related momentum axis intercepts of the phase space ellipse
-        amrex::ParticleReal m_muxpx, m_muypy, m_mutpt;  //! correlation length-momentum
-        amrex::ParticleReal m_meanx, m_meany, m_meant;  //! spatial coordinates of centroid offset
-        amrex::ParticleReal m_meanpx, m_meanpy, m_meanpt;  //! momentum coordinates of centroid offset
-        amrex::ParticleReal m_dispx, m_disppx, m_dispy, m_disppy;  //! dispersion and its derivative
+        amrex::ParticleReal m_lambda_x, m_lambda_y, m_lambda_t;  //! related position axis intercepts (length) of the phase space ellipse
+        amrex::ParticleReal m_lambda_px, m_lambda_py, m_lambda_pt;  //! related momentum axis intercepts of the phase space ellipse
+        amrex::ParticleReal m_mu_x_px, m_mu_y_py, m_mu_t_pt;  //! correlation length-momentum
+        amrex::ParticleReal m_mean_x, m_mean_y, m_mean_t;  //! spatial coordinates of centroid offset
+        amrex::ParticleReal m_mean_px, m_mean_py, m_mean_pt;  //! momentum coordinates of centroid offset
+        amrex::ParticleReal m_dispersion_x, m_dispersion_px, m_dispersion_y, m_dispersion_py;  //! dispersion and its derivative
     };
 
 } // namespace impactx::distribution

--- a/src/particles/distribution/Triangle.H
+++ b/src/particles/distribution/Triangle.H
@@ -30,30 +30,30 @@ namespace impactx::distribution
          * with a Gaussian energy spread (possibly correlated).  The
          * transverse distribution is a 4D waterbag.
          *
-         * @param lambdax,lambday,lambdat for zero correlation, these are the related
+         * @param lambda_x,lambda_y,lambda_t for zero correlation, these are the related
          *                       RMS sizes (in meters)
-         * @param lambdapx,lambdapy,lambdapt RMS momentum
-         * @param muxpx,muypy,mutpt correlation length-momentum
-         * @param meanx,meany,meant offsets of the mean (centroid) positions from those of the reference particle
-         * @param meanpx,meanpy,meanpt offsets of the mean (centroid) momenta from those of the reference particle
-         * @param dispx,disppx,dispy,disppy dispersion and its derivative in horizontal and vertical directions
+         * @param lambda_px,lambda_py,lambda_pt RMS momentum
+         * @param mu_x_px,mu_y_py,mu_t_pt correlation length-momentum
+         * @param mean_x,mean_y,mean_t offsets of the mean (centroid) positions from those of the reference particle
+         * @param mean_px,mean_py,mean_pt offsets of the mean (centroid) momenta from those of the reference particle
+         * @param dispersion_x,dispersion_px,dispersion_y,dispersion_py dispersion and its derivative in horizontal and vertical directions
          */
         Triangle (
-                amrex::ParticleReal const lambdax, amrex::ParticleReal const lambday,
-                amrex::ParticleReal const lambdat, amrex::ParticleReal const lambdapx,
-                amrex::ParticleReal const lambdapy, amrex::ParticleReal const lambdapt,
-                amrex::ParticleReal const muxpx=0.0, amrex::ParticleReal const muypy=0.0,
-                amrex::ParticleReal const mutpt=0.0, amrex::ParticleReal const meanx=0.0,
-                amrex::ParticleReal const meany=0.0, amrex::ParticleReal const meant=0.0,
-                amrex::ParticleReal const meanpx=0.0, amrex::ParticleReal const meanpy=0.0,
-                amrex::ParticleReal const meanpt=0.0, amrex::ParticleReal const dispx=0.0,
-                amrex::ParticleReal const disppx=0.0, amrex::ParticleReal const dispy=0.0,
-                amrex::ParticleReal const disppy=0.0
+            amrex::ParticleReal const lambda_x, amrex::ParticleReal const lambda_y,
+            amrex::ParticleReal const lambda_t, amrex::ParticleReal const lambda_px,
+            amrex::ParticleReal const lambda_py, amrex::ParticleReal const lambda_pt,
+            amrex::ParticleReal const mu_x_px=0.0, amrex::ParticleReal const mu_y_py=0.0,
+            amrex::ParticleReal const mu_t_pt=0.0, amrex::ParticleReal const mean_x=0.0,
+            amrex::ParticleReal const mean_y=0.0, amrex::ParticleReal const mean_t=0.0,
+            amrex::ParticleReal const mean_px=0.0, amrex::ParticleReal const mean_py=0.0,
+            amrex::ParticleReal const mean_pt=0.0, amrex::ParticleReal const dispersion_x=0.0,
+            amrex::ParticleReal const dispersion_px=0.0, amrex::ParticleReal const dispersion_y=0.0,
+            amrex::ParticleReal const dispersion_py=0.0
         )
-          : m_lambdaX(lambdax), m_lambdaY(lambday), m_lambdaT(lambdat), m_lambdaPx(lambdapx), m_lambdaPy(lambdapy),
-            m_lambdaPt(lambdapt), m_muxpx(muxpx), m_muypy(muypy), m_mutpt(mutpt), m_meanx(meanx), m_meany(meany),
-          m_meant(meant), m_meanpx(meanpx), m_meanpy(meanpy), m_meanpt(meanpt), m_dispx(dispx), m_disppx(disppx),
-          m_dispy(dispy), m_disppy(disppy)
+          : m_lambda_x(lambda_x), m_lambda_y(lambda_y), m_lambda_t(lambda_t), m_lambda_px(lambda_px), m_lambda_py(lambda_py),
+            m_lambda_pt(lambda_pt), m_mu_x_px(mu_x_px), m_mu_y_py(mu_y_py), m_mu_t_pt(mu_t_pt), m_mean_x(mean_x), m_mean_y(mean_y),
+          m_mean_t(mean_t), m_mean_px(mean_px), m_mean_py(mean_py), m_mean_pt(mean_pt), m_dispersion_x(dispersion_x), m_dispersion_px(dispersion_px),
+          m_dispersion_y(dispersion_y), m_dispersion_py(dispersion_py)
         {
         }
 
@@ -147,43 +147,43 @@ namespace impactx::distribution
             py = g4*u2;
 
             // Transform to produce the desired second moments/correlations:
-            root = std::sqrt(1.0_prt-m_muxpx*m_muxpx);
-            a1 = m_lambdaX * x / root;
-            a2 = m_lambdaPx * (-m_muxpx * x / root + px);
+            root = std::sqrt(1.0_prt-m_mu_x_px*m_mu_x_px);
+            a1 = m_lambda_x * x / root;
+            a2 = m_lambda_px * (-m_mu_x_px * x / root + px);
             x = a1;
             px = a2;
-            root = std::sqrt(1.0_prt-m_muypy*m_muypy);
-            a1 = m_lambdaY * y / root;
-            a2 = m_lambdaPy * (-m_muypy * y / root + py);
+            root = std::sqrt(1.0_prt-m_mu_y_py*m_mu_y_py);
+            a1 = m_lambda_y * y / root;
+            a2 = m_lambda_py * (-m_mu_y_py * y / root + py);
             y = a1;
             py = a2;
-            root = std::sqrt(1.0_prt-m_mutpt*m_mutpt);
-            a1 = m_lambdaT * t / root;
-            a2 = m_lambdaPt * (-m_mutpt * t / root + pt);
+            root = std::sqrt(1.0_prt-m_mu_t_pt*m_mu_t_pt);
+            a1 = m_lambda_t * t / root;
+            a2 = m_lambda_pt * (-m_mu_t_pt * t / root + pt);
             t = a1;
             pt = a2;
 
             // Apply dispersive correlations
-            x = x - m_dispx * pt;
-            px = px - m_disppx * pt;
-            y = y - m_dispy * pt;
-            py = py - m_disppy * pt;
+            x = x - m_dispersion_x * pt;
+            px = px - m_dispersion_px * pt;
+            y = y - m_dispersion_y * pt;
+            py = py - m_dispersion_py * pt;
 
             // Apply centroid translation
-            x = x + m_meanx;
-            px = px + m_meanpx;
-            y = y + m_meany;
-            py = py + m_meanpy;
-            t = t + m_meant;
-            pt = pt + m_meanpt;
+            x = x + m_mean_x;
+            px = px + m_mean_px;
+            y = y + m_mean_y;
+            py = py + m_mean_py;
+            t = t + m_mean_t;
+            pt = pt + m_mean_pt;
         }
 
-        amrex::ParticleReal m_lambdaX, m_lambdaY, m_lambdaT;  //! related position axis intercepts (length) of the phase space ellipse
-        amrex::ParticleReal m_lambdaPx, m_lambdaPy, m_lambdaPt;  //! related momentum axis intercepts of the phase space ellipse
-        amrex::ParticleReal m_muxpx, m_muypy, m_mutpt; //! correlation length-momentum
-        amrex::ParticleReal m_meanx, m_meany, m_meant;  //! spatial coordinates of centroid offset
-        amrex::ParticleReal m_meanpx, m_meanpy, m_meanpt;  //! momentum coordinates of centroid offset
-        amrex::ParticleReal m_dispx, m_disppx, m_dispy, m_disppy;  //! dispersion and its derivative
+        amrex::ParticleReal m_lambda_x, m_lambda_y, m_lambda_t;  //! related position axis intercepts (length) of the phase space ellipse
+        amrex::ParticleReal m_lambda_px, m_lambda_py, m_lambda_pt;  //! related momentum axis intercepts of the phase space ellipse
+        amrex::ParticleReal m_mu_x_px, m_mu_y_py, m_mu_t_pt; //! correlation length-momentum
+        amrex::ParticleReal m_mean_x, m_mean_y, m_mean_t;  //! spatial coordinates of centroid offset
+        amrex::ParticleReal m_mean_px, m_mean_py, m_mean_pt;  //! momentum coordinates of centroid offset
+        amrex::ParticleReal m_dispersion_x, m_dispersion_px, m_dispersion_y, m_dispersion_py;  //! dispersion and its derivative
     };
 
 } // namespace impactx::distribution

--- a/src/particles/distribution/Waterbag.H
+++ b/src/particles/distribution/Waterbag.H
@@ -28,39 +28,39 @@ namespace impactx::distribution
          *
          * Return sampling from a 6D Waterbag distribution.
          *
-         * @param lambdax,lambday,lambdat for zero correlation, these are the related
+         * @param lambda_x,lambda_y,lambda_t for zero correlation, these are the related
          *                                   RMS sizes (in meters)
-         * @param lambdapx,lambdapy,lambdapt RMS momentum
-         * @param muxpx,muypy,mutpt correlation length-momentum
-         * @param meanx,meany,meant offsets of the mean (centroid) positions from those of the reference particle
-         * @param meanpx,meanpy,meanpt offsets of the mean (centroid) momenta from those of the reference particle
-         * @param dispx,disppx,dispy,disppy dispersion and its derivative in horizontal and vertical directions
+         * @param lambda_px,lambda_py,lambda_pt RMS momentum
+         * @param mu_x_px,mu_y_py,mu_t_pt correlation length-momentum
+         * @param mean_x,mean_y,mean_t offsets of the mean (centroid) positions from those of the reference particle
+         * @param mean_px,mean_py,mean_pt offsets of the mean (centroid) momenta from those of the reference particle
+         * @param dispersion_x,dispersion_px,dispersion_y,dispersion_py dispersion and its derivative in horizontal and vertical directions
          */
         Waterbag (
-            amrex::ParticleReal lambdax,
-            amrex::ParticleReal lambday,
-            amrex::ParticleReal lambdat,
-            amrex::ParticleReal lambdapx,
-            amrex::ParticleReal lambdapy,
-            amrex::ParticleReal lambdapt,
-            amrex::ParticleReal muxpx=0.0,
-            amrex::ParticleReal muypy=0.0,
-            amrex::ParticleReal mutpt=0.0,
-            amrex::ParticleReal meanx=0.0,
-            amrex::ParticleReal meany=0.0,
-            amrex::ParticleReal meant=0.0,
-            amrex::ParticleReal meanpx=0.0,
-            amrex::ParticleReal meanpy=0.0,
-            amrex::ParticleReal meanpt=0.0,
-            amrex::ParticleReal dispx=0.0,
-            amrex::ParticleReal disppx=0.0,
-            amrex::ParticleReal dispy=0.0,
-            amrex::ParticleReal disppy=0.0
+            amrex::ParticleReal lambda_x,
+            amrex::ParticleReal lambda_y,
+            amrex::ParticleReal lambda_t,
+            amrex::ParticleReal lambda_px,
+            amrex::ParticleReal lambda_py,
+            amrex::ParticleReal lambda_pt,
+            amrex::ParticleReal mu_x_px=0.0,
+            amrex::ParticleReal mu_y_py=0.0,
+            amrex::ParticleReal mu_t_pt=0.0,
+            amrex::ParticleReal mean_x=0.0,
+            amrex::ParticleReal mean_y=0.0,
+            amrex::ParticleReal mean_t=0.0,
+            amrex::ParticleReal mean_px=0.0,
+            amrex::ParticleReal mean_py=0.0,
+            amrex::ParticleReal mean_pt=0.0,
+            amrex::ParticleReal dispersion_x=0.0,
+            amrex::ParticleReal dispersion_px=0.0,
+            amrex::ParticleReal dispersion_y=0.0,
+            amrex::ParticleReal dispersion_py=0.0
         )
-        : m_lambdaX(lambdax), m_lambdaY(lambday), m_lambdaT(lambdat), m_lambdaPx(lambdapx), m_lambdaPy(lambdapy),
-          m_lambdaPt(lambdapt), m_muxpx(muxpx), m_muypy(muypy), m_mutpt(mutpt), m_meanx(meanx), m_meany(meany),
-          m_meant(meant), m_meanpx(meanpx), m_meanpy(meanpy), m_meanpt(meanpt), m_dispx(dispx), m_disppx(disppx),
-          m_dispy(dispy), m_disppy(disppy)
+        : m_lambda_x(lambda_x), m_lambda_y(lambda_y), m_lambda_t(lambda_t), m_lambda_px(lambda_px), m_lambda_py(lambda_py),
+          m_lambda_pt(lambda_pt), m_mu_x_px(mu_x_px), m_mu_y_py(mu_y_py), m_mu_t_pt(mu_t_pt), m_mean_x(mean_x), m_mean_y(mean_y),
+          m_mean_t(mean_t), m_mean_px(mean_px), m_mean_py(mean_py), m_mean_pt(mean_pt), m_dispersion_x(dispersion_x), m_dispersion_px(dispersion_px),
+          m_dispersion_y(dispersion_y), m_dispersion_py(dispersion_py)
         {
         }
 
@@ -149,43 +149,43 @@ namespace impactx::distribution
             pt = g6*u2;
 
             // Transform to produce the desired second moments/correlations:
-            root = std::sqrt(1.0_prt-m_muxpx*m_muxpx);
-            a1 = m_lambdaX * x / root;
-            a2 = m_lambdaPx * (-m_muxpx * x / root + px);
+            root = std::sqrt(1.0_prt-m_mu_x_px*m_mu_x_px);
+            a1 = m_lambda_x * x / root;
+            a2 = m_lambda_px * (-m_mu_x_px * x / root + px);
             x = a1;
             px = a2;
-            root = std::sqrt(1.0_prt-m_muypy*m_muypy);
-            a1 = m_lambdaY * y / root;
-            a2 = m_lambdaPy * (-m_muypy * y / root + py);
+            root = std::sqrt(1.0_prt-m_mu_y_py*m_mu_y_py);
+            a1 = m_lambda_y * y / root;
+            a2 = m_lambda_py * (-m_mu_y_py * y / root + py);
             y = a1;
             py = a2;
-            root = std::sqrt(1.0_prt-m_mutpt*m_mutpt);
-            a1 = m_lambdaT * t / root;
-            a2 = m_lambdaPt * (-m_mutpt * t / root + pt);
+            root = std::sqrt(1.0_prt-m_mu_t_pt*m_mu_t_pt);
+            a1 = m_lambda_t * t / root;
+            a2 = m_lambda_pt * (-m_mu_t_pt * t / root + pt);
             t = a1;
             pt = a2;
 
             // Apply dispersive correlations
-            x = x - m_dispx * pt;
-            px = px - m_disppx * pt;
-            y = y - m_dispy * pt;
-            py = py - m_disppy * pt;
+            x = x - m_dispersion_x * pt;
+            px = px - m_dispersion_px * pt;
+            y = y - m_dispersion_y * pt;
+            py = py - m_dispersion_py * pt;
 
             // Apply centroid translation
-            x = x + m_meanx;
-            px = px + m_meanpx;
-            y = y + m_meany;
-            py = py + m_meanpy;
-            t = t + m_meant;
-            pt = pt + m_meanpt;
+            x = x + m_mean_x;
+            px = px + m_mean_px;
+            y = y + m_mean_y;
+            py = py + m_mean_py;
+            t = t + m_mean_t;
+            pt = pt + m_mean_pt;
         }
 
-        amrex::ParticleReal m_lambdaX, m_lambdaY, m_lambdaT;  //! related position axis intercepts (length) of the phase space ellipse
-        amrex::ParticleReal m_lambdaPx, m_lambdaPy, m_lambdaPt;  //! related momentum axis intercepts of the phase space ellipse
-        amrex::ParticleReal m_muxpx, m_muypy, m_mutpt;  //! correlation length-momentum
-        amrex::ParticleReal m_meanx, m_meany, m_meant;  //! spatial coordinates of centroid offset
-        amrex::ParticleReal m_meanpx, m_meanpy, m_meanpt;  //! momentum coordinates of centroid offset
-        amrex::ParticleReal m_dispx, m_disppx, m_dispy, m_disppy;  //! dispersion and its derivative
+        amrex::ParticleReal m_lambda_x, m_lambda_y, m_lambda_t;  //! related position axis intercepts (length) of the phase space ellipse
+        amrex::ParticleReal m_lambda_px, m_lambda_py, m_lambda_pt;  //! related momentum axis intercepts of the phase space ellipse
+        amrex::ParticleReal m_mu_x_px, m_mu_y_py, m_mu_t_pt;  //! correlation length-momentum
+        amrex::ParticleReal m_mean_x, m_mean_y, m_mean_t;  //! spatial coordinates of centroid offset
+        amrex::ParticleReal m_mean_px, m_mean_py, m_mean_pt;  //! momentum coordinates of centroid offset
+        amrex::ParticleReal m_dispersion_x, m_dispersion_px, m_dispersion_y, m_dispersion_py;  //! dispersion and its derivative
     };
 
 } // namespace impactx::distribution

--- a/src/python/distribution.cpp
+++ b/src/python/distribution.cpp
@@ -34,13 +34,13 @@ void init_distribution(py::module& m)
                 amrex::ParticleReal, amrex::ParticleReal,
                 amrex::ParticleReal, amrex::ParticleReal
              >(),
-             py::arg("lambdaX"), py::arg("lambdaY"), py::arg("lambdaT"),
-             py::arg("lambdaPx"), py::arg("lambdaPy"), py::arg("lambdaPt"),
-             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0,
-             py::arg("meanX")=0.0, py::arg("meanY")=0.0, py::arg("meanT")=0.0,
-             py::arg("meanPx")=0.0, py::arg("meanPy")=0.0, py::arg("meanPt")=0.0,
-             py::arg("dispX")=0.0, py::arg("dispPx")=0.0,
-             py::arg("dispY")=0.0, py::arg("dispPy")=0.0,
+             py::arg("lambda_x"), py::arg("lambda_y"), py::arg("lambda_t"),
+             py::arg("lambda_px"), py::arg("lambda_py"), py::arg("lambda_pt"),
+             py::arg("mu_x_px")=0.0, py::arg("mu_y_py")=0.0, py::arg("mu_t_pt")=0.0,
+             py::arg("mean_x")=0.0, py::arg("mean_y")=0.0, py::arg("mean_t")=0.0,
+             py::arg("mean_px")=0.0, py::arg("mean_py")=0.0, py::arg("mean_pt")=0.0,
+             py::arg("dispersion_x")=0.0, py::arg("dispersion_px")=0.0,
+             py::arg("dispersion_y")=0.0, py::arg("dispersion_py")=0.0,
              "A 6D Gaussian distribution"
         );
 
@@ -54,13 +54,13 @@ void init_distribution(py::module& m)
                  amrex::ParticleReal, amrex::ParticleReal,
                  amrex::ParticleReal, amrex::ParticleReal
          >(),
-             py::arg("lambdaX"), py::arg("lambdaY"), py::arg("lambdaT"),
-             py::arg("lambdaPx"), py::arg("lambdaPy"), py::arg("lambdaPt"),
-             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0,
-             py::arg("meanX")=0.0, py::arg("meanY")=0.0, py::arg("meanT")=0.0,
-             py::arg("meanPx")=0.0, py::arg("meanPy")=0.0, py::arg("meanPt")=0.0,
-             py::arg("dispX")=0.0, py::arg("dispPx")=0.0,
-             py::arg("dispY")=0.0, py::arg("dispPy")=0.0,
+             py::arg("lambda_x"), py::arg("lambda_y"), py::arg("lambda_t"),
+             py::arg("lambda_px"), py::arg("lambda_py"), py::arg("lambda_pt"),
+             py::arg("mu_x_px")=0.0, py::arg("mu_y_py")=0.0, py::arg("mu_t_pt")=0.0,
+             py::arg("mean_x")=0.0, py::arg("mean_y")=0.0, py::arg("mean_t")=0.0,
+             py::arg("mean_px")=0.0, py::arg("mean_py")=0.0, py::arg("mean_pt")=0.0,
+             py::arg("dispersion_x")=0.0, py::arg("dispersion_px")=0.0,
+             py::arg("dispersion_y")=0.0, py::arg("dispersion_py")=0.0,
              "A 4D Kurth distribution transversely + a uniform distribution\n"
              "in t + a Gaussian distribution in pt"
         );
@@ -75,13 +75,13 @@ void init_distribution(py::module& m)
                  amrex::ParticleReal, amrex::ParticleReal,
                  amrex::ParticleReal, amrex::ParticleReal
              >(),
-             py::arg("lambdaX"), py::arg("lambdaY"), py::arg("lambdaT"),
-             py::arg("lambdaPx"), py::arg("lambdaPy"), py::arg("lambdaPt"),
-             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0,
-             py::arg("meanX")=0.0, py::arg("meanY")=0.0, py::arg("meanT")=0.0,
-             py::arg("meanPx")=0.0, py::arg("meanPy")=0.0, py::arg("meanPt")=0.0,
-             py::arg("dispX")=0.0, py::arg("dispPx")=0.0,
-             py::arg("dispY")=0.0, py::arg("dispPy")=0.0,
+             py::arg("lambda_x"), py::arg("lambda_y"), py::arg("lambda_t"),
+             py::arg("lambda_px"), py::arg("lambda_py"), py::arg("lambda_pt"),
+             py::arg("mu_x_px")=0.0, py::arg("mu_y_py")=0.0, py::arg("mu_t_pt")=0.0,
+             py::arg("mean_x")=0.0, py::arg("mean_y")=0.0, py::arg("mean_t")=0.0,
+             py::arg("mean_px")=0.0, py::arg("mean_py")=0.0, py::arg("mean_pt")=0.0,
+             py::arg("dispersion_x")=0.0, py::arg("dispersion_px")=0.0,
+             py::arg("dispersion_y")=0.0, py::arg("dispersion_py")=0.0,
              "A 6D Kurth distribution\n\n"
              "R. Kurth, Quarterly of Applied Mathematics vol. 32, pp. 325-329 (1978)\n"
              "C. Mitchell, K. Hwang and R. D. Ryne, IPAC2021, WEPAB248 (2021)"
@@ -97,13 +97,13 @@ void init_distribution(py::module& m)
                  amrex::ParticleReal, amrex::ParticleReal,
                  amrex::ParticleReal, amrex::ParticleReal
              >(),
-             py::arg("lambdaX"), py::arg("lambdaY"), py::arg("lambdaT"),
-             py::arg("lambdaPx"), py::arg("lambdaPy"), py::arg("lambdaPt"),
-             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0,
-             py::arg("meanX")=0.0, py::arg("meanY")=0.0, py::arg("meanT")=0.0,
-             py::arg("meanPx")=0.0, py::arg("meanPy")=0.0, py::arg("meanPt")=0.0,
-             py::arg("dispX")=0.0, py::arg("dispPx")=0.0,
-             py::arg("dispY")=0.0, py::arg("dispPy")=0.0,
+             py::arg("lambda_x"), py::arg("lambda_y"), py::arg("lambda_t"),
+             py::arg("lambda_px"), py::arg("lambda_py"), py::arg("lambda_pt"),
+             py::arg("mu_x_px")=0.0, py::arg("mu_y_py")=0.0, py::arg("mu_t_pt")=0.0,
+             py::arg("mean_x")=0.0, py::arg("mean_y")=0.0, py::arg("mean_t")=0.0,
+             py::arg("mean_px")=0.0, py::arg("mean_py")=0.0, py::arg("mean_pt")=0.0,
+             py::arg("dispersion_x")=0.0, py::arg("dispersion_px")=0.0,
+             py::arg("dispersion_y")=0.0, py::arg("dispersion_py")=0.0,
              "A K-V distribution transversely + a uniform distribution\n"
              "in t + a Gaussian distribution in pt"
         );
@@ -123,13 +123,13 @@ void init_distribution(py::module& m)
                  amrex::ParticleReal, amrex::ParticleReal,
                  amrex::ParticleReal, amrex::ParticleReal
              >(),
-             py::arg("lambdaX"), py::arg("lambdaY"), py::arg("lambdaT"),
-             py::arg("lambdaPx"), py::arg("lambdaPy"), py::arg("lambdaPt"),
-             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0,
-             py::arg("meanX")=0.0, py::arg("meanY")=0.0, py::arg("meanT")=0.0,
-             py::arg("meanPx")=0.0, py::arg("meanPy")=0.0, py::arg("meanPt")=0.0,
-             py::arg("dispX")=0.0, py::arg("dispPx")=0.0,
-             py::arg("dispY")=0.0, py::arg("dispPy")=0.0,
+             py::arg("lambda_x"), py::arg("lambda_y"), py::arg("lambda_t"),
+             py::arg("lambda_px"), py::arg("lambda_py"), py::arg("lambda_pt"),
+             py::arg("mu_x_px")=0.0, py::arg("mu_y_py")=0.0, py::arg("mu_t_pt")=0.0,
+             py::arg("mean_x")=0.0, py::arg("mean_y")=0.0, py::arg("mean_t")=0.0,
+             py::arg("mean_px")=0.0, py::arg("mean_py")=0.0, py::arg("mean_pt")=0.0,
+             py::arg("dispersion_x")=0.0, py::arg("dispersion_px")=0.0,
+             py::arg("dispersion_y")=0.0, py::arg("dispersion_py")=0.0,
              "A 6D Semi-Gaussian distribution (uniform in position, Gaussian in momentum)."
         );
 
@@ -155,13 +155,13 @@ void init_distribution(py::module& m)
                  amrex::ParticleReal, amrex::ParticleReal,
                  amrex::ParticleReal, amrex::ParticleReal
              >(),
-             py::arg("lambdaX"), py::arg("lambdaY"), py::arg("lambdaT"),
-             py::arg("lambdaPx"), py::arg("lambdaPy"), py::arg("lambdaPt"),
-             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0,
-             py::arg("meanX")=0.0, py::arg("meanY")=0.0, py::arg("meanT")=0.0,
-             py::arg("meanPx")=0.0, py::arg("meanPy")=0.0, py::arg("meanPt")=0.0,
-             py::arg("dispX")=0.0, py::arg("dispPx")=0.0,
-             py::arg("dispY")=0.0, py::arg("dispPy")=0.0,
+             py::arg("lambda_x"), py::arg("lambda_y"), py::arg("lambda_t"),
+             py::arg("lambda_px"), py::arg("lambda_py"), py::arg("lambda_pt"),
+             py::arg("mu_x_px")=0.0, py::arg("mu_y_py")=0.0, py::arg("mu_t_pt")=0.0,
+             py::arg("mean_x")=0.0, py::arg("mean_y")=0.0, py::arg("mean_t")=0.0,
+             py::arg("mean_px")=0.0, py::arg("mean_py")=0.0, py::arg("mean_pt")=0.0,
+             py::arg("dispersion_x")=0.0, py::arg("dispersion_px")=0.0,
+             py::arg("dispersion_y")=0.0, py::arg("dispersion_py")=0.0,
              "A triangle distribution for laser-plasma acceleration related applications.\n\n"
              "A ramped, triangular current profile with a Gaussian energy spread (possibly correlated).\n"
              "The transverse distribution is a 4D waterbag."
@@ -177,13 +177,13 @@ void init_distribution(py::module& m)
                  amrex::ParticleReal, amrex::ParticleReal,
                  amrex::ParticleReal, amrex::ParticleReal
              >(),
-             py::arg("lambdaX"), py::arg("lambdaY"), py::arg("lambdaT"),
-             py::arg("lambdaPx"), py::arg("lambdaPy"), py::arg("lambdaPt"),
-             py::arg("muxpx")=0.0, py::arg("muypy")=0.0, py::arg("mutpt")=0.0,
-             py::arg("meanX")=0.0, py::arg("meanY")=0.0, py::arg("meanT")=0.0,
-             py::arg("meanPx")=0.0, py::arg("meanPy")=0.0, py::arg("meanPt")=0.0,
-             py::arg("dispX")=0.0, py::arg("dispPx")=0.0,
-             py::arg("dispY")=0.0, py::arg("dispPy")=0.0,
+             py::arg("lambda_x"), py::arg("lambda_y"), py::arg("lambda_t"),
+             py::arg("lambda_px"), py::arg("lambda_py"), py::arg("lambda_pt"),
+             py::arg("mu_x_px")=0.0, py::arg("mu_y_py")=0.0, py::arg("mu_t_pt")=0.0,
+             py::arg("mean_x")=0.0, py::arg("mean_y")=0.0, py::arg("mean_t")=0.0,
+             py::arg("mean_px")=0.0, py::arg("mean_py")=0.0, py::arg("mean_pt")=0.0,
+             py::arg("dispersion_x")=0.0, py::arg("dispersion_px")=0.0,
+             py::arg("dispersion_y")=0.0, py::arg("dispersion_py")=0.0,
              "A 6D Waterbag distribution"
         );
 

--- a/src/python/impactx/distribution_input_helpers.py
+++ b/src/python/impactx/distribution_input_helpers.py
@@ -19,16 +19,16 @@ def twiss(
     alpha_x: np.float64 = 0.0,
     alpha_y: np.float64 = 0.0,
     alpha_t: np.float64 = 0.0,
-    meanX: np.float64 = 0.0,
-    meanY: np.float64 = 0.0,
-    meanT: np.float64 = 0.0,
-    meanPx: np.float64 = 0.0,
-    meanPy: np.float64 = 0.0,
-    meanPt: np.float64 = 0.0,
-    dispX: np.float64 = 0.0,
-    dispY: np.float64 = 0.0,
-    dispPx: np.float64 = 0.0,
-    dispPy: np.float64 = 0.0,
+    mean_x: np.float64 = 0.0,
+    mean_y: np.float64 = 0.0,
+    mean_t: np.float64 = 0.0,
+    mean_px: np.float64 = 0.0,
+    mean_py: np.float64 = 0.0,
+    mean_pt: np.float64 = 0.0,
+    dispersion_x: np.float64 = 0.0,
+    dispersion_y: np.float64 = 0.0,
+    dispersion_px: np.float64 = 0.0,
+    dispersion_py: np.float64 = 0.0,
 ):
     """
     Helper function to convert Courant-Snyder / Twiss input into phase space ellipse input.
@@ -42,16 +42,16 @@ def twiss(
     :param alpha_x: Alpha function value () in the x dimension, default is 0.0.
     :param alpha_y: Alpha function value in the y dimension, default is 0.0.
     :param alpha_t: Alpha function value in the t dimension, default is 0.0.
-    :param meanX: offset of the mean (centroid) position in x from that of the reference particle
-    :param meanY: offset of the mean (centroid) position in y from that of the reference particle
-    :param meanT: offset of the mean (centroid) position in t from that of the reference particle
-    :param meanPx: offset of the mean (centroid) momentum in x from that of the reference particle
-    :param meanPy: offset of the mean (centroid) momentum in y from that of the reference particle
-    :param meanPt: offset of the mean (centroid) momentum in t from that of the reference particle
-    :param dispX: dispersion and its derivative in horizontal and vertical directions
-    :param dispY: dispersion and its derivative in horizontal and vertical directions
-    :param dispPx: dispersion and its derivative in horizontal and vertical directions
-    :param dispPy: dispersion and its derivative in horizontal and vertical directions
+    :param mean_x: offset of the mean (centroid) position in x from that of the reference particle
+    :param mean_y: offset of the mean (centroid) position in y from that of the reference particle
+    :param mean_t: offset of the mean (centroid) position in t from that of the reference particle
+    :param mean_px: offset of the mean (centroid) momentum in x from that of the reference particle
+    :param mean_py: offset of the mean (centroid) momentum in y from that of the reference particle
+    :param mean_pt: offset of the mean (centroid) momentum in t from that of the reference particle
+    :param dispersion_x: dispersion and its derivative in horizontal and vertical directions
+    :param dispersion_y: dispersion and its derivative in horizontal and vertical directions
+    :param dispersion_px: dispersion and its derivative in horizontal and vertical directions
+    :param dispersion_py: dispersion and its derivative in horizontal and vertical directions
     :return: A dictionary containing calculated phase space input: 'lambdaX', 'lambdaY', 'lambdaT', 'lambdaPx', 'lambdaPy', 'lambdaPt', 'muxpx', 'muypy', 'mutpt'.
     """
     if beta_x <= 0.0 or beta_y <= 0.0 or beta_t <= 0.0:
@@ -74,23 +74,23 @@ def twiss(
     gamma_x, gamma_y, gamma_t = gammas
 
     return {
-        "lambdaX": np.sqrt(emitt_x / gamma_x),
-        "lambdaY": np.sqrt(emitt_y / gamma_y),
-        "lambdaT": np.sqrt(emitt_t / gamma_t),
-        "lambdaPx": np.sqrt(emitt_x / beta_x),
-        "lambdaPy": np.sqrt(emitt_y / beta_y),
-        "lambdaPt": np.sqrt(emitt_t / beta_t),
-        "muxpx": alpha_x / np.sqrt(beta_x * gamma_x),
-        "muypy": alpha_y / np.sqrt(beta_y * gamma_y),
-        "mutpt": alpha_t / np.sqrt(beta_t * gamma_t),
-        "meanX": meanX,
-        "meanY": meanY,
-        "meanT": meanT,
-        "meanPx": meanPx,
-        "meanPy": meanPy,
-        "meanPt": meanPt,
-        "dispX": dispX,
-        "dispY": dispY,
-        "dispPx": dispPx,
-        "dispPy": dispPy,
+        "lambda_x": np.sqrt(emitt_x / gamma_x),
+        "lambda_y": np.sqrt(emitt_y / gamma_y),
+        "lambda_t": np.sqrt(emitt_t / gamma_t),
+        "lambda_px": np.sqrt(emitt_x / beta_x),
+        "lambda_py": np.sqrt(emitt_y / beta_y),
+        "lambda_pt": np.sqrt(emitt_t / beta_t),
+        "mu_x_px": alpha_x / np.sqrt(beta_x * gamma_x),
+        "mu_y_py": alpha_y / np.sqrt(beta_y * gamma_y),
+        "mu_t_pt": alpha_t / np.sqrt(beta_t * gamma_t),
+        "mean_x": mean_x,
+        "mean_y": mean_y,
+        "mean_t": mean_t,
+        "mean_px": mean_px,
+        "mean_py": mean_py,
+        "mean_pt": mean_pt,
+        "dispersion_x": dispersion_x,
+        "dispersion_y": dispersion_y,
+        "dispersion_px": dispersion_px,
+        "dispersion_py": dispersion_py,
     }

--- a/src/python/impactx/distribution_input_helpers.py
+++ b/src/python/impactx/distribution_input_helpers.py
@@ -19,6 +19,16 @@ def twiss(
     alpha_x: np.float64 = 0.0,
     alpha_y: np.float64 = 0.0,
     alpha_t: np.float64 = 0.0,
+    meanX: np.float64 = 0.0,
+    meanY: np.float64 = 0.0,
+    meanT: np.float64 = 0.0,
+    meanPx: np.float64 = 0.0,
+    meanPy: np.float64 = 0.0,
+    meanPt: np.float64 = 0.0,
+    dispX: np.float64 = 0.0,
+    dispY: np.float64 = 0.0,
+    dispPx: np.float64 = 0.0,
+    dispPy: np.float64 = 0.0,
 ):
     """
     Helper function to convert Courant-Snyder / Twiss input into phase space ellipse input.
@@ -32,6 +42,16 @@ def twiss(
     :param alpha_x: Alpha function value () in the x dimension, default is 0.0.
     :param alpha_y: Alpha function value in the y dimension, default is 0.0.
     :param alpha_t: Alpha function value in the t dimension, default is 0.0.
+    :param meanX: offset of the mean (centroid) position in x from that of the reference particle
+    :param meanY: offset of the mean (centroid) position in y from that of the reference particle
+    :param meanT: offset of the mean (centroid) position in t from that of the reference particle
+    :param meanPx: offset of the mean (centroid) momentum in x from that of the reference particle
+    :param meanPy: offset of the mean (centroid) momentum in y from that of the reference particle
+    :param meanPt: offset of the mean (centroid) momentum in t from that of the reference particle
+    :param dispX: dispersion and its derivative in horizontal and vertical directions
+    :param dispY: dispersion and its derivative in horizontal and vertical directions
+    :param dispPx: dispersion and its derivative in horizontal and vertical directions
+    :param dispPy: dispersion and its derivative in horizontal and vertical directions
     :return: A dictionary containing calculated phase space input: 'lambdaX', 'lambdaY', 'lambdaT', 'lambdaPx', 'lambdaPy', 'lambdaPt', 'muxpx', 'muypy', 'mutpt'.
     """
     if beta_x <= 0.0 or beta_y <= 0.0 or beta_t <= 0.0:
@@ -63,4 +83,14 @@ def twiss(
         "muxpx": alpha_x / np.sqrt(beta_x * gamma_x),
         "muypy": alpha_y / np.sqrt(beta_y * gamma_y),
         "mutpt": alpha_t / np.sqrt(beta_t * gamma_t),
+        "meanX": meanX,
+        "meanY": meanY,
+        "meanT": meanT,
+        "meanPx": meanPx,
+        "meanPy": meanPy,
+        "meanPt": meanPt,
+        "dispX": dispX,
+        "dispY": dispY,
+        "dispPx": dispPx,
+        "dispPy": dispPy,
     }


### PR DESCRIPTION
Proposing a few breaking changes for distributions for clarity, ease of use and potential change in defaults

Checklist
- [ ] rebase after #1099
- [x]  Distribution arguments in `snake_case`: use consistent spelling of argument names, spell out abbreviations
- [ ] use twiss by default? (at least in Python?)
- [ ] update docs