### PR TITLE
Generalize logic for setting default tile size for OMP threading.

### DIFF
--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -156,27 +156,40 @@ namespace impactx
         // Then we try to reduce the tile size in the (z, y, x) directions alternately
         // until there are enough tiles for the number of threads.
 
-        const auto& ba = ParticleBoxArray(lid);
-        tile_size = ba[gid].size();
-        auto n_logical = numTilesInBox(ba[gid], true, tile_size);
+        // if the user has set particles.tile_size, do not override this choice
+        // unlike particles.do_tiling, we do not add this to the table in init,
+        // so if it's there the user set it
+    bool user_set = false;
+    {
+        amrex::ParmParse pp_particles("particles");
+            amrex::Vector<int> tilesize(AMREX_SPACEDIM);
+        user_set = pp_particles.queryarr("tile_size", tilesize, 0, AMREX_SPACEDIM);
+    }
 
+    const auto& ba = ParticleBoxArray(lid);
+    auto n_logical = numTilesInBox(ba[gid], true, tile_size);
+
+    if (!user_set) {
+        tile_size = ba[gid].size();
         int ntry = 0;
         constexpr int max_tries = 10;
         while ((n_logical < nthreads) && (ntry++ < max_tries)) {
-            int idim = 2 - (ntry % 3);  // alternate between (2, 1, 0)
-            if (tile_size[idim] == 1) { continue; }
-            tile_size[idim] /= 2;
-            n_logical = numTilesInBox(ba[gid], true, tile_size);
+        int idim = 2 - (ntry % 3);  // alternate between (2, 1, 0)
+        if (tile_size[idim] == 1) { continue; }
+        tile_size[idim] /= 2;
+        n_logical = numTilesInBox(ba[gid], true, tile_size);
         }
+    }
 
         if (n_logical < nthreads) {
         ablastr::warn_manager::WMRecordWarning(
-        "ImpactxParticleContainer::prepare",
-        "Could not find good tile size for the number of OpenMP threads. "
-        "Lowering the number of OpenMP threads used compared to the environment variable OMP_NUM_THREADS. "
-        "This may result in poorer than expected performance. "
-        "You may want to try increasing the blocking factor and max grid size.",
-        ablastr::warn_manager::WarnPriority::medium
+            "ImpactxParticleContainer::prepare",
+            "Could not find a good tile size for the requested number of OpenMP threads. "
+            "The number of threads is " + std::to_string(nthreads) + ", while the number "
+            "of available tiles is " + std::to_string(n_logical) + ". Using a lower number "
+            "of threads instead. This may result in poorer than expected performance. "
+            "You may want to try increasing the blocking factor and max grid size.",
+            ablastr::warn_manager::WarnPriority::medium
         );
 
 #if defined(AMREX_USE_OMP)

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -179,7 +179,7 @@ namespace impactx
         );
 
 #if defined(AMREX_USE_OMP)
-        omp_set_max_threads(n_logical);
+        omp_set_num_threads(n_logical);
 #endif
         }
 

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -152,17 +152,18 @@ namespace impactx
         // When running without space charge and OpenMP parallelization,
         // we need to make sure we have enough tiles on level 0, grid 0
         // to thread over the available tiles. We try to set the tile_size
-        // appropriately here. The tiles start as (very large number, 8, 8)
-        // in (x, y, z). So we try to reduce the tile size in the y and z
-        // directions alternately until there are enough tiles for the number of threads.
+        // appropriately here. We start by setting the tile_size to the size of box 0.
+        // Then we try to reduce the tile size in the (z, y, x) directions alternately
+        // until there are enough tiles for the number of threads.
 
         const auto& ba = ParticleBoxArray(lid);
+        tile_size = ba[gid].size();
         auto n_logical = numTilesInBox(ba[gid], true, tile_size);
 
         int ntry = 0;
-        constexpr int max_tries = 6;
+        constexpr int max_tries = 10;
         while ((n_logical < nthreads) && (ntry++ < max_tries)) {
-            int idim = (ntry % 2) + 1;  // alternate between 1 and 2
+            int idim = 2 - (ntry % 3);  // alternate between (2, 1, 0)
             tile_size[idim] /= 2;
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(tile_size[idim] > 0,
                                              "Failed to set proper tile size for the number of OpenMP threads. "

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -171,8 +171,9 @@ namespace impactx
 
         if (n_logical < nthreads) {
         ablastr::warn_manager::WMRecordWarning(
-                "Could not find good tile size for the number of OpenMP threads. "
-                "Lowering the number of OpenMP threads used compared to the environment variable OMP_NUM_THREADS. "
+        "ImpactxParticleContainer::prepare",
+        "Could not find good tile size for the number of OpenMP threads. "
+        "Lowering the number of OpenMP threads used compared to the environment variable OMP_NUM_THREADS. "
         "This may result in poorer than expected performance. "
         "You may want to try increasing the blocking factor and max grid size.",
         ablastr::warn_manager::WarnPriority::medium

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -168,34 +168,41 @@ namespace impactx
 
         int n_logical = 0;
         const auto& ba = ParticleBoxArray(lid);
-    if (!user_set) {
-        tile_size = ba[gid].size();
+        if (!user_set)
+        {
+            tile_size = ba[gid].size();
             n_logical = numTilesInBox(ba[gid], true, tile_size);
-        int ntry = 0;
-        constexpr int max_tries = 10;
-        while ((n_logical < nthreads) && (ntry++ < max_tries)) {
-        int idim = 2 - (ntry % 3);  // alternate between (2, 1, 0)
-        if (tile_size[idim] == 1) { continue; }
-        tile_size[idim] /= 2;
-        n_logical = numTilesInBox(ba[gid], true, tile_size);
-        }
-    } else {
+            int ntry = 0;
+            constexpr int max_tries = 10;
+            while ((n_logical < nthreads) && (ntry++ < max_tries))
+            {
+                int idim = 2 - (ntry % 3);  // alternate between (2, 1, 0)
+                if (tile_size[idim] == 1) { continue; }
+                tile_size[idim] /= 2;
+                n_logical = numTilesInBox(ba[gid], true, tile_size);
+            }
+        } else
+        {
             n_logical = numTilesInBox(ba[gid], true, tile_size);
         }
 
-        if (n_logical < nthreads) {
-        ablastr::warn_manager::WMRecordWarning(
-            "ImpactxParticleContainer::prepare",
-            "Could not find a good tile size for the requested number of OpenMP threads. "
-            "The number of threads is " + std::to_string(nthreads) + ", while the number "
-            "of available tiles is " + std::to_string(n_logical) + ". Using a lower number "
-            "of threads instead. This may result in poorer than expected performance. "
-            "You may want to try increasing the blocking factor and max grid size.",
-            ablastr::warn_manager::WarnPriority::medium
-        );
+        if (n_logical < nthreads)
+        {
+            ablastr::warn_manager::WMRecordWarning(
+                "ImpactXParticleContainer::prepare",
+                "Could not find a good tile size for the requested number of "
+                "OpenMP threads. The number of threads is " +
+                std::to_string(nthreads) + ", while the number of available "
+                "tiles is " + std::to_string(n_logical) + ". Lowering the number "
+                "of threads to match the available tiles now. This may result "
+                "in poorer performance than expected. "
+                "You may want to try increasing the blocking factor and max "
+                "grid size.",
+                ablastr::warn_manager::WarnPriority::medium
+            );
 
 #if defined(AMREX_USE_OMP)
-        omp_set_num_threads(n_logical);
+            omp_set_num_threads(n_logical);
 #endif
         }
 

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -164,19 +164,23 @@ namespace impactx
         constexpr int max_tries = 10;
         while ((n_logical < nthreads) && (ntry++ < max_tries)) {
             int idim = 2 - (ntry % 3);  // alternate between (2, 1, 0)
+            if (tile_size[idim] == 1) { continue; }
             tile_size[idim] /= 2;
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(tile_size[idim] > 0,
-                                             "Failed to set proper tile size for the number of OpenMP threads. "
-                                             "Consider lowering the number of OpenMP threads via the environment variable OMP_NUM_THREADS."
-                                             );
             n_logical = numTilesInBox(ba[gid], true, tile_size);
         }
 
         if (n_logical < nthreads) {
-            amrex::Abort("ImpactParticleContainer::prepare() "
-                "could not find good tile size for the number of OpenMP threads. "
-                "Consider lowering the number of OpenMP threads via the environment variable OMP_NUM_THREADS."
-            );
+	    ablastr::warn_manager::WMRecordWarning(
+                "Could not find good tile size for the number of OpenMP threads. "
+                "Lowering the number of OpenMP threads used compared to the environment variable OMP_NUM_THREADS. "
+		"This may result in poorer than expected performance. "
+		"You may want to try increasing the blocking factor and max grid size.",
+		ablastr::warn_manager::WarnPriority::medium
+	    );
+
+#if defined(AMREX_USE_OMP)
+	    omp_set_max_threads(n_logical);
+#endif
         }
 
         reserveData();

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -159,18 +159,18 @@ namespace impactx
         // if the user has set particles.tile_size, do not override this choice
         // unlike particles.do_tiling, we do not add this to the table in init,
         // so if it's there the user set it
-    bool user_set = false;
-    {
-        amrex::ParmParse pp_particles("particles");
+        bool user_set = false;
+        {
+            amrex::ParmParse pp_particles("particles");
             amrex::Vector<int> tilesize(AMREX_SPACEDIM);
-        user_set = pp_particles.queryarr("tile_size", tilesize, 0, AMREX_SPACEDIM);
-    }
+            user_set = pp_particles.queryarr("tile_size", tilesize, 0, AMREX_SPACEDIM);
+        }
 
-    const auto& ba = ParticleBoxArray(lid);
-    auto n_logical = numTilesInBox(ba[gid], true, tile_size);
-
+        int n_logical = 0;
+        const auto& ba = ParticleBoxArray(lid);
     if (!user_set) {
         tile_size = ba[gid].size();
+            n_logical = numTilesInBox(ba[gid], true, tile_size);
         int ntry = 0;
         constexpr int max_tries = 10;
         while ((n_logical < nthreads) && (ntry++ < max_tries)) {
@@ -179,7 +179,9 @@ namespace impactx
         tile_size[idim] /= 2;
         n_logical = numTilesInBox(ba[gid], true, tile_size);
         }
-    }
+    } else {
+            n_logical = numTilesInBox(ba[gid], true, tile_size);
+        }
 
         if (n_logical < nthreads) {
         ablastr::warn_manager::WMRecordWarning(

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -170,16 +170,16 @@ namespace impactx
         }
 
         if (n_logical < nthreads) {
-	    ablastr::warn_manager::WMRecordWarning(
+        ablastr::warn_manager::WMRecordWarning(
                 "Could not find good tile size for the number of OpenMP threads. "
                 "Lowering the number of OpenMP threads used compared to the environment variable OMP_NUM_THREADS. "
-		"This may result in poorer than expected performance. "
-		"You may want to try increasing the blocking factor and max grid size.",
-		ablastr::warn_manager::WarnPriority::medium
-	    );
+        "This may result in poorer than expected performance. "
+        "You may want to try increasing the blocking factor and max grid size.",
+        ablastr::warn_manager::WarnPriority::medium
+        );
 
 #if defined(AMREX_USE_OMP)
-	    omp_set_max_threads(n_logical);
+        omp_set_max_threads(n_logical);
 #endif
         }
 

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <iterator>
 #include <stdexcept>
+#include <sstream>
 
 
 namespace
@@ -188,16 +189,29 @@ namespace impactx
 
         if (n_logical < nthreads)
         {
+            std::string warning_message;
+            if (!user_set) {
+                warning_message.append(
+                    "Could not find a good tile size for the requested " +
+                    std::to_string(nthreads) + " OpenMP threads. "
+                );
+            }
+            std::stringstream sstr_tile_size;
+            sstr_tile_size << tile_size;
+            warning_message.append(
+                "The number of available tiles is " +
+                std::to_string(n_logical) + " with each a size of " + sstr_tile_size.str() +
+                ". Lowering the number of threads to match the available tiles now. This may result "
+                "in poorer performance than expected. "
+            );
+            warning_message.append("You may want to try ");
+            if (user_set) {
+                warning_message.append("decreasing the particles.tile_size or ");
+            }
+            warning_message.append("increasing the blocking factor and max grid size.");
             ablastr::warn_manager::WMRecordWarning(
                 "ImpactXParticleContainer::prepare",
-                "Could not find a good tile size for the requested number of "
-                "OpenMP threads. The number of threads is " +
-                std::to_string(nthreads) + ", while the number of available "
-                "tiles is " + std::to_string(n_logical) + ". Lowering the number "
-                "of threads to match the available tiles now. This may result "
-                "in poorer performance than expected. "
-                "You may want to try increasing the blocking factor and max "
-                "grid size.",
+                warning_message,
                 ablastr::warn_manager::WarnPriority::medium
             );
 


### PR DESCRIPTION
Fix #1132. 

This increases the number of threads available by default to 512 by changing the strategy to consider all three dimensions.

Also, if a good tile_size can't be set for the default number of threads, this throws a warning and reduces the number of threads OMP will use.

