### PR TITLE
Python: Warning for Deprecated APIs

### DIFF
--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -275,7 +275,11 @@ void init_ImpactX (py::module& m)
                     amrex::ParmParse pp_algo("algo");
                     if (std::get<bool>(space_charge_v)) {
                         // TODO: boolean True is deprecated since 25.03, remove some time after
-                        py::print("sim.space_charge = True is deprecated, please use space_charge = \"3D\"");
+                        py::warnings::warn(
+                            "sim.space_charge = True is deprecated, please use space_charge = \"3D\"",
+                            PyExc_DeprecationWarning,
+                            2
+                        );
                         pp_algo.add("space_charge", std::string("3D"));
                     } else {
                         // map boolean False to "false" / off
@@ -616,7 +620,12 @@ void init_ImpactX (py::module& m)
 
         .def("evolve",  /** TODO: deprecated API. Only for internal use. Remove after a few releases. */
              [](ImpactX & ix) {
-                py::print("Warning: evolve() is deprecated and will soon be removed. Use track_particles() instead.");
+                py::warnings::warn(
+                    "Warning: evolve() is deprecated and will soon be removed. "
+                    "Use track_particles() instead.",
+                    PyExc_DeprecationWarning,
+                    2
+                );
                 ix.evolve();
              },
              "Run the main simulation loop."

--- a/src/python/ImpactXParticleContainer.cpp
+++ b/src/python/ImpactXParticleContainer.cpp
@@ -122,11 +122,11 @@ void init_impactxparticlecontainer(py::module& m)
         )
         .def("reduced_beam_characteristics",
              [](ImpactXParticleContainer & pc) {
-                 ablastr::warn_manager::WMRecordWarning(
-                    "reduced_beam_characteristics",
+                 py::warnings::warn(
                     "WARNING: reduced_beam_characteristics() is deprecated. "
                     "Use beam_moments() instead.",
-                    ablastr::warn_manager::WarnPriority::medium
+                    PyExc_DeprecationWarning,
+                    2
                  );
                  return diagnostics::reduced_beam_characteristics(pc);
              },

--- a/src/python/pyImpactX.H
+++ b/src/python/pyImpactX.H
@@ -14,6 +14,7 @@
 // include <pybind11/numpy.h>  // not yet used
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
+#include <pybind11/warnings.h>
 
 #include <ImpactX.H>
 #include <elements/All.H>


### PR DESCRIPTION
Use Python's own warning system for deprecated APIs. This integrates better in workflows with Jupyter and can be explicitly be filtered for.

Python docs:
https://docs.python.org/3/library/warnings.html

pybind11 docs:
https://pybind11.readthedocs.io/en/stable/advanced/exceptions.html#handling-warnings-from-the-python-c-api