### PR TITLE
Updates to DipEdge documentation.

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -338,6 +338,8 @@ If ``model = "linear"``, then the linearized map is used.  This model is identic
 
 when expanded to first order in ``g/rc`` (gap / radius of curvature).
 
+By comparison, note that the MAD-X DIPEDGE element uses as input the half-gap ``HGAP = g/2``, and sets the default value ``FINT = 0`` (while the corresponding default value of ``K2`` is set to 1).
+
 This requires these additional parameters:
 
 * ``<element_name>.psi`` (``float``, in radians) the pole face rotation angle
@@ -346,7 +348,7 @@ This requires these additional parameters:
 * ``<element_name>.R`` (``float``, in meters) scale length for the field integrals (default: ``1 m``)
 * ``<element_name>.K0`` (``float``, dimensionless) normalized field integral for fringe field
 * ``<element_name>.K1`` (``float``, dimensionless) normalized field integral for fringe field
-* ``<element_name>.K2`` (``float``, dimensionless) normalized field integral for fringe field (FINT)
+* ``<element_name>.K2`` (``float``, dimensionless) normalized field integral for fringe field (FINT, default: ``1``)
 * ``<element_name>.K3`` (``float``, dimensionless) normalized field integral for fringe field
 * ``<element_name>.K4`` (``float``, dimensionless) normalized field integral for fringe field
 * ``<element_name>.K5`` (``float``, dimensionless) normalized field integral for fringe field

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -346,13 +346,13 @@ This requires these additional parameters:
 * ``<element_name>.rc`` (``float``, in meters) the bend radius
 * ``<element_name>.g`` (``float``, in meters) the full magnetic gap size
 * ``<element_name>.R`` (``float``, in meters) scale length for the field integrals (default: ``1 m``)
-* ``<element_name>.K0`` (``float``, dimensionless) normalized field integral for fringe field
-* ``<element_name>.K1`` (``float``, dimensionless) normalized field integral for fringe field
+* ``<element_name>.K0`` (``float``, dimensionless) normalized field integral for fringe field (default: ``pi/6``)
+* ``<element_name>.K1`` (``float``, dimensionless) normalized field integral for fringe field (default: ``0``)
 * ``<element_name>.K2`` (``float``, dimensionless) normalized field integral for fringe field (FINT, default: ``1``)
-* ``<element_name>.K3`` (``float``, dimensionless) normalized field integral for fringe field
-* ``<element_name>.K4`` (``float``, dimensionless) normalized field integral for fringe field
-* ``<element_name>.K5`` (``float``, dimensionless) normalized field integral for fringe field
-* ``<element_name>.K6`` (``float``, dimensionless) normalized field integral for fringe field
+* ``<element_name>.K3`` (``float``, dimensionless) normalized field integral for fringe field (default: ``1/6``)
+* ``<element_name>.K4`` (``float``, dimensionless) normalized field integral for fringe field (default: ``0``)
+* ``<element_name>.K5`` (``float``, dimensionless) normalized field integral for fringe field (default: ``0``)
+* ``<element_name>.K6`` (``float``, dimensionless) normalized field integral for fringe field (default: ``0``)
 * ``<element_name>.model`` (``string``) the fringe field model: ``linear`` (default) or ``nonlinear``
 * ``<element_name>.location`` (``string``) the fringe field edge location: ``entry`` (default) or ``exit``
 * ``<element_name>.dx`` (``float``, in meters) horizontal translation error

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -809,7 +809,7 @@ This module provides elements and methods for the accelerator lattice.
 
       focusing t strength in 1/m
 
-.. py:class:: impactx.elements.DipEdge(psi, rc, g, K2, dx=0, dy=0, rotation=0, name=None)
+.. py:class:: impactx.elements.DipEdge(psi, rc, g, R=1, K0=pi/6, K1=0, K2=1, K3=1/6, K4=0, K5=0, K6=0, model="linear", location="entry", dx=0, dy=0, rotation=0, name=None)
 
    Edge focusing associated with bend entry or exit
 
@@ -831,6 +831,9 @@ This module provides elements and methods for the accelerator lattice.
    * K. L. Brown, SLAC Report No. 75 (1982)
 
    when expanded to first order in ``g/rc`` (gap / radius of curvature).
+
+   By comparison, note that the MAD-X DIPEDGE element uses as input the half-gap ``HGAP = g/2``, and sets the default value ``FINT = 0`` (while
+   the corresponding default value of ``K2`` is set to 1).
 
    :param psi: Pole face angle [radians]
    :param rc: Radius of curvature [m]


### PR DESCRIPTION
This PR makes a few changes to the documentation of the DipEdge element.

In particular, this is meant to address / close #1220 