### PR TITLE
Dashboard: Fix population of distribution values & Python 3.14 issue

### DIFF
--- a/src/python/impactx/dashboard/Input/distribution/ui.py
+++ b/src/python/impactx/dashboard/Input/distribution/ui.py
@@ -15,7 +15,7 @@ from ..defaults_helper import InputDefaultsHelper
 from ..utils import GeneralFunctions
 from ..validation import DashboardValidation, errors_tracker
 from .utils import DistributionFunctions
-
+from ...Toolbar.file_imports.ui_populator import _apply_distribution_inputs
 # -----------------------------------------------------------------------------
 # Helpful
 # -----------------------------------------------------------------------------
@@ -62,6 +62,7 @@ def populate_distribution_parameters():
 
     state.selected_distribution_parameters = params
     errors_tracker.update_simulation_validation_status()
+    _apply_distribution_inputs()
     return params
 
 

--- a/src/python/impactx/dashboard/Input/distribution/ui.py
+++ b/src/python/impactx/dashboard/Input/distribution/ui.py
@@ -10,12 +10,13 @@ from impactx import distribution
 
 from ... import ctrl, state, vuetify
 from ...Input.components import CardBase, CardComponents, InputComponents
+from ...Toolbar.file_imports.ui_populator import _apply_distribution_inputs
 from .. import DashboardDefaults
 from ..defaults_helper import InputDefaultsHelper
 from ..utils import GeneralFunctions
 from ..validation import DashboardValidation, errors_tracker
 from .utils import DistributionFunctions
-from ...Toolbar.file_imports.ui_populator import _apply_distribution_inputs
+
 # -----------------------------------------------------------------------------
 # Helpful
 # -----------------------------------------------------------------------------

--- a/src/python/impactx/dashboard/Toolbar/file_imports/ui_populator.py
+++ b/src/python/impactx/dashboard/Toolbar/file_imports/ui_populator.py
@@ -26,6 +26,19 @@ def on_import_file_change(import_file, **kwargs):
             state.importing_file = False
 
 
+def _apply_distribution_inputs():
+    """
+    Push any cached distribution parameters into the UI.
+    """
+
+    imported_params = getattr(state, "imported_distribution_parameters", None)
+    if imported_params:
+        for param_name, raw_value in imported_params.items():
+            if param_name in state.selected_distribution_parameters:
+                ctrl.update_distribution_parameter(param_name, raw_value)
+        state.imported_distribution_parameters = None
+
+
 def populate_impactx_simulation_file_to_ui(file) -> None:
     """
     Auto fills the dashboard with parsed inputs.
@@ -45,21 +58,20 @@ def populate_impactx_simulation_file_to_ui(file) -> None:
         if hasattr(state, input_name) and input_name not in non_state_inputs:
             setattr(state, input_name, input_value)
 
-    _populate_distribution_inputs_to_ui(imported_distribution_data)
+    _prepare_distribution_update(imported_distribution_data)
     _populate_lattice_config_to_ui(imported_lattice_data)
     _populate_lattice_config_variables_to_ui(parsed_variables)
 
 
 @staticmethod
-def _populate_distribution_inputs_to_ui(parsed_data):
+def _prepare_distribution_update(parsed_data):
     # the below two calls do not call state.change("distribution") or state.change("distribution_type")
     # since they are both part of a nested state (ie. distribution_type=["Twiss","Quadratic"]).
+    parameters = parsed_data["parameters"]
+    state.imported_distribution_parameters = parameters.copy() if parameters else None
     state.distribution = parsed_data["name"]
     state.distribution_type = parsed_data["type"]
     state.flush()  # force calls state.change("distribution") and state.change("distribution_type")
-
-    for distr_param_name, distr_param_value in parsed_data["parameters"].items():
-        ctrl.update_distribution_parameter(distr_param_name, distr_param_value)
 
 
 @staticmethod

--- a/src/python/impactx/dashboard/start.py
+++ b/src/python/impactx/dashboard/start.py
@@ -6,6 +6,8 @@ Authors: Parthib Roy, Axel Huebl
 License: BSD-3-Clause-LBNL
 """
 
+import asyncio
+
 from . import server, state
 from .app import application
 from .Input.defaults import DashboardDefaults
@@ -42,6 +44,10 @@ class DashboardApp:
 
     def start(self):
         setup_dashboard()
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.set_event_loop(asyncio.new_event_loop())
         server.start()
         return 0
 


### PR DESCRIPTION
This PR fixes issues from https://github.com/BLAST-ImpactX/impactx/pull/1204.
It’s submitted as a separate PR since I don’t have direct push access to that branch.

Fixes:
` Element {#lambdaX} was not visible after 10 seconds!` 

Right before we set distribution_type, we stash the parsed values from the import file; once `@state.change("distribution_type")` runs via the flush, we apply those cached numbers to the UI so the fields stay populated.

Unsure if the `state.flush()` mechanism changed recently in Trame to cause this error.