### PR TITLE
ABLASTR/WarpX: development

### DIFF
--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -178,7 +178,7 @@ set(ImpactX_openpmd_src ""
 set(ImpactX_ablastr_repo "https://github.com/BLAST-WarpX/warpx.git"
     CACHE STRING
     "Repository URI to pull and build ABLASTR from if(ImpactX_ablastr_internal)")
-set(ImpactX_ablastr_branch "25.09"
+set(ImpactX_ablastr_branch "e1e16ace9d8386571295092415cdddbe4446141b"
     CACHE STRING
     "Repository branch for ImpactX_ablastr_repo if(ImpactX_ablastr_internal)")
 


### PR DESCRIPTION
Update the ABLASTR dependency to the latest development branch. Mainly to pull in [this PR](https://github.com/BLAST-WarpX/warpx/pull/6127) for 2/2.5D space charge #909

- [x] rebase after #1142 was merged