### PR TITLE
Fix KnownElementsList Stubs

### DIFF
--- a/src/python/impactx/extensions/KnownElementsList.py
+++ b/src/python/impactx/extensions/KnownElementsList.py
@@ -8,7 +8,6 @@ License: BSD-3-Clause-LBNL
 
 import os
 import re
-from typing import List, Tuple, Union
 
 from impactx import elements
 
@@ -123,10 +122,8 @@ class FilteredElementsList:
     def select(
         self,
         *,
-        kind: Union[
-            str, type, List[Union[str, type]], Tuple[Union[str, type], ...], None
-        ] = None,
-        name: Union[str, List[str], Tuple[str, ...], None] = None,
+        kind=None,
+        name=None,
     ):
         """Apply filtering to this filtered list.
 
@@ -198,7 +195,7 @@ class FilteredElementsList:
         """
         return get_kinds(self)
 
-    def count_by_kind(self, kind_pattern: Union[str, type]) -> int:
+    def count_by_kind(self, kind_pattern) -> int:
         """Count elements of a specific kind in the filtered list.
 
         Args:
@@ -212,7 +209,7 @@ class FilteredElementsList:
         """
         return count_by_kind(self, kind_pattern)
 
-    def has_kind(self, kind_pattern: Union[str, type]) -> bool:
+    def has_kind(self, kind_pattern) -> bool:
         """Check if filtered list contains elements of a specific kind.
 
         Args:
@@ -364,10 +361,8 @@ def _check_element_match(element, kind, name):
 def select(
     self,
     *,
-    kind: Union[
-        str, type, List[Union[str, type]], Tuple[Union[str, type], ...], None
-    ] = None,
-    name: Union[str, List[str], Tuple[str, ...], None] = None,
+    kind=None,
+    name=None,
 ) -> FilteredElementsList:
     """Filter elements by type and name with OR-based logic.
 
@@ -489,7 +484,7 @@ def get_kinds(self) -> list[type]:
     return sorted(list(kinds), key=lambda t: t.__name__)
 
 
-def count_by_kind(self, kind_pattern: Union[str, type]) -> int:
+def count_by_kind(self, kind_pattern) -> int:
     """Count elements of a specific kind.
 
     Args:
@@ -508,7 +503,7 @@ def count_by_kind(self, kind_pattern: Union[str, type]) -> int:
     return count
 
 
-def has_kind(self, kind_pattern: Union[str, type]) -> bool:
+def has_kind(self, kind_pattern) -> bool:
     """Check if list contains elements of a specific kind.
 
     Args:

--- a/src/python/impactx/extensions/KnownElementsList.pyi
+++ b/src/python/impactx/extensions/KnownElementsList.pyi
@@ -41,7 +41,7 @@ class FilteredElementsList:
     def __len__(self): ...
     def __repr__(self): ...
     def __str__(self): ...
-    def count_by_kind(self, kind_pattern: typing.Union[str, type]) -> int:
+    def count_by_kind(self, kind_pattern) -> int:
         """
         Count elements of a specific kind in the filtered list.
 
@@ -63,7 +63,7 @@ class FilteredElementsList:
                     list[type]: List of unique element types (sorted by name).
 
         """
-    def has_kind(self, kind_pattern: typing.Union[str, type]) -> bool:
+    def has_kind(self, kind_pattern) -> bool:
         """
         Check if filtered list contains elements of a specific kind.
 
@@ -77,20 +77,7 @@ class FilteredElementsList:
                     bool: True if at least one element of the specified kind exists.
 
         """
-    def select(
-        self,
-        *,
-        kind: typing.Union[
-            str,
-            type,
-            typing.List[typing.Union[str, type]],
-            typing.Tuple[typing.Union[str, type], ...],
-            NoneType,
-        ] = None,
-        name: typing.Union[
-            str, typing.List[str], typing.Tuple[str, ...], NoneType
-        ] = None,
-    ):
+    def select(self, *, kind=None, name=None):
         """
         Apply filtering to this filtered list.
 
@@ -202,7 +189,7 @@ def _validate_select_parameters(kind, name):
 
     """
 
-def count_by_kind(self, kind_pattern: typing.Union[str, type]) -> int:
+def count_by_kind(self, kind_pattern) -> int:
     """
     Count elements of a specific kind.
 
@@ -234,7 +221,7 @@ def get_kinds(self) -> list[type]:
 
     """
 
-def has_kind(self, kind_pattern: typing.Union[str, type]) -> bool:
+def has_kind(self, kind_pattern) -> bool:
     """
     Check if list contains elements of a specific kind.
 
@@ -259,18 +246,7 @@ def register_KnownElementsList_extension(kel):
     KnownElementsList helper methods
     """
 
-def select(
-    self,
-    *,
-    kind: typing.Union[
-        str,
-        type,
-        typing.List[typing.Union[str, type]],
-        typing.Tuple[typing.Union[str, type], ...],
-        NoneType,
-    ] = None,
-    name: typing.Union[str, typing.List[str], typing.Tuple[str, ...], NoneType] = None,
-) -> FilteredElementsList:
+def select(self, *, kind=None, name=None) -> FilteredElementsList:
     """
     Filter elements by type and name with OR-based logic.
 

--- a/src/python/impactx/impactx_pybind/elements/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/elements/__init__.pyi
@@ -1456,7 +1456,7 @@ class KnownElementsList:
         """
         Clear the list to become empty.
         """
-    def count_by_kind(self, kind_pattern: typing.Union[str, type]) -> int:
+    def count_by_kind(self, kind_pattern) -> int:
         """
         Count elements of a specific kind.
 
@@ -1495,7 +1495,7 @@ class KnownElementsList:
                 list[type]: List of unique element types (sorted by name).
 
         """
-    def has_kind(self, kind_pattern: typing.Union[str, type]) -> bool:
+    def has_kind(self, kind_pattern) -> bool:
         """
         Check if list contains elements of a specific kind.
 
@@ -1547,18 +1547,7 @@ class KnownElementsList:
         Return and remove the last element of the list.
         """
     def select(
-        self,
-        *,
-        kind: typing.Union[
-            str,
-            type,
-            typing.List[typing.Union[str, type]],
-            typing.Tuple[typing.Union[str, type], ...],
-            NoneType,
-        ] = None,
-        name: typing.Union[
-            str, typing.List[str], typing.Tuple[str, ...], NoneType
-        ] = None,
+        self, *, kind=None, name=None
     ) -> impactx.extensions.KnownElementsList.FilteredElementsList:
         """
         Filter elements by type and name with OR-based logic.


### PR DESCRIPTION
Avoid importing `typing` for type hints, because pybind11-stubgen
forgets the import when generating `pyi` files...

Follow-up to #1182