### PR TITLE
Hooks: Return `None` if Invalid

### DIFF
--- a/src/tracking/TrackingState.H
+++ b/src/tracking/TrackingState.H
@@ -11,6 +11,8 @@
 
 #include "elements/All.H"
 
+#include <optional>
+
 
 namespace impactx
 {
@@ -31,12 +33,9 @@ namespace impactx
         int m_period = 0;
 
         /** For tracking hooks/callbacks, the current lattice element */
-        elements::KnownElements* m_element = &empty_element;
+        std::optional<elements::KnownElements*> m_element;
 
-        void set_no_element () { m_element = &empty_element; }
-
-    private:
-        static inline elements::KnownElements empty_element = elements::Empty{};
+        void set_no_element () { m_element = std::nullopt; }
     };
 
 } // namespace impactx

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -286,3 +286,38 @@ def test_impactx_change_resolution():
 
     # finalize simulation
     sim.finalize()
+
+
+def test_impactx_fodo_hook():
+    """
+    Test hooks (callback functions) into evolve loops
+    """
+    sim = ImpactX()
+
+    sim.load_inputs_file(basepath + "/examples/fodo/input_fodo.in")
+
+    sim.init_grids()
+    sim.init_beam_distribution_from_inputs()
+    sim.init_lattice_elements_from_inputs()
+
+    def hook_before_element(sim):
+        element = sim.tracking_element
+        print(
+            f"  Current element name: {element.name} with ds={element.ds:.2f}",
+            flush=True,
+        )
+
+        if element.name != "monitor":
+            print(f"  Drift ds is: {element.ds:.2f}m", flush=True)
+
+    sim.hook["before_element"] = hook_before_element
+
+    assert sim.tracking_element is None
+    sim.track_particles()
+    assert sim.tracking_element is None
+
+    # validate the results
+    validate_fodo(sim.particle_container())
+
+    # finalize simulation
+    sim.finalize()


### PR DESCRIPTION
There is an easier way to indicate there is no active tracking element in Python: returning `None`.

Remove special usage of the `Empty` element for this state. Follow-up to #1172