### PR TITLE
Envelope: Silence Warning w/o Space-Charge

### DIFF
--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -161,8 +161,6 @@ namespace impactx
                     {
                         // push Covariance Matrix in 3D space charge fields
                         envelope::spacecharge::space_charge3D_push(ref, cm, intensity, slice_ds);
-                    } else {
-                        amrex::Print() << "Warning: Space charge is off by default." << "\n";
                     }
 
                     std::visit([&ref, &cm](auto&& element)


### PR DESCRIPTION
Consistent with the other two tracking modes, we only print options upfront and do not warn every simulation step if space charge is not used.

Fix #1170