### PR TITLE
Fix Add Element Example

### DIFF
--- a/docs/source/usage/howto/add_element.rst
+++ b/docs/source/usage/howto/add_element.rst
@@ -98,7 +98,7 @@ As a last step, we expose our C++ beamline elements to Python in `src/python/ele
       :language: cpp
       :dedent: 4
       :start-at: py::class_<Drift, elements::mixin::Named, elements::mixin::Thick, elements::mixin::Alignment, elements::mixin::PipeAperture> py_Drift(me, "Drift");
-      :end-at: register_envelope_push(py_Drift);
+      :end-at: register_push(py_Drift);
 
 Pull requests that added a new element and can be taken as examples are:
 


### PR DESCRIPTION
The code that the snippet end to referred to in the docs had changed. This updates it and fixes the include to be shown again / fixes the sphinx warning.

Fix #1231