### PR TITLE
Fix: NERSC PM Interactive

### DIFF
--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
@@ -37,10 +37,10 @@ fi
 
 # an alias to request an interactive batch node for one hour
 #   for parallel execution, start on the batch node: srun <command>
-alias getNode="salloc -N 1 --ntasks-per-node=4 -t 1:00:00 -q interactive -C gpu --gpu-bind=single:1 -c 32 -G 4 -A $proj"
+alias getNode="salloc -N 1 --ntasks-per-node=4 -t 1:00:00 -q interactive -C gpu --gpu-bind=none -c 32 -G 4 -A $proj"
 # an alias to run a command on a batch node for up to 30min
 #   usage: runNode <command>
-alias runNode="srun -N 1 --ntasks-per-node=4 -t 0:30:00 -q interactive -C gpu --gpu-bind=single:1 -c 32 -G 4 -A $proj"
+alias runNode="srun -N 1 --ntasks-per-node=4 -t 0:30:00 -q interactive -C gpu --gpu-bind=none -c 32 -G 4 -A $proj"
 
 # necessary to use CUDA-Aware MPI and run a job
 export CRAY_ACCEL_TARGET=nvidia80


### PR DESCRIPTION
Fix the `getNode` and `runNode` alias in our profile to support multiple GPUs well.

See https://github.com/BLAST-WarpX/warpx/pull/6414