### PR TITLE
CMake `pip_install`: Package Examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,13 @@ if(ImpactX_PYTHON)
             pyImpactX
             ${ImpactX_CUSTOM_TARGET_PREFIX}pip_wheel
     )
+
+    # copy examples into pip package, e.g., for dashboard GUI
+    add_custom_command(TARGET pyImpactX POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${ImpactX_SOURCE_DIR}/examples
+            $<TARGET_FILE_DIR:pyImpactX>/examples
+    )
 endif()
 
 


### PR DESCRIPTION
Ensure the `examples/` directory is part of the `pip` wheels we build, e.g., on `cmake --build build -j 6 --target pip_install`.

Fix for issue introduced in #876