### PR TITLE
CMake: Install Python Wrappers w/o Test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,6 +493,13 @@ if(ImpactX_PYTHON)
             ${ImpactX_CUSTOM_TARGET_PREFIX}pip_wheel
     )
 
+    # copy Python wrapper library to build directory
+    add_custom_command(TARGET pyImpactX POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${ImpactX_SOURCE_DIR}/src/python/impactx
+            $<TARGET_FILE_DIR:pyImpactX>
+    )
+
     # copy examples into pip package, e.g., for dashboard GUI
     add_custom_command(TARGET pyImpactX POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory
@@ -513,14 +520,6 @@ if(BUILD_TESTING)
     endif()
 
     # unit tests
-    if(ImpactX_PYTHON)
-        # copy Python wrapper library to build directory
-        add_custom_command(TARGET pyImpactX POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_directory
-                ${ImpactX_SOURCE_DIR}/src/python/impactx
-                $<TARGET_FILE_DIR:pyImpactX>
-        )
-    endif()
     add_subdirectory(tests)
 endif()
 


### PR DESCRIPTION
The Python wrapper files and classes should be always installed, not only when tests are performed. Also, ideally before the examples #1179 are copied in.