### PR TITLE
Dashboard: add lattice configuration scrollbar and refine documentation warning

### DIFF
--- a/src/python/impactx/dashboard/Input/components/card.py
+++ b/src/python/impactx/dashboard/Input/components/card.py
@@ -27,15 +27,16 @@ class CardBase(UIDefaults):
         """
         Creates UI content for a section.
         """
-
-        if (
-            self.header not in DashboardDefaults.DOCUMENTATION
-            and self.header not in _missing_docs
-        ):
-            print(
-                f"WARNING: Card '{self.header}' has no doc link in DashboardDefaults.DOCUMENTATION"
-            )
-            _missing_docs.add(self.header)
+        # Allow subclasses to suppress missing documentation warning
+        if not getattr(self, "SUPPRESS_DOC_WARNING", False):
+            if (
+                self.header not in DashboardDefaults.DOCUMENTATION
+                and self.header not in _missing_docs
+            ):
+                print(
+                    f"WARNING: Card '{self.header}' has no doc link in DashboardDefaults.DOCUMENTATION"
+                )
+                _missing_docs.add(self.header)
 
         self.init_dialog(self.HEADER_NAME, self.card_content)
         self.card_content()

--- a/src/python/impactx/dashboard/Input/defaults.py
+++ b/src/python/impactx/dashboard/Input/defaults.py
@@ -246,6 +246,7 @@ class UIDefaults:
             "flex": "1",
             "overflow-y": "auto",
             "overflow-x": "auto",
+            "max-height": "50vh",
         },
     }
 

--- a/src/python/impactx/dashboard/Input/visualization/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/visualization/lattice/ui.py
@@ -31,6 +31,9 @@ class LatticeVisualizer(CardBase):
     Displays the lattice visualizer section on the inputs page of the dashboard.
     """
 
+    HEADER_NAME = "Lattice Statistics"
+    SUPPRESS_DOC_WARNING = True
+
     def __init__(self):
         super().__init__()
 


### PR DESCRIPTION
This update adds a scrollbar to the lattice configuration panel, which now appears automatically when the number of elements exceeds a defined height threshold.

It also refines the warning system for missing documentation. Previously, any section using the shared card component would trigger the warning, even if documentation wasn’t required. For example, the lattice statistics section was incorrectly flagged. With this change, the warning only applies to input sections that explicitly require documentation.