### PR TITLE
Fix typo in turn-dependent example README

### DIFF
--- a/examples/turn_update/README.rst
+++ b/examples/turn_update/README.rst
@@ -1,6 +1,6 @@
 .. _examples-turn-update:
 
-Turn-Dependend Element Changes
+Turn-Dependent Element Changes
 ==============================
 
 10 periods of drift elements, where each drift is a stand-in for a "turn" map.


### PR DESCRIPTION
Fixed a typo in the README header.