### PR TITLE
Fix RFCavity edge case

### DIFF
--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -408,7 +408,7 @@ namespace RFCavityData
             }
             else  // endpoint of the RF, outsize zlen
             {
-               efieldint = std::copysign(z, z)*zmid*0.5_prt*cos_data[0];;
+               efieldint = std::copysign(zmid, z)*0.5_prt*cos_data[0];;
                for (int j=1; j < m_ncoef; ++j)
                {
                  efieldint = efieldint - zlen*sin_data[j] * std::cos(j*pi)/(j*2*pi);

--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -408,7 +408,7 @@ namespace RFCavityData
             }
             else  // endpoint of the RF, outsize zlen
             {
-               efieldint = std::copysign(zmid, z)*0.5_prt*cos_data[0];;
+               efieldint = std::copysign(zmid, z)*0.5_prt*cos_data[0];
                for (int j=1; j < m_ncoef; ++j)
                {
                  efieldint = efieldint - zlen*sin_data[j] * std::cos(j*pi)/(j*2*pi);


### PR DESCRIPTION
In the special "edge case" when the local element longitudinal coordinate z in an RFCavity lies at or beyond the endpoint defined by the element length, the integrated on-axis field (callled internally `ezint`) contains a special treatment.  This special edge case previously contained a bug, which is repaired here.