### PR TITLE
Fix: `track_particles` with `1` particle

### DIFF
--- a/src/initialization/Validate.cpp
+++ b/src/initialization/Validate.cpp
@@ -43,13 +43,13 @@ namespace impactx
                 auto & first_element = m_lattice.front();
                 std::visit([](auto&& element){
                     if (std::string_view(element.type) != std::string_view("Source")) {
-                        throw std::runtime_error("No particles found. Cannot run evolve without a beam.");
+                        throw std::runtime_error(
+                            "No particles found. "
+                            "Cannot track particles without an initialized beam. "
+                            "Did you forget to call sim.add_particles ?"
+                        );
                     }
                 }, first_element);
-            }
-            else if (nParticles == 1)
-            {
-                throw std::runtime_error("Only one particle found. This is not yet supported: https://github.com/BLAST-ImpactX/impactx/issues/44");
             }
         }
 

--- a/src/particles/wakefields/HandleWakefield.H
+++ b/src/particles/wakefields/HandleWakefield.H
@@ -17,9 +17,7 @@
 #include "WakePush.H"
 
 #include <cmath>
-#ifndef ImpactX_USE_FFT
 #include <stdexcept>
-#endif
 #include <vector>
 
 
@@ -63,6 +61,25 @@ namespace impactx::particles::wakefields
             // Measure beam size, extract the min, max of particle positions
             [[maybe_unused]] auto const [x_min, y_min, t_min, x_max, y_max, t_max] =
                 particle_container.MinAndMaxPositions();
+
+            // Ensure we have a beam with a finite extend in t
+            if (t_min == t_max)
+            {
+                auto const npart = particle_container.TotalNumberOfParticles();
+                std::string error_msg = "Coherent Synchrotron Radiation (CSR) "
+                                        "modeling was enabled, but ";
+                if (npart == 1) {
+                    error_msg.append("there is only one particle in the beam. ");
+                } else {
+                    error_msg.append("the beam is flat in t. ");
+                }
+                error_msg.append(
+                    "CSR modeling is a collective effect and requires "
+                    "a particle beam with a finite extend in t. "
+                    "Please set the CSR option to false."
+                );
+                throw std::runtime_error(error_msg);
+            }
 
             // Set parameters for charge deposition
             bool const is_unity_particle_weight = false; // Only true if w = 1

--- a/src/particles/wakefields/HandleWakefield.H
+++ b/src/particles/wakefields/HandleWakefield.H
@@ -62,7 +62,7 @@ namespace impactx::particles::wakefields
             [[maybe_unused]] auto const [x_min, y_min, t_min, x_max, y_max, t_max] =
                 particle_container.MinAndMaxPositions();
 
-            // Ensure we have a beam with a finite extend in t
+            // Ensure we have a beam with a finite extent in t
             if (t_min == t_max)
             {
                 auto const npart = particle_container.TotalNumberOfParticles();
@@ -75,7 +75,7 @@ namespace impactx::particles::wakefields
                 }
                 error_msg.append(
                     "CSR modeling is a collective effect and requires "
-                    "a particle beam with a finite extend in t. "
+                    "a particle beam with a finite extent in t. "
                     "Please set the CSR option to false."
                 );
                 throw std::runtime_error(error_msg);

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -196,7 +196,10 @@ def test_impactx_noparticles():
     sim.lattice.append(elements.Drift(ds=0.5))
 
     with pytest.raises(
-        RuntimeError, match="No particles found. Cannot run evolve without a beam."
+        RuntimeError,
+        match="No particles found. "
+        "Cannot track particles without an initialized beam. "
+        "Did you forget to call sim.add_particles ?",
     ):
         sim.track_particles()
 


### PR DESCRIPTION
We can in principle allow to run with `1` particle in `track_particles()`, even though we do have the `track_reference(ref)` mode now: https://impactx.readthedocs.io/en/25.12/usage/how_to_run.html#how-to-select-a-tracking-mode

As long as no space charge and no CSR/wakefield effects are requested, this is still a valid configuration.

This PR removes an old assert, for which we have a more specific assert in the space charge routines, if enabled. Additionally, it adds a new check into the `HandleWakefield` routines (for CSR), which also rely on a non-flat beam to model anything sensible.

Other routines we have, notably ISR, are modeled on individual particles and need no asserts.

First seen in https://github.com/BLAST-ImpactX/impactx/issues/44#issuecomment-3667400046