### PR TITLE
Copy the Reference Particle

### DIFF
--- a/src/elements/Programmable.cpp
+++ b/src/elements/Programmable.cpp
@@ -28,7 +28,7 @@ namespace impactx::elements
             push_all(pc, *this, step, period, m_threadsafe);
         }
         else {
-            BL_PROFILE("impactx::Push::Programmable");
+            BL_PROFILE("impactx::push::Programmable");
             m_push(&pc, step, period);
         }
     }

--- a/src/elements/diagnostics/AdditionalProperties.cpp
+++ b/src/elements/diagnostics/AdditionalProperties.cpp
@@ -55,7 +55,7 @@ namespace impactx::elements::diagnostics
         NonlinearLensInvariants const nonlinear_lens_invariants(alpha, beta, tn, cn);
 
         // profile time spent here
-        std::string profile_name = "impactx::Push::" + std::string(BeamMonitor::type) + "::add_optional_properties";
+        std::string profile_name = "impactx::push::" + std::string(BeamMonitor::type) + "::add_optional_properties";
         BL_PROFILE(profile_name);
 
         // add runtime properties for H and I

--- a/src/elements/diagnostics/BeamMonitor.cpp
+++ b/src/elements/diagnostics/BeamMonitor.cpp
@@ -311,7 +311,7 @@ namespace detail {
             return;
 
 #ifdef ImpactX_USE_OPENPMD
-        std::string profile_name = "impactx::Push::" + std::string(BeamMonitor::type);
+        std::string profile_name = "impactx::push::" + std::string(BeamMonitor::type);
         BL_PROFILE(profile_name);
 
         // preparing to access reference particle data: RefPart

--- a/src/particles/Push.H
+++ b/src/particles/Push.H
@@ -24,7 +24,7 @@ namespace impactx
      * @param[in] step global step for diagnostics
      * @param[in] period for periodic lattices, this is the current period (turn or cycle)
      */
-    void Push (
+    void push (
         ImpactXParticleContainer & pc,
         elements::KnownElements & element_variant,
         int step,
@@ -36,7 +36,7 @@ namespace impactx
      * @param[inout] ref the reference particle
      * @param[inout] element_variant a single element to push the particles through
      */
-    void Push (
+    void push (
         RefPart & ref,
         elements::KnownElements & element_variant
     );

--- a/src/particles/Push.H
+++ b/src/particles/Push.H
@@ -12,13 +12,12 @@
 
 #include "elements/All.H"
 #include "particles/ImpactXParticleContainer.H"
-
-#include <list>
+#include "particles/ReferenceParticle.H"
 
 
 namespace impactx
 {
-    /** Push particles
+    /** Push a whole particle beam (incl. reference particle) through an element
      *
      * @param[inout] pc container of the particles to push
      * @param[inout] element_variant a single element to push the particles through
@@ -30,6 +29,16 @@ namespace impactx
         elements::KnownElements & element_variant,
         int step,
         int period
+    );
+
+    /** Push the reference particle through an element
+     *
+     * @param[inout] ref the reference particle
+     * @param[inout] element_variant a single element to push the particles through
+     */
+    void Push (
+        RefPart & ref,
+        elements::KnownElements & element_variant
     );
 
 } // namespace impactx

--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -33,4 +33,18 @@ namespace impactx
         }, element_variant);
     }
 
+    void Push (
+        RefPart & ref,
+        elements::KnownElements & element_variant
+    )
+    {
+        // here we just access the element by its respective type
+        std::visit([&ref](auto&& element)
+        {
+            // push reference particle in global coordinates
+            BL_PROFILE("impactx::Push::RefPart");
+            element(ref);
+        }, element_variant);
+    }
+
 } // namespace impactx

--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -16,7 +16,7 @@
 
 namespace impactx
 {
-    void Push (
+    void push (
         ImpactXParticleContainer & pc,
         elements::KnownElements & element_variant,
         int step,
@@ -26,14 +26,14 @@ namespace impactx
         // here we just access the element by its respective type
         std::visit([&pc, step, period](auto&& element)
         {
-            BL_PROFILE("impactx::Push");
+            BL_PROFILE("impactx::push");
 
             // push reference particle & all particles
             element(pc, step, period);
         }, element_variant);
     }
 
-    void Push (
+    void push (
         RefPart & ref,
         elements::KnownElements & element_variant
     )
@@ -42,7 +42,7 @@ namespace impactx
         std::visit([&ref](auto&& element)
         {
             // push reference particle in global coordinates
-            BL_PROFILE("impactx::Push::RefPart");
+            BL_PROFILE("impactx::push::RefPart");
             element(ref);
         }, element_variant);
     }

--- a/src/particles/PushAll.H
+++ b/src/particles/PushAll.H
@@ -39,7 +39,7 @@ namespace impactx
     )
     {
         // performance profiling per element
-        std::string const profile_name = "impactx::Push::" + std::string(T_Element::type);
+        std::string const profile_name = "impactx::push::" + std::string(T_Element::type);
         BL_PROFILE(profile_name);
 
         // preparing to access reference particle data: RefPart
@@ -47,7 +47,7 @@ namespace impactx
 
         // push reference particle in global coordinates
         {
-            BL_PROFILE("impactx::Push::RefPart");
+            BL_PROFILE("impactx::push::RefPart");
             element(ref_part);
         }
 

--- a/src/particles/ReferenceParticle.H
+++ b/src/particles/ReferenceParticle.H
@@ -44,6 +44,17 @@ namespace impactx
         amrex::ParticleReal sedge = 0.0;  ///< value of s at entrance of the current beamline element
         amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> map{}; ///< linearized map
 
+        /** Copy the reference particle
+         *
+         * Use this if you want to do an operation that modifies the reference particle,
+         * but you want to avoid modifying the particle container that it is assigned to.
+         */
+        RefPart
+        copy () const
+        {
+            return RefPart{*this};
+        }
+
         /** Reset the reference particle
          *
          * @param keep_mass do not reset the reference particle mass

--- a/src/python/ReferenceParticle.cpp
+++ b/src/python/ReferenceParticle.cpp
@@ -43,6 +43,9 @@ void init_refparticle(py::module& m)
         .def_property_readonly("rigidity_Tm", &RefPart::rigidity_Tm, "Get reference particle magnetic rigidity Brho (T*m)")
         .def_property_readonly("qm_ratio_SI", &RefPart::qm_ratio_SI, "Get reference particle charge to mass ratio (C/kg)")
 
+        .def("copy", &RefPart::copy,
+             py::return_value_policy::copy,
+             "Copy the reference particle")
         .def("reset", &RefPart::reset,
              py::arg("keep_mass")=false, py::arg("keep_charge")=false,
              "Reset the reference particle")

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -2348,11 +2348,11 @@ void init_elements(py::module& m)
      register_push(py_LinearMap);
 
     // freestanding push function
-    m.def("push", py::overload_cast<ImpactXParticleContainer &, elements::KnownElements &, int, int>(&Push),
+    m.def("push", py::overload_cast<ImpactXParticleContainer &, elements::KnownElements &, int, int>(&push),
         py::arg("pc"), py::arg("element"), py::arg("step")=0, py::arg("period")=0,
         "Push a whole particle beam (incl. reference particle) through an element"
     );
-    m.def("push", py::overload_cast<RefPart &, elements::KnownElements &>(&Push),
+    m.def("push", py::overload_cast<RefPart &, elements::KnownElements &>(&push),
         py::arg("ref"), py::arg("element"),
         "Push the reference particle through an element"
     );

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -2348,9 +2348,13 @@ void init_elements(py::module& m)
      register_push(py_LinearMap);
 
     // freestanding push function
-    m.def("push", &Push,
+    m.def("push", py::overload_cast<ImpactXParticleContainer &, elements::KnownElements &, int, int>(&Push),
         py::arg("pc"), py::arg("element"), py::arg("step")=0, py::arg("period")=0,
-        "Push particles through an element"
+        "Push a whole particle beam (incl. reference particle) through an element"
+    );
+    m.def("push", py::overload_cast<RefPart &, elements::KnownElements &>(&Push),
+        py::arg("ref"), py::arg("element"),
+        "Push the reference particle through an element"
     );
 
 

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -163,7 +163,7 @@ namespace impactx
                     {
                         // push reference particle in global coordinates
                         {
-                            BL_PROFILE("impactx::Push::RefPart");
+                            BL_PROFILE("impactx::push::RefPart");
                             element(ref);
                         }
 

--- a/src/tracking/particles.cpp
+++ b/src/tracking/particles.cpp
@@ -133,7 +133,7 @@ namespace impactx
                     particles::spacecharge::HandleSpacecharge(amr_data, [this](){ this->ResizeMesh(); }, slice_ds);
 
                     // push all particles with external maps
-                    Push(*amr_data->track_particles.m_particle_container, element_variant, step, period);
+                    push(*amr_data->track_particles.m_particle_container, element_variant, step, period);
 
                     // move "lost" particles to another particle container
                     collect_lost_particles(*amr_data->track_particles.m_particle_container);

--- a/src/tracking/reference.cpp
+++ b/src/tracking/reference.cpp
@@ -107,7 +107,7 @@ namespace impactx
                     }
 
                     // push the reference particle with external maps
-                    Push(ref, element_variant);
+                    push(ref, element_variant);
 
                     // just prints an empty newline at the end of the slice_step
                     if (verbose > 0)

--- a/src/tracking/reference.cpp
+++ b/src/tracking/reference.cpp
@@ -106,12 +106,8 @@ namespace impactx
                                        << " slice_step=" << slice_step << "\n";
                     }
 
-                    std::visit([&ref](auto&& element)
-                    {
-                        // push reference particle in global coordinates
-                        BL_PROFILE("impactx::Push::RefPart");
-                        element(ref);
-                    }, element_variant);
+                    // push the reference particle with external maps
+                    Push(ref, element_variant);
 
                     // just prints an empty newline at the end of the slice_step
                     if (verbose > 0)

--- a/tests/python/test_push.py
+++ b/tests/python/test_push.py
@@ -68,5 +68,17 @@ def test_element_push():
     # alternative formulation
     push(pc, elements.Drift(ds=0.25))
 
+    # push only the reference particle
+    assert ref.s == 3.0
+    dr1 = elements.Drift(ds=0.25)
+    push(ref, dr1)
+    assert ref.s == 3.25
+
+    # push a copy of the reference particle
+    ref_copy = ref.copy()
+    push(ref_copy, dr1)
+    assert ref.s == 3.25  # must be unchanged!
+    assert ref_copy.s == 3.5  # copy + dr1
+
     # finalize simulation
     sim.finalize()


### PR DESCRIPTION
Use this if you want to do an operation that modifies the reference particle, but you want to avoid modifying the particle container that it is assigned to.

### Example 1: Test Case

See test case in the PR.
Copies a reference particle, advances it, makes sure it does not change the original one.

### Example 2: Plotting a lattice by doing a loop over all elements.

In that loop, one wants to do always plot the next element, then push a reference particle through it, then continue with the next element. This is important to get the global coordinates of the next element and to properly treat accelerating elements (e.g., because energy changes the bending radius `rc` of following elements).

Global floor plan visualization pseudo-code:
```py
def plot_element(element, ref_vis)
    element_params = get_element_params(element, ref_vis)

    if thin:
    elif straight:
    elif arch/wedge:


def visualize():
    # ...
    ref_vis = sim.particle_container().ref_particle().copy()

    for element in sim.lattice:
        plot_element(element, ref_vis)
        push(ref_vis, element)
```