### PR TITLE
Add solvable s-dependent benchmark for a soft-edge solenoid

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1589,3 +1589,13 @@ add_impactx_test(fodo-pals.py
     examples/pals/analysis_fodo_pals.py
     OFF  # no plot script yet
 )
+
+# Exactly-solvable (non-uniform) soft-edge solenoid ##############
+#
+# copy PALS lattice file
+add_impactx_test(solenoid-softedge-solvable.py
+    examples/solenoid_softedge/run_solenoid_softedge_solvable.py
+    ON   # ImpactX MPI-parallel
+    examples/solenoid_softedge/analysis_solenoid_softedge_solvable.py
+    OFF  # no plot script yet
+)

--- a/examples/solenoid_softedge/README.rst
+++ b/examples/solenoid_softedge/README.rst
@@ -61,7 +61,7 @@ We run the following script to analyze correctness:
 .. _solenoid-softedge-solvable:
 
 Exactly-solvable (non-uniform) soft-edge solenoid
-==================================================
+=================================================
 
 This benchmark checks the calculation of the linear map for a soft-edge solenoid with a non-uniform longitudinal
 on-axis magnetic field profile, in the special case of a field profile for which the map is exactly-solvable.

--- a/examples/solenoid_softedge/README.rst
+++ b/examples/solenoid_softedge/README.rst
@@ -56,3 +56,46 @@ We run the following script to analyze correctness:
    .. literalinclude:: analysis_solenoid_softedge.py
       :language: python3
       :caption: You can copy this file from ``examples/solenoid_softedge/analysis_solenoid_softedge.py``.
+
+
+.. _solenoid-softedge-solvable:
+
+Exactly-solvable (non-uniform) soft-edge solenoid
+==================================================
+
+This benchmark checks the calculation of the linear map for a soft-edge solenoid with a non-uniform longitudinal
+on-axis magnetic field profile, in the special case of a field profile for which the map is exactly-solvable.
+
+The test involves 250 MeV protons propagating through a 2 m region with a solenoidal magnetic field.
+
+In this test, all 36 elements of the 6x6 transport matrix must agree with predicted values to within numerical tolerance (currently 1e-7).
+
+
+Run
+---
+
+This example can be run as:
+
+* **Python** script: ``python3 run_solenoid_softedge.py``
+
+For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+
+.. tab-set::
+
+   .. tab-item:: Python: Script
+
+       .. literalinclude:: run_solenoid_softedge.py
+          :language: python3
+          :caption: You can copy this file from ``examples/solenoid_softedge/run_solenoid_softedge_solvable.py``.
+
+
+Analyze
+-------
+
+We run the following script to analyze correctness:
+
+.. dropdown:: Script ``analysis_solenoid_softedge_solvable.py``
+
+   .. literalinclude:: analysis_solenoid_softedge_solvable.py
+      :language: python3
+      :caption: You can copy this file from ``examples/solenoid_softedge/analysis_solenoid_softedge_solvable.py``.

--- a/examples/solenoid_softedge/README.rst
+++ b/examples/solenoid_softedge/README.rst
@@ -1,7 +1,7 @@
 .. _examples-solenoid-softedge:
 
 Soft-edge solenoid
-===================
+==================
 
 Proton beam propagating through a 6 m region containing a soft-edge
 solenoid.
@@ -72,102 +72,153 @@ The user can run this test for various values of the magnetic field strength by 
 
 In this test, all 36 elements of the 6x6 transport matrix must agree with predicted values to within numerical tolerance (currently 1e-7).
 
-Details .. tab-set::
+.. dropdown:: Details
+   :color: light
+   :icon: info
+   :animate: fade-in-slide-down
 
-\section{Introduction}
-Consider a Hamiltonian $H$ quadratic in the phase space variables $\zeta=(x,p_x,y,p_y,t,p_t)$.  Then $H$ can be written in the form:
-\begin{equation}
-H(\zeta,z)=\frac{1}{2}\zeta^TS(z)\zeta,
-\end{equation}
-where $S$ is a $6\times 6$ symmetric matrix.  The linear symplectic map $M$ describing transport from $z_0\mapsto z$ is the unique solution of:
-\begin{align}
-\frac{dM(z)}{dz}=JS(z)M(z),\quad\quad M(z_0)=I,
-\end{align}
-where $J$ is the $6\times 6$ matrix of the symplectic form.
+    **Introduction**
 
-From R. Ryne's USPAS notes \cite{Ryne}, the Hamiltonian for linear transport in a solenoid is given by:
-\begin{equation}
-H=H_2^{foc}+H_2^{rot},
-\end{equation}
-where
-\begin{align}
-H_2^{foc}&=\frac{p_t^2}{2\beta_0^2\gamma_0^2}+\frac{1}{2}(p_x^2+p_y^2)+\frac{\alpha^2}{2}(x^2+y^2), \\
-H_2^{rot}&=-\alpha(xp_y-yp_x),
-\end{align}
-and $\alpha$ is related to the on-axis (solenoidal) magnetic field $B_z$ by:
-\begin{equation}
-\alpha(z)=\frac{1}{2}\frac{B_z(z)}{B\rho}.
-\end{equation}
-We consider an on-axis solenoid field profile of the following special form:
-\begin{equation}
-B_z(z)=\frac{B_0}{1+(z/g)^2},
-\end{equation}
-where $B_0$ is just the peak magnetic field on-axis, and $g$ is a length parameter describing the rate of decay of the field away from its peak at $z=0$.
+    Consider a Hamiltonian :math:`H` quadratic in the phase space variables :math:`\zeta=(x,p_x,y,p_y,t,p_t)`.
+    Then :math:`H` can be written in the form:
 
-Since $H_2^{foc}$ and $H_2^{rot}$ Poisson-commute, the linear map $M$ can be written in the factorized form:
-\begin{equation}
-M=M^0R,
-\end{equation}
-where $M^0$ is the linear map associated with $H_2^{foc}$, and $R$ is the linear map associated with $H_2^{rot}$ \cite{Ryne}.
+    .. math::
 
-To express the linear map between points $z_0$ and $z$, we define the following dimensionless parameters:
-\begin{equation}
-\Delta\phi=\tan^{-1}\left(\frac{z}{g}\right)-\tan^{-1}\left(\frac{z_0}{g}\right),\quad\quad b=\frac{1}{2}\frac{B_0g}{B\rho},\quad\quad \beta=\sqrt{1+b^2}.
-\end{equation}
-Then we obtain for the focusing matrix:
-\begin{align}
-M^0_{11}&=M^0_{33}=\sqrt{\frac{g^2+z^2}{g^2+z_0^2}}\left\{\cos(\beta\Delta\phi)-\frac{z_0\sin(\beta\Delta\phi)}{g\beta}\right\}, \\
-M^0_{12}&=M^0_{34}=\sqrt{(g^2+z^2)(g^2+z_0^2)}\frac{\sin(\beta\Delta\phi)}{g\beta}, \\
-M^0_{21}&=M^0_{43}=\frac{\beta(z-z_0)\cos(\beta\Delta\phi)-g(\beta^2+zz_0/g^2)\sin(\beta\Delta\phi)}{\beta\sqrt{(g^2+z^2)(g^2+z_0^2)}}, \\
-M^0_{22}&=M^0_{44}=\sqrt{\frac{g^2+z_0^2}{g^2+z^2}}\left\{\cos(\beta\Delta\phi)+\frac{z\sin(\beta\Delta\phi)}{g\beta}\right\}, \\
-M^0_{56}&=\frac{z-z_0}{\beta_0^2\gamma_0^2},\quad\quad M^0_{55}=M^0_{66}=1.
-\end{align}
-Likewise, for the rotation matrix we obtain:
-\begin{align}
-R_{11}&=R_{22}=\cos(b\Delta\phi),\quad\quad R_{13}=R_{24}=\sin(b\Delta\phi), \\
-R_{31}&=R_{42}=-\sin(b\Delta\phi),\quad\quad R_{33}=R_{44}=\cos(b\Delta\phi), \\
-R_{55}&=R_{66}=1.
-\end{align}
-The reader can verify that the map equations and the symplectic condition are satisfied:
-\begin{align}
-&\frac{dM^0(z)}{dz}=JS^{foc}(z)M^0(z),\quad\quad M^0(z_0)=I, \quad\quad (M^0)^TJM^0=J\\
-&\frac{dR(z)}{dz}=JS^{rot}(z)R(z),\quad\quad R(z_0)=I, \quad\quad R^TJR=J.
-\end{align}
-Here the $6\times 6$ symmetric matrices $S^{foc}$ and $S^{rot}$ are defined such that:
-\begin{equation}
-H^{foc}(\zeta,z)=\frac{1}{2}\zeta^TS^{foc}(z)\zeta,\quad\quad H^{rot}(\zeta,z)=\frac{1}{2}\zeta^TS^{rot}(z)\zeta.
-\end{equation}
+        H(\zeta,z)=\frac{1}{2}\zeta^TS(z)\zeta,
 
-\subsection{End-to-end map}
-A case of special interest occurs when the map is taken over a region symmetric about the solenoid midpoint at $z=0$.  In this case, we define $z_0=-\lambda g$ and $z=\lambda g$.  Then we obtain:
-\begin{equation}
-\Delta\phi=2\tan^{-1}\lambda,\quad\quad \lambda=\frac{L}{2g},
-\end{equation}
-where $L$ is the length of the field region over which the map is computed.  The map takes the form:
-\begin{align}
-M^0_{11}&=M^0_{33}=\cos(\beta\Delta\phi)+\frac{\lambda\sin(\beta\Delta\phi)}{\beta}, \\
-M^0_{12}&=M^0_{34}=g(1+\lambda^2)\frac{\sin(\beta\Delta\phi)}{\beta}, \\
-M^0_{21}&=M^0_{43}=\frac{2\beta\lambda\cos(\beta\Delta\phi)+(\lambda^2-\beta^2)\sin(\beta\Delta\phi)}{\beta g(1+\lambda^2)}, \\
-M^0_{22}&=M^0_{44}=\cos(\beta\Delta\phi)+\frac{\lambda\sin(\beta\Delta\phi)}{\beta}, \\
-M^0_{56}&=\frac{2\lambda g}{\beta_0^2\gamma_0^2},\quad\quad M^0_{55}=M^0_{66}=1.
-\end{align}
-The expression for the rotation matrix $R$ is unchanged.  Note from the form of $R$ that the Larmor rotation angle $\Omega$ is given by:
-\begin{equation}
-\Omega=b\Delta\phi=2b\tan^{-1}\lambda.
-\end{equation}
-This has a well defined limit as $\lambda\rightarrow\infty$, which is:
-\begin{equation}
-\lim_{\lambda\rightarrow\infty}\Omega= b\pi =\frac{\pi}{2}\frac{B_0g}{B\rho}.
-\end{equation}
-This is consistent with the Larmor angle we expect, namely:
-\begin{equation}
-\Omega_{\infty}=\int_{-\infty}^{\infty}\alpha(z)dz=\frac{\pi}{2}\frac{B_0g}{B\rho}.
-\end{equation}
+    where :math:`S` is a :math:`6\times 6` symmetric matrix.
+    The linear symplectic map :math:`M` describing transport from :math:`z_0\mapsto z` is the unique solution of:
 
-\begin{thebibliography}{9}
-\bibitem{Ryne}
-R.D. Ryne, ``Computational Methods in Accelerator Physics," USPAS Lecture Notes (2009).
-\end{thebibliography}
+    .. math::
+
+        \frac{dM(z)}{dz}=JS(z)M(z),\quad\quad M(z_0)=I,
+
+    where :math:`J` is the :math:`6\times 6` matrix of the symplectic form.
+
+    From :ref:`R. Ryne's USPAS notes <solenoid-softedge-solvable-ryne>`, the Hamiltonian for linear transport in a solenoid is given by:
+
+    .. math::
+
+        H=H_2^{foc}+H_2^{rot},
+
+    where
+
+    .. math::
+
+        H_2^{foc}&=\frac{p_t^2}{2\beta_0^2\gamma_0^2}+\frac{1}{2}(p_x^2+p_y^2)+\frac{\alpha^2}{2}(x^2+y^2), \\
+        H_2^{rot}&=-\alpha(xp_y-yp_x),
+
+    and :math:`\alpha` is
+    related to the on-axis (solenoidal) magnetic field :math:`B_z` by:
+
+    .. math::
+
+        \alpha(z)=\frac{1}{2}\frac{B_z(z)}{B\rho}.
+
+    We consider an on-axis solenoid field profile of the following special form:
+
+    .. math::
+
+        B_z(z)=\frac{B_0}{1+(z/g)^2},
+
+    where :math:`B_0`
+    is just the peak magnetic field on-axis, and :math:`g` is a length parameter describing the rate of decay of the field away from its peak at :math:`z=0`.
+
+    Since :math:`H_2^{foc}` and
+    :math:`H_2^{rot}` Poisson-commute, the linear map :math:`M` can be written in the factorized form:
+
+    .. math::
+
+        M=M^0R,
+
+    where :math:`M^0`
+    is the linear map associated with
+    :math:`H_2^{foc}`
+    , and :math:`R` is the linear map associated with :math:`H_2^{rot}` :ref:`(see ref) <solenoid-softedge-solvable-ryne>`.
+
+    To express the linear map between points :math:`z_0` and :math:`z`, we define the following dimensionless parameters:
+
+    .. math::
+
+        \Delta\phi=\tan^{-1}\left(\frac{z}{g}\right)-\tan^{-1}\left(\frac{z_0}{g}\right),\quad\quad b=\frac{1}{2}\frac{B_0g}{B\rho},\quad\quad \beta=\sqrt{1+b^2}.
+
+    Then we obtain for the focusing matrix:
+
+    .. math::
+
+        M^0_{11}&=M^0_{33}=\sqrt{\frac{g^2+z^2}{g^2+z_0^2}}\left\{\cos(\beta\Delta\phi)-\frac{z_0\sin(\beta\Delta\phi)}{g\beta}\right\}, \\
+        M^0_{12}&=M^0_{34}=\sqrt{(g^2+z^2)(g^2+z_0^2)}\frac{\sin(\beta\Delta\phi)}{g\beta}, \\
+        M^0_{21}&=M^0_{43}=\frac{\beta(z-z_0)\cos(\beta\Delta\phi)-g(\beta^2+zz_0/g^2)\sin(\beta\Delta\phi)}{\beta\sqrt{(g^2+z^2)(g^2+z_0^2)}}, \\
+        M^0_{22}&=M^0_{44}=\sqrt{\frac{g^2+z_0^2}{g^2+z^2}}\left\{\cos(\beta\Delta\phi)+\frac{z\sin(\beta\Delta\phi)}{g\beta}\right\}, \\
+        M^0_{56}&=\frac{z-z_0}{\beta_0^2\gamma_0^2},\quad\quad M^0_{55}=M^0_{66}=1.
+
+    Likewise, for the rotation matrix we obtain:
+
+    .. math::
+
+        R_{11}&=R_{22}=\cos(b\Delta\phi),\quad\quad R_{13}=R_{24}=\sin(b\Delta\phi), \\
+        R_{31}&=R_{42}=-\sin(b\Delta\phi),\quad\quad R_{33}=R_{44}=\cos(b\Delta\phi), \\
+        R_{55}&=R_{66}=1.
+
+    The reader can verify that the map equations and the symplectic condition are satisfied:
+
+    .. math::
+
+        &\frac{dM^0(z)}{dz}=JS^{foc}(z)M^0(z),\quad\quad M^0(z_0)=I, \quad\quad (M^0)^TJM^0=J\\
+        &\frac{dR(z)}{dz}=JS^{rot}(z)R(z),\quad\quad R(z_0)=I, \quad\quad R^TJR=J.
+
+    Here the :math:`6\times 6`
+    symmetric matrices :math:`S^{foc}`
+    and :math:`S^{rot}` are defined such that:
+
+    .. math::
+
+        H^{foc}(\zeta,z)=\frac{1}{2}\zeta^TS^{foc}(z)\zeta,\quad\quad H^{rot}(\zeta,z)=\frac{1}{2}\zeta^TS^{rot}(z)\zeta.
+
+
+    **End-to-end map**
+
+    A case of special interest occurs when the map is taken over a region symmetric about the solenoid midpoint at :math:`z=0`.
+    In this case, we define :math:`z_0=-\lambda g`
+    and :math:`z=\lambda g`.  Then we obtain:
+
+    .. math::
+
+        \Delta\phi=2\tan^{-1}\lambda,\quad\quad \lambda=\frac{L}{2g},
+
+    where :math:`L` is the length of the field region over which the map is computed.  The map takes the form:
+
+    .. math::
+
+        M^0_{11}&=M^0_{33}=\cos(\beta\Delta\phi)+\frac{\lambda\sin(\beta\Delta\phi)}{\beta}, \\
+        M^0_{12}&=M^0_{34}=g(1+\lambda^2)\frac{\sin(\beta\Delta\phi)}{\beta}, \\
+        M^0_{21}&=M^0_{43}=\frac{2\beta\lambda\cos(\beta\Delta\phi)+(\lambda^2-\beta^2)\sin(\beta\Delta\phi)}{\beta g(1+\lambda^2)}, \\
+        M^0_{22}&=M^0_{44}=\cos(\beta\Delta\phi)+\frac{\lambda\sin(\beta\Delta\phi)}{\beta}, \\
+        M^0_{56}&=\frac{2\lambda g}{\beta_0^2\gamma_0^2},\quad\quad M^0_{55}=M^0_{66}=1.
+
+    The expression for the rotation matrix :math:`R` is unchanged.  Note from the form of :math:`R` that the Larmor rotation angle :math:`\Omega` is given by:
+
+    .. math::
+
+        \Omega=b\Delta\phi=2b\tan^{-1}\lambda.
+
+    This has a well defined limit as :math:`\lambda\rightarrow\infty`, which is:
+
+    .. math::
+
+        \lim_{\lambda\rightarrow\infty}\Omega= b\pi =\frac{\pi}{2}\frac{B_0g}{B\rho}.
+
+    This is consistent with the Larmor angle we expect, namely:
+
+    .. math::
+
+        \Omega_{\infty}=\int_{-\infty}^{\infty}\alpha(z)dz=\frac{\pi}{2}\frac{B_0g}{B\rho}.
+
+    .. _solenoid-softedge-solvable-ryne:
+
+    **References**
+
+    * R.D. Ryne, "Computational Methods in Accelerator Physics," USPAS Lecture Notes (2009)
 
 
 Run

--- a/examples/solenoid_softedge/README.rst
+++ b/examples/solenoid_softedge/README.rst
@@ -68,6 +68,8 @@ on-axis magnetic field profile, in the special case of a field profile for which
 
 The test involves 250 MeV protons propagating through a 2 m region with a solenoidal magnetic field.
 
+The user can run this test for various values of the magnetic field strength by modifying the parameter "bscale" in both the input file and in the analysis script.  (The values in the two files must be consistent.)
+
 In this test, all 36 elements of the 6x6 transport matrix must agree with predicted values to within numerical tolerance (currently 1e-7).
 
 

--- a/examples/solenoid_softedge/README.rst
+++ b/examples/solenoid_softedge/README.rst
@@ -72,7 +72,7 @@ The user can run this test for various values of the magnetic field strength by 
 
 In this test, all 36 elements of the 6x6 transport matrix must agree with predicted values to within numerical tolerance (currently 1e-7).
 
-.. tab-set::
+Details .. tab-set::
 
 \section{Introduction}
 Consider a Hamiltonian $H$ quadratic in the phase space variables $\zeta=(x,p_x,y,p_y,t,p_t)$.  Then $H$ can be written in the form:

--- a/examples/solenoid_softedge/README.rst
+++ b/examples/solenoid_softedge/README.rst
@@ -72,6 +72,103 @@ The user can run this test for various values of the magnetic field strength by 
 
 In this test, all 36 elements of the 6x6 transport matrix must agree with predicted values to within numerical tolerance (currently 1e-7).
 
+.. tab-set::
+
+\section{Introduction}
+Consider a Hamiltonian $H$ quadratic in the phase space variables $\zeta=(x,p_x,y,p_y,t,p_t)$.  Then $H$ can be written in the form:
+\begin{equation}
+H(\zeta,z)=\frac{1}{2}\zeta^TS(z)\zeta,
+\end{equation}
+where $S$ is a $6\times 6$ symmetric matrix.  The linear symplectic map $M$ describing transport from $z_0\mapsto z$ is the unique solution of:
+\begin{align}
+\frac{dM(z)}{dz}=JS(z)M(z),\quad\quad M(z_0)=I,
+\end{align}
+where $J$ is the $6\times 6$ matrix of the symplectic form.
+
+From R. Ryne's USPAS notes \cite{Ryne}, the Hamiltonian for linear transport in a solenoid is given by:
+\begin{equation}
+H=H_2^{foc}+H_2^{rot},
+\end{equation}
+where
+\begin{align}
+H_2^{foc}&=\frac{p_t^2}{2\beta_0^2\gamma_0^2}+\frac{1}{2}(p_x^2+p_y^2)+\frac{\alpha^2}{2}(x^2+y^2), \\
+H_2^{rot}&=-\alpha(xp_y-yp_x),
+\end{align}
+and $\alpha$ is related to the on-axis (solenoidal) magnetic field $B_z$ by:
+\begin{equation}
+\alpha(z)=\frac{1}{2}\frac{B_z(z)}{B\rho}.
+\end{equation}
+We consider an on-axis solenoid field profile of the following special form:
+\begin{equation}
+B_z(z)=\frac{B_0}{1+(z/g)^2},
+\end{equation}
+where $B_0$ is just the peak magnetic field on-axis, and $g$ is a length parameter describing the rate of decay of the field away from its peak at $z=0$.
+
+Since $H_2^{foc}$ and $H_2^{rot}$ Poisson-commute, the linear map $M$ can be written in the factorized form:
+\begin{equation}
+M=M^0R,
+\end{equation}
+where $M^0$ is the linear map associated with $H_2^{foc}$, and $R$ is the linear map associated with $H_2^{rot}$ \cite{Ryne}.
+
+To express the linear map between points $z_0$ and $z$, we define the following dimensionless parameters:
+\begin{equation}
+\Delta\phi=\tan^{-1}\left(\frac{z}{g}\right)-\tan^{-1}\left(\frac{z_0}{g}\right),\quad\quad b=\frac{1}{2}\frac{B_0g}{B\rho},\quad\quad \beta=\sqrt{1+b^2}.
+\end{equation}
+Then we obtain for the focusing matrix:
+\begin{align}
+M^0_{11}&=M^0_{33}=\sqrt{\frac{g^2+z^2}{g^2+z_0^2}}\left\{\cos(\beta\Delta\phi)-\frac{z_0\sin(\beta\Delta\phi)}{g\beta}\right\}, \\
+M^0_{12}&=M^0_{34}=\sqrt{(g^2+z^2)(g^2+z_0^2)}\frac{\sin(\beta\Delta\phi)}{g\beta}, \\
+M^0_{21}&=M^0_{43}=\frac{\beta(z-z_0)\cos(\beta\Delta\phi)-g(\beta^2+zz_0/g^2)\sin(\beta\Delta\phi)}{\beta\sqrt{(g^2+z^2)(g^2+z_0^2)}}, \\
+M^0_{22}&=M^0_{44}=\sqrt{\frac{g^2+z_0^2}{g^2+z^2}}\left\{\cos(\beta\Delta\phi)+\frac{z\sin(\beta\Delta\phi)}{g\beta}\right\}, \\
+M^0_{56}&=\frac{z-z_0}{\beta_0^2\gamma_0^2},\quad\quad M^0_{55}=M^0_{66}=1.
+\end{align}
+Likewise, for the rotation matrix we obtain:
+\begin{align}
+R_{11}&=R_{22}=\cos(b\Delta\phi),\quad\quad R_{13}=R_{24}=\sin(b\Delta\phi), \\
+R_{31}&=R_{42}=-\sin(b\Delta\phi),\quad\quad R_{33}=R_{44}=\cos(b\Delta\phi), \\
+R_{55}&=R_{66}=1.
+\end{align}
+The reader can verify that the map equations and the symplectic condition are satisfied:
+\begin{align}
+&\frac{dM^0(z)}{dz}=JS^{foc}(z)M^0(z),\quad\quad M^0(z_0)=I, \quad\quad (M^0)^TJM^0=J\\
+&\frac{dR(z)}{dz}=JS^{rot}(z)R(z),\quad\quad R(z_0)=I, \quad\quad R^TJR=J.
+\end{align}
+Here the $6\times 6$ symmetric matrices $S^{foc}$ and $S^{rot}$ are defined such that:
+\begin{equation}
+H^{foc}(\zeta,z)=\frac{1}{2}\zeta^TS^{foc}(z)\zeta,\quad\quad H^{rot}(\zeta,z)=\frac{1}{2}\zeta^TS^{rot}(z)\zeta.
+\end{equation}
+
+\subsection{End-to-end map}
+A case of special interest occurs when the map is taken over a region symmetric about the solenoid midpoint at $z=0$.  In this case, we define $z_0=-\lambda g$ and $z=\lambda g$.  Then we obtain:
+\begin{equation}
+\Delta\phi=2\tan^{-1}\lambda,\quad\quad \lambda=\frac{L}{2g},
+\end{equation}
+where $L$ is the length of the field region over which the map is computed.  The map takes the form:
+\begin{align}
+M^0_{11}&=M^0_{33}=\cos(\beta\Delta\phi)+\frac{\lambda\sin(\beta\Delta\phi)}{\beta}, \\
+M^0_{12}&=M^0_{34}=g(1+\lambda^2)\frac{\sin(\beta\Delta\phi)}{\beta}, \\
+M^0_{21}&=M^0_{43}=\frac{2\beta\lambda\cos(\beta\Delta\phi)+(\lambda^2-\beta^2)\sin(\beta\Delta\phi)}{\beta g(1+\lambda^2)}, \\
+M^0_{22}&=M^0_{44}=\cos(\beta\Delta\phi)+\frac{\lambda\sin(\beta\Delta\phi)}{\beta}, \\
+M^0_{56}&=\frac{2\lambda g}{\beta_0^2\gamma_0^2},\quad\quad M^0_{55}=M^0_{66}=1.
+\end{align}
+The expression for the rotation matrix $R$ is unchanged.  Note from the form of $R$ that the Larmor rotation angle $\Omega$ is given by:
+\begin{equation}
+\Omega=b\Delta\phi=2b\tan^{-1}\lambda.
+\end{equation}
+This has a well defined limit as $\lambda\rightarrow\infty$, which is:
+\begin{equation}
+\lim_{\lambda\rightarrow\infty}\Omega= b\pi =\frac{\pi}{2}\frac{B_0g}{B\rho}.
+\end{equation}
+This is consistent with the Larmor angle we expect, namely:
+\begin{equation}
+\Omega_{\infty}=\int_{-\infty}^{\infty}\alpha(z)dz=\frac{\pi}{2}\frac{B_0g}{B\rho}.
+\end{equation}
+
+\begin{thebibliography}{9}
+\bibitem{Ryne}
+R.D. Ryne, ``Computational Methods in Accelerator Physics," USPAS Lecture Notes (2009).
+\end{thebibliography}
+
 
 Run
 ---

--- a/examples/solenoid_softedge/analysis_solenoid_softedge_solvable.py
+++ b/examples/solenoid_softedge/analysis_solenoid_softedge_solvable.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+import numpy as np
+import openpmd_api as io
+
+# initial/final beam
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+last_step = list(series.iterations)[-1]
+initial = series.iterations[1].particles["beam"].to_df()
+beam_final = series.iterations[last_step].particles["beam"]
+final = beam_final.to_df()
+
+# compare number of particles
+num_particles = 6
+# assert num_particles == len(initial)
+# assert num_particles == len(final)
+
+# initial data
+xi = [1, 0, 0, 0, 0, 0]
+pxi = [0, 1, 0, 0, 0, 0]
+yi = [0, 0, 1, 0, 0, 0]
+pyi = [0, 0, 0, 1, 0, 0]
+ti = [0, 0, 0, 0, 1, 0]
+pti = [0, 0, 0, 0, 0, 1]
+
+# problem parameters
+g = 0.1
+L = 2.0
+bscale = -1.0  # This coincides with the value set in the input file.
+gamma_ref = beam_final.get_attribute("gamma_ref")
+
+# derived parameters
+lbda = L / (2.0 * g)
+phi = 2.0 * np.arctan(lbda)
+b = 0.5 * bscale * g
+beta = np.sqrt(1.0 + b**2)
+cos1 = np.cos(b * phi)
+cos2 = np.cos(beta * phi)
+sin1 = np.sin(b * phi)
+sin2 = np.sin(beta * phi)
+bg = np.sqrt(gamma_ref**2 - 1.0)
+
+# exact transfer matrix
+r11 = cos1 * (cos2 + lbda * sin2 / beta)
+r12 = g * (1.0 + lbda**2) * cos1 * sin2 / beta
+r13 = sin1 * (cos2 + lbda * sin2 / beta)
+r14 = g * (1.0 + lbda**2) * sin1 * sin2 / beta
+r21 = (
+    cos1
+    * (2.0 * beta * lbda * cos2 + (lbda**2 - beta**2) * sin2)
+    / (g * beta * (1.0 + lbda**2))
+)
+r22 = cos1 * (cos2 + lbda * sin2 / beta)
+r23 = (
+    sin1
+    * (2.0 * beta * lbda * cos2 + (lbda**2 - beta**2) * sin2)
+    / (g * beta * (1.0 + lbda**2))
+)
+r24 = sin1 * (cos2 + lbda * sin2 / beta)
+r31 = -r13
+r32 = -r14
+r33 = r22
+r34 = r12
+r41 = -r23
+r42 = -r24
+r43 = r21
+r44 = r22
+r55 = 1.0
+r56 = 2.0 * lbda * g / bg**2
+r66 = 1.0
+
+# final data
+# initial data
+xf = [r11, r12, r13, r14, 0, 0]
+pxf = [r21, r22, r23, r24, 0, 0]
+yf = [r31, r32, r33, r34, 0, 0]
+pyf = [r41, r42, r43, r44, 0, 0]
+tf = [0, 0, 0, 0, 1.0, r56]
+ptf = [0, 0, 0, 0, 0, 1.0]
+
+# compute differences
+error_xi = (xi - initial["position_x"]).abs().max()
+error_pxi = (pxi - initial["momentum_x"]).abs().max()
+error_yi = (yi - initial["position_y"]).abs().max()
+error_pyi = (pyi - initial["momentum_y"]).abs().max()
+error_ti = (ti - initial["position_t"]).abs().max()
+error_pti = (pti - initial["momentum_t"]).abs().max()
+
+error_xf = (xf - final["position_x"]).abs().max()
+error_pxf = (pxf - final["momentum_x"]).abs().max()
+error_yf = (yf - final["position_y"]).abs().max()
+error_pyf = (pyf - final["momentum_y"]).abs().max()
+error_tf = (tf - final["position_t"]).abs().max()
+error_ptf = (ptf - final["momentum_t"]).abs().max()
+
+xf_max = np.max(np.abs(xf))
+pxf_max = np.max(np.abs(pxf))
+yf_max = np.max(np.abs(yf))
+pyf_max = np.max(np.abs(pyf))
+tf_max = np.max(np.abs(tf))
+ptf_max = np.max(np.abs(ptf))
+
+print("Initial maximum absolute difference in each column:")
+print("Difference x, px, y, py, t, pt:")
+print(error_xi)
+print(error_pxi)
+print(error_yi)
+print(error_pyi)
+print(error_ti)
+print(error_pti)
+
+atol = 1.0e-13
+print(f"  atol={atol}")
+
+assert np.allclose(
+    [error_xi, error_pxi, error_yi, error_pyi, error_ti, error_pti],
+    [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+    ],
+    atol=atol,
+)
+
+print("")
+print("Final maximum relative difference in each column:")
+print("Difference x, px, y, py, t, pt:")
+print(error_xf / xf_max)
+print(error_pxf / pxf_max)
+print(error_yf / yf_max)
+print(error_pyf / pyf_max)
+print(error_tf / tf_max)
+print(error_ptf / ptf_max)
+
+atol = 1.0e-7
+print(f"  tol={atol}")
+
+assert np.allclose(
+    [
+        error_xf / xf_max,
+        error_pxf / pxf_max,
+        error_yf / yf_max,
+        error_pyf / pyf_max,
+        error_tf / tf_max,
+        error_ptf / ptf_max,
+    ],
+    [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+    ],
+    atol=atol,
+)

--- a/examples/solenoid_softedge/analysis_solenoid_softedge_solvable.py
+++ b/examples/solenoid_softedge/analysis_solenoid_softedge_solvable.py
@@ -84,19 +84,19 @@ tf = [0, 0, 0, 0, 1.0, r56]
 ptf = [0, 0, 0, 0, 0, 1.0]
 
 # compute differences
-error_xi = (xi - initial["position_x"]).abs().max()
-error_pxi = (pxi - initial["momentum_x"]).abs().max()
-error_yi = (yi - initial["position_y"]).abs().max()
-error_pyi = (pyi - initial["momentum_y"]).abs().max()
-error_ti = (ti - initial["position_t"]).abs().max()
-error_pti = (pti - initial["momentum_t"]).abs().max()
+error_xi = np.max(np.abs(xi - initial["position_x"].to_numpy()))
+error_pxi = np.max(np.abs(pxi - initial["momentum_x"].to_numpy()))
+error_yi = np.max(np.abs(yi - initial["position_y"].to_numpy()))
+error_pyi = np.max(np.abs(pyi - initial["momentum_y"].to_numpy()))
+error_ti = np.max(np.abs(ti - initial["position_t"].to_numpy()))
+error_pti = np.max(np.abs(pti - initial["momentum_t"].to_numpy()))
 
-error_xf = (xf - final["position_x"]).abs().max()
-error_pxf = (pxf - final["momentum_x"]).abs().max()
-error_yf = (yf - final["position_y"]).abs().max()
-error_pyf = (pyf - final["momentum_y"]).abs().max()
-error_tf = (tf - final["position_t"]).abs().max()
-error_ptf = (ptf - final["momentum_t"]).abs().max()
+error_xf = np.max(np.abs(xf - final["position_x"].to_numpy()))
+error_pxf = np.max(np.abs(pxf - final["momentum_x"].to_numpy()))
+error_yf = np.max(np.abs(yf - final["position_y"].to_numpy()))
+error_pyf = np.max(np.abs(pyf - final["momentum_y"].to_numpy()))
+error_tf = np.max(np.abs(tf - final["position_t"].to_numpy()))
+error_ptf = np.max(np.abs(ptf - final["momentum_t"].to_numpy()))
 
 xf_max = np.max(np.abs(xf))
 pxf_max = np.max(np.abs(pxf))

--- a/examples/solenoid_softedge/analysis_solenoid_softedge_solvable.py
+++ b/examples/solenoid_softedge/analysis_solenoid_softedge_solvable.py
@@ -17,8 +17,8 @@ final = beam_final.to_df()
 
 # compare number of particles
 num_particles = 6
-# assert num_particles == len(initial)
-# assert num_particles == len(final)
+assert num_particles == len(initial)
+assert num_particles == len(final)
 
 # initial data
 xi = np.array([1, 0, 0, 0, 0, 0])

--- a/examples/solenoid_softedge/analysis_solenoid_softedge_solvable.py
+++ b/examples/solenoid_softedge/analysis_solenoid_softedge_solvable.py
@@ -21,12 +21,12 @@ num_particles = 6
 # assert num_particles == len(final)
 
 # initial data
-xi = [1, 0, 0, 0, 0, 0]
-pxi = [0, 1, 0, 0, 0, 0]
-yi = [0, 0, 1, 0, 0, 0]
-pyi = [0, 0, 0, 1, 0, 0]
-ti = [0, 0, 0, 0, 1, 0]
-pti = [0, 0, 0, 0, 0, 1]
+xi = np.array([1, 0, 0, 0, 0, 0])
+pxi = np.array([0, 1, 0, 0, 0, 0])
+yi = np.array([0, 0, 1, 0, 0, 0])
+pyi = np.array([0, 0, 0, 1, 0, 0])
+ti = np.array([0, 0, 0, 0, 1, 0])
+pti = np.array([0, 0, 0, 0, 0, 1])
 
 # problem parameters
 g = 0.1
@@ -75,13 +75,12 @@ r56 = 2.0 * lbda * g / bg**2
 r66 = 1.0
 
 # final data
-# initial data
-xf = [r11, r12, r13, r14, 0, 0]
-pxf = [r21, r22, r23, r24, 0, 0]
-yf = [r31, r32, r33, r34, 0, 0]
-pyf = [r41, r42, r43, r44, 0, 0]
-tf = [0, 0, 0, 0, 1.0, r56]
-ptf = [0, 0, 0, 0, 0, 1.0]
+xf = np.array([r11, r12, r13, r14, 0, 0])
+pxf = np.array([r21, r22, r23, r24, 0, 0])
+yf = np.array([r31, r32, r33, r34, 0, 0])
+pyf = np.array([r41, r42, r43, r44, 0, 0])
+tf = np.array([0, 0, 0, 0, 1.0, r56])
+ptf = np.array([0, 0, 0, 0, 0, 1.0])
 
 # compute differences
 error_xi = np.max(np.abs(xi - initial["position_x"].to_numpy()))

--- a/examples/solenoid_softedge/run_solenoid_softedge_solvable.py
+++ b/examples/solenoid_softedge/run_solenoid_softedge_solvable.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Chad Mitchell, Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+import amrex.space3d as amr
+from impactx import Config, ImpactX, elements
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = False
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# load a 250 MeV proton beam with an initial
+# horizontal rms emittance of 1 um and an
+# initial vertical rms emittance of 2 um
+kin_energy_MeV = 250.0  # reference energy
+bunch_charge_C = 1.0e-9  # used with space charge
+npart = 10000  # number of macro particles
+
+#   reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
+qm_eev = 1.0 / 938.27208816 / 1e6  # electron charge/mass in e / eV
+
+#   particle bunch
+pc = sim.particle_container()
+
+dx = [1, 0, 0, 0, 0, 0]
+dpx = [0, 1, 0, 0, 0, 0]
+dy = [0, 0, 1, 0, 0, 0]
+dpy = [0, 0, 0, 1, 0, 0]
+dt = [0, 0, 0, 0, 1, 0]
+dpt = [0, 0, 0, 0, 0, 1]
+
+if not Config.have_gpu:  # initialize using cpu-based PODVectors
+    dx_podv = amr.PODVector_real_std()
+    dy_podv = amr.PODVector_real_std()
+    dt_podv = amr.PODVector_real_std()
+    dpx_podv = amr.PODVector_real_std()
+    dpy_podv = amr.PODVector_real_std()
+    dpt_podv = amr.PODVector_real_std()
+else:  # initialize on device using arena/gpu-based PODVectors
+    dx_podv = amr.PODVector_real_arena()
+    dy_podv = amr.PODVector_real_arena()
+    dt_podv = amr.PODVector_real_arena()
+    dpx_podv = amr.PODVector_real_arena()
+    dpy_podv = amr.PODVector_real_arena()
+    dpt_podv = amr.PODVector_real_arena()
+
+for p_dx in dx:
+    dx_podv.push_back(p_dx)
+for p_dy in dy:
+    dy_podv.push_back(p_dy)
+for p_dt in dt:
+    dt_podv.push_back(p_dt)
+for p_dpx in dpx:
+    dpx_podv.push_back(p_dpx)
+for p_dpy in dpy:
+    dpy_podv.push_back(p_dpy)
+for p_dpt in dpt:
+    dpt_podv.push_back(p_dpt)
+
+pc.add_n_particles(
+    dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, bunch_charge_C
+)
+
+# design the accelerator lattice
+sol = elements.SoftSolenoid(
+    name="sol1",
+    ds=2.0,
+    bscale=-1.0,
+    cos_coefficients=[
+        0.294225534860747,
+        0.2317701877038734,
+        0.166794824926630,
+        0.122811705237718,
+        0.089180156215475,
+        0.065459443762749,
+        0.047593623793664,
+        0.034919898089417,
+        0.0253867332415233,
+        0.018635438261000,
+        0.013536778750496,
+        0.009948507321628,
+        0.0072152939652668,
+        0.005313407598416,
+        0.003843724102950,
+        0.002839750408934,
+        0.0020458821109883,
+        0.001519293408286,
+        0.001087477417341,
+        0.000814190355962,
+        0.000576771050997,
+    ],
+    sin_coefficients=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    mapsteps=200,
+    nslice=1,
+)
+
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+
+sim.lattice.extend(
+    [
+        monitor,
+        sol,
+        monitor,
+    ]
+)
+
+# run simulation
+sim.track_particles()
+
+# clean shutdown
+sim.finalize()

--- a/examples/solenoid_softedge/run_solenoid_softedge_solvable.py
+++ b/examples/solenoid_softedge/run_solenoid_softedge_solvable.py
@@ -24,7 +24,6 @@ sim.init_grids()
 # initial vertical rms emittance of 2 um
 kin_energy_MeV = 250.0  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
-npart = 10000  # number of macro particles
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
@@ -69,9 +68,10 @@ for p_dpy in dpy:
 for p_dpt in dpt:
     dpt_podv.push_back(p_dpt)
 
-pc.add_n_particles(
-    dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, bunch_charge_C
-)
+if amr.ParallelDescriptor.IOProcessor():
+    pc.add_n_particles(
+        dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, bunch_charge_C
+    )
 
 # design the accelerator lattice
 sol = elements.SoftSolenoid(


### PR DESCRIPTION
This PR adds a benchmark of the linear map computed for a soft-edge solenoid with a non-uniform longitudinal profile, for a special case that is exactly-solvable.