### PR TITLE
Source: `active_once = True`

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -829,6 +829,8 @@ Currently, this only supports openPMD files from our ``beam_monitor``.
   Distribution type of particles in the source. currently, only ``"openPMD"`` is supported
 * ``<element_name>.openpmd_path`` (``string``)
   path to the openPMD series
+* ``<element_name>.active_once`` (``boolean``, default: ``true``)
+  Inject particles only for the first lattice period.
 
 
 ``tapered_pl``

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1093,6 +1093,7 @@ This module provides elements and methods for the accelerator lattice.
 
    :param distribution: Distribution type of particles in the source. currently, only ``"openPMD"`` is supported
    :param openpmd_path: path to the openPMD series
+   :param active_once: Inject particles only for the first lattice period. Default: ``True``
    :param name: an optional name for the element
 
 .. py:class:: impactx.elements.Programmable(ds=0.0, nslice=1, name=None)

--- a/src/elements/Source.H
+++ b/src/elements/Source.H
@@ -35,16 +35,19 @@ namespace impactx::elements
          *
          * @param distribution Must read "openPMD" for this constructor
          * @param openpmd_path path to openPMD series as accepted by openPMD::Series
+         * @param active_once inject particles only for the first lattice period
          * @param name a user defined and not necessarily unique name of the element
          */
         Source (
             std::string distribution,
             std::string openpmd_path,
+            bool active_once = true,
             std::optional<std::string> name = std::nullopt
         )
         : Named(std::move(name)),
           m_distribution(distribution),
-          m_series_name(std::move(openpmd_path))
+          m_series_name(std::move(openpmd_path)),
+          m_active_once(active_once)
         {
             if (distribution != "openPMD") {
                 throw std::runtime_error("Only 'openPMD' distribution is supported if openpmd_path is provided!");
@@ -62,7 +65,7 @@ namespace impactx::elements
         void operator() (
             ImpactXParticleContainer & pc,
             [[maybe_unused]] int step,
-            [[maybe_unused]] int period
+            int period
         );
 
         /** This function returns the linear transport map.
@@ -86,6 +89,7 @@ namespace impactx::elements
 
         std::string m_distribution; //! Distribution type of particles in the source
         std::string m_series_name; //! openPMD filename
+        bool m_active_once = true; //! Inject particles only for the first lattice period
     };
 
 } // namespace impactx

--- a/src/elements/Source.cpp
+++ b/src/elements/Source.cpp
@@ -26,9 +26,14 @@ namespace impactx::elements
     Source::operator() (
         ImpactXParticleContainer & pc,
         int,
-        int
+        int period
     )
     {
+        // Check if only active for lattice period zero (0), e.g., in rings
+        if (m_active_once && period > 0) {
+            return;
+        }
+
 #ifdef ImpactX_USE_OPENPMD
         auto series = io::Series(m_series_name, io::Access::READ_ONLY
 #   if openPMD_HAVE_MPI==1

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -611,7 +611,10 @@ element_name) );
                 pp_element.get("openpmd_path", openpmd_path);
             }
 
-            m_lattice.emplace_back( Source(distribution, openpmd_path, element_name) );
+            bool active_once = true;
+            pp_element.queryAdd("active_once", active_once);
+
+            m_lattice.emplace_back( Source(distribution, openpmd_path, active_once, element_name) );
         } else if (element_type == "line")
         {
             // Parse the lattice elements for the sub-lattice in the line

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -2190,7 +2190,8 @@ void init_elements(py::module& m)
                  return element_name(
                      src,
                      std::make_pair("distribution", src.m_distribution),
-                     std::make_pair("path", src.m_series_name)
+                     std::make_pair("path", src.m_series_name),
+                     std::make_pair("active_once", src.m_active_once)
                  );
              }
         )
@@ -2199,17 +2200,20 @@ void init_elements(py::module& m)
                 return element_dict(
                     src,
                     std::make_pair("distribution", src.m_distribution),
-                    std::make_pair("path", src.m_series_name)
+                    std::make_pair("path", src.m_series_name),
+                    std::make_pair("active_once", src.m_active_once)
                 );
             }
         )
         .def(py::init<
              std::string,
              std::string,
+             bool,
              std::optional<std::string>
          >(),
              py::arg("distribution"),
              py::arg("openpmd_path"),
+             py::arg("active_once") = true,
              py::arg("name") = py::none(),
              "A particle source."
         )
@@ -2222,6 +2226,11 @@ void init_elements(py::module& m)
             [](Source & src) { return src.m_series_name; },
             [](Source & src, std::string series_name) { src.m_series_name = series_name; },
             "Path to openPMD series as accepted by openPMD_api.Series"
+        )
+        .def_property("active_once",
+            [](Source & src) { return src.m_active_once; },
+            [](Source & src, bool actice_once) { src.m_active_once = actice_once; },
+            "Inject particles only for the first lattice period."
         )
     ;
     register_push(py_Source);


### PR DESCRIPTION
Add an option `active_once` to the `Source` element. This controls if the source should only inject particles when tracking through lattice period 0. This is useful when defining rings or periodic channels with a source that shall only inject particles once.

Breaking change: `active_once = True` is also the new default, since it is the most common use case.

Thanks to @egstern for raising this! :pray: 