### PR TITLE
pyproject: isort only via ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,3 @@ ignore = ["E402", "E501", "F405"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["amrex", "impactx"]
-
-[tool.isort]
-known_first_party = ["amrex", "impactx"]
-profile = "black"


### PR DESCRIPTION
We do not run the `isort` tool (slow) but rely on the isort implementation in `ruff`.

See if this helps with https://github.com/astral-sh/ruff/issues/19890