### PR TITLE
Apply ISR to reference particle (optional).

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1042,7 +1042,7 @@ However, a Taylor expansion is used to evaluate the dependence on the quantum pa
 
   Flag specifying whether ISR is to be applied to the reference particle.  When ``algo.isr_on_ref_part = false``, the reference particle does not lose energy due to radiation, and the
   mean energy of the beam particles will decrease.  This option is natural if the lattice optics, magnet settings, etc. are chosen without accounting for radiative energy loss.
-  When ``algo.isr_on_ref_part = true``, the reference particle does lose energy due to radiation, and little centroid evolution is expected in the beam particles.
+  When ``algo.isr_on_ref_part = true``, the reference particle does lose energy due to radiation, and little centroid evolution is expected in the beam particles.  This option is natural if the lattice optics, magnet settings, etc. are chosen to account for radiative energy loss.
 
 .. note::
 

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1038,6 +1038,12 @@ However, a Taylor expansion is used to evaluate the dependence on the quantum pa
 
   The number of terms retained in the Taylor series for the functions :math:`g(\chi)` and :math:`h(\chi)` appearing in equations (25) and (41) describing quantum effects.
 
+* ``algo.isr_ref_part`` (``integer`, optional, default: ``0``)
+
+  Flag specifying whether ISR is to be applied to the reference particle.  When ``algo.isr_ref_part = 0``, the reference particle does not lose energy due to radiation, and the
+  mean energy of the beam particles will decrease.  This option is natural if the lattice optics, magnet settings, etc. are chosen without accounting for radiative energy loss.
+  When ``algo.isr_ref_part = 1``, the reference particle does lose energy due to radiation, and little centroid evolution is expected in the beam particles.
+
 .. note::
 
    ISR effects are only calculated for lattice elements that include bending, such as ``Sbend``, ``ExactSbend`` and ``CFbend``.

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1038,11 +1038,11 @@ However, a Taylor expansion is used to evaluate the dependence on the quantum pa
 
   The number of terms retained in the Taylor series for the functions :math:`g(\chi)` and :math:`h(\chi)` appearing in equations (25) and (41) describing quantum effects.
 
-* ``algo.isr_ref_part`` (``boolean`, optional, default: ``false``)
+* ``algo.isr_on_ref_part`` (``boolean`, optional, default: ``false``)
 
-  Flag specifying whether ISR is to be applied to the reference particle.  When ``algo.isr_ref_part = false``, the reference particle does not lose energy due to radiation, and the
+  Flag specifying whether ISR is to be applied to the reference particle.  When ``algo.isr_on_ref_part = false``, the reference particle does not lose energy due to radiation, and the
   mean energy of the beam particles will decrease.  This option is natural if the lattice optics, magnet settings, etc. are chosen without accounting for radiative energy loss.
-  When ``algo.isr_ref_part = true``, the reference particle does lose energy due to radiation, and little centroid evolution is expected in the beam particles.
+  When ``algo.isr_on_ref_part = true``, the reference particle does lose energy due to radiation, and little centroid evolution is expected in the beam particles.
 
 .. note::
 

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1038,11 +1038,11 @@ However, a Taylor expansion is used to evaluate the dependence on the quantum pa
 
   The number of terms retained in the Taylor series for the functions :math:`g(\chi)` and :math:`h(\chi)` appearing in equations (25) and (41) describing quantum effects.
 
-* ``algo.isr_ref_part`` (``integer`, optional, default: ``0``)
+* ``algo.isr_ref_part`` (``boolean`, optional, default: ``false``)
 
-  Flag specifying whether ISR is to be applied to the reference particle.  When ``algo.isr_ref_part = 0``, the reference particle does not lose energy due to radiation, and the
+  Flag specifying whether ISR is to be applied to the reference particle.  When ``algo.isr_ref_part = false``, the reference particle does not lose energy due to radiation, and the
   mean energy of the beam particles will decrease.  This option is natural if the lattice optics, magnet settings, etc. are chosen without accounting for radiative energy loss.
-  When ``algo.isr_ref_part = 1``, the reference particle does lose energy due to radiation, and little centroid evolution is expected in the beam particles.
+  When ``algo.isr_ref_part = true``, the reference particle does lose energy due to radiation, and little centroid evolution is expected in the beam particles.
 
 .. note::
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -174,11 +174,11 @@ Collective Effects & Overall Simulation Parameters
 
       The number of terms retained in the Taylor series for the functions :math:`g(\chi)` and :math:`h(\chi)` appearing in Niel et al, equations (25) and (41) describing quantum effects.
 
-   .. py:property:: isr_ref_part
+   .. py:property:: isr_on_ref_part
 
-      Flag specifying whether ISR is to be applied to the reference particle.  When ``sim.isr_ref_part = False``, the reference particle does not lose energy due to radiation, and the
+      Flag specifying whether ISR is to be applied to the reference particle.  When ``sim.isr_on_ref_part = False``, the reference particle does not lose energy due to radiation, and the
       mean energy of the beam particles will decrease.  This option is natural if the lattice optics, magnet settings, etc. are chosen without accounting for radiative energy loss.
-      When ``sim.isr_ref_part = True``, the reference particle does lose energy due to radiation, and little centroid evolution is expected in the beam particles.
+      When ``sim.isr_on_ref_part = True``, the reference particle does lose energy due to radiation, and little centroid evolution is expected in the beam particles.
 
    .. py:property:: diagnostics
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -174,6 +174,12 @@ Collective Effects & Overall Simulation Parameters
 
       The number of terms retained in the Taylor series for the functions :math:`g(\chi)` and :math:`h(\chi)` appearing in Niel et al, equations (25) and (41) describing quantum effects.
 
+   .. py:property:: isr_ref_part
+
+      Flag specifying whether ISR is to be applied to the reference particle.  When ``algo.isr_ref_part = 0``, the reference particle does not lose energy due to radiation, and the
+      mean energy of the beam particles will decrease.  This option is natural if the lattice optics, magnet settings, etc. are chosen without accounting for radiative energy loss.
+      When ``algo.isr_ref_part = 1``, the reference particle does lose energy due to radiation, and little centroid evolution is expected in the beam particles.
+
    .. py:property:: diagnostics
 
       Enable (``True``) or disable (``False``) diagnostics generally (default: ``True``).

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -176,9 +176,9 @@ Collective Effects & Overall Simulation Parameters
 
    .. py:property:: isr_ref_part
 
-      Flag specifying whether ISR is to be applied to the reference particle.  When ``algo.isr_ref_part = 0``, the reference particle does not lose energy due to radiation, and the
+      Flag specifying whether ISR is to be applied to the reference particle.  When ``sim.isr_ref_part = False``, the reference particle does not lose energy due to radiation, and the
       mean energy of the beam particles will decrease.  This option is natural if the lattice optics, magnet settings, etc. are chosen without accounting for radiative energy loss.
-      When ``algo.isr_ref_part = 1``, the reference particle does lose energy due to radiation, and little centroid evolution is expected in the beam particles.
+      When ``sim.isr_ref_part = True``, the reference particle does lose energy due to radiation, and little centroid evolution is expected in the beam particles.
 
    .. py:property:: diagnostics
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -178,7 +178,7 @@ Collective Effects & Overall Simulation Parameters
 
       Flag specifying whether ISR is to be applied to the reference particle.  When ``sim.isr_on_ref_part = False``, the reference particle does not lose energy due to radiation, and the
       mean energy of the beam particles will decrease.  This option is natural if the lattice optics, magnet settings, etc. are chosen without accounting for radiative energy loss.
-      When ``sim.isr_on_ref_part = True``, the reference particle does lose energy due to radiation, and little centroid evolution is expected in the beam particles.
+      When ``sim.isr_on_ref_part = True``, the reference particle does lose energy due to radiation, and little centroid evolution is expected in the beam particles.  This option is natural if the lattice optics, magnet settings, etc. are chosen to account for radiative energy loss.
 
    .. py:property:: diagnostics
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1419,6 +1419,21 @@ add_impactx_test(bend-isr.py
     OFF  # no plot script yet
 )
 
+# A single bend with incoherent synchrotron radiation & reference energy loss #################
+# no space charge
+add_impactx_test(bend-isr-ref
+    examples/incoherent_synchrotron/input_bend_isr_ref.in
+    ON   # ImpactX MPI-parallel
+    examples/incoherent_synchrotron/analysis_bend_isr_ref.py
+    OFF  # no plot script yet
+)
+add_impactx_test(bend-isr-ref.py
+    examples/incoherent_synchrotron/run_bend_isr_ref.py
+    OFF   # ImpactX MPI-parallel
+    examples/incoherent_synchrotron/analysis_bend_isr_ref.py
+    OFF  # no plot script yet
+)
+
 # Bending Dipole with Zero Field Strength ######################
 #
 # no space charge

--- a/examples/incoherent_synchrotron/README.rst
+++ b/examples/incoherent_synchrotron/README.rst
@@ -59,9 +59,9 @@ We run the following script to analyze correctness:
 .. _examples-bend-isr-ref:
 
 A Single Bend with ISR, Reference Energy Loss
-==============================================
+=============================================
 
-This is identical to the preceding test, except for the flag ``isr_ref_part = 1``.  In this test, the reference particle experiences radiative energy loss.  For the beam particles,
+This is identical to the preceding test, except for the flag ``isr_ref_part`` option being enabled.  In this test, the reference particle experiences radiative energy loss.  For the beam particles,
 whose coordinates and momenta are measured relative to the reference particle, the primary effect of ISR is to induce an increase in energy spread.  Little effect is visible on
 the beam centroid.
 

--- a/examples/incoherent_synchrotron/README.rst
+++ b/examples/incoherent_synchrotron/README.rst
@@ -62,7 +62,7 @@ A Single Bend with ISR, Reference Energy Loss
 ==============================================
 
 This is identical to the preceding test, except for the flag ``isr_ref_part = 1``.  In this test, the reference particle experiences radiative energy loss.  For the beam particles,
-whose coordinates and momenta are measured relative to the reference particle, the primary effect of ISR is to induce an increase in energy spread.  Little effect is visible on 
+whose coordinates and momenta are measured relative to the reference particle, the primary effect of ISR is to induce an increase in energy spread.  Little effect is visible on
 the beam centroid.
 
 
@@ -89,7 +89,7 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
        .. literalinclude:: input_bend_isr_ref.in
           :language: ini
           :caption: You can copy this file from ``examples/incoherent_synchrotron/input_bend_isr_ref.in``.
-   
+
 Analyze
 -------
 
@@ -100,5 +100,3 @@ We run the following script to analyze correctness:
    .. literalinclude:: analysis_bend_isr_ref.py
       :language: python3
       :caption: You can copy this file from ``examples/incoherent_synchrotron/analysis_bend_isr_ref.py``.
-
-

--- a/examples/incoherent_synchrotron/README.rst
+++ b/examples/incoherent_synchrotron/README.rst
@@ -61,7 +61,7 @@ We run the following script to analyze correctness:
 A Single Bend with ISR, Reference Energy Loss
 =============================================
 
-This is identical to the preceding test, except for the flag ``isr_ref_part`` option being enabled.  In this test, the reference particle experiences radiative energy loss.  For the beam particles,
+This is identical to the preceding test, except for the flag ``isr_on_ref_part`` option being enabled.  In this test, the reference particle experiences radiative energy loss.  For the beam particles,
 whose coordinates and momenta are measured relative to the reference particle, the primary effect of ISR is to induce an increase in energy spread.  Little effect is visible on
 the beam centroid.
 

--- a/examples/incoherent_synchrotron/README.rst
+++ b/examples/incoherent_synchrotron/README.rst
@@ -54,3 +54,51 @@ We run the following script to analyze correctness:
    .. literalinclude:: analysis_bend_isr.py
       :language: python3
       :caption: You can copy this file from ``examples/incoherent_synchrotron/analysis_bend_isr.py``.
+
+
+.. _examples-bend-isr-ref:
+
+A Single Bend with ISR, Reference Energy Loss
+==============================================
+
+This is identical to the preceding test, except for the flag ``isr_ref_part = 1``.  In this test, the reference particle experiences radiative energy loss.  For the beam particles,
+whose coordinates and momenta are measured relative to the reference particle, the primary effect of ISR is to induce an increase in energy spread.  Little effect is visible on 
+the beam centroid.
+
+
+Run
+---
+
+This example can be run **either** as:
+
+* **Python** script: ``python3 run_bend_isr_ref.py`` or
+* ImpactX **executable** using an input file: ``impactx input_bend_isr_ref.in``
+
+For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+
+.. tab-set::
+
+   .. tab-item:: Python: Script
+
+       .. literalinclude:: run_bend_isr_ref.py
+          :language: python3
+          :caption: You can copy this file from ``examples/incoherent_synchrotron/run_bend_isr_ref.py``.
+
+   .. tab-item:: Executable: Input File
+
+       .. literalinclude:: input_bend_isr_ref.in
+          :language: ini
+          :caption: You can copy this file from ``examples/incoherent_synchrotron/input_bend_isr_ref.in``.
+   
+Analyze
+-------
+
+We run the following script to analyze correctness:
+
+.. dropdown:: Script ``analysis_bend_isr_ref.py``
+
+   .. literalinclude:: analysis_bend_isr_ref.py
+      :language: python3
+      :caption: You can copy this file from ``examples/incoherent_synchrotron/analysis_bend_isr_ref.py``.
+
+

--- a/examples/incoherent_synchrotron/analysis_bend_isr_ref.py
+++ b/examples/incoherent_synchrotron/analysis_bend_isr_ref.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+import glob
+import re
+
+import numpy as np
+import pandas as pd
+
+
+def read_file(file_pattern):
+    for filename in glob.glob(file_pattern):
+        df = pd.read_csv(filename, delimiter=r"\s+")
+        if "step" not in df.columns:
+            step = int(re.findall(r"[0-9]+", filename)[0])
+            df["step"] = step
+        yield df
+
+
+def read_time_series(file_pattern):
+    """Read in all CSV files from each MPI rank (and potentially OpenMP
+    thread). Concatenate into one Pandas dataframe.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    return pd.concat(
+        read_file(file_pattern),
+        axis=0,
+        ignore_index=True,
+    )  # .set_index('id')
+
+
+# read reduced diagnostics
+rbc = read_time_series("diags/reduced_beam_characteristics.*")
+ref = read_time_series("diags/ref_particle.0.0")
+
+s = rbc["s"]
+px_mean = rbc["mean_px"]
+py_mean = rbc["mean_py"]
+pt_mean = rbc["mean_pt"]
+sigma_px = rbc["sigma_px"]
+sigma_py = rbc["sigma_py"]
+sigma_pt = rbc["sigma_pt"]
+ref_gamma = ref["gamma"]
+
+px_meani = px_mean.iloc[0]
+py_meani = py_mean.iloc[0]
+pt_meani = pt_mean.iloc[0]
+sig_pxi = sigma_px.iloc[0]
+sig_pyi = sigma_py.iloc[0]
+sig_pti = sigma_pt.iloc[0]
+ref_gammai = ref_gamma.iloc[0]
+
+length = len(s) - 1
+
+sf = s.iloc[length]
+
+px_meanf = px_mean.iloc[length]
+py_meanf = py_mean.iloc[length]
+pt_meanf = pt_mean.iloc[length]
+sig_pxf = sigma_px.iloc[length]
+sig_pyf = sigma_py.iloc[length]
+sig_ptf = sigma_pt.iloc[length]
+ref_gammaf = ref_gamma.iloc[length]
+
+print("Initial Beam:")
+print(f"  px_mean={px_meani:e} py_mean={py_meani:e} pt_mean={pt_meani:e}")
+print(f"  sig_px={sig_pxi:e} sig_py={sig_pyi:e} sig_pt={sig_pti:e}")
+print(f" reference gamma={ref_gammai:e}")
+
+atol = 1.0e-6
+print(f"  atol={atol}")
+assert np.allclose(
+    [px_meani, py_meani, pt_meani, sig_pxi, sig_pyi, sig_pti],
+    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    atol=atol,
+)
+
+# Physical constants:
+re_classical = 2.8179403205e-15  # classical electron radius
+lambda_compton_reduced = 3.8615926744e-13  # reduced Compton wavelength
+
+# Problem parameters:
+ds = 0.1
+rc = 10.0
+gamma = 195696.117901
+num_particles = 10000
+
+# Characteristic length of energy loss:
+length_isr = 3.0 / 2.0 * rc**2 / (re_classical * gamma**3)
+
+print("")
+print("Length and characteristic length for energy loss [m]:")
+print(f" Length={ds:e} Length_ISR={length_isr:e}")
+
+# Predicted energy loss and energy spread:
+dpt = 2.0 / 3.0 * re_classical * ds / (rc**2) * gamma**3
+
+dsigpt2 = (
+    55.0
+    / (24 * np.sqrt(3.0))
+    * lambda_compton_reduced
+    * re_classical
+    * ds
+    / rc**3
+    * gamma**5
+)
+dsigpt = np.sqrt(dsigpt2)
+
+# Relative (total) energy change in the reference particle:
+dpt_ref = -(ref_gammaf - ref_gammai)/ref_gammai
+
+print("")
+print("Final Beam:")
+print(f" pt_mean={pt_meanf:e} sig_pt={sig_ptf}")
+print("Predicted (assuming that Length << Length_isr):")
+print(f" pt_mean={dpt:e} sig_pt={dsigpt:e}")
+print(f" reference gamma={ref_gammaf:e}")
+print("")
+
+print(f" relative reference energy loss={dpt_ref:e}")
+
+rtol = 10.0 * num_particles**-0.5  # from random sampling of a smooth distribution
+assert np.allclose(
+    [dpt_ref, sig_ptf],
+    [
+        dpt,
+        dsigpt,
+    ],
+    rtol=rtol,
+    atol=atol,
+)

--- a/examples/incoherent_synchrotron/analysis_bend_isr_ref.py
+++ b/examples/incoherent_synchrotron/analysis_bend_isr_ref.py
@@ -38,7 +38,7 @@ def read_time_series(file_pattern):
 
 # read reduced diagnostics
 rbc = read_time_series("diags/reduced_beam_characteristics.*")
-ref = read_time_series("diags/ref_particle.0.0")
+ref = read_time_series("diags/ref_particle.*")
 
 s = rbc["s"]
 px_mean = rbc["mean_px"]

--- a/examples/incoherent_synchrotron/analysis_bend_isr_ref.py
+++ b/examples/incoherent_synchrotron/analysis_bend_isr_ref.py
@@ -114,7 +114,7 @@ dsigpt2 = (
 dsigpt = np.sqrt(dsigpt2)
 
 # Relative (total) energy change in the reference particle:
-dpt_ref = -(ref_gammaf - ref_gammai)/ref_gammai
+dpt_ref = -(ref_gammaf - ref_gammai) / ref_gammai
 
 print("")
 print("Final Beam:")

--- a/examples/incoherent_synchrotron/analysis_bend_isr_ref.py
+++ b/examples/incoherent_synchrotron/analysis_bend_isr_ref.py
@@ -67,7 +67,7 @@ pt_meanf = pt_mean.iloc[length]
 sig_pxf = sigma_px.iloc[length]
 sig_pyf = sigma_py.iloc[length]
 sig_ptf = sigma_pt.iloc[length]
-ref_gammaf = ref_gamma.iloc[length]
+ref_gammaf = ref_gamma.iloc[-1]
 
 print("Initial Beam:")
 print(f"  px_mean={px_meani:e} py_mean={py_meani:e} pt_mean={pt_meani:e}")

--- a/examples/incoherent_synchrotron/input_bend_isr_ref.in
+++ b/examples/incoherent_synchrotron/input_bend_isr_ref.in
@@ -1,0 +1,49 @@
+###############################################################################
+# Particle Beam(s)
+###############################################################################
+beam.npart = 100000
+beam.units = static
+beam.kin_energy = 100.0e3  # 100 GeV nominal energy
+beam.charge = 1.0e-12  # 1 pC charge
+beam.particle = electron
+beam.distribution = gaussian
+beam.lambdaX = 1.0e-4
+beam.lambdaY = beam.lambdaX
+beam.lambdaT = 1.0e-4
+beam.lambdaPx = 0.0
+beam.lambdaPy = 0.0
+beam.lambdaPt = 0.0
+beam.muxpx = 0.0
+beam.muypy = 0.0
+beam.mutpt = 0.0
+
+###############################################################################
+# Beamline: lattice elements and segments
+###############################################################################
+lattice.elements = monitor bend monitor
+lattice.nslice = 25
+
+monitor.type = beam_monitor
+monitor.backend = h5
+
+bend.type = sbend_exact
+bend.ds = 0.1  #used only to parameterize reference arc length
+bend.phi = 0.5729577951308232  #deg
+
+#bend.type = sbend
+#bend.ds = 0.1  #used only to parameterize reference arc length
+#bend.rc = 10.0  #0.5729577951308232 deg
+
+###############################################################################
+# Algorithms
+###############################################################################
+algo.space_charge = false
+algo.isr = true
+algo.isr_order = 1
+algo.isr_ref_part = 1
+
+###############################################################################
+# Diagnostics
+###############################################################################
+diag.slice_step_diagnostics = true
+diag.eigenemittances = true

--- a/examples/incoherent_synchrotron/input_bend_isr_ref.in
+++ b/examples/incoherent_synchrotron/input_bend_isr_ref.in
@@ -40,7 +40,7 @@ bend.phi = 0.5729577951308232  #deg
 algo.space_charge = false
 algo.isr = true
 algo.isr_order = 1
-algo.isr_ref_part = 1
+algo.isr_ref_part = true
 
 ###############################################################################
 # Diagnostics

--- a/examples/incoherent_synchrotron/input_bend_isr_ref.in
+++ b/examples/incoherent_synchrotron/input_bend_isr_ref.in
@@ -40,7 +40,7 @@ bend.phi = 0.5729577951308232  #deg
 algo.space_charge = false
 algo.isr = true
 algo.isr_order = 1
-algo.isr_ref_part = true
+algo.isr_on_ref_part = true
 
 ###############################################################################
 # Diagnostics

--- a/examples/incoherent_synchrotron/run_bend_isr_ref.py
+++ b/examples/incoherent_synchrotron/run_bend_isr_ref.py
@@ -14,7 +14,7 @@ sim = ImpactX()
 sim.space_charge = False
 sim.isr = True
 sim.isr_order = 1
-sim.isr_ref_part = True
+sim.isr_on_ref_part = True
 sim.slice_step_diagnostics = True
 
 # domain decomposition & space charge mesh

--- a/examples/incoherent_synchrotron/run_bend_isr_ref.py
+++ b/examples/incoherent_synchrotron/run_bend_isr_ref.py
@@ -14,7 +14,7 @@ sim = ImpactX()
 sim.space_charge = False
 sim.isr = True
 sim.isr_order = 1
-sim.isr_ref_part = 1
+sim.isr_ref_part = True
 sim.slice_step_diagnostics = True
 
 # domain decomposition & space charge mesh

--- a/examples/incoherent_synchrotron/run_bend_isr_ref.py
+++ b/examples/incoherent_synchrotron/run_bend_isr_ref.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+from impactx import ImpactX, distribution, elements
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.space_charge = False
+sim.isr = True
+sim.isr_order = 1
+sim.isr_ref_part = 1
+sim.slice_step_diagnostics = True
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# load a 2 GeV electron beam with an initial
+# unnormalized rms emittance of 2 nm
+kin_energy_MeV = 100.0e3  # reference energy
+bunch_charge_C = 1.0e-12  # used with space charge
+npart = 100000  # number of macro particles
+
+#   reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
+
+#   particle bunch
+distr = distribution.Gaussian(
+    lambdaX=1.0e-4,
+    lambdaY=1.0e-4,
+    lambdaT=1.0e-4,
+    lambdaPx=0.0,
+    lambdaPy=0.0,
+    lambdaPt=0.0,
+    muxpx=0.0,
+    muypy=0.0,
+    mutpt=0.0,
+)
+sim.add_particles(bunch_charge_C, distr, npart)
+
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+
+# design the accelerator lattice)
+ns = 25  # number of slices per ds in the element
+
+bend = elements.ExactSbend(
+    name="sbend_exact", ds=0.1, phi=0.5729577951308232, nslice=ns
+)
+
+lattice_line = [monitor, bend, monitor]
+
+# define the lattice
+sim.lattice.extend(lattice_line)
+
+# run simulation
+sim.track_particles()
+
+# clean shutdown
+sim.finalize()

--- a/src/particles/wakefields/HandleISR.H
+++ b/src/particles/wakefields/HandleISR.H
@@ -50,10 +50,10 @@ namespace impactx::particles::wakefields
             pp_algo.queryAddWithParser("isr_order", isr_order);
 
             bool isr_ref_part = false;
-            pp_algo.queryAdd("isr_ref_part", isr_ref_part);
+            pp_algo.queryAdd("isr_on_ref_part", isr_on_ref_part);
 
             // Call function to kick particles with wake
-            impactx::particles::wakefields::ISRPush(particle_container, slice_ds, R, isr_order, isr_ref_part);
+            impactx::particles::wakefields::ISRPush(particle_container, slice_ds, R, isr_order, isr_on_ref_part);
         }
     }
 

--- a/src/particles/wakefields/HandleISR.H
+++ b/src/particles/wakefields/HandleISR.H
@@ -49,7 +49,7 @@ namespace impactx::particles::wakefields
             int isr_order = 1;
             pp_algo.queryAddWithParser("isr_order", isr_order);
 
-            int isr_ref_part = 0;
+            bool isr_ref_part = false;
             pp_algo.queryAddWithParser("isr_ref_part", isr_ref_part);
 
             // Call function to kick particles with wake

--- a/src/particles/wakefields/HandleISR.H
+++ b/src/particles/wakefields/HandleISR.H
@@ -49,8 +49,11 @@ namespace impactx::particles::wakefields
             int isr_order = 1;
             pp_algo.queryAddWithParser("isr_order", isr_order);
 
+            int isr_ref_part = 0;
+            pp_algo.queryAddWithParser("isr_ref_part", isr_ref_part);
+
             // Call function to kick particles with wake
-            impactx::particles::wakefields::ISRPush(particle_container, slice_ds, R, isr_order);
+            impactx::particles::wakefields::ISRPush(particle_container, slice_ds, R, isr_order, isr_ref_part);
         }
     }
 

--- a/src/particles/wakefields/HandleISR.H
+++ b/src/particles/wakefields/HandleISR.H
@@ -49,7 +49,7 @@ namespace impactx::particles::wakefields
             int isr_order = 1;
             pp_algo.queryAddWithParser("isr_order", isr_order);
 
-            bool isr_ref_part = false;
+            bool isr_on_ref_part = false;
             pp_algo.queryAdd("isr_on_ref_part", isr_on_ref_part);
 
             // Call function to kick particles with wake

--- a/src/particles/wakefields/HandleISR.H
+++ b/src/particles/wakefields/HandleISR.H
@@ -50,7 +50,7 @@ namespace impactx::particles::wakefields
             pp_algo.queryAddWithParser("isr_order", isr_order);
 
             bool isr_ref_part = false;
-            pp_algo.queryAddWithParser("isr_ref_part", isr_ref_part);
+            pp_algo.queryAdd("isr_ref_part", isr_ref_part);
 
             // Call function to kick particles with wake
             impactx::particles::wakefields::ISRPush(particle_container, slice_ds, R, isr_order, isr_ref_part);

--- a/src/particles/wakefields/ISRPush.H
+++ b/src/particles/wakefields/ISRPush.H
@@ -26,14 +26,14 @@ namespace impactx::particles::wakefields
      * @param[in] slice_ds slice spacing [m]
      * @param[in] rc bending radius [m]
      * @param[in] isr_order order of quantum ISR effects
-     * @param[in] ref_part_flag flag specifying whether ISR is applied to the reference particle
+     * @param[in] isr_on_ref_part flag specifying whether ISR is applied to the reference particle
      */
     void ISRPush (
         ImpactXParticleContainer & pc,
         amrex::ParticleReal slice_ds,
         amrex::ParticleReal rc,
         [[maybe_unused]] int isr_order,
-        [[maybe_unused]] bool ref_part_flag
+        [[maybe_unused]] bool isr_on_ref_part
     );
 
 } // namespace impactx::particles::wakefields

--- a/src/particles/wakefields/ISRPush.H
+++ b/src/particles/wakefields/ISRPush.H
@@ -33,7 +33,7 @@ namespace impactx::particles::wakefields
         amrex::ParticleReal slice_ds,
         amrex::ParticleReal rc,
         [[maybe_unused]] int isr_order,
-        [[maybe_unused]] int ref_part_flag
+        [[maybe_unused]] bool ref_part_flag
     );
 
 } // namespace impactx::particles::wakefields

--- a/src/particles/wakefields/ISRPush.H
+++ b/src/particles/wakefields/ISRPush.H
@@ -26,12 +26,14 @@ namespace impactx::particles::wakefields
      * @param[in] slice_ds slice spacing [m]
      * @param[in] rc bending radius [m]
      * @param[in] isr_order order of quantum ISR effects
+     * @param[in] ref_part_flag flag specifying whether ISR is applied to the reference particle
      */
     void ISRPush (
         ImpactXParticleContainer & pc,
         amrex::ParticleReal slice_ds,
         amrex::ParticleReal rc,
-        [[maybe_unused]] int isr_order
+        [[maybe_unused]] int isr_order,
+        [[maybe_unused]] int ref_part_flag
     );
 
 } // namespace impactx::particles::wakefields

--- a/src/particles/wakefields/ISRPush.cpp
+++ b/src/particles/wakefields/ISRPush.cpp
@@ -25,7 +25,7 @@ namespace impactx::particles::wakefields
         amrex::ParticleReal slice_ds,
         amrex::ParticleReal rc,
         [[maybe_unused]] int isr_order,
-        [[maybe_unused]] bool isr_ref_part
+        [[maybe_unused]] bool isr_on_ref_part
     )
     {
         BL_PROFILE("impactx::particles::wakefields::ISRPush")
@@ -110,7 +110,7 @@ namespace impactx::particles::wakefields
                     // Value of the ISR kick in total momentum (relative to total momentum):
                     amrex::ParticleReal dp = -tau*g + std::sqrt(tau*h)*xi;
 
-                    if (isr_ref_part) {
+                    if (isr_on_ref_part) {
                         dp -= dp_ref;
                     }
 
@@ -133,7 +133,7 @@ namespace impactx::particles::wakefields
         // Update the reference particle (if isr_ref_part is set):
         RefPart ref = pc.GetRefParticle();
 
-        if (isr_ref_part) {
+        if (isr_on_ref_part) {
 
            // Update reference particle momentum
            ref.px = ref.px * (1_prt + dp_ref);

--- a/src/particles/wakefields/ISRPush.cpp
+++ b/src/particles/wakefields/ISRPush.cpp
@@ -25,7 +25,7 @@ namespace impactx::particles::wakefields
         amrex::ParticleReal slice_ds,
         amrex::ParticleReal rc,
         [[maybe_unused]] int isr_order,
-        [[maybe_unused]] int isr_ref_part
+        [[maybe_unused]] bool isr_ref_part
     )
     {
         BL_PROFILE("impactx::particles::wakefields::ISRPush")
@@ -110,7 +110,7 @@ namespace impactx::particles::wakefields
                     // Value of the ISR kick in total momentum (relative to total momentum):
                     amrex::ParticleReal dp = (-tau*g + std::sqrt(tau*h)*xi);
 
-                    if (isr_ref_part == 1) {
+                    if (isr_ref_part) {
                         dp -= dp_ref;
                     }
 
@@ -133,7 +133,7 @@ namespace impactx::particles::wakefields
         // Update the reference particle (if isr_ref_part = 1):
         RefPart ref = pc.GetRefParticle();
 
-        if (isr_ref_part == 1) {
+        if (isr_ref_part) {
 
            // Update reference particle momentum
            ref.px = ref.px * (1_prt + dp_ref);

--- a/src/particles/wakefields/ISRPush.cpp
+++ b/src/particles/wakefields/ISRPush.cpp
@@ -24,7 +24,8 @@ namespace impactx::particles::wakefields
         ImpactXParticleContainer & pc,
         amrex::ParticleReal slice_ds,
         amrex::ParticleReal rc,
-        [[maybe_unused]] int isr_order
+        [[maybe_unused]] int isr_order,
+        [[maybe_unused]] int isr_ref_part
     )
     {
         BL_PROFILE("impactx::particles::wakefields::ISRPush")
@@ -44,6 +45,7 @@ namespace impactx::particles::wakefields
         amrex::ParticleReal const B_normal = bg_ref/std::abs(rc);
         amrex::ParticleReal const c1 = 2.0_prt/3.0_prt * r_e * slice_ds * powi<2>(B_normal);
         amrex::ParticleReal const c2 = B_normal * lambda_e;
+        amrex::ParticleReal const dp_ref = -c1 * bg_ref;
 
         // Coefficients of the Taylor expansion of polynomials g and h
         amrex::ParticleReal const g0 = 1_prt;
@@ -106,7 +108,11 @@ namespace impactx::particles::wakefields
                     }
 
                     // Value of the ISR kick in total momentum (relative to total momentum):
-                    amrex::ParticleReal const dp = (-tau*g + std::sqrt(tau*h)*xi);
+                    amrex::ParticleReal dp = (-tau*g + std::sqrt(tau*h)*xi);
+
+                    if (isr_ref_part == 1) {
+                        dp -= dp_ref;
+                    }
 
                     // Final value of updated particle gamma:
                     amrex::ParticleReal const bg_f = bg*(1_prt + dp);
@@ -123,6 +129,23 @@ namespace impactx::particles::wakefields
         } // End mesh-refinement level loop
 
         amrex::Gpu::streamSynchronize();
+
+        // Update the reference particle (if isr_ref_part = 1):
+        RefPart ref = pc.GetRefParticle();
+
+        if (isr_ref_part == 1) {
+                    
+           // Update reference particle momentum
+           ref.px = ref.px * (1_prt + dp_ref);
+           ref.py = ref.py * (1_prt + dp_ref);
+           ref.pz = ref.pz * (1_prt + dp_ref);
+
+           amrex::ParticleReal p2_ref = powi<2>(ref.px) + powi<2>(ref.py) + powi<2>(ref.pz);
+           ref.pt = -std::sqrt(p2_ref + 1_prt);
+
+           pc.SetRefParticle(ref);
+
+        }
 
    }
 } // namespace impactx::particles::wakefields

--- a/src/particles/wakefields/ISRPush.cpp
+++ b/src/particles/wakefields/ISRPush.cpp
@@ -108,7 +108,7 @@ namespace impactx::particles::wakefields
                     }
 
                     // Value of the ISR kick in total momentum (relative to total momentum):
-                    amrex::ParticleReal dp = (-tau*g + std::sqrt(tau*h)*xi);
+                    amrex::ParticleReal dp = -tau*g + std::sqrt(tau*h)*xi;
 
                     if (isr_ref_part) {
                         dp -= dp_ref;
@@ -130,7 +130,7 @@ namespace impactx::particles::wakefields
 
         amrex::Gpu::streamSynchronize();
 
-        // Update the reference particle (if isr_ref_part = 1):
+        // Update the reference particle (if isr_ref_part is set):
         RefPart ref = pc.GetRefParticle();
 
         if (isr_ref_part) {
@@ -140,7 +140,7 @@ namespace impactx::particles::wakefields
            ref.py = ref.py * (1_prt + dp_ref);
            ref.pz = ref.pz * (1_prt + dp_ref);
 
-           amrex::ParticleReal p2_ref = powi<2>(ref.px) + powi<2>(ref.py) + powi<2>(ref.pz);
+           amrex::ParticleReal const p2_ref = powi<2>(ref.px) + powi<2>(ref.py) + powi<2>(ref.pz);
            ref.pt = -std::sqrt(p2_ref + 1_prt);
 
            pc.SetRefParticle(ref);

--- a/src/particles/wakefields/ISRPush.cpp
+++ b/src/particles/wakefields/ISRPush.cpp
@@ -134,7 +134,7 @@ namespace impactx::particles::wakefields
         RefPart ref = pc.GetRefParticle();
 
         if (isr_ref_part == 1) {
-                    
+
            // Update reference particle momentum
            ref.px = ref.px * (1_prt + dp_ref);
            ref.py = ref.py * (1_prt + dp_ref);

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -242,6 +242,16 @@ void init_ImpactX (py::module& m)
             },
             "Number of terms in the Taylor series retained for quantum effects (default: 1)."
         )
+        .def_property("isr_ref_part",
+            [](ImpactX & /* ix */) {
+                return detail::get_or_throw<bool>("algo", "isr_ref_part");
+            },
+            [](ImpactX & /* ix */, int isr_ref_part) {
+                amrex::ParmParse pp_algo("algo");
+                pp_algo.add("isr_ref_part", isr_ref_part);
+            },
+            "Flag to determine whether ISR radiation loss is applied to the reference particle (default: 0)."
+        )
         .def_property("eigenemittances",
             [](ImpactX & /* ix */) {
                 return detail::get_or_throw<bool>("diag", "eigenemittances");

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -246,11 +246,11 @@ void init_ImpactX (py::module& m)
             [](ImpactX & /* ix */) {
                 return detail::get_or_throw<bool>("algo", "isr_ref_part");
             },
-            [](ImpactX & /* ix */, int isr_ref_part) {
+            [](ImpactX & /* ix */, bool isr_ref_part) {
                 amrex::ParmParse pp_algo("algo");
                 pp_algo.add("isr_ref_part", isr_ref_part);
             },
-            "Flag to determine whether ISR radiation loss is applied to the reference particle (default: 0)."
+            "Flag to determine whether ISR radiation loss is applied to the reference particle (default: False)."
         )
         .def_property("eigenemittances",
             [](ImpactX & /* ix */) {

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -242,13 +242,13 @@ void init_ImpactX (py::module& m)
             },
             "Number of terms in the Taylor series retained for quantum effects (default: 1)."
         )
-        .def_property("isr_ref_part",
+        .def_property("isr_on_ref_part",
             [](ImpactX & /* ix */) {
-                return detail::get_or_throw<bool>("algo", "isr_ref_part");
+                return detail::get_or_throw<bool>("algo", "isr_on_ref_part");
             },
-            [](ImpactX & /* ix */, bool isr_ref_part) {
+            [](ImpactX & /* ix */, bool isr_on_ref_part) {
                 amrex::ParmParse pp_algo("algo");
-                pp_algo.add("isr_ref_part", isr_ref_part);
+                pp_algo.add("isr_on_ref_part", isr_on_ref_part);
             },
             "Flag to determine whether ISR radiation loss is applied to the reference particle (default: False)."
         )


### PR DESCRIPTION
This PR adds a new option in the ISR model, to allow the user to turn on/off the application of ISR to the reference particle.

If `algo.isr_on_ref_part == false`, then the reference particle is treated as if radiation is neglected, and the mean energy of the particle distribution will decrease in the presence of ISR.  This option is natural when the magnet/optics design does not account for radiative energy loss.

If `algo.isr_on_ref_part == true`, then the reference particle experiences (classical) radiative energy loss, and there is little effect visible on the mean energy of the particle distribution.  This option is natural when the magnet/optics design has been tuned to account for radiative energy loss.

- [x] add classical energy loss calculation for reference particle
- [x] add user input flag and update particle ISR push
- [x] add benchmark example
- [x] update documentation

This closes #953 .