### PR TITLE
Element Names: All, `None`

### DIFF
--- a/src/elements/Empty.H
+++ b/src/elements/Empty.H
@@ -13,20 +13,21 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/thin.H"
 #include "mixin/lineartransport.H"
+#include "mixin/named.H"
 #include "mixin/nofinalize.H"
 
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
 #include <AMReX_SIMD.H>
 
-#include <stdexcept>
-#include <string>
+#include <optional>
 
 
 namespace impactx::elements
 {
     struct Empty
-    : public mixin::Thin,
+    : public mixin::Named,
+      public mixin::Thin,
       public mixin::LinearTransport<Empty>,
       public mixin::NoFinalize,
       public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
@@ -37,6 +38,7 @@ namespace impactx::elements
         /** This element does nothing.
          */
         Empty ()
+        : Named(std::nullopt)
         {
         }
 
@@ -118,14 +120,6 @@ namespace impactx::elements
 
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();
-
-        /** Provide impactx::elements::mixin::Named::name */
-        AMREX_FORCE_INLINE
-        std::string name () const { throw std::runtime_error("Name not set on element!"); }
-
-        /** Provide impactx::elements::mixin::Named::has_name */
-        AMREX_FORCE_INLINE
-        bool has_name () const { return false; }
     };
 
 } // namespace impactx

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -249,7 +249,9 @@ void init_elements(py::module& m)
 
     py::class_<elements::mixin::Named>(mx, "Named")
         .def_property("name",
-            [](elements::mixin::Named & nm) { return nm.name(); },
+            [](elements::mixin::Named & nm) -> std::optional<std::string> {
+                return nm.has_name() ? std::optional<std::string>{nm.name()} : std::nullopt;
+            },
             [](elements::mixin::Named & nm, std::string new_name) { nm.set_name(new_name); },
             "segment length in m"
         )
@@ -352,6 +354,7 @@ void init_elements(py::module& m)
             &diagnostics::BeamMonitor::name,
             "name of the series"
         )
+        .def_property_readonly("has_name", &diagnostics::BeamMonitor::has_name)
         .def_property("nonlinear_lens_invariants",
             [](diagnostics::BeamMonitor & bm) { return detail::get_or_throw<bool>(bm.name(), "nonlinear_lens_invariants"); },
             [](diagnostics::BeamMonitor & bm, bool nonlinear_lens_invariants) {
@@ -1392,7 +1395,7 @@ void init_elements(py::module& m)
     ;
     register_push(py_Multipole);
 
-    py::class_<Empty, elements::mixin::Thin> py_Empty(me, "Empty");
+    py::class_<Empty, elements::mixin::Named, elements::mixin::Thin> py_Empty(me, "Empty");
     py_Empty
         .def("__repr__",
              [](Empty const & /* empty */) {


### PR DESCRIPTION
It is easier for user-facing workflows if `.name` exists for all elements, even `Empty`.

In Python, instead of throwing an exception we return the `None` value for elements without a user-provided name, which simplifies user-logic. In this case `.has_name` is `False`.

Isolated from #1172