### PR TITLE
Envelope Tracking: No Mean or Dispersion

### DIFF
--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -224,6 +224,8 @@ namespace impactx
         std::optional<amrex::ParticleReal> intensity
     )
     {
+        using namespace amrex::literals;  // for _rt and _prt
+
         // zero out the 6x6 matrix
         CovarianceMatrix cv{};
 
@@ -245,6 +247,21 @@ namespace impactx
                 amrex::ParticleReal muxpx = distribution.m_muxpx;
                 amrex::ParticleReal muypy = distribution.m_muypy;
                 amrex::ParticleReal mutpt = distribution.m_mutpt;
+
+                // some things we cannot represent in envelope mode
+                if (distribution.m_meanx  != 0.0_prt ||
+                    distribution.m_meany  != 0.0_prt ||
+                    distribution.m_meant  != 0.0_prt ||
+                    distribution.m_meanpx != 0.0_prt ||
+                    distribution.m_meanpy != 0.0_prt ||
+                    distribution.m_meanpt != 0.0_prt ||
+                    distribution.m_dispx  != 0.0_prt ||
+                    distribution.m_disppx != 0.0_prt ||
+                    distribution.m_dispy  != 0.0_prt ||
+                    distribution.m_disppy != 0.0_prt
+                ) {
+                    throw std::runtime_error("Cannot create envelope for distribution with non-zero means or dispersion!");
+                }
 
                 // use distribution inputs to populate a 6x6 covariance matrix
                 amrex::ParticleReal denom_x = 1.0 - muxpx*muxpx;

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -260,7 +260,7 @@ namespace impactx
                     distribution.m_dispy  != 0.0_prt ||
                     distribution.m_disppy != 0.0_prt
                 ) {
-                    throw std::runtime_error("Cannot create envelope for distribution with non-zero means or dispersion!");
+                    throw std::runtime_error("Cannot (yet) create envelope for distribution with non-zero means or dispersion! Please see: https://github.com/BLAST-ImpactX/impactx/issues/...");
                 }
 
                 // use distribution inputs to populate a 6x6 covariance matrix

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -260,7 +260,7 @@ namespace impactx
                     distribution.m_dispy  != 0.0_prt ||
                     distribution.m_disppy != 0.0_prt
                 ) {
-                    throw std::runtime_error("Cannot (yet) create envelope for distribution with non-zero means or dispersion! Please see: https://github.com/BLAST-ImpactX/impactx/issues/...");
+                    throw std::runtime_error("Cannot (yet) create envelope for distribution with non-zero means or dispersion! Please see: https://github.com/BLAST-ImpactX/impactx/issues/1114");
                 }
 
                 // use distribution inputs to populate a 6x6 covariance matrix


### PR DESCRIPTION
We do not support ininitalizing envelopes with a mean offset or dispersion.

Before this PR, provided means or dispersion were silently ignored

To be addressed:  Issue #1114 