### PR TITLE
CI: Free Disk Space (CUDA)

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -16,8 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event.pull_request.draft == false
     env:
-      CXXFLAGS: "-Werror -Wno-pedantic"
-      CUDAFLAGS: "-Wno-pedantic -Xcompiler '-Wno-pedantic' --display-error-number"
+      CXXFLAGS: "-Werror"
       CMAKE_GENERATOR: Ninja
     steps:
     - name: Free More Disk Space

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -19,6 +19,17 @@ jobs:
       CXXFLAGS: "-Werror"
       CMAKE_GENERATOR: Ninja
     steps:
+    - name: Free More Disk Space
+      uses: ax3l/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false  # apt takes ~1:30min
+        docker-images: true
+        swap-storage: false
+
     - uses: actions/checkout@v5
 
     - name: install dependencies

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event.pull_request.draft == false
     env:
-      CXXFLAGS: "-Werror"
+      CXXFLAGS: "-Werror -Wno-pedantic"
+      CUDAFLAGS: "-Wno-pedantic -Xcompiler '-Wno-pedantic' --display-error-number"
       CMAKE_GENERATOR: Ninja
     steps:
     - name: Free More Disk Space

--- a/cmake/ImpactXFunctions.cmake
+++ b/cmake/ImpactXFunctions.cmake
@@ -190,7 +190,13 @@ function(impactx_set_compile_warnings tgt)
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
         target_compile_options(${tgt} PRIVATE -Wall -Wextra -Wpedantic -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code)
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-        target_compile_options(${tgt} PRIVATE -Wall -Wextra -Wpedantic -Wshadow -Woverloaded-virtual -Wunreachable-code -Wno-array-bounds)
+        target_compile_options(${tgt} PRIVATE -Wall -Wextra  -Wshadow -Woverloaded-virtual -Wunreachable-code -Wno-array-bounds)
+        if(NOT ImpactX_COMPUTE STREQUAL CUDA)
+            # In older NVCC, -Wpedantic causes "warning: style of line directive is a GCC extension"
+            target_compile_options(${tgt} PRIVATE -Wpedantic)
+        else()
+
+        endif()
     elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
         # Warning C4503: "decorated name length exceeded, name was truncated"
         # Symbols longer than 4096 chars are truncated (and hashed instead)


### PR DESCRIPTION
Let's see if this solves the failing CUDA CI runners.

https://github.com/BLAST-ImpactX/impactx/pull/1143#issuecomment-3313487804

Also fixes a warning: "warning: style of line directive is a GCC extension" for GCC 11.4 + NVCC 11.7.1