### PR TITLE
"Starting step" Print: Spaces

### DIFF
--- a/src/initialization/Warnings.cpp
+++ b/src/initialization/Warnings.cpp
@@ -66,7 +66,9 @@ bool ImpactX::early_param_check ()
     int verbose = 1;
     pp_impactx.queryAddWithParser("verbose", verbose);
 
-    if (verbose > 0) {
+    // Print a warning for unused inputs early on, so users are informed and
+    // might decide to abort their long-running runs, if needed.
+    if (verbose > 0 && amrex::ParmParse::hasUnusedInputs()) {
         amrex::Print() << "\n";
     }
     amrex::ParmParse::QueryUnusedInputs();

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -149,8 +149,8 @@ namespace impactx
                     step++;
                     if (verbose > 0)
                     {
-                        amrex::Print() << " ++++ Starting step=" << step
-                                       << " slice_step=" << slice_step << "\n";
+                        amrex::Print() << "\n++++ Starting step=" << step
+                                       << " slice_step=" << slice_step;
                     }
 
                     if (space_charge == SpaceChargeAlgo::True_2D)

--- a/src/tracking/particles.cpp
+++ b/src/tracking/particles.cpp
@@ -119,8 +119,8 @@ namespace impactx
                     BL_PROFILE("ImpactX::evolve::slice_step");
                     step++;
                     if (verbose > 0) {
-                        amrex::Print() << " ++++ Starting step=" << step
-                                       << " slice_step=" << slice_step << "\n";
+                        amrex::Print() << "\n++++ Starting step=" << step
+                                       << " slice_step=" << slice_step;
                     }
 
                     // Wakefield calculation: call wakefield function to apply wake effects

--- a/src/tracking/reference.cpp
+++ b/src/tracking/reference.cpp
@@ -102,8 +102,8 @@ namespace impactx
                     BL_PROFILE("ImpactX::track_reference::slice_step");
                     step++;
                     if (verbose > 0) {
-                        amrex::Print() << " ++++ Starting step=" << step
-                                       << " slice_step=" << slice_step << "\n";
+                        amrex::Print() << "\n++++ Starting step=" << step
+                                       << " slice_step=" << slice_step;
                     }
 
                     // push the reference particle with external maps


### PR DESCRIPTION
Update formatting, preparing for #1172

- newline before new step
- no space before `++++ Starting step`
- more careful spacing with/without unused parameter warnings

## New

<img width="400" alt="Screenshot from 2025-10-16 11-46-20" src="https://github.com/user-attachments/assets/de8acf31-6b19-4838-b6e0-90f3321b9153" />
<img width="400" alt="Screenshot from 2025-10-16 11-46-10" src="https://github.com/user-attachments/assets/3d5c81ca-c6f8-4d25-b5d6-35775c75a982" />

## Old

<img width="400" alt="Screenshot from 2025-10-16 11-48-23" src="https://github.com/user-attachments/assets/eae16f07-d193-4586-9131-8e7fa67b2269" />
<img width="400" alt="Screenshot from 2025-10-16 11-48-36" src="https://github.com/user-attachments/assets/a6f85618-c30b-44df-98e9-ece329900c4a" />