### PR TITLE
Fix import errors in stub files autoupdate

### DIFF
--- a/.github/update_stub.sh
+++ b/.github/update_stub.sh
@@ -19,3 +19,13 @@ pybind11-stubgen --exit-code -o ${this_dir}/../src/python/ impactx
 # fix weird missing import issues after update to pybind11 v3.0
 sed -i 's/impactx.impactx_pybind.elements/elements/g' src/python/impactx/impactx_pybind/__init__.pyi
 sed -i 's/impactx.impactx_pybind.distribution/distribution/g' src/python/impactx/impactx_pybind/__init__.pyi
+for pyi_file in $(find src/python -name "*.pyi"); do
+    # Add typing import if typing. is used but not imported
+    if grep -q "typing\." "${pyi_file}" && ! grep -q "^import typing" "${pyi_file}"; then
+        sed -i '/^from __future__ import/a import typing' "${pyi_file}"
+    fi
+    # Add NoneType import if NoneType is used but not imported
+    if grep -q "NoneType" "${pyi_file}" && ! grep -q "^from types import.*NoneType" "${pyi_file}"; then
+        sed -i '/^from __future__ import/a from types import NoneType' "${pyi_file}"
+    fi
+done


### PR DESCRIPTION
I think this could be a workaround. I tested the bash code snippet by running it locally and it produces the following diff:
```diff
diff --git a/src/python/impactx/extensions/KnownElementsList.pyi b/src/python/impactx/extensions/KnownElementsList.pyi
index 83f9931e..7cbb72fe 100644
--- a/src/python/impactx/extensions/KnownElementsList.pyi
+++ b/src/python/impactx/extensions/KnownElementsList.pyi
@@ -8,6 +8,8 @@ License: BSD-3-Clause-LBNL
 """
 
 from __future__ import annotations
+from types import NoneType
+import typing
 
 import os as os
 import re as re
diff --git a/src/python/impactx/impactx_pybind/elements/__init__.pyi b/src/python/impactx/impactx_pybind/elements/__init__.pyi
index d2d83923..c20f26fe 100644
--- a/src/python/impactx/impactx_pybind/elements/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/elements/__init__.pyi
@@ -3,6 +3,7 @@ Accelerator lattice elements in ImpactX
 """
 
 from __future__ import annotations
+from types import NoneType
 
 import collections.abc
 import typing
```
which I think coincides with the diff from the changes I had implemented manually in #1186, https://patch-diff.githubusercontent.com/raw/BLAST-ImpactX/impactx/pull/1186.diff.