### PR TITLE
Add HTU lattice examples illustrating off-energy transport

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1527,6 +1527,26 @@ add_impactx_test(htu-beamline.py
     OFF  # no plot script yet
 )
 
+# HTU Beamline Model with Off-Energy Transport ##############
+# 
+# no space charge
+file(COPY ${ImpactX_SOURCE_DIR}/examples/htu_beamline/htu_lattice.py
+        DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/htu-beamline-offenergy1.py)
+file(COPY ${ImpactX_SOURCE_DIR}/examples/htu_beamline/htu_lattice.py
+        DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/htu-beamline-offenergy2.py)
+add_impactx_test(htu-beamline-offenergy1.py
+    examples/htu_beamline/run_impactx_offenergy1.py
+    ON   # ImpactX MPI-parallel
+    examples/htu_beamline/analysis_htu_beamline_offenergy.py
+    OFF  # no plot script yet
+)
+add_impactx_test(htu-beamline-offenergy2.py
+    examples/htu_beamline/run_impactx_offenergy2.py
+    ON   # ImpactX MPI-parallel  
+    examples/htu_beamline/analysis_htu_beamline_offenergy.py
+    OFF  # no plot script yet  
+)
+
 # Symplectic Integration in an Exact Combined-Function Bend ##############
 #
 # no space charge

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1528,7 +1528,7 @@ add_impactx_test(htu-beamline.py
 )
 
 # HTU Beamline Model with Off-Energy Transport ##############
-# 
+#
 # no space charge
 file(COPY ${ImpactX_SOURCE_DIR}/examples/htu_beamline/htu_lattice.py
         DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/htu-beamline-offenergy1.py)
@@ -1542,9 +1542,9 @@ add_impactx_test(htu-beamline-offenergy1.py
 )
 add_impactx_test(htu-beamline-offenergy2.py
     examples/htu_beamline/run_impactx_offenergy2.py
-    ON   # ImpactX MPI-parallel  
+    ON   # ImpactX MPI-parallel
     examples/htu_beamline/analysis_htu_beamline_offenergy.py
-    OFF  # no plot script yet  
+    OFF  # no plot script yet
 )
 
 # Symplectic Integration in an Exact Combined-Function Bend ##############

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1529,7 +1529,6 @@ add_impactx_test(htu-beamline.py
 
 # HTU Beamline Model with Off-Energy Transport ##############
 #
-# no space charge
 file(COPY ${ImpactX_SOURCE_DIR}/examples/htu_beamline/htu_lattice.py
         DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/htu-beamline-offenergy1.py)
 file(COPY ${ImpactX_SOURCE_DIR}/examples/htu_beamline/htu_lattice.py

--- a/examples/htu_beamline/README.rst
+++ b/examples/htu_beamline/README.rst
@@ -56,9 +56,9 @@ We run the following script to analyze correctness:
 Off-energy transport in the HTU Beamline
 ==========================================
 
-This is a modification of the example htu-beamline, as follows.  The beam total energy is increased from 100 MeV to 150 MeV, and the chicane R_56 is decreased from 200 microns to 0.
+This is a modification of the example htu-beamline, as follows.  The beam total energy is increased from 100 MeV to 150 MeV, and the chicane :math:`R_{56}` is decreased from 200 microns to 0.
 
-The purpose of this example is compare two distinct methods for transporting highly off-energy beams:
+The purpose of this example is to compare two distinct methods for transporting highly off-energy beams:
 
 1) keep the 100 MeV reference energy, but displace the mean energy of the initial beam distribution by setting the parameter meanPt
 2) modify the reference energy to 150 MeV, and rescale the input parameters of the initial beam distribution to yield a distribution with the same second moments as 1)

--- a/examples/htu_beamline/README.rst
+++ b/examples/htu_beamline/README.rst
@@ -60,7 +60,7 @@ This is a modification of the example htu-beamline, as follows.  The beam total 
 
 The purpose of this example is to compare two distinct methods for transporting highly off-energy beams:
 
-1) keep the 100 MeV reference energy, but displace the mean energy of the initial beam distribution by setting the parameter meanPt
+1) keep the 100 MeV reference energy, but displace the mean energy of the initial beam distribution by setting the parameter mean_pt
 2) modify the reference energy to 150 MeV, and rescale the input parameters of the initial beam distribution to yield a distribution with the same second moments as 1)
 
 The bunch is generated in practice from a laser-plasma accelerator stage, resulting in a small intial rms beam size (3.9, 3.9, 1.0) microns, 2 mrad transverse divergence and 2.5% energy spread.  Due

--- a/examples/htu_beamline/README.rst
+++ b/examples/htu_beamline/README.rst
@@ -68,6 +68,7 @@ to the large energy spread, chromatic focusing effects are important.
 
 In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
 
+The two methods described in 1) and 2) are physically equivalent and the test verifies that the two methods produce physically equivalent output.
 
 Run
 ---

--- a/examples/htu_beamline/README.rst
+++ b/examples/htu_beamline/README.rst
@@ -100,6 +100,8 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
          :language: python3
          :caption: You can copy this file from ``examples/htu_beamline/run_impactx_offenergy2.py``.
 
+The two scripts are physically equivalent, corresponding to methods 1) and 2) above, and should produce physically equivalent output.
+
 Analyze
 -------
 

--- a/examples/htu_beamline/README.rst
+++ b/examples/htu_beamline/README.rst
@@ -109,5 +109,3 @@ We run the following script to analyze correctness:
    .. literalinclude:: analysis_htu_beamline_offenergy.py
       :language: python3
       :caption: You can copy this file from ``examples/htu_beamline/analysis_htu_beamline_offenergy.py``.
-   
-

--- a/examples/htu_beamline/README.rst
+++ b/examples/htu_beamline/README.rst
@@ -48,3 +48,66 @@ We run the following script to analyze correctness:
    .. literalinclude:: analysis_htu_beamline.py
       :language: python3
       :caption: You can copy this file from ``examples/htu_beamline/analysis_htu_beamline.py``.
+
+
+
+.. _htu-beamline-off-energy:
+
+Off-energy transport in the HTU Beamline
+==========================================
+
+This is a modification of the example htu-beamline, as follows.  The beam total energy is increased from 100 MeV to 150 MeV, and the chicane R_56 is decreased from 200 microns to 0.
+
+The purpose of this example is compare two distinct methods for transporting highly off-energy beams:
+
+1) keep the 100 MeV reference energy, but displace the mean energy of the initial beam distribution by setting the parameter meanPt
+2) modify the reference energy to 150 MeV, and rescale the input parameters of the initial beam distribution to yield a distribution with the same second moments as 1)
+
+The bunch is generated in practice from a laser-plasma accelerator stage, resulting in a small intial rms beam size (3.9, 3.9, 1.0) microns, 2 mrad transverse divergence and 2.5% energy spread.  Due
+to the large energy spread, chromatic focusing effects are important.
+
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+
+
+Run
+---
+
+This example can be run as:
+
+* **Python** script: ``python3 run_impactx_offenergy1.py`` or ``python3 run_impactx_offenergy2.py``
+
+For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+
+.. tab-set::
+
+   .. tab-item:: Python: Script
+
+      .. dropdown:: HTU Beamline: Lattice File
+         :color: light
+         :icon: info
+         :animate: fade-in-slide-down
+
+         .. literalinclude:: htu_lattice.py
+            :language: python3
+            :caption: You can copy this file from ``examples/htu_beamline/htu_lattice.py``.
+
+      .. literalinclude:: run_impactx_offenergy1.py
+         :language: python3
+         :caption: You can copy this file from ``examples/htu_beamline/run_impactx_offenergy1.py``.
+
+      .. literalinclude:: run_impactx_offenergy2.py
+         :language: python3
+         :caption: You can copy this file from ``examples/htu_beamline/run_impactx_offenergy2.py``.
+
+Analyze
+-------
+
+We run the following script to analyze correctness:
+
+.. dropdown:: Script ``analysis_htu_beamline_offenergy.py``
+
+   .. literalinclude:: analysis_htu_beamline_offenergy.py
+      :language: python3
+      :caption: You can copy this file from ``examples/htu_beamline/analysis_htu_beamline_offenergy.py``.
+   
+

--- a/examples/htu_beamline/analysis_htu_beamline_offenergy.py
+++ b/examples/htu_beamline/analysis_htu_beamline_offenergy.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+
+import numpy as np
+import openpmd_api as io
+from scipy.stats import moment
+
+
+def get_moments(beam):
+    """Calculate standard deviations of beam position & momenta
+    and emittance values
+
+    Returns
+    -------
+    sigx, sigy, sigt, emittance_x, emittance_y, emittance_t
+    """
+    sigx = moment(beam["position_x"], moment=2) ** 0.5  # variance -> std dev.
+    sigpx = moment(beam["momentum_x"], moment=2) ** 0.5
+    sigy = moment(beam["position_y"], moment=2) ** 0.5
+    sigpy = moment(beam["momentum_y"], moment=2) ** 0.5
+    sigt = moment(beam["position_t"], moment=2) ** 0.5
+    sigpt = moment(beam["momentum_t"], moment=2) ** 0.5
+
+    epstrms = beam.cov(ddof=0)
+    emittance_x = (sigx**2 * sigpx**2 - epstrms["position_x"]["momentum_x"] ** 2) ** 0.5
+    emittance_y = (sigy**2 * sigpy**2 - epstrms["position_y"]["momentum_y"] ** 2) ** 0.5
+    emittance_t = (sigt**2 * sigpt**2 - epstrms["position_t"]["momentum_t"] ** 2) ** 0.5
+
+    return (sigx, sigy, sigt, emittance_x, emittance_y, emittance_t)
+
+
+# initial/final beam
+series1 = io.Series("diags/openPMD/TCPhosphor.h5", io.Access.read_only)
+last_step = list(series1.iterations)[-1]
+initial = series1.iterations[last_step].particles["beam"].to_df()
+
+series2 = io.Series("diags/openPMD/UC_VisaEBeam8.h5", io.Access.read_only)
+last_step = list(series2.iterations)[-1]
+beam_final = series2.iterations[last_step].particles["beam"]
+final = beam_final.to_df()
+
+# compare number of particles
+num_particles = 10000
+assert num_particles == len(initial)
+assert num_particles == len(final)
+
+print("Initial Beam (at TCPhosphor screen):")
+sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(initial)
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
+print(
+    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
+)
+
+atol = 0.0  # ignored
+rtol = 20.0 * num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
+    [
+        4.786098e-04,
+        2.983777e-04,
+        1.147205e-06,
+        1.937316e-08,
+        1.106004e-08,
+        2.856312e-08
+    ],
+    rtol=rtol,
+    atol=atol,
+)
+
+
+print("")
+print("Final Beam (at VisaEbeam8 screen):")
+sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(final)
+s_ref = beam_final.get_attribute("s_ref")
+gamma_ref = beam_final.get_attribute("gamma_ref")
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
+print(
+    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}\n"
+)
+
+atol = 0.0  # ignored
+rtol = 20.0 * num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
+    [
+        7.554152e-03,
+        2.151019e-03,
+        9.054048e-04,
+        3.112212e-05,
+        3.187780e-06,
+        2.261387e-05,
+    ],
+    rtol=rtol,
+    atol=atol,
+)

--- a/examples/htu_beamline/analysis_htu_beamline_offenergy.py
+++ b/examples/htu_beamline/analysis_htu_beamline_offenergy.py
@@ -55,9 +55,9 @@ bg = np.sqrt(gamma_ref**2 - 1.0)
 print("Initial Beam (at TCPhosphor screen):")
 sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(initial)
 
-emittance_xn = emittance_x*bg
-emittance_yn = emittance_y*bg
-emittance_tn = emittance_t*bg
+emittance_xn = emittance_x * bg
+emittance_yn = emittance_y * bg
+emittance_tn = emittance_t * bg
 
 print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
 print(
@@ -89,9 +89,9 @@ print("")
 print("Final Beam (at VisaEbeam8 screen):")
 sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(final)
 
-emittance_xn = emittance_x*bg
-emittance_yn = emittance_y*bg
-emittance_tn = emittance_t*bg
+emittance_xn = emittance_x * bg
+emittance_yn = emittance_y * bg
+emittance_tn = emittance_t * bg
 
 print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
 print(

--- a/examples/htu_beamline/analysis_htu_beamline_offenergy.py
+++ b/examples/htu_beamline/analysis_htu_beamline_offenergy.py
@@ -37,7 +37,8 @@ def get_moments(beam):
 # initial/final beam
 series1 = io.Series("diags/openPMD/TCPhosphor.h5", io.Access.read_only)
 last_step = list(series1.iterations)[-1]
-initial = series1.iterations[last_step].particles["beam"].to_df()
+beam_initial = series1.iterations[last_step].particles["beam"]
+initial = beam_initial.to_df()
 
 series2 = io.Series("diags/openPMD/UC_VisaEBeam8.h5", io.Access.read_only)
 last_step = list(series2.iterations)[-1]
@@ -49,11 +50,18 @@ num_particles = 10000
 assert num_particles == len(initial)
 assert num_particles == len(final)
 
+gamma_ref = beam_initial.get_attribute("gamma_ref")
+bg = np.sqrt(gamma_ref**2 - 1.0)
 print("Initial Beam (at TCPhosphor screen):")
 sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(initial)
+
+emittance_xn = emittance_x*bg
+emittance_yn = emittance_y*bg
+emittance_tn = emittance_t*bg
+
 print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
 print(
-    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
+    f"  emittance_xn={emittance_xn:e} emittance_yn={emittance_yn:e} emittance_tn={emittance_tn:e}"
 )
 
 atol = 0.0  # ignored
@@ -61,28 +69,33 @@ rtol = 20.0 * num_particles**-0.5  # from random sampling of a smooth distributi
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
-    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
+    [sigx, sigy, sigt, emittance_xn, emittance_yn, emittance_tn],
     [
         4.786098e-04,
         2.983777e-04,
         1.147205e-06,
-        1.937316e-08,
-        1.106004e-08,
-        2.856312e-08,
+        3.791183e-06,
+        2.164368e-06,
+        5.589590e-06,
     ],
     rtol=rtol,
     atol=atol,
 )
 
+gamma_ref = beam_final.get_attribute("gamma_ref")
+bg = np.sqrt(gamma_ref**2 - 1.0)
 
 print("")
 print("Final Beam (at VisaEbeam8 screen):")
 sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(final)
-s_ref = beam_final.get_attribute("s_ref")
-gamma_ref = beam_final.get_attribute("gamma_ref")
+
+emittance_xn = emittance_x*bg
+emittance_yn = emittance_y*bg
+emittance_tn = emittance_t*bg
+
 print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
 print(
-    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}\n"
+    f"  emittance_xn={emittance_xn:e} emittance_yn={emittance_yn:e} emittance_tn={emittance_tn:e}\n"
 )
 
 atol = 0.0  # ignored
@@ -90,14 +103,14 @@ rtol = 20.0 * num_particles**-0.5  # from random sampling of a smooth distributi
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(
-    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
+    [sigx, sigy, sigt, emittance_xn, emittance_yn, emittance_tn],
     [
         7.554152e-03,
         2.151019e-03,
         9.054048e-04,
-        3.112212e-05,
-        3.187780e-06,
-        2.261387e-05,
+        6.090367e-03,
+        6.238249e-04,
+        4.425367e-03,
     ],
     rtol=rtol,
     atol=atol,

--- a/examples/htu_beamline/analysis_htu_beamline_offenergy.py
+++ b/examples/htu_beamline/analysis_htu_beamline_offenergy.py
@@ -68,7 +68,7 @@ assert np.allclose(
         1.147205e-06,
         1.937316e-08,
         1.106004e-08,
-        2.856312e-08
+        2.856312e-08,
     ],
     rtol=rtol,
     atol=atol,

--- a/examples/htu_beamline/htu_lattice.py
+++ b/examples/htu_beamline/htu_lattice.py
@@ -440,12 +440,14 @@ def quadrupole(
         Bgradient = current_to_Bgradient(current, design)
     return elements.ChrQuad(name=name, ds=L, k=-Bgradient, unit=1, nslice=1)
 
+
 # Define a drift element
 def drift(name, L, code):
     """
     Define a drift element.
     """
     return elements.ExactDrift(name=name, ds=L, nslice=1)
+
 
 # Define a kicker element
 def current_to_integrated_field(current, max_current, max_integrated_field):
@@ -476,7 +478,7 @@ def kicker(
     return elements.Kicker(
         name=name, xkick=integrated_field_h, ykick=integrated_field_v, unit="T-m"
     )
-   
+
 
 # Define a dipole element
 def chicane_r56_to_field(r56, L, reference_energy_eV):

--- a/examples/htu_beamline/htu_lattice.py
+++ b/examples/htu_beamline/htu_lattice.py
@@ -435,14 +435,14 @@ def quadrupole(
     Need to provide k1, current, or bore_radius and B.
     """
     if k1 is None and current is None:
-        Bgradient = -1.0*peakfield_to_Bgradient(bore_radius, B)
-        unit=1
+        Bgradient = -1.0 * peakfield_to_Bgradient(bore_radius, B)
+        unit = 1
     elif k1 is None:
-        Bgradient = -1.0*current_to_Bgradient(current, design)
-        unit=1
+        Bgradient = -1.0 * current_to_Bgradient(current, design)
+        unit = 1
     else:
         Bgradient = k1
-        unit=0
+        unit = 0
     return elements.ChrQuad(name=name, ds=L, k=Bgradient, unit=unit, nslice=1)
 
 

--- a/examples/htu_beamline/htu_lattice.py
+++ b/examples/htu_beamline/htu_lattice.py
@@ -12,6 +12,7 @@ from impactx import elements
 
 impactx_available = True
 
+
 def get_lattice(
     code,
     vs_current_x=[0] * 8,
@@ -54,26 +55,26 @@ def get_lattice(
         code,
     )
     Aline2 = screen(
-        "UC_ALineEBeam2",   
+        "UC_ALineEBeam2",
         code,
     )
     Aline3 = screen(
         "UC_ALineEBeam3",
-        code,   
+        code,
     )
-    VisaEBeam1 = screen( 
-        "UC_VisaEBeam1", 
+    VisaEBeam1 = screen(
+        "UC_VisaEBeam1",
         code,
     )
     VisaEBeam2 = screen(
         "UC_VisaEBeam2",
         code,
-    )  
+    )
     VisaEBeam3 = screen(
         "UC_VisaEBeam3",
-        code,  
+        code,
     )
-    VisaEBeam4 = screen(   
+    VisaEBeam4 = screen(
         "UC_VisaEBeam4",
         code,
     )
@@ -86,7 +87,7 @@ def get_lattice(
         code,
     )
     VisaEBeam7 = screen(
-        "UC_VisaEBeam7", 
+        "UC_VisaEBeam7",
         code,
     )
     VisaEBeam8 = screen(
@@ -105,17 +106,25 @@ def get_lattice(
     L1 = drift("L1", 0.029035, code)
     L2 = drift("L2", 0.0473895, code)
 
-    PMQTrip = [PMQ1V,L1,PMQ2H,L2,PMQ3V]
+    PMQTrip = [PMQ1V, L1, PMQ2H, L2, PMQ3V]
 
     PMQTripToTCPhos = drift("PMQTripToTCPhos", 0.2158, code)
     TCPhosToChicane = drift("TCPhosToChicane", 0.42, code)
 
     # Integrated field (converted from G.cm to T.m) and max current from HTU_Kickers_SteeringMagnets.pdf
     # https://drive.google.com/drive/u/0/folders/1r9InjfW7-92OUpZo4xADUm6rVM5u13yt
-    S1 = kicker("S1", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code)
-    S2 = kicker("S2", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code)
-    S3 = kicker("S3", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code)
-    S4 = kicker("S4", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code)
+    S1 = kicker(
+        "S1", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code
+    )
+    S2 = kicker(
+        "S2", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code
+    )
+    S3 = kicker(
+        "S3", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code
+    )
+    S4 = kicker(
+        "S4", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code
+    )
 
     # Calculation of the bending field and bend angle are now found in the dipole definitions below.
     BEND1 = dipole("BEND1", 0.175, r56=chicane_r56, bend=1, code=code)
@@ -126,17 +135,23 @@ def get_lattice(
     L12 = drift("L12", 0.125, code)
     L23 = drift("L23", 0.15, code)
 
-    Chicane = [BEND1,L12,BEND2,L23,ChicaneSlit,L23,BEND3,L12,BEND4]
+    Chicane = [BEND1, L12, BEND2, L23, ChicaneSlit, L23, BEND3, L12, BEND4]
 
     DriftToDCPhos = drift("DriftToDCPhos", 0.27, code)
     DriftToEMQTrip = drift("DriftToEMQTrip", 0.405, code)
-    EMQ1H = quadrupole("EMQ1H", L=0.1408, current=emq_currents[0], design="EMQD-113-394", code=code)
+    EMQ1H = quadrupole(
+        "EMQ1H", L=0.1408, current=emq_currents[0], design="EMQD-113-394", code=code
+    )
     EMQL1 = drift("EMQL1", 0.112735, code)
-    EMQ2V = quadrupole("EMQ2V", L=0.28141, current=emq_currents[1], design="EMQD-113-949", code=code)
+    EMQ2V = quadrupole(
+        "EMQ2V", L=0.28141, current=emq_currents[1], design="EMQD-113-949", code=code
+    )
     EMQL2 = drift("EMQL2", 0.112735, code)
-    EMQ3H = quadrupole("EMQ3H", L=0.1409, current=emq_currents[2], design="EMQD-113-394", code=code)
+    EMQ3H = quadrupole(
+        "EMQ3H", L=0.1409, current=emq_currents[2], design="EMQD-113-394", code=code
+    )
 
-    EMQTriplet = [EMQ1H,EMQL1,EMQ2V,EMQL2,EMQ3H]
+    EMQTriplet = [EMQ1H, EMQL1, EMQ2V, EMQL2, EMQ3H]
 
     DriftToPhos1 = drift("DriftToPhos1", 0.084325, code)
     DriftToSpec = drift("DriftToSpec", 0.28, code)
@@ -149,69 +164,200 @@ def get_lattice(
     DriftToUndulator = drift("DriftToUndulator", 0.2945, code)
     # TODO: UndulatorAperture = aperture("UndulatorAperture", 0.005, 0.003, code)
 
-    Aline = [DriftToAline1, Aline1, DriftToAline2, Aline2, DriftToAline3, Aline3, DriftToUndulator]
+    Aline = [
+        DriftToAline1,
+        Aline1,
+        DriftToAline2,
+        Aline2,
+        DriftToAline3,
+        Aline3,
+        DriftToUndulator,
+    ]
 
     # Integrated field (converted from G.cm to T.m) is from HTU_Kickers_SteeringMagnets.pdf
     # but scaled by 0.5 to account for lower peak field, per Sam's recommendation
-    VS1 = kicker("VS1", vs_current_x[0], vs_current_y[0], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
-    VS2 = kicker("VS2", vs_current_x[1], vs_current_y[1], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
-    VS3 = kicker("VS3", vs_current_x[2], vs_current_y[2], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
-    VS4 = kicker("VS4", vs_current_x[3], vs_current_y[3], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
-    VS5 = kicker("VS5", vs_current_x[4], vs_current_y[4], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
-    VS6 = kicker("VS6", vs_current_x[5], vs_current_y[5], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
-    VS7 = kicker("VS7", vs_current_x[6], vs_current_y[6], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
-    VS8 = kicker("VS8", vs_current_x[7], vs_current_y[7], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
+    VS1 = kicker(
+        "VS1",
+        vs_current_x[0],
+        vs_current_y[0],
+        max_integrated_field=1970e-6 * 0.5,
+        max_current=5.0,
+        code=code,
+    )
+    VS2 = kicker(
+        "VS2",
+        vs_current_x[1],
+        vs_current_y[1],
+        max_integrated_field=1970e-6 * 0.5,
+        max_current=5.0,
+        code=code,
+    )
+    VS3 = kicker(
+        "VS3",
+        vs_current_x[2],
+        vs_current_y[2],
+        max_integrated_field=1970e-6 * 0.5,
+        max_current=5.0,
+        code=code,
+    )
+    VS4 = kicker(
+        "VS4",
+        vs_current_x[3],
+        vs_current_y[3],
+        max_integrated_field=1970e-6 * 0.5,
+        max_current=5.0,
+        code=code,
+    )
+    VS5 = kicker(
+        "VS5",
+        vs_current_x[4],
+        vs_current_y[4],
+        max_integrated_field=1970e-6 * 0.5,
+        max_current=5.0,
+        code=code,
+    )
+    VS6 = kicker(
+        "VS6",
+        vs_current_x[5],
+        vs_current_y[5],
+        max_integrated_field=1970e-6 * 0.5,
+        max_current=5.0,
+        code=code,
+    )
+    VS7 = kicker(
+        "VS7",
+        vs_current_x[6],
+        vs_current_y[6],
+        max_integrated_field=1970e-6 * 0.5,
+        max_current=5.0,
+        code=code,
+    )
+    VS8 = kicker(
+        "VS8",
+        vs_current_x[7],
+        vs_current_y[7],
+        max_integrated_field=1970e-6 * 0.5,
+        max_current=5.0,
+        code=code,
+    )
 
     VD = drift("VD", 0.018, code)
 
     VQ1 = quadrupole("VQ1", L=0.0504, bore_radius=0.004, B=0.132, code=code)
     VQ2 = quadrupole("VQ2", L=0.0504, bore_radius=0.004, B=-0.132, code=code)
-    FODOCell1 = [VQ1,VQ1,VD,VQ2,VQ2,VD]
-    UndulatorSegment1 = [*FODOCell1,VS1,VisaEBeam1,*FODOCell1,*FODOCell1,VS2,VisaEBeam2,*FODOCell1]
+    FODOCell1 = [VQ1, VQ1, VD, VQ2, VQ2, VD]
+    UndulatorSegment1 = [
+        *FODOCell1,
+        VS1,
+        VisaEBeam1,
+        *FODOCell1,
+        *FODOCell1,
+        VS2,
+        VisaEBeam2,
+        *FODOCell1,
+    ]
 
     VQ3 = quadrupole("VQ3", L=0.0504, bore_radius=0.004, B=0.132, code=code)
     VQ4 = quadrupole("VQ4", L=0.0504, bore_radius=0.004, B=-0.132, code=code)
-    FODOCell2 = [VQ3,VQ3,VD,VQ4,VQ4,VD]
-    UndulatorSegment2 = [*FODOCell2,VS3,VisaEBeam3,*FODOCell2,*FODOCell2,VS4,VisaEBeam4,*FODOCell2]
+    FODOCell2 = [VQ3, VQ3, VD, VQ4, VQ4, VD]
+    UndulatorSegment2 = [
+        *FODOCell2,
+        VS3,
+        VisaEBeam3,
+        *FODOCell2,
+        *FODOCell2,
+        VS4,
+        VisaEBeam4,
+        *FODOCell2,
+    ]
 
     VQ5 = quadrupole("VQ5", L=0.0504, bore_radius=0.004, B=0.132, code=code)
     VQ6 = quadrupole("VQ6", L=0.0504, bore_radius=0.004, B=-0.132, code=code)
-    FODOCell3 = [VQ5,VQ5,VD,VQ6,VQ6,VD]
-    UndulatorSegment3 = [*FODOCell3,VS5,VisaEBeam5,*FODOCell3,*FODOCell3,VS6,VisaEBeam6,*FODOCell3]
+    FODOCell3 = [VQ5, VQ5, VD, VQ6, VQ6, VD]
+    UndulatorSegment3 = [
+        *FODOCell3,
+        VS5,
+        VisaEBeam5,
+        *FODOCell3,
+        *FODOCell3,
+        VS6,
+        VisaEBeam6,
+        *FODOCell3,
+    ]
 
     VQ7 = quadrupole("VQ7", L=0.0504, bore_radius=0.004, B=0.132, code=code)
     VQ8 = quadrupole("VQ8", L=0.0504, bore_radius=0.004, B=-0.132, code=code)
-    FODOCell4 = [VQ7,VQ7,VD,VQ8,VQ8,VD]
-    UndulatorSegment4 = [*FODOCell4,VS7,VisaEBeam7,*FODOCell4,*FODOCell4,VS8,VisaEBeam8,*FODOCell4]
+    FODOCell4 = [VQ7, VQ7, VD, VQ8, VQ8, VD]
+    UndulatorSegment4 = [
+        *FODOCell4,
+        VS7,
+        VisaEBeam7,
+        *FODOCell4,
+        *FODOCell4,
+        VS8,
+        VisaEBeam8,
+        *FODOCell4,
+    ]
 
-    B0 = [SrcToPMQ1,*PMQTrip,PMQTripToTCPhos,TCPhosphor,TCPhosToChicane,S1,*Chicane,S2,DriftToDCPhos,DCPhosphor,DriftToEMQTrip,*EMQTriplet,S3,DriftToPhos1,Phosphor1,DriftToSpec,MagSpec,S4,*Aline]
-    Undulator = UndulatorSegment1 + UndulatorSegment2 + UndulatorSegment3 + UndulatorSegment4
+    B0 = [
+        SrcToPMQ1,
+        *PMQTrip,
+        PMQTripToTCPhos,
+        TCPhosphor,
+        TCPhosToChicane,
+        S1,
+        *Chicane,
+        S2,
+        DriftToDCPhos,
+        DCPhosphor,
+        DriftToEMQTrip,
+        *EMQTriplet,
+        S3,
+        DriftToPhos1,
+        Phosphor1,
+        DriftToSpec,
+        MagSpec,
+        S4,
+        *Aline,
+    ]
+    Undulator = (
+        UndulatorSegment1 + UndulatorSegment2 + UndulatorSegment3 + UndulatorSegment4
+    )
     full_beamline = B0 + Undulator
 
     # Only return the elements between from_element and to_element
     if from_element is not None:
-        element_indices = [ i for i, elem in enumerate(full_beamline) if elem.name == from_element ]
+        element_indices = [
+            i for i, elem in enumerate(full_beamline) if elem.name == from_element
+        ]
         if len(element_indices) == 0:
             raise ValueError(f"Element {from_element} not found in beamline.")
         elif len(element_indices) > 1:
-            raise ValueError(f"Multiple elements with name {from_element} found in beamline.")
+            raise ValueError(
+                f"Multiple elements with name {from_element} found in beamline."
+            )
         # Get the first index of the element
         from_index = element_indices[0]
     else:
         from_index = 0
     if to_element is not None:
-        element_indices = [ i for i, elem in enumerate(full_beamline) if elem.name == to_element ]
+        element_indices = [
+            i for i, elem in enumerate(full_beamline) if elem.name == to_element
+        ]
         if len(element_indices) == 0:
             raise ValueError(f"Element {to_element} not found in beamline.")
         elif len(element_indices) > 1:
-            raise ValueError(f"Multiple elements with name {to_element} found in beamline.")
+            raise ValueError(
+                f"Multiple elements with name {to_element} found in beamline."
+            )
         # Get the first index of the element
         to_index = element_indices[0]
     else:
-        to_index = len(full_beamline)-1
-    beamline = full_beamline[from_index:to_index+1]
+        to_index = len(full_beamline) - 1
+    beamline = full_beamline[from_index : to_index + 1]
 
     return beamline
+
 
 # Define a screen element
 def screen(name, code):
@@ -223,8 +369,9 @@ def screen(name, code):
     else:
         raise ValueError(f"Unsupported code: {code}")
 
+
 # Define a quadrupole element
-def peakfield_to_Bgradient( bore_radius, B ):
+def peakfield_to_Bgradient(bore_radius, B):
     """
     Convert the peak field in T (and corresponding bore radius) to the field gradient in T/m of a quadrupole.
 
@@ -237,7 +384,8 @@ def peakfield_to_Bgradient( bore_radius, B ):
     Bgradient = B / bore_radius
     return Bgradient
 
-def current_to_Bgradient( current, design ):
+
+def current_to_Bgradient(current, design):
     """
     Convert a current in A to the field gradient in T/m of a quadrupole.
 
@@ -249,29 +397,41 @@ def current_to_Bgradient( current, design ):
     """
     if design == "EMQD-113-394":
         # From "LBM6_03 Calibration" in EMQD-113-394 Testing Report-FINAL.pdf
-        Bgradient = 2.9217*current + 0.0965  # T/m
+        Bgradient = 2.9217 * current + 0.0965  # T/m
     elif design == "EMQD-113-949":
         # From "LBM6_03 Calibration" in EMQD-113-949 Testing Report-FINAL.pdf
-        Bgradient = 2.9318*current + 0.0077  # T/m
+        Bgradient = 2.9318 * current + 0.0077  # T/m
     else:
         raise ValueError(f"Unsupported design: {design}")
     return Bgradient
 
-def get_rigidity( reference_energy_eV ):
+
+def get_rigidity(reference_energy_eV):
     """
     Return the magnetic rigidity associated with reference_energy_eV in
     units of T-m, to be used for field strength normalization.
-        
+
     Parameters:
         Bfield (float):
             The reference energy in eV.
     """
-    gamma = reference_energy_eV*e/(m_e*c**2)
-    beta = (1-1/gamma**2)**.5
-    rigidity = m_e*gamma*beta*c/e
+    gamma = reference_energy_eV * e / (m_e * c**2)
+    beta = (1 - 1 / gamma**2) ** 0.5
+    rigidity = m_e * gamma * beta * c / e
     return rigidity
 
-def quadrupole( name, L, k1=None, current=None, design=None, bore_radius=None, B=None, code=None, reference_energy_eV=100e6 ):
+
+def quadrupole(
+    name,
+    L,
+    k1=None,
+    current=None,
+    design=None,
+    bore_radius=None,
+    B=None,
+    code=None,
+    reference_energy_eV=100e6,
+):
     """
     Define a quadrupole element.
 
@@ -286,8 +446,9 @@ def quadrupole( name, L, k1=None, current=None, design=None, bore_radius=None, B
     else:
         raise ValueError(f"Unsupported code: {code}")
 
+
 # Define a drift element
-def drift( name, L, code ):
+def drift(name, L, code):
     """
     Define a drift element.
     """
@@ -296,30 +457,47 @@ def drift( name, L, code ):
     else:
         raise ValueError(f"Unsupported code: {code}")
 
+
 # Define a kicker element
-def current_to_integrated_field( current, max_current, max_integrated_field ):
-    integrated_field = current * max_integrated_field/max_current
+def current_to_integrated_field(current, max_current, max_integrated_field):
+    integrated_field = current * max_integrated_field / max_current
     return integrated_field
 
-def kicker( name, current_h, current_v, max_current, max_integrated_field, code, reference_energy_eV=100e6 ):
+
+def kicker(
+    name,
+    current_h,
+    current_v,
+    max_current,
+    max_integrated_field,
+    code,
+    reference_energy_eV=100e6,
+):
     """
     Define a kicker element.
     """
-    integrated_field_h = current_to_integrated_field(current_h, max_current, max_integrated_field )
-    integrated_field_v = current_to_integrated_field(current_v, max_current, max_integrated_field )
+    integrated_field_h = current_to_integrated_field(
+        current_h, max_current, max_integrated_field
+    )
+    integrated_field_v = current_to_integrated_field(
+        current_v, max_current, max_integrated_field
+    )
     angle_h = integrated_field_h / get_rigidity(reference_energy_eV)
     angle_v = integrated_field_v / get_rigidity(reference_energy_eV)
     if code == "impactx" and impactx_available:
-        return elements.Kicker(name=name, xkick=integrated_field_h, ykick=integrated_field_v, unit="T-m")
+        return elements.Kicker(
+            name=name, xkick=integrated_field_h, ykick=integrated_field_v, unit="T-m"
+        )
     else:
         raise ValueError(f"Unsupported code: {code}")
 
+
 # Define a dipole element
-def chicane_r56_to_field( r56, L, reference_energy_eV ):
+def chicane_r56_to_field(r56, L, reference_energy_eV):
     """
     Return the magnetic field in T associated with the chicane setting of r56
     defined at the reference energy reference_energy_eV.
-        
+
     Parameters:
         r56 (float):
             The chicane r56 at nominal energy in microns.
@@ -329,10 +507,10 @@ def chicane_r56_to_field( r56, L, reference_energy_eV ):
             The reference energy in eV.
     """
 
-    #Polynomial fit to find the dipole angle as a function of chicane r56 (no longer used)
-    #angle_rad = 0.00743627 + 6.32812981e-05*chicane_r56 -4.83395592e-08*chicane_r56**2 + 1.91504783e-11*chicane_r56**3
-    #Updated r56 formula valid near r56=0
-    angle_rad = 0.001438389904456 * r56**.5
+    # Polynomial fit to find the dipole angle as a function of chicane r56 (no longer used)
+    # angle_rad = 0.00743627 + 6.32812981e-05*chicane_r56 -4.83395592e-08*chicane_r56**2 + 1.91504783e-11*chicane_r56**3
+    # Updated r56 formula valid near r56=0
+    angle_rad = 0.001438389904456 * r56**0.5
     # TODO: This angle explicitly assumes that the reference energy of the beam is 100 MeV! We should make
     # sure that this is the case. In particular, for beams with fluctuations in energy, we should keep the
     # energy of the reference particles constant.
@@ -340,15 +518,16 @@ def chicane_r56_to_field( r56, L, reference_energy_eV ):
     B = -1.0 * get_rigidity(reference_energy_eV) * angle_rad / L
     return B
 
-def Bfield_to_angle( Bfield, L, reference_energy_eV ):
+
+def Bfield_to_angle(Bfield, L, reference_energy_eV):
     """
     Return the bend angle in radians associated with a magnetic field Bfield
     in units of T, for a bend of length L and specified energy.
-    
+
     Parameters:
         Bfield (float):
             The value of the magnetic field in T.
-        L (float):  
+        L (float):
             The bend length in m.
         reference_energy_eV (float):
             The reference energy in eV.
@@ -357,20 +536,22 @@ def Bfield_to_angle( Bfield, L, reference_energy_eV ):
     return angle
 
 
-def dipole( name, L, angle=None, r56=None, bend=None, code=None, reference_energy_eV=100e6):
+def dipole(
+    name, L, angle=None, r56=None, bend=None, code=None, reference_energy_eV=100e6
+):
     """
     Define a dipole element.
     """
     if angle is None:
-        Bfield = chicane_r56_to_field( r56, L, reference_energy_eV=100e6 )
-        angle = Bfield_to_angle( Bfield, L, reference_energy_eV )
+        Bfield = chicane_r56_to_field(r56, L, reference_energy_eV=100e6)
+        angle = Bfield_to_angle(Bfield, L, reference_energy_eV)
     else:
         Bfield = 0.0
-    if bend==1 or bend==4:
+    if bend == 1 or bend == 4:
         Bfield = -Bfield
         angle = -angle
     if code == "impactx" and impactx_available:
-        angle_deg = angle * 180.0/(3.1415926535898)
+        angle_deg = angle * 180.0 / (3.1415926535898)
         return elements.ExactSbend(name=name, ds=L, phi=angle_deg, B=Bfield, nslice=1)
     else:
         raise ValueError(f"Unsupported code: {code}")

--- a/examples/htu_beamline/htu_lattice.py
+++ b/examples/htu_beamline/htu_lattice.py
@@ -435,10 +435,15 @@ def quadrupole(
     Need to provide k1, current, or bore_radius and B.
     """
     if k1 is None and current is None:
-        Bgradient = peakfield_to_Bgradient(bore_radius, B)
+        Bgradient = -1.0*peakfield_to_Bgradient(bore_radius, B)
+        unit=1
     elif k1 is None:
-        Bgradient = current_to_Bgradient(current, design)
-    return elements.ChrQuad(name=name, ds=L, k=-Bgradient, unit=1, nslice=1)
+        Bgradient = -1.0*current_to_Bgradient(current, design)
+        unit=1
+    else:
+        Bgradient = k1
+        unit=0
+    return elements.ChrQuad(name=name, ds=L, k=Bgradient, unit=unit, nslice=1)
 
 
 # Define a drift element

--- a/examples/htu_beamline/htu_lattice.py
+++ b/examples/htu_beamline/htu_lattice.py
@@ -473,8 +473,6 @@ def kicker(
     integrated_field_v = current_to_integrated_field(
         current_v, max_current, max_integrated_field
     )
-    angle_h = integrated_field_h / get_rigidity(reference_energy_eV)
-    angle_v = integrated_field_v / get_rigidity(reference_energy_eV)
     return elements.Kicker(
         name=name, xkick=integrated_field_h, ykick=integrated_field_v, unit="T-m"
     )

--- a/examples/htu_beamline/htu_lattice.py
+++ b/examples/htu_beamline/htu_lattice.py
@@ -364,10 +364,7 @@ def screen(name, code):
     """
     Define a screen element.
     """
-    if code == "impactx" and impactx_available:
-        return elements.BeamMonitor(name=name, backend="h5")
-    else:
-        raise ValueError(f"Unsupported code: {code}")
+    return elements.BeamMonitor(name=name, backend="h5")
 
 
 # Define a quadrupole element
@@ -441,22 +438,14 @@ def quadrupole(
         Bgradient = peakfield_to_Bgradient(bore_radius, B)
     elif k1 is None:
         Bgradient = current_to_Bgradient(current, design)
-    if code == "impactx" and impactx_available:
-        return elements.ChrQuad(name=name, ds=L, k=-Bgradient, unit=1, nslice=1)
-    else:
-        raise ValueError(f"Unsupported code: {code}")
-
+    return elements.ChrQuad(name=name, ds=L, k=-Bgradient, unit=1, nslice=1)
 
 # Define a drift element
 def drift(name, L, code):
     """
     Define a drift element.
     """
-    if code == "impactx" and impactx_available:
-        return elements.ExactDrift(name=name, ds=L, nslice=1)
-    else:
-        raise ValueError(f"Unsupported code: {code}")
-
+    return elements.ExactDrift(name=name, ds=L, nslice=1)
 
 # Define a kicker element
 def current_to_integrated_field(current, max_current, max_integrated_field):
@@ -484,13 +473,10 @@ def kicker(
     )
     angle_h = integrated_field_h / get_rigidity(reference_energy_eV)
     angle_v = integrated_field_v / get_rigidity(reference_energy_eV)
-    if code == "impactx" and impactx_available:
-        return elements.Kicker(
-            name=name, xkick=integrated_field_h, ykick=integrated_field_v, unit="T-m"
-        )
-    else:
-        raise ValueError(f"Unsupported code: {code}")
-
+    return elements.Kicker(
+        name=name, xkick=integrated_field_h, ykick=integrated_field_v, unit="T-m"
+    )
+   
 
 # Define a dipole element
 def chicane_r56_to_field(r56, L, reference_energy_eV):
@@ -550,8 +536,5 @@ def dipole(
     if bend == 1 or bend == 4:
         Bfield = -Bfield
         angle = -angle
-    if code == "impactx" and impactx_available:
-        angle_deg = angle * 180.0 / (3.1415926535898)
-        return elements.ExactSbend(name=name, ds=L, phi=angle_deg, B=Bfield, nslice=1)
-    else:
-        raise ValueError(f"Unsupported code: {code}")
+    angle_deg = angle * 180.0 / (3.1415926535898)
+    return elements.ExactSbend(name=name, ds=L, phi=angle_deg, B=Bfield, nslice=1)

--- a/examples/htu_beamline/htu_lattice.py
+++ b/examples/htu_beamline/htu_lattice.py
@@ -12,7 +12,6 @@ from impactx import elements
 
 impactx_available = True
 
-
 def get_lattice(
     code,
     vs_current_x=[0] * 8,
@@ -27,7 +26,7 @@ def get_lattice(
 
     Parameters:
         code (str):
-            "impactx", ....
+            "impactx", ...
         vs_current_x (list of 8 elements):
             The current in the VISA horizontal steering magnets, in amps.
         vs_current_y (list of 8 elements):
@@ -42,8 +41,6 @@ def get_lattice(
             The name of the element to start from. If None, start from the beginning.
         to_element (str):
             The name of the element to end at. If None, end at the last element.
-        experiment_configuration_file (str): The path to the experiment configuration file. If None, use the default configuration.
-        experiment_analysis_settings (dict): The settings of the default analysis of images ; used to crop the screen images
 
     Returns:
         list: The lattice for the HTU accelerator.
@@ -57,26 +54,26 @@ def get_lattice(
         code,
     )
     Aline2 = screen(
-        "UC_ALineEBeam2",
+        "UC_ALineEBeam2",   
         code,
     )
     Aline3 = screen(
         "UC_ALineEBeam3",
-        code,
+        code,   
     )
-    VisaEBeam1 = screen(
-        "UC_VisaEBeam1",
+    VisaEBeam1 = screen( 
+        "UC_VisaEBeam1", 
         code,
     )
     VisaEBeam2 = screen(
         "UC_VisaEBeam2",
         code,
-    )
+    )  
     VisaEBeam3 = screen(
         "UC_VisaEBeam3",
-        code,
+        code,  
     )
-    VisaEBeam4 = screen(
+    VisaEBeam4 = screen(   
         "UC_VisaEBeam4",
         code,
     )
@@ -89,7 +86,7 @@ def get_lattice(
         code,
     )
     VisaEBeam7 = screen(
-        "UC_VisaEBeam7",
+        "UC_VisaEBeam7", 
         code,
     )
     VisaEBeam8 = screen(
@@ -108,61 +105,42 @@ def get_lattice(
     L1 = drift("L1", 0.029035, code)
     L2 = drift("L2", 0.0473895, code)
 
-    PMQTrip = [PMQ1V, L1, PMQ2H, L2, PMQ3V]
+    PMQTrip = [PMQ1V,L1,PMQ2H,L2,PMQ3V]
 
     PMQTripToTCPhos = drift("PMQTripToTCPhos", 0.2158, code)
     TCPhosToChicane = drift("TCPhosToChicane", 0.42, code)
 
     # Integrated field (converted from G.cm to T.m) and max current from HTU_Kickers_SteeringMagnets.pdf
     # https://drive.google.com/drive/u/0/folders/1r9InjfW7-92OUpZo4xADUm6rVM5u13yt
-    S1 = kicker(
-        "S1", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code
-    )
-    S2 = kicker(
-        "S2", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code
-    )
-    S3 = kicker(
-        "S3", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code
-    )
-    S4 = kicker(
-        "S4", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code
-    )
+    S1 = kicker("S1", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code)
+    S2 = kicker("S2", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code)
+    S3 = kicker("S3", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code)
+    S4 = kicker("S4", 0.0, 0.0, max_integrated_field=1970e-6, max_current=5.0, code=code)
 
-    # Use polynomial fit to find the dipole angle as a function of chicane r56
-    angle_rad = 0.001438389904456 * chicane_r56**0.5
-    # angle_rad = 0.00743627 + 6.32812981e-05*chicane_r56 -4.83395592e-08*chicane_r56**2 + 1.91504783e-11*chicane_r56**3
-    # TODO: This angle explicitly assumes that the reference energy of the beam is 100 MeV! We should make
-    # sure that this is the case. In particular, for beams with fluctuations in energy, we should keep the
-    # energy of the reference particles constant.
-    BEND1 = dipole("BEND1", 0.175, -angle_rad, code)
-    BEND2 = dipole("BEND2", 0.175, angle_rad, code)
-    BEND3 = dipole("BEND3", 0.175, angle_rad, code)
-    BEND4 = dipole("BEND4", 0.175, -angle_rad, code)
+    # Calculation of the bending field and bend angle are now found in the dipole definitions below.
+    BEND1 = dipole("BEND1", 0.175, r56=chicane_r56, bend=1, code=code)
+    BEND2 = dipole("BEND2", 0.175, r56=chicane_r56, bend=2, code=code)
+    BEND3 = dipole("BEND3", 0.175, r56=chicane_r56, bend=3, code=code)
+    BEND4 = dipole("BEND4", 0.175, r56=chicane_r56, bend=4, code=code)
 
     L12 = drift("L12", 0.125, code)
     L23 = drift("L23", 0.15, code)
 
-    Chicane = [BEND1, L12, BEND2, L23, ChicaneSlit, L23, BEND3, L12, BEND4]
+    Chicane = [BEND1,L12,BEND2,L23,ChicaneSlit,L23,BEND3,L12,BEND4]
 
     DriftToDCPhos = drift("DriftToDCPhos", 0.27, code)
     DriftToEMQTrip = drift("DriftToEMQTrip", 0.405, code)
-    EMQ1H = quadrupole(
-        "EMQ1H", L=0.1408, current=emq_currents[0], design="EMQD-113-394", code=code
-    )
+    EMQ1H = quadrupole("EMQ1H", L=0.1408, current=emq_currents[0], design="EMQD-113-394", code=code)
     EMQL1 = drift("EMQL1", 0.112735, code)
-    EMQ2V = quadrupole(
-        "EMQ2V", L=0.28141, current=emq_currents[1], design="EMQD-113-949", code=code
-    )
+    EMQ2V = quadrupole("EMQ2V", L=0.28141, current=emq_currents[1], design="EMQD-113-949", code=code)
     EMQL2 = drift("EMQL2", 0.112735, code)
-    EMQ3H = quadrupole(
-        "EMQ3H", L=0.1409, current=emq_currents[2], design="EMQD-113-394", code=code
-    )
+    EMQ3H = quadrupole("EMQ3H", L=0.1409, current=emq_currents[2], design="EMQD-113-394", code=code)
 
-    EMQTriplet = [EMQ1H, EMQL1, EMQ2V, EMQL2, EMQ3H]
+    EMQTriplet = [EMQ1H,EMQL1,EMQ2V,EMQL2,EMQ3H]
 
     DriftToPhos1 = drift("DriftToPhos1", 0.084325, code)
     DriftToSpec = drift("DriftToSpec", 0.28, code)
-    MagSpec = dipole("MagSpec", 0.4826, 0.0, code)
+    MagSpec = dipole("MagSpec", 0.4826, angle=0.0, code=code)
 
     DriftToAline1 = drift("DriftToAline1", 0.4009, code)
     DriftToAline2 = drift("DriftToAline2", 0.3825, code)
@@ -171,200 +149,69 @@ def get_lattice(
     DriftToUndulator = drift("DriftToUndulator", 0.2945, code)
     # TODO: UndulatorAperture = aperture("UndulatorAperture", 0.005, 0.003, code)
 
-    Aline = [
-        DriftToAline1,
-        Aline1,
-        DriftToAline2,
-        Aline2,
-        DriftToAline3,
-        Aline3,
-        DriftToUndulator,
-    ]
+    Aline = [DriftToAline1, Aline1, DriftToAline2, Aline2, DriftToAline3, Aline3, DriftToUndulator]
 
     # Integrated field (converted from G.cm to T.m) is from HTU_Kickers_SteeringMagnets.pdf
     # but scaled by 0.5 to account for lower peak field, per Sam's recommendation
-    VS1 = kicker(
-        "VS1",
-        vs_current_x[0],
-        vs_current_y[0],
-        max_integrated_field=1970e-6 * 0.5,
-        max_current=5.0,
-        code=code,
-    )
-    VS2 = kicker(
-        "VS2",
-        vs_current_x[1],
-        vs_current_y[1],
-        max_integrated_field=1970e-6 * 0.5,
-        max_current=5.0,
-        code=code,
-    )
-    VS3 = kicker(
-        "VS3",
-        vs_current_x[2],
-        vs_current_y[2],
-        max_integrated_field=1970e-6 * 0.5,
-        max_current=5.0,
-        code=code,
-    )
-    VS4 = kicker(
-        "VS4",
-        vs_current_x[3],
-        vs_current_y[3],
-        max_integrated_field=1970e-6 * 0.5,
-        max_current=5.0,
-        code=code,
-    )
-    VS5 = kicker(
-        "VS5",
-        vs_current_x[4],
-        vs_current_y[4],
-        max_integrated_field=1970e-6 * 0.5,
-        max_current=5.0,
-        code=code,
-    )
-    VS6 = kicker(
-        "VS6",
-        vs_current_x[5],
-        vs_current_y[5],
-        max_integrated_field=1970e-6 * 0.5,
-        max_current=5.0,
-        code=code,
-    )
-    VS7 = kicker(
-        "VS7",
-        vs_current_x[6],
-        vs_current_y[6],
-        max_integrated_field=1970e-6 * 0.5,
-        max_current=5.0,
-        code=code,
-    )
-    VS8 = kicker(
-        "VS8",
-        vs_current_x[7],
-        vs_current_y[7],
-        max_integrated_field=1970e-6 * 0.5,
-        max_current=5.0,
-        code=code,
-    )
+    VS1 = kicker("VS1", vs_current_x[0], vs_current_y[0], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
+    VS2 = kicker("VS2", vs_current_x[1], vs_current_y[1], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
+    VS3 = kicker("VS3", vs_current_x[2], vs_current_y[2], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
+    VS4 = kicker("VS4", vs_current_x[3], vs_current_y[3], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
+    VS5 = kicker("VS5", vs_current_x[4], vs_current_y[4], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
+    VS6 = kicker("VS6", vs_current_x[5], vs_current_y[5], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
+    VS7 = kicker("VS7", vs_current_x[6], vs_current_y[6], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
+    VS8 = kicker("VS8", vs_current_x[7], vs_current_y[7], max_integrated_field=1970e-6*0.5, max_current=5.0, code=code)
 
     VD = drift("VD", 0.018, code)
 
     VQ1 = quadrupole("VQ1", L=0.0504, bore_radius=0.004, B=0.132, code=code)
     VQ2 = quadrupole("VQ2", L=0.0504, bore_radius=0.004, B=-0.132, code=code)
-    FODOCell1 = [VQ1, VQ1, VD, VQ2, VQ2, VD]
-    UndulatorSegment1 = [
-        *FODOCell1,
-        VS1,
-        VisaEBeam1,
-        *FODOCell1,
-        *FODOCell1,
-        VS2,
-        VisaEBeam2,
-        *FODOCell1,
-    ]
+    FODOCell1 = [VQ1,VQ1,VD,VQ2,VQ2,VD]
+    UndulatorSegment1 = [*FODOCell1,VS1,VisaEBeam1,*FODOCell1,*FODOCell1,VS2,VisaEBeam2,*FODOCell1]
 
     VQ3 = quadrupole("VQ3", L=0.0504, bore_radius=0.004, B=0.132, code=code)
     VQ4 = quadrupole("VQ4", L=0.0504, bore_radius=0.004, B=-0.132, code=code)
-    FODOCell2 = [VQ3, VQ3, VD, VQ4, VQ4, VD]
-    UndulatorSegment2 = [
-        *FODOCell2,
-        VS3,
-        VisaEBeam3,
-        *FODOCell2,
-        *FODOCell2,
-        VS4,
-        VisaEBeam4,
-        *FODOCell2,
-    ]
+    FODOCell2 = [VQ3,VQ3,VD,VQ4,VQ4,VD]
+    UndulatorSegment2 = [*FODOCell2,VS3,VisaEBeam3,*FODOCell2,*FODOCell2,VS4,VisaEBeam4,*FODOCell2]
 
     VQ5 = quadrupole("VQ5", L=0.0504, bore_radius=0.004, B=0.132, code=code)
     VQ6 = quadrupole("VQ6", L=0.0504, bore_radius=0.004, B=-0.132, code=code)
-    FODOCell3 = [VQ5, VQ5, VD, VQ6, VQ6, VD]
-    UndulatorSegment3 = [
-        *FODOCell3,
-        VS5,
-        VisaEBeam5,
-        *FODOCell3,
-        *FODOCell3,
-        VS6,
-        VisaEBeam6,
-        *FODOCell3,
-    ]
+    FODOCell3 = [VQ5,VQ5,VD,VQ6,VQ6,VD]
+    UndulatorSegment3 = [*FODOCell3,VS5,VisaEBeam5,*FODOCell3,*FODOCell3,VS6,VisaEBeam6,*FODOCell3]
 
     VQ7 = quadrupole("VQ7", L=0.0504, bore_radius=0.004, B=0.132, code=code)
     VQ8 = quadrupole("VQ8", L=0.0504, bore_radius=0.004, B=-0.132, code=code)
-    FODOCell4 = [VQ7, VQ7, VD, VQ8, VQ8, VD]
-    UndulatorSegment4 = [
-        *FODOCell4,
-        VS7,
-        VisaEBeam7,
-        *FODOCell4,
-        *FODOCell4,
-        VS8,
-        VisaEBeam8,
-        *FODOCell4,
-    ]
+    FODOCell4 = [VQ7,VQ7,VD,VQ8,VQ8,VD]
+    UndulatorSegment4 = [*FODOCell4,VS7,VisaEBeam7,*FODOCell4,*FODOCell4,VS8,VisaEBeam8,*FODOCell4]
 
-    B0 = [
-        SrcToPMQ1,
-        *PMQTrip,
-        PMQTripToTCPhos,
-        TCPhosphor,
-        TCPhosToChicane,
-        S1,
-        *Chicane,
-        S2,
-        DriftToDCPhos,
-        DCPhosphor,
-        DriftToEMQTrip,
-        *EMQTriplet,
-        S3,
-        DriftToPhos1,
-        Phosphor1,
-        DriftToSpec,
-        MagSpec,
-        S4,
-        *Aline,
-    ]
-    Undulator = (
-        UndulatorSegment1 + UndulatorSegment2 + UndulatorSegment3 + UndulatorSegment4
-    )
+    B0 = [SrcToPMQ1,*PMQTrip,PMQTripToTCPhos,TCPhosphor,TCPhosToChicane,S1,*Chicane,S2,DriftToDCPhos,DCPhosphor,DriftToEMQTrip,*EMQTriplet,S3,DriftToPhos1,Phosphor1,DriftToSpec,MagSpec,S4,*Aline]
+    Undulator = UndulatorSegment1 + UndulatorSegment2 + UndulatorSegment3 + UndulatorSegment4
     full_beamline = B0 + Undulator
 
     # Only return the elements between from_element and to_element
     if from_element is not None:
-        element_indices = [
-            i for i, elem in enumerate(full_beamline) if elem.name == from_element
-        ]
+        element_indices = [ i for i, elem in enumerate(full_beamline) if elem.name == from_element ]
         if len(element_indices) == 0:
             raise ValueError(f"Element {from_element} not found in beamline.")
         elif len(element_indices) > 1:
-            raise ValueError(
-                f"Multiple elements with name {from_element} found in beamline."
-            )
+            raise ValueError(f"Multiple elements with name {from_element} found in beamline.")
         # Get the first index of the element
         from_index = element_indices[0]
     else:
         from_index = 0
     if to_element is not None:
-        element_indices = [
-            i for i, elem in enumerate(full_beamline) if elem.name == to_element
-        ]
+        element_indices = [ i for i, elem in enumerate(full_beamline) if elem.name == to_element ]
         if len(element_indices) == 0:
             raise ValueError(f"Element {to_element} not found in beamline.")
         elif len(element_indices) > 1:
-            raise ValueError(
-                f"Multiple elements with name {to_element} found in beamline."
-            )
+            raise ValueError(f"Multiple elements with name {to_element} found in beamline.")
         # Get the first index of the element
         to_index = element_indices[0]
     else:
-        to_index = len(full_beamline) - 1
-    beamline = full_beamline[from_index : to_index + 1]
+        to_index = len(full_beamline)-1
+    beamline = full_beamline[from_index:to_index+1]
 
     return beamline
-
 
 # Define a screen element
 def screen(name, code):
@@ -376,132 +223,154 @@ def screen(name, code):
     else:
         raise ValueError(f"Unsupported code: {code}")
 
-
 # Define a quadrupole element
-def peakfield_to_k(bore_radius, B, reference_energy_eV):
+def peakfield_to_Bgradient( bore_radius, B ):
     """
-    Convert the peak field in T (and corresponding bore radius) to the K parameter of a quadrupole.
+    Convert the peak field in T (and corresponding bore radius) to the field gradient in T/m of a quadrupole.
 
     Parameters:
         bore_radius (float):
             The bore radius in m.
         B (float):
             The peak field in T.
-        reference_energy_eV (float):
-            The reference energy in eV.
     """
-    gamma = reference_energy_eV * e / (m_e * c**2)
-    beta = (1 - 1 / gamma**2) ** 0.5
-    rigidity = m_e * gamma * beta * c / e
-    k = B / bore_radius / rigidity
-    return k
+    Bgradient = B / bore_radius
+    return Bgradient
 
-
-def current_to_k(current, design, reference_energy_eV):
+def current_to_Bgradient( current, design ):
     """
-    Convert a current in A to the K parameter of a quadrupole.
+    Convert a current in A to the field gradient in T/m of a quadrupole.
 
     Parameters:
         current (float):
             The current in A.
         design (str):
             Indicates which EMQ design is being used
-        reference_energy_eV (float):
-            The reference energy in eV.
     """
-    gamma = reference_energy_eV * e / (m_e * c**2)
-    beta = (1 - 1 / gamma**2) ** 0.5
-    rigidity = m_e * gamma * beta * c / e
     if design == "EMQD-113-394":
         # From "LBM6_03 Calibration" in EMQD-113-394 Testing Report-FINAL.pdf
-        Bgradient = 2.9217 * current + 0.0965  # T/m
+        Bgradient = 2.9217*current + 0.0965  # T/m
     elif design == "EMQD-113-949":
         # From "LBM6_03 Calibration" in EMQD-113-949 Testing Report-FINAL.pdf
-        Bgradient = 2.9318 * current + 0.0077  # T/m
+        Bgradient = 2.9318*current + 0.0077  # T/m
     else:
         raise ValueError(f"Unsupported design: {design}")
-    k = Bgradient / rigidity
-    return k
+    return Bgradient
 
+def get_rigidity( reference_energy_eV ):
+    """
+    Return the magnetic rigidity associated with reference_energy_eV in
+    units of T-m, to be used for field strength normalization.
+        
+    Parameters:
+        Bfield (float):
+            The reference energy in eV.
+    """
+    gamma = reference_energy_eV*e/(m_e*c**2)
+    beta = (1-1/gamma**2)**.5
+    rigidity = m_e*gamma*beta*c/e
+    return rigidity
 
-def quadrupole(
-    name,
-    L,
-    k1=None,
-    current=None,
-    design=None,
-    bore_radius=None,
-    B=None,
-    code=None,
-    reference_energy_eV=100e6,
-):
+def quadrupole( name, L, k1=None, current=None, design=None, bore_radius=None, B=None, code=None, reference_energy_eV=100e6 ):
     """
     Define a quadrupole element.
 
     Need to provide k1, current, or bore_radius and B.
     """
     if k1 is None and current is None:
-        k1 = peakfield_to_k(bore_radius, B, reference_energy_eV)
+        Bgradient = peakfield_to_Bgradient(bore_radius, B)
     elif k1 is None:
-        k1 = current_to_k(current, design, reference_energy_eV)
+        Bgradient = current_to_Bgradient(current, design)
     if code == "impactx" and impactx_available:
-        return elements.ChrQuad(name=name, ds=L, k=k1, nslice=20)
+        return elements.ChrQuad(name=name, ds=L, k=-Bgradient, unit=1, nslice=1)
     else:
         raise ValueError(f"Unsupported code: {code}")
 
-
 # Define a drift element
-def drift(name, L, code):
+def drift( name, L, code ):
     """
     Define a drift element.
     """
     if code == "impactx" and impactx_available:
-        return elements.ExactDrift(name=name, ds=L, nslice=10)
+        return elements.ExactDrift(name=name, ds=L, nslice=1)
     else:
         raise ValueError(f"Unsupported code: {code}")
 
-
 # Define a kicker element
-def current_to_angle(current, max_current, max_integrated_field, reference_energy_eV):
-    integrated_field = current * max_integrated_field / max_current
-    gamma = reference_energy_eV * e / (m_e * c**2)
-    angle = e * integrated_field / (gamma * m_e * c)
-    return angle
+def current_to_integrated_field( current, max_current, max_integrated_field ):
+    integrated_field = current * max_integrated_field/max_current
+    return integrated_field
 
-
-def kicker(
-    name,
-    current_h,
-    current_v,
-    max_current,
-    max_integrated_field,
-    code,
-    reference_energy_eV=100e6,
-):
+def kicker( name, current_h, current_v, max_current, max_integrated_field, code, reference_energy_eV=100e6 ):
     """
     Define a kicker element.
     """
-    angle_h = current_to_angle(
-        current_h, max_current, max_integrated_field, reference_energy_eV
-    )
-    angle_v = current_to_angle(
-        current_v, max_current, max_integrated_field, reference_energy_eV
-    )
+    integrated_field_h = current_to_integrated_field(current_h, max_current, max_integrated_field )
+    integrated_field_v = current_to_integrated_field(current_v, max_current, max_integrated_field )
+    angle_h = integrated_field_h / get_rigidity(reference_energy_eV)
+    angle_v = integrated_field_v / get_rigidity(reference_energy_eV)
     if code == "impactx" and impactx_available:
-        return elements.Kicker(
-            name=name, xkick=angle_h, ykick=angle_v, unit="dimensionless"
-        )
+        return elements.Kicker(name=name, xkick=integrated_field_h, ykick=integrated_field_v, unit="T-m")
     else:
         raise ValueError(f"Unsupported code: {code}")
 
-
 # Define a dipole element
-def dipole(name, L, angle, code):
+def chicane_r56_to_field( r56, L, reference_energy_eV ):
+    """
+    Return the magnetic field in T associated with the chicane setting of r56
+    defined at the reference energy reference_energy_eV.
+        
+    Parameters:
+        r56 (float):
+            The chicane r56 at nominal energy in microns.
+        L (float):
+            The bend length in m.
+        reference_energy_eV (float):
+            The reference energy in eV.
+    """
+
+    #Polynomial fit to find the dipole angle as a function of chicane r56 (no longer used)
+    #angle_rad = 0.00743627 + 6.32812981e-05*chicane_r56 -4.83395592e-08*chicane_r56**2 + 1.91504783e-11*chicane_r56**3
+    #Updated r56 formula valid near r56=0
+    angle_rad = 0.001438389904456 * r56**.5
+    # TODO: This angle explicitly assumes that the reference energy of the beam is 100 MeV! We should make
+    # sure that this is the case. In particular, for beams with fluctuations in energy, we should keep the
+    # energy of the reference particles constant.
+
+    B = -1.0 * get_rigidity(reference_energy_eV) * angle_rad / L
+    return B
+
+def Bfield_to_angle( Bfield, L, reference_energy_eV ):
+    """
+    Return the bend angle in radians associated with a magnetic field Bfield
+    in units of T, for a bend of length L and specified energy.
+    
+    Parameters:
+        Bfield (float):
+            The value of the magnetic field in T.
+        L (float):  
+            The bend length in m.
+        reference_energy_eV (float):
+            The reference energy in eV.
+    """
+    angle = -1.0 * Bfield * L / get_rigidity(reference_energy_eV)
+    return angle
+
+
+def dipole( name, L, angle=None, r56=None, bend=None, code=None, reference_energy_eV=100e6):
     """
     Define a dipole element.
     """
+    if angle is None:
+        Bfield = chicane_r56_to_field( r56, L, reference_energy_eV=100e6 )
+        angle = Bfield_to_angle( Bfield, L, reference_energy_eV )
+    else:
+        Bfield = 0.0
+    if bend==1 or bend==4:
+        Bfield = -Bfield
+        angle = -angle
     if code == "impactx" and impactx_available:
-        angle_deg = angle * 180.0 / (3.1415926535898)
-        return elements.ExactSbend(name=name, ds=L, phi=angle_deg, nslice=10)
+        angle_deg = angle * 180.0/(3.1415926535898)
+        return elements.ExactSbend(name=name, ds=L, phi=angle_deg, B=Bfield, nslice=1)
     else:
         raise ValueError(f"Unsupported code: {code}")

--- a/examples/htu_beamline/run_impactx_offenergy1.py
+++ b/examples/htu_beamline/run_impactx_offenergy1.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# HTU References:
+# - https://doi.org/10.1103/vh62-gz1p
+# - https://doi.org/10.1117/12.3056776
+#
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from htu_lattice import get_lattice
+from scipy.constants import c, e, m_e
+
+from impactx import ImpactX, distribution, twiss
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.space_charge = False
+sim.slice_step_diagnostics = True
+
+# silent running
+silent = False
+if silent:
+    sim.verbose = 0
+    sim.tiny_profiler = False
+    # note: lattice beam monitors will still write files
+    sim.diagnostics = False
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# basic beam parameters
+total_energy_MeV_nominal = 100.0  # reference energy (total)
+total_energy_MeV_target = 150.0  # desired total energy
+mass_MeV = 0.510998950  # particle mass
+kin_energy_MeV = total_energy_MeV_nominal - mass_MeV
+bunch_charge_C = 25.0e-12  # used with space charge
+npart = 10000  # number of macro particles
+
+# set reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(-1.0).set_mass_MeV(mass_MeV).set_kin_energy_MeV(kin_energy_MeV)
+
+# factors converting the beam distribution to ImpactX input
+gamma = total_energy_MeV_nominal / mass_MeV
+bg = np.sqrt(gamma**2 - 1.0)
+sigma_tau = 1e-6  # in m
+sigma_p = 2.5e-2  # dimensionless
+
+# energy shift
+delta_gamma = (total_energy_MeV_target - total_energy_MeV_nominal) / mass_MeV
+mu_p = delta_gamma / bg
+
+#   particle bunch
+distr = distribution.Gaussian(
+    **twiss(
+        beta_x=0.002,
+        beta_y=0.002,
+        beta_t=sigma_tau / sigma_p,
+        emitt_x=1.5e-6 / bg,
+        emitt_y=1.5e-6 / bg,
+        emitt_t=sigma_tau * sigma_p,
+        alpha_x=0.0,
+        alpha_y=0.0,
+        alpha_t=0.0,
+    ),
+    meanPt=-mu_p,
+)
+sim.add_particles(bunch_charge_C, distr, npart)
+
+# set the lattice
+sim.lattice.extend(get_lattice("impactx", chicane_r56=0.0))
+
+# run simulation
+sim.track_particles()
+
+# in situ calculate the reduced beam characteristics
+# note: rbc us a dataframe, sim can be finalized once rbc was created
+# beam = sim.particle_container()
+# rbc = beam.reduced_beam_characteristics()
+
+# clean shutdown
+sim.finalize()

--- a/examples/htu_beamline/run_impactx_offenergy1.py
+++ b/examples/htu_beamline/run_impactx_offenergy1.py
@@ -12,7 +12,6 @@
 
 import numpy as np
 from htu_lattice import get_lattice
-from scipy.constants import c, e, m_e
 
 from impactx import ImpactX, distribution, twiss
 

--- a/examples/htu_beamline/run_impactx_offenergy2.py
+++ b/examples/htu_beamline/run_impactx_offenergy2.py
@@ -12,7 +12,6 @@
 
 import numpy as np
 from htu_lattice import get_lattice
-from scipy.constants import c, e, m_e
 
 from impactx import ImpactX, distribution, twiss
 

--- a/examples/htu_beamline/run_impactx_offenergy2.py
+++ b/examples/htu_beamline/run_impactx_offenergy2.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# HTU References:
+# - https://doi.org/10.1103/vh62-gz1p
+# - https://doi.org/10.1117/12.3056776
+#
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from htu_lattice import get_lattice
+from scipy.constants import c, e, m_e
+
+from impactx import ImpactX, distribution, twiss
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.space_charge = False
+sim.slice_step_diagnostics = True
+
+# silent running
+silent = False
+if silent:
+    sim.verbose = 0
+    sim.tiny_profiler = False
+    # note: lattice beam monitors will still write files
+    sim.diagnostics = False
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# basic beam parameters
+total_energy_MeV_nominal = 100.0  # reference energy (total)
+total_energy_MeV_target = 150.0  # desired total energy
+mass_MeV = 0.510998950  # particle mass
+kin_energy_MeV = total_energy_MeV_target - mass_MeV
+bunch_charge_C = 25.0e-12  # used with space charge
+npart = 10000  # number of macro particles
+
+# set reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(-1.0).set_mass_MeV(mass_MeV).set_kin_energy_MeV(kin_energy_MeV)
+
+# factors converting the beam distribution to ImpactX input
+gamma_nominal = total_energy_MeV_nominal / mass_MeV
+gamma_target = total_energy_MeV_target / mass_MeV
+bg_nominal = np.sqrt(gamma_nominal**2 - 1.0)
+bg_target = np.sqrt(gamma_target**2 - 1.0)
+ratio = bg_target / bg_nominal
+sigma_tau = 1e-6  # in m
+sigma_p = 2.5e-2 / ratio  # dimensionless
+mu_p = 0.0
+
+#   particle bunch
+distr = distribution.Gaussian(
+    **twiss(
+        beta_x=0.002 * ratio,
+        beta_y=0.002 * ratio,
+        beta_t=sigma_tau / sigma_p,
+        emitt_x=1.5e-6 / bg_target,
+        emitt_y=1.5e-6 / bg_target,
+        emitt_t=sigma_tau * sigma_p,
+        alpha_x=0.0,
+        alpha_y=0.0,
+        alpha_t=0.0,
+    ),
+    meanPt=-mu_p,
+)
+sim.add_particles(bunch_charge_C, distr, npart)
+
+# set the lattice
+sim.lattice.extend(get_lattice("impactx", chicane_r56=0.0))
+
+# run simulation
+sim.track_particles()
+
+# in situ calculate the reduced beam characteristics
+# note: rbc us a dataframe, sim can be finalized once rbc was created
+# beam = sim.particle_container()
+# rbc = beam.reduced_beam_characteristics()
+
+# clean shutdown
+sim.finalize()


### PR DESCRIPTION
- [x] Update HTU lattice file to the newest version (using SI units for all ImpactX elements).
- [x] Add two examples, demonstrating two distinct methods for off-energy beam transport at 150 MeV.
- [x] Update documentation.

[ImpactX_OffEnergy_Transport.pdf](https://github.com/user-attachments/files/21992193/ImpactX_OffEnergy_Transport.pdf)
