### PR TITLE
Fix `BeamMonitor`: Delay Open

### DIFF
--- a/src/elements/diagnostics/BeamMonitor.H
+++ b/src/elements/diagnostics/BeamMonitor.H
@@ -176,8 +176,12 @@ namespace detail
         finalize ();
 
     private:
+        /** Open the openPMD series (on first access) */
+        void open ();
+
         std::string m_series_name; //! openPMD filename
         std::string m_OpenPMDFileType; //! openPMD backend: usually HDF5 (h5) or ADIOS2 (bp/bp4/bp5) or ADIOS2 SST (sst)
+        std::string m_encoding; //! openPMD iteration encoding: "v"ariable based, "f"ile based, "g"roup based (default)
         std::any m_series; //! openPMD::Series that holds potentially multiple outputs
         int m_step = 0; //! global step for output
 

--- a/src/elements/diagnostics/BeamMonitor.cpp
+++ b/src/elements/diagnostics/BeamMonitor.cpp
@@ -124,7 +124,10 @@ namespace detail {
     }
 
     BeamMonitor::BeamMonitor (std::string series_name, std::string backend, std::string encoding, int period_sample_intervals) :
-        m_series_name(std::move(series_name)), m_OpenPMDFileType(std::move(backend)), m_period_sample_intervals(period_sample_intervals)
+        m_series_name(std::move(series_name)), m_OpenPMDFileType(std::move(backend)), m_encoding(std::move(encoding)), m_period_sample_intervals(period_sample_intervals) {
+    }
+
+    void BeamMonitor::open ()
     {
 #ifdef ImpactX_USE_OPENPMD
         // pick first available backend if default is chosen
@@ -141,11 +144,11 @@ namespace detail {
 
         // encoding of iterations in the series
         openPMD::IterationEncoding series_encoding = openPMD::IterationEncoding::groupBased;
-        if ("v" == encoding)
+        if ("v" == m_encoding)
             series_encoding = openPMD::IterationEncoding::variableBased;
-        else if ("g" == encoding)
+        else if ("g" == m_encoding)
             series_encoding = openPMD::IterationEncoding::groupBased;
-        else if ("f" == encoding)
+        else if ("f" == m_encoding)
             series_encoding = openPMD::IterationEncoding::fileBased;
 
         // BP5 does not support groupBased (metadata explosion)
@@ -309,6 +312,8 @@ namespace detail {
         // filter out this turn?
         if (period % m_period_sample_intervals != 0)
             return;
+
+        this->open();
 
 #ifdef ImpactX_USE_OPENPMD
         std::string profile_name = "impactx::push::" + std::string(BeamMonitor::type);


### PR DESCRIPTION
`BeamMonitor` opens the openPMD series now on first output. This simplifies usage dramatically, now allowing to:

* create the lattice (monitor elements) before the `sim` is even initialized
* creating a monitor element and not using it in a lattice

Fix #963
Fix #1169