### PR TITLE
Function Hooks (Callbacks) for Tracking Loop

### DIFF
--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -113,6 +113,7 @@ Lattice Design & Optimization
 
    examples/fodo_tune/README.rst
    examples/optimize_triplet/README.rst
+   examples/turn_update/README.rst
 
 
 Virtual Test Stands

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -303,6 +303,44 @@ Collective Effects & Overall Simulation Parameters
 
       :param ref: the reference particle (object from :py:class:`impactx.RefPart`)
 
+   .. py:property:: hook
+
+      User-defined function hooks that are called, e.g, during tracking.
+      Supported hook locations names are:
+
+      * ``"before_period"``: before each period (e.g., turn or channel period)
+      * ``"after_period"``: after each period (e.g., turn or channel period)
+      * ``"before_element"``: before each element is entered
+      * ``"after_element"``: after each element is exited
+      * ``"before_slice"``: before each element slice
+
+      Example: Function hook that can be called before each turn (sim):
+
+      .. code-block:: python3
+
+         def hook_before_period(sim):
+             beam = sim.particle_container()
+             turn = sim.tracking_period
+             # Example: you could now manipulate elements in sim.lattice
+             #          for the next turn.
+
+         sim.hook["before_period"] = hook_before_period
+
+   .. py:property:: tracking_step
+
+      For tracking hooks/callbacks, a global step of the simulation.
+
+      A state of internal simulation steps, increments also for space charge slice steps in elements.
+      We start in "step 0" (initial state).
+
+   .. py:property:: tracking_period
+
+      For tracking hooks/callbacks, the period in the lattice (e.g., turn or channel period).
+
+   .. py:property:: tracking_element
+
+      For tracking hooks/callbacks, the current lattice element.
+
    .. py:method:: resize_mesh()
 
       Resize the mesh :py:attr:`~domain` based on the :py:attr:`~dynamic_size` and related parameters.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -290,6 +290,14 @@ add_impactx_test(FODO.programmable.py
     examples/fodo_programmable/plot_fodo.py
 )
 
+# Python: Change Elements Per Turn ############################################
+#
+add_impactx_test(turn_update.py
+    examples/turn_update/run_turn_update.py
+    OFF  # ImpactX MPI-parallel
+    examples/turn_update/analysis_turn_update.py
+    OFF  # no plot script yet
+)
 
 # Python MADX: FODO Cell ######################################################
 #

--- a/examples/turn_update/README.rst
+++ b/examples/turn_update/README.rst
@@ -1,0 +1,40 @@
+.. _examples-turn-update:
+
+Turn-Dependend Element Changes
+==============================
+
+10 periods of drift elements, where each drift is a stand-in for a "turn" map.
+On each turn, the next turn map (drift) is modified based in particle properties.
+
+A 2 GeV electron bunch with normalized transverse rms emittance of 50 pm.
+
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values.
+
+
+Run
+---
+
+This example can be run as:
+
+* **Python** script: ``python3 run_turn_update.py`` or
+For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+
+.. tab-set::
+
+   .. tab-item:: Python: Script
+
+       .. literalinclude:: run_turn_update.py
+          :language: python3
+          :caption: You can copy this file from ``examples/turn_update/run_turn_update.py``.
+
+
+Analyze
+-------
+
+We run the following script to analyze correctness:
+
+.. dropdown:: Script ``analysis_turn_update.py``
+
+   .. literalinclude:: analysis_turn_update.py
+      :language: python3
+      :caption: You can copy this file from ``examples/turn_update/analysis_turn_update.py``.

--- a/examples/turn_update/analysis_turn_update.py
+++ b/examples/turn_update/analysis_turn_update.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+
+import numpy as np
+import openpmd_api as io
+from scipy.stats import moment
+
+
+def get_moments(beam):
+    """Calculate standard deviations of beam position & momenta
+    and emittance values
+
+    Returns
+    -------
+    sigx, sigy, sigt, emittance_x, emittance_y, emittance_t
+    """
+    sigx = moment(beam["position_x"], moment=2) ** 0.5  # variance -> std dev.
+    sigpx = moment(beam["momentum_x"], moment=2) ** 0.5
+    sigy = moment(beam["position_y"], moment=2) ** 0.5
+    sigpy = moment(beam["momentum_y"], moment=2) ** 0.5
+    sigt = moment(beam["position_t"], moment=2) ** 0.5
+    sigpt = moment(beam["momentum_t"], moment=2) ** 0.5
+
+    epstrms = beam.cov(ddof=0)
+    emittance_x = (sigx**2 * sigpx**2 - epstrms["position_x"]["momentum_x"] ** 2) ** 0.5
+    emittance_y = (sigy**2 * sigpy**2 - epstrms["position_y"]["momentum_y"] ** 2) ** 0.5
+    emittance_t = (sigt**2 * sigpt**2 - epstrms["position_t"]["momentum_t"] ** 2) ** 0.5
+
+    return (sigx, sigy, sigt, emittance_x, emittance_y, emittance_t)
+
+
+# initial/final beam
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+last_step = list(series.iterations)[-1]
+initial = series.iterations[1].particles["beam"].to_df()
+final = series.iterations[last_step].particles["beam"].to_df()
+s_final = series.iterations[last_step].particles["beam"].get_attribute("s_ref")
+
+# compare number of particles
+num_particles = 10000
+assert num_particles == len(initial)
+assert num_particles == len(final)
+
+print("Initial Beam:")
+sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(initial)
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
+print(
+    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
+    f"  s_final={s_final}"
+)
+
+atol = 0.0  # ignored
+rtol = 1.8 * num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t, s_final],
+    [
+        5.0e-6,
+        8.0e-6,
+        0.0599584916,
+        1.277171100130637e-14,
+        1.277171100130637e-14,
+        5.396264243e-005,
+        4.339439692724345,
+    ],
+    rtol=rtol,
+    atol=atol,
+)
+
+
+print("")
+print("Final Beam:")
+sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(final)
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
+print(
+    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
+)
+
+atol = 0.0  # ignored
+rtol = 1.8 * num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
+    [
+        5.0e-6,
+        8.0e-6,
+        0.0599584916,
+        1.277171100130637e-14,
+        1.277171100130637e-14,
+        5.396264243e-005,
+    ],
+    rtol=rtol,
+    atol=atol,
+)

--- a/examples/turn_update/run_turn_update.py
+++ b/examples/turn_update/run_turn_update.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Chad Mitchell, Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+from impactx import ImpactX, distribution, elements
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.space_charge = False
+sim.slice_step_diagnostics = True
+sim.tiny_profiler = False
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# load a 5 GeV electron beam with an initial
+# normalized transverse rms emittance of 1 um
+kin_energy_MeV = 2.0e3  # reference energy
+bunch_charge_C = 1.0e-9  # used with space charge
+npart = 10000  # number of macro particles
+
+#   reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(-1.0).set_mass_MeV(0.510998950).set_kin_energy_MeV(kin_energy_MeV)
+
+#   particle bunch
+distr = distribution.Waterbag(
+    lambdaX=5.0e-6,  # 5 um
+    lambdaY=8.0e-6,  # 8 um
+    lambdaT=0.0599584916,  # 200 ps
+    lambdaPx=2.5543422003e-9,  # exn = 50 pm-rad
+    lambdaPy=1.5964638752e-9,  # eyn = 50 pm-rad
+    lambdaPt=9.0e-4,  # approximately dE/E
+    muxpx=0.0,
+    muypy=0.0,
+    mutpt=0.0,
+)
+sim.add_particles(bunch_charge_C, distr, npart)
+
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+
+# design the accelerator lattice
+ns = 1  # number of slices per ds in the element
+
+bend = [
+    monitor,
+    elements.Drift(ds=1.0, nslice=ns, name="drift1"),
+]
+
+# assign a lattice segment
+sim.lattice.extend(bend)
+sim.periods = 10
+
+
+# at the beginning of each period (e.g, turn or channel period), modify the lattice
+def hook_before_period(sim):
+    turn = sim.tracking_period
+    step = sim.tracking_step
+    print("- Before turn:")
+    print(f"  Updating lattice at turn {turn}, step {step}", flush=True)
+
+    beam = sim.particle_container()
+    ref = beam.ref_particle()
+    rbc = beam.beam_moments()
+    print(
+        f"  Beam at s={ref.s:.2f}m, t={ref.t:.2f}s with beta_x={rbc['beta_x']}m",
+        flush=True,
+    )
+
+    if turn > 0:
+        next_ds = 1.0 / ref.s
+        print(f"  Updating next drift ds to: {next_ds:.2f}m", flush=True)
+        sim.lattice.select(name="drift1")[0].ds = next_ds
+
+
+def hook_before_element(sim):
+    element = sim.tracking_element
+    print("- Before element:")
+    print(
+        f"  Current element name: {element.name} with ds={element.ds:.2f}", flush=True
+    )
+
+    if element.name != "monitor":
+        print(f"  Drift ds is: {element.ds:.2f}m", flush=True)
+
+
+sim.hook["before_period"] = hook_before_period
+sim.hook["before_element"] = hook_before_element
+
+# run simulation
+sim.track_particles()
+
+# clean shutdown
+sim.finalize()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@
 target_sources(lib
   PRIVATE
     ImpactX.cpp
+    Hooks.cpp
 )
 
 add_subdirectory(diagnostics)

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -1,0 +1,29 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl, Chad Mitchell, Eric  Stern
+ * License: BSD-3-Clause-LBNL
+ */
+#include "ImpactX.H"
+
+#include <string>
+
+
+namespace impactx
+{
+    void ImpactX::call_hook (std::string const & name)
+    {
+        if (m_hook.count(name) > 0u)
+        {
+            if (m_hook[name] != nullptr)
+            {
+                BL_PROFILE("impactx::hook::" + name);
+                m_hook[name](this);
+            }
+        }
+    }
+
+} // namespace impactx

--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -10,15 +10,18 @@
 #ifndef IMPACT_X_H
 #define IMPACT_X_H
 
-#include "particles/distribution/All.H"
 #include "elements/All.H"
-
 #include "initialization/AmrCoreData.H"
+#include "particles/distribution/All.H"
+#include "tracking/TrackingState.H"
 
 #include <AMReX_REAL.H>
 
+#include <functional>
 #include <list>
 #include <memory>
+#include <string>
+#include <unordered_map>
 
 
 namespace impactx
@@ -150,6 +153,25 @@ namespace impactx
         {
             return m_grids_initialized;
         }
+
+        /** Call user-defined functions while the simulation is running.
+         *
+         * Check if an optional, user-defined function is registered by
+         * name and if yes, call it.
+         *
+         * @see m_hook for function signature:
+         *   void user_defined_hook (ImpactX *);
+         */
+        void call_hook (std::string const & name);
+
+        std::unordered_map<
+            std::string,
+            std::function<void(ImpactX *)>
+        > m_hook;  //! hooks that users can call
+
+        /** A few states during tracking loops, useful to know in hooks (Python callback functions).
+         */
+        TrackingState m_tracking_state;
 
       private:
         /** Keeps track if init_grids was called.

--- a/src/initialization/Warnings.cpp
+++ b/src/initialization/Warnings.cpp
@@ -17,6 +17,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 
 
 namespace impactx
@@ -60,6 +61,26 @@ void ImpactX::init_warning_logger ()
 bool ImpactX::early_param_check ()
 {
     BL_PROFILE("ImpactX::early_param_check");
+
+    // any unknown hooks?
+    // see python.rst docs
+    std::unordered_set<std::string> allowed_hook_names = {
+        "before_period",
+        "after_period",
+        "before_element",
+        "after_element",
+        "before_slice"
+    };
+    for (auto const & pair : m_hook) {
+        std::string const & key = pair.first;
+        if (allowed_hook_names.find(key) == allowed_hook_names.end()) {
+            ablastr::warn_manager::WMRecordWarning(
+                "ImpactX Python Hook",
+                "The hook name '" + key + "' is not defined.",
+                ablastr::warn_manager::WarnPriority::high
+            );
+        }
+    }
 
     // verbosity
     amrex::ParmParse pp_impactx("impactx");

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -68,6 +68,10 @@ namespace detail
 void init_ImpactX (py::module& m)
 {
     py::class_<ImpactX> impactx(m, "ImpactX", py::dynamic_attr());
+
+    using ImpactXHooks = std::unordered_map<std::string, std::function<void(ImpactX *)> >;
+    py::bind_map<ImpactXHooks>(m, "UnorderedMap");
+
     impactx
         .def(py::init<>())
 
@@ -492,6 +496,10 @@ void init_ImpactX (py::module& m)
             "If it's not empty, it specifies the file name for the output. "
             "Note that /dev/null is a special name that mean a null file."
         )
+        .def_readwrite("hook",
+            &ImpactX::m_hook,
+            "User-defined function hooks that are called, e.g, during tracking."
+        )
 
         .def("deposit_charge",
             [](ImpactX & ix) {
@@ -567,6 +575,22 @@ void init_ImpactX (py::module& m)
         )
         .def("track_reference", &ImpactX::track_reference,
              "Run the reference orbit tracking simulation loop."
+        )
+
+
+        .def_property_readonly("tracking_period",
+            [](ImpactX & ix) { return ix.m_tracking_state.m_period; },
+            "For tracking hooks/callbacks, the period in the lattice (e.g., turn or channel period)"
+        )
+        .def_property_readonly("tracking_step",
+            [](ImpactX & ix) { return ix.m_tracking_state.m_step; },
+            "For tracking hooks/callbacks, a global step of the simulation.\n\n"
+            "A state of internal simulation steps, increments also for space charge slice steps in elements.\n"
+            "We start in 'step 0' (initial state)."
+        )
+        .def_property_readonly("tracking_element",
+            [](ImpactX & ix) { return ix.m_tracking_state.m_element; },
+            "For tracking hooks/callbacks, the current lattice element."
         )
 
         .def("resize_mesh", &ImpactX::ResizeMesh,

--- a/src/python/pyImpactX.H
+++ b/src/python/pyImpactX.H
@@ -15,13 +15,17 @@
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
 
+#include <ImpactX.H>
 #include <elements/All.H>
 
+#include <functional>
 #include <list>
+#include <string>
 
 namespace py = pybind11;
 using namespace impactx;
 
 PYBIND11_MAKE_OPAQUE(std::list<elements::KnownElements>)
+PYBIND11_MAKE_OPAQUE(std::unordered_map<std::string, std::function<void(ImpactX *)> >)
 
 #endif // IMPACTX_PYIMPACTX_H

--- a/src/tracking/TrackingState.H
+++ b/src/tracking/TrackingState.H
@@ -1,0 +1,44 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl, Chad Mitchell * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_TRACKING_STATE_H
+#define IMPACTX_TRACKING_STATE_H
+
+#include "elements/All.H"
+
+
+namespace impactx
+{
+    /** This class wraps a few states during tracking loops.
+     *
+     * These states are useful to know in hooks (Python callback functions).
+     */
+    struct TrackingState
+    {
+        /** For tracking hooks/callbacks, a global step of the simulation
+         *
+         * A state of internal simulation steps, increments also for space charge slice steps in elements.
+         * We start in "step 0" (initial state).
+         */
+        int m_step = 0;
+
+        /** For tracking hooks/callbacks, the period in the lattice (e.g., turn or channel period) */
+        int m_period = 0;
+
+        /** For tracking hooks/callbacks, the current lattice element */
+        elements::KnownElements* m_element = &empty_element;
+
+        void set_no_element () { m_element = &empty_element; }
+
+    private:
+        static inline elements::KnownElements empty_element = elements::Empty{};
+    };
+
+} // namespace impactx
+
+#endif // IMPACT_X_H

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -43,8 +43,13 @@ namespace impactx
         pp_impactx.queryAddWithParser("verbose", verbose);
 
         // a global step for diagnostics including space charge slice steps in elements
-        //   before we start the evolve loop, we are in "step 0" (initial state)
-        int step = 0;
+        //   before we start the tracking loop, we are in "step 0" (initial state)
+        int & step = m_tracking_state.m_step;
+        step = 0;
+
+        // period in the lattice (e.g., turns)
+        int & period = m_tracking_state.m_period;
+        period = 0;
 
         // check typos in inputs after step 1
         bool early_params_checked = false;
@@ -125,13 +130,21 @@ namespace impactx
         int num_periods = 1;
         amrex::ParmParse("lattice").queryAddWithParser("periods", num_periods);
 
-        for (int period=0; period < num_periods; ++period)
+        for (period=0; period < num_periods; ++period)
         {
+            // optional, user-defined function call
+            m_tracking_state.m_element = &m_lattice.front();
+            call_hook("before_period");
+
             // loop over all beamline elements
             for (auto &element_variant: m_lattice)
             {
                 // update element edge of the reference particle
                 ref.sedge = ref.s;
+
+                // optional, user-defined function call
+                m_tracking_state.m_element = &element_variant;
+                call_hook("before_element");
 
                 // number of slices used for the application of space charge
                 int nslice = 1;
@@ -152,6 +165,9 @@ namespace impactx
                         amrex::Print() << "\n++++ Starting step=" << step
                                        << " slice_step=" << slice_step;
                     }
+
+                    // optional, user-defined function call
+                    call_hook("before_slice");
 
                     if (space_charge == SpaceChargeAlgo::True_2D)
                     {
@@ -202,9 +218,18 @@ namespace impactx
 
                 } // end in-element space-charge slice-step loop
 
+                // optional, user-defined function call
+                call_hook("after_element");
+
             } // end beamline element loop
 
+            // optional, user-defined function call
+            call_hook("after_period");
+
         } // end periods though the lattice loop
+
+        // avoid dangling references if users manipulate the lattice
+        m_tracking_state.set_no_element();
 
         if (diag_enable)
         {

--- a/src/tracking/particles.cpp
+++ b/src/tracking/particles.cpp
@@ -41,8 +41,13 @@ namespace impactx
         pp_impactx.queryAddWithParser("verbose", verbose);
 
         // a global step for diagnostics including space charge slice steps in elements
-        //   before we start the evolve loop, we are in "step 0" (initial state)
-        int step = 0;
+        //   before we start the tracking loop, we are in "step 0" (initial state)
+        int & step = m_tracking_state.m_step;
+        step = 0;
+
+        // period in the lattice (e.g., turns)
+        int & period = m_tracking_state.m_period;
+        period = 0;
 
         // check typos in inputs after step 1
         bool early_params_checked = false;
@@ -100,11 +105,19 @@ namespace impactx
         int num_periods = 1;
         amrex::ParmParse("lattice").queryAddWithParser("periods", num_periods);
 
-        for (int period=0; period < num_periods; ++period) {
+        for (period=0; period < num_periods; ++period) {
+            // optional, user-defined function call
+            m_tracking_state.m_element = &m_lattice.front();
+            call_hook("before_period");
+
             // loop over all beamline elements
             for (auto &element_variant: m_lattice) {
                 // update element edge of the reference particle
                 amr_data->track_particles.m_particle_container->SetRefParticleEdge();
+
+                // optional, user-defined function call
+                m_tracking_state.m_element = &element_variant;
+                call_hook("before_element");
 
                 // number of slices used for the application of space charge
                 int nslice = 1;
@@ -122,6 +135,9 @@ namespace impactx
                         amrex::Print() << "\n++++ Starting step=" << step
                                        << " slice_step=" << slice_step;
                     }
+
+                    // optional, user-defined function call
+                    call_hook("before_slice");
 
                     // Wakefield calculation: call wakefield function to apply wake effects
                     particles::wakefields::HandleWakefield(*amr_data->track_particles.m_particle_container, element_variant, slice_ds);
@@ -171,8 +187,17 @@ namespace impactx
 
                 } // end in-element space-charge slice-step loop
 
+                // optional, user-defined function call
+                call_hook("after_element");
+
             } // end beamline element loop
+
+            // optional, user-defined function call
+            call_hook("after_period");
         } // end periods though the lattice loop
+
+        // avoid dangling references if users manipulate the lattice
+        m_tracking_state.set_no_element();
 
         if (diag_enable)
         {

--- a/src/tracking/reference.cpp
+++ b/src/tracking/reference.cpp
@@ -37,8 +37,13 @@ namespace impactx
         pp_impactx.queryAddWithParser("verbose", verbose);
 
         // a global step for diagnostics including space charge slice steps in elements
-        //   before we start the evolve loop, we are in "step 0" (initial state)
-        int step = 0;
+        //   before we start the tracking loop, we are in "step 0" (initial state)
+        int & step = m_tracking_state.m_step;
+        step = 0;
+
+        // period in the lattice (e.g., turns)
+        int & period = m_tracking_state.m_period;
+        period = 0;
 
         // check typos in inputs after step 1
         bool early_params_checked = false;
@@ -80,12 +85,20 @@ namespace impactx
         int num_periods = 1;
         amrex::ParmParse("lattice").queryAddWithParser("periods", num_periods);
 
-        for (int period=0; period < num_periods; ++period)
+        for (period=0; period < num_periods; ++period)
         {
+            // optional, user-defined function call
+            m_tracking_state.m_element = &m_lattice.front();
+            call_hook("before_period");
+
             // loop over all beamline elements
             for (auto &element_variant: m_lattice) {
                 // update element edge of the reference particle
                 ref.sedge = ref.s;
+
+                // optional, user-defined function call
+                m_tracking_state.m_element = &element_variant;
+                call_hook("before_element");
 
                 // number of slices through the element
                 int nslice = 1;
@@ -105,6 +118,9 @@ namespace impactx
                         amrex::Print() << "\n++++ Starting step=" << step
                                        << " slice_step=" << slice_step;
                     }
+
+                    // optional, user-defined function call
+                    call_hook("before_slice");
 
                     // push the reference particle with external maps
                     push(ref, element_variant);
@@ -131,9 +147,18 @@ namespace impactx
 
                 } // end in-element slice-step loop
 
+                // optional, user-defined function call
+                call_hook("after_element");
+
             } // end beamline element loop
 
+            // optional, user-defined function call
+            call_hook("after_period");
+
         } // end periods though the lattice loop
+
+        // avoid dangling references if users manipulate the lattice
+        m_tracking_state.set_no_element();
 
         if (diag_enable)
         {


### PR DESCRIPTION
Expose a callback function per turn/element/slice that allows to modify the simulation, e.g., to manipulate the lattice.

[Here is a preview of the docs with an example.](https://impactx--1172.org.readthedocs.build/en/1172/usage/examples/turn_update/README.html#run)
And here are the [available hooks](https://impactx--1172.org.readthedocs.build/en/1172/usage/python.html#impactx.ImpactX.hook).

Close #1171

---

- [x] We could refactor this a bit more and, as in WarpX, do something like `sim.hooks["name"]` to have it easier adding more hooks later on.
- [x] The `sim.hooks` element could become its own type, deriving from the current type, and check instantaneous on assignment if the hook name is valid. That way we can throw clear errors if a hook does not exist.
- [x] Add a `sim.tracking_element` that points to the current/next element? Useful to write `if element == ...` in `before/after_element` hooks.