### PR TITLE
Fix CSR error message in reference particle mode.

### DIFF
--- a/src/tracking/reference.cpp
+++ b/src/tracking/reference.cpp
@@ -71,7 +71,7 @@ namespace impactx
         amrex::ParmParse const pp_algo("algo");
         bool csr = false;
         pp_algo.query("csr", csr);
-        if (!csr)
+        if (csr)
         {
             throw std::runtime_error("CSR effects cannot be modeled for single particle tracking.");
         }


### PR DESCRIPTION
This PR fixes a bug in the error message related to CSR when running in reference particle mode using `track_reference(ref)`.

It affects only this mode, and is not relevant when using `track_particles` or `track_envelope`.