### PR TITLE
`beam.clear()`: Reset Moment History

### DIFF
--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -153,6 +153,8 @@ namespace impactx
 
         /** Empty the container and reset the reference particle
          *
+         * Also clears the history of the beam moments, see reset_beam_moments_history()
+         *
          * @param keep_mass do not reset the reference particle mass
          * @param keep_charge do not reset the reference particle charge
          */

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -186,6 +186,7 @@ namespace impactx
     ImpactXParticleContainer::clear (bool keep_mass, bool keep_charge)
     {
         this->clearParticles();
+        this->reset_beam_moments_history();
         m_refpart.reset(keep_mass, keep_charge);
     }
 


### PR DESCRIPTION
It seems expected that the moment history would be cleared out if `particle_container.clear()` is called on our beam particles. Mostly confusing in interactive usage.