### PR TITLE
`BeamOptics`: Generalize SIMD Logic

### DIFF
--- a/src/elements/mixin/beamoptic.H
+++ b/src/elements/mixin/beamoptic.H
@@ -22,10 +22,124 @@
 #include <type_traits>
 
 
+namespace impactx
+{
+    /** A generalized ParallelFor that dispatches to amrex::ParallelFor or amrex::ParallelForSIMD
+     *  depending on whether the element type T_Element is vectorized.
+     *
+     * @tparam T_Element the element type
+     * @tparam F the functor type
+     * @param n the number of items to iterate over
+     * @param f the functor to execute
+     */
+    template <typename T_Element, typename F>
+    void ParallelFor (int n, F&& f) {
+#ifdef AMREX_USE_SIMD
+        if constexpr (amrex::simd::is_vectorized<T_Element>) {
+            amrex::ParallelForSIMD<T_Element::simd_width>(n, std::forward<F>(f));
+        } else
+#endif
+        {
+            amrex::ParallelFor(n, std::forward<F>(f));
+        }
+    }
+} // namespace impactx
+
 namespace impactx::elements::mixin
 {
 namespace detail
 {
+    /** Load particle data from array pointers
+     *
+     * On GPU and CPU w/o SIMD, this dereferences a particle property at the
+     * index position i.
+     * On CPU with SIMD, this loads a SIMD register at the IndexType::width
+     * SIMD-wide index position i.
+     *
+     * @tparam T data type (amrex::ParticleReal or uint64_t)
+     * @tparam IndexType int or amrex::SIMDindex<SIMD_WIDTH, int>
+     * @param ptr pointer to the array data
+     * @param i index or SIMD index
+     * @return a reference to the data (scalar) or a SIMD register (SIMD)
+     */
+    template <typename T, typename IndexType>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    decltype(auto) load_pdata (T* ptr, IndexType const i)
+    {
+        if constexpr (std::is_integral_v<IndexType>) {
+            return ptr[i];
+        } else {
+#ifdef AMREX_USE_SIMD
+            using namespace amrex::simd;
+            using RealType = SIMDParticleReal<IndexType::width>;
+            using IdCpuType = SIMDIdCpu<RealType>;
+            using DataType = std::conditional_t<
+                std::is_same_v<T, amrex::ParticleReal>,
+                RealType,
+                IdCpuType
+            >;
+
+            // initialize vector register
+            // TODO stdx::vector_aligned needs alignment guarantees
+            //      https://github.com/AMReX-Codes/amrex/issues/4592
+            //      https://en.cppreference.com/w/cpp/experimental/simd/simd/copy_from
+            DataType val;
+            val.copy_from(&ptr[i.index], stdx::element_aligned);
+            return val;
+
+#else
+            // error handling: we should never get here
+            amrex::ignore_unused(ptr, i);
+            amrex::Abort("SIMD index used but SIMD is not enabled");
+            return ptr[0];
+#endif
+        }
+    }
+
+    /** Store particle data back to array pointers
+     *
+     * On GPU and CPU without SIMD, this does nothing because we already
+     * modified the (global) RAM directly via pointer.
+     *
+     * On CPU with SIMD, this performs a conditional writeback of a SIMD register
+     * to RAM (index in pointer array), but only if the argument was not passed
+     * as const and thus was likely changed.
+     *
+     * Good optimizing compilers can eliminate writebacks of unchanged values
+     * themselves, but we better help a little for robustness. Background:
+     * https://github.com/AMReX-Codes/amrex/pull/4520#issuecomment-3064064215
+     *
+     * @tparam P_Method pointer to the push method (for is_nth_arg_non_const)
+     * @tparam N the argument index (for is_nth_arg_non_const)
+     * @tparam T data type
+     * @tparam IndexType int or SIMD index
+     * @tparam ValType the type of the value to store
+     * @param val the value to store
+     * @param ptr pointer to the SoA data
+     * @param i index or SIMD index
+     */
+    template <auto P_Method, int N, typename T, typename IndexType, typename ValType>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    void store_pdata (
+        ValType const & AMREX_RESTRICT val,
+        T * const AMREX_RESTRICT ptr,
+        IndexType const i
+    )
+    {
+#ifdef AMREX_USE_SIMD
+        if constexpr (!std::is_integral_v<IndexType>) {
+            if constexpr (amrex::simd::is_nth_arg_non_const(P_Method, N)) {
+                // write back to memory
+                // TODO stdx::vector_aligned needs alignment guarantees
+                //      https://github.com/AMReX-Codes/amrex/issues/4592
+                //      https://en.cppreference.com/w/cpp/experimental/simd/simd/copy_from
+                val.copy_to(&ptr[i.index], amrex::simd::stdx::element_aligned);
+            }
+        }
+#endif
+        amrex::ignore_unused(val, ptr, i);
+    }
+
     /** Push a single particle through an element
      *
      * Note: we usually would just write a C++ lambda below in ParallelFor. But, due to restrictions
@@ -93,100 +207,50 @@ namespace detail
          *
          * @param i particle index in the current box
          */
+        template <typename IndexType>
         AMREX_GPU_DEVICE AMREX_FORCE_INLINE
         void
-        operator() (int i) const
-        {
-            // access SoA Real data
-            // note: an optimizing compiler will eliminate loads of unused parameters
-            amrex::ParticleReal & AMREX_RESTRICT x = m_part_x[i];
-            amrex::ParticleReal & AMREX_RESTRICT y = m_part_y[i];
-            amrex::ParticleReal & AMREX_RESTRICT t = m_part_t[i];
-            amrex::ParticleReal & AMREX_RESTRICT px = m_part_px[i];
-            amrex::ParticleReal & AMREX_RESTRICT py = m_part_py[i];
-            amrex::ParticleReal & AMREX_RESTRICT pt = m_part_pt[i];
-            amrex::ParticleReal & AMREX_RESTRICT sx = m_part_sx[i];
-            amrex::ParticleReal & AMREX_RESTRICT sy = m_part_sy[i];
-            amrex::ParticleReal & AMREX_RESTRICT sz = m_part_sz[i];
-            uint64_t & AMREX_RESTRICT idcpu = m_part_idcpu[i];
-
-            // push spin & phase space through element
-            m_element.spin_and_phasespace_push(x, y, t, px, py, pt, sx, sy, sz, idcpu, m_ref_part);
-        }
-
-#ifdef AMREX_USE_SIMD
-        /** Push N SIMD particles through an element
-         *
-         * @param i particle index in the current box
-         */
-        template<int SIMD_WIDTH>
-        AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-        void
-        operator() (amrex::SIMDindex<SIMD_WIDTH, int> idx) const
+        operator() (IndexType i) const
         {
             using namespace amrex::simd;
 
-            int const i = idx.index;
-
-            // uninitialized memory
-            SIMDParticleReal<SIMD_WIDTH> part_x;
-            SIMDParticleReal<SIMD_WIDTH> part_y;
-            SIMDParticleReal<SIMD_WIDTH> part_t;
-            SIMDParticleReal<SIMD_WIDTH> part_px;
-            SIMDParticleReal<SIMD_WIDTH> part_py;
-            SIMDParticleReal<SIMD_WIDTH> part_pt;
-            SIMDParticleReal<SIMD_WIDTH> part_sx;
-            SIMDParticleReal<SIMD_WIDTH> part_sy;
-            SIMDParticleReal<SIMD_WIDTH> part_sz;
-            SIMDIdCpu<decltype(part_x)> part_idcpu;
-
-            // initialize vector registers
-            // TODO stdx::vector_aligned needs alignment guarantees
-            //      https://github.com/AMReX-Codes/amrex/issues/4592
-            //      https://en.cppreference.com/w/cpp/experimental/simd/simd/copy_from
-            part_x.copy_from(&m_part_x[i], stdx::element_aligned);
-            part_y.copy_from(&m_part_y[i], stdx::element_aligned);
-            part_t.copy_from(&m_part_t[i], stdx::element_aligned);
-            part_px.copy_from(&m_part_px[i], stdx::element_aligned);
-            part_py.copy_from(&m_part_py[i], stdx::element_aligned);
-            part_pt.copy_from(&m_part_pt[i], stdx::element_aligned);
-            part_sx.copy_from(&m_part_sx[i], stdx::element_aligned);
-            part_sy.copy_from(&m_part_sy[i], stdx::element_aligned);
-            part_sz.copy_from(&m_part_sz[i], stdx::element_aligned);
-            part_idcpu.copy_from(&m_part_idcpu[i], stdx::element_aligned);
+            // access SoA data
+            // note: an optimizing compiler will eliminate loads of unused parameters
+            decltype(auto) x = load_pdata(m_part_x, i);
+            decltype(auto) y = load_pdata(m_part_y, i);
+            decltype(auto) t = load_pdata(m_part_t, i);
+            decltype(auto) px = load_pdata(m_part_px, i);
+            decltype(auto) py = load_pdata(m_part_py, i);
+            decltype(auto) pt = load_pdata(m_part_pt, i);
+            decltype(auto) sx = load_pdata(m_part_sx, i);
+            decltype(auto) sy = load_pdata(m_part_sy, i);
+            decltype(auto) sz = load_pdata(m_part_sz, i);
+            decltype(auto) idcpu = load_pdata(m_part_idcpu, i);
 
             // push spin & phase space through element
-            m_element.spin_and_phasespace_push(part_x, part_y, part_t, part_px, part_py, part_pt, part_sx, part_sy, part_sz, part_idcpu, m_ref_part);
+            m_element.spin_and_phasespace_push(x, y, t, px, py, pt, sx, sy, sz, idcpu, m_ref_part);
 
-            // write back to memory
-            // TODO stdx::vector_aligned needs alignment guarantees
-            //      https://github.com/AMReX-Codes/amrex/issues/4592
-            //      https://en.cppreference.com/w/cpp/experimental/simd/simd/copy_from
-            constexpr auto push_nth_arg_non_const = [](int n) {
-                return is_nth_arg_non_const(&T_Element::template spin_and_phasespace_push<decltype(part_x), decltype(part_idcpu)>, n);
-            };
-            if constexpr (push_nth_arg_non_const(0))
-                part_x.copy_to(&m_part_x[i], stdx::element_aligned);
-            if constexpr (push_nth_arg_non_const(1))
-                part_y.copy_to(&m_part_y[i], stdx::element_aligned);
-            if constexpr (push_nth_arg_non_const(2))
-                part_t.copy_to(&m_part_t[i], stdx::element_aligned);
-            if constexpr (push_nth_arg_non_const(3))
-                part_px.copy_to(&m_part_px[i], stdx::element_aligned);
-            if constexpr (push_nth_arg_non_const(4))
-                part_py.copy_to(&m_part_py[i], stdx::element_aligned);
-            if constexpr (push_nth_arg_non_const(5))
-                part_pt.copy_to(&m_part_pt[i], stdx::element_aligned);
-            if constexpr (push_nth_arg_non_const(6))
-                part_sx.copy_to(&m_part_sx[i], stdx::element_aligned);
-            if constexpr (push_nth_arg_non_const(7))
-                part_sy.copy_to(&m_part_sy[i], stdx::element_aligned);
-            if constexpr (push_nth_arg_non_const(8))
-                part_sz.copy_to(&m_part_sz[i], stdx::element_aligned);
-            if constexpr (push_nth_arg_non_const(9))
-                part_idcpu.copy_to(&m_part_idcpu[i], stdx::element_aligned);
-        }
+            // SIMD: write back to memory
+#ifdef AMREX_USE_SIMD
+            if constexpr (amrex::simd::is_vectorized<T_Element>)
+            {
+                using RealType = std::decay_t<decltype(x)>;
+                using IdCpuType = std::decay_t<decltype(idcpu)>;
+                constexpr auto P_Method = &T_Element::template spin_and_phasespace_push<RealType, IdCpuType>;
+
+                store_pdata<P_Method, 0>(x, m_part_x, i);
+                store_pdata<P_Method, 1>(y, m_part_y, i);
+                store_pdata<P_Method, 2>(t, m_part_t, i);
+                store_pdata<P_Method, 3>(px, m_part_px, i);
+                store_pdata<P_Method, 4>(py, m_part_py, i);
+                store_pdata<P_Method, 5>(pt, m_part_pt, i);
+                store_pdata<P_Method, 6>(sx, m_part_sx, i);
+                store_pdata<P_Method, 7>(sy, m_part_sy, i);
+                store_pdata<P_Method, 8>(sz, m_part_sz, i);
+                store_pdata<P_Method, 9>(idcpu, m_part_idcpu, i);
+            }
 #endif
+        }
 
     private:
         T_Element m_element;
@@ -263,85 +327,44 @@ namespace detail
          *
          * @param i particle index in the current box
          */
+        template <typename IndexType>
         AMREX_GPU_DEVICE AMREX_FORCE_INLINE
         void
-        operator() (int i) const
-        {
-            // access SoA Real data
-            // note: an optimizing compiler will eliminate loads of unused parameters
-            amrex::ParticleReal & AMREX_RESTRICT x = m_part_x[i];
-            amrex::ParticleReal & AMREX_RESTRICT y = m_part_y[i];
-            amrex::ParticleReal & AMREX_RESTRICT t = m_part_t[i];
-            amrex::ParticleReal & AMREX_RESTRICT px = m_part_px[i];
-            amrex::ParticleReal & AMREX_RESTRICT py = m_part_py[i];
-            amrex::ParticleReal & AMREX_RESTRICT pt = m_part_pt[i];
-            uint64_t & AMREX_RESTRICT idcpu = m_part_idcpu[i];
-
-            // push through element
-            m_element(x, y, t, px, py, pt, idcpu, m_ref_part);
-        }
-
-#ifdef AMREX_USE_SIMD
-        /** Push N SIMD particles through an element
-         *
-         * @param i particle index in the current box
-         */
-        template<int SIMD_WIDTH>
-        AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-        void
-        operator() (amrex::SIMDindex<SIMD_WIDTH, int> idx) const
+        operator() (IndexType i) const
         {
             using namespace amrex::simd;
 
-            int const i = idx.index;
-
-            // uninitialized memory
-            SIMDParticleReal<SIMD_WIDTH> part_x;
-            SIMDParticleReal<SIMD_WIDTH> part_y;
-            SIMDParticleReal<SIMD_WIDTH> part_t;
-            SIMDParticleReal<SIMD_WIDTH> part_px;
-            SIMDParticleReal<SIMD_WIDTH> part_py;
-            SIMDParticleReal<SIMD_WIDTH> part_pt;
-            SIMDIdCpu<decltype(part_x)> part_idcpu;
-
-            // initialize vector registers
-            // TODO stdx::vector_aligned needs alignment guarantees
-            //      https://github.com/AMReX-Codes/amrex/issues/4592
-            //      https://en.cppreference.com/w/cpp/experimental/simd/simd/copy_from
-            part_x.copy_from(&m_part_x[i], stdx::element_aligned);
-            part_y.copy_from(&m_part_y[i], stdx::element_aligned);
-            part_t.copy_from(&m_part_t[i], stdx::element_aligned);
-            part_px.copy_from(&m_part_px[i], stdx::element_aligned);
-            part_py.copy_from(&m_part_py[i], stdx::element_aligned);
-            part_pt.copy_from(&m_part_pt[i], stdx::element_aligned);
-            part_idcpu.copy_from(&m_part_idcpu[i], stdx::element_aligned);
+            // access SoA data
+            // note: an optimizing compiler will eliminate loads of unused parameters
+            decltype(auto) x = load_pdata(m_part_x, i);
+            decltype(auto) y = load_pdata(m_part_y, i);
+            decltype(auto) t = load_pdata(m_part_t, i);
+            decltype(auto) px = load_pdata(m_part_px, i);
+            decltype(auto) py = load_pdata(m_part_py, i);
+            decltype(auto) pt = load_pdata(m_part_pt, i);
+            decltype(auto) idcpu = load_pdata(m_part_idcpu, i);
 
             // push through element
-            m_element(part_x, part_y, part_t, part_px, part_py, part_pt, part_idcpu, m_ref_part);
+            m_element(x, y, t, px, py, pt, idcpu, m_ref_part);
 
             // write back to memory
-            // TODO stdx::vector_aligned needs alignment guarantees
-            //      https://github.com/AMReX-Codes/amrex/issues/4592
-            //      https://en.cppreference.com/w/cpp/experimental/simd/simd/copy_from
-            constexpr auto push_nth_arg_non_const = [](int n) {
-                return is_nth_arg_non_const(&T_Element::template operator()<decltype(part_x), decltype(part_idcpu)>, n);
-            };
-            if constexpr (push_nth_arg_non_const(0))
-                part_x.copy_to(&m_part_x[i], stdx::element_aligned);
-            if constexpr (push_nth_arg_non_const(1))
-                part_y.copy_to(&m_part_y[i], stdx::element_aligned);
-            if constexpr (push_nth_arg_non_const(2))
-                part_t.copy_to(&m_part_t[i], stdx::element_aligned);
-            if constexpr (push_nth_arg_non_const(3))
-                part_px.copy_to(&m_part_px[i], stdx::element_aligned);
-            if constexpr (push_nth_arg_non_const(4))
-                part_py.copy_to(&m_part_py[i], stdx::element_aligned);
-            if constexpr (push_nth_arg_non_const(5))
-                part_pt.copy_to(&m_part_pt[i], stdx::element_aligned);
-            if constexpr (push_nth_arg_non_const(6))
-                part_idcpu.copy_to(&m_part_idcpu[i], stdx::element_aligned);
-        }
+#ifdef AMREX_USE_SIMD
+            if constexpr (amrex::simd::is_vectorized<T_Element>)
+            {
+                using RealType = std::decay_t<decltype(x)>;
+                using IdCpuType = std::decay_t<decltype(idcpu)>;
+                constexpr auto P_Method = &T_Element::template operator()<RealType, IdCpuType>;
+
+                store_pdata<P_Method, 0>(x, m_part_x, i);
+                store_pdata<P_Method, 1>(y, m_part_y, i);
+                store_pdata<P_Method, 2>(t, m_part_t, i);
+                store_pdata<P_Method, 3>(px, m_part_px, i);
+                store_pdata<P_Method, 4>(py, m_part_py, i);
+                store_pdata<P_Method, 5>(pt, m_part_pt, i);
+                store_pdata<P_Method, 6>(idcpu, m_part_idcpu, i);
+            }
 #endif
+        }
 
     private:
         T_Element m_element;
@@ -367,35 +390,30 @@ namespace detail
         const int np = pti.numParticles();
 
         // preparing access to particle data: SoA of Reals
-        auto& soa_real = pti.GetStructOfArrays().GetRealData();
+        auto& soa = pti.GetStructOfArrays();
+        auto& soa_real = soa.GetRealData();
         amrex::ParticleReal* const AMREX_RESTRICT part_x = soa_real[RealSoA::x].dataPtr();
         amrex::ParticleReal* const AMREX_RESTRICT part_y = soa_real[RealSoA::y].dataPtr();
         amrex::ParticleReal* const AMREX_RESTRICT part_t = soa_real[RealSoA::t].dataPtr();
         amrex::ParticleReal* const AMREX_RESTRICT part_px = soa_real[RealSoA::px].dataPtr();
         amrex::ParticleReal* const AMREX_RESTRICT part_py = soa_real[RealSoA::py].dataPtr();
         amrex::ParticleReal* const AMREX_RESTRICT part_pt = soa_real[RealSoA::pt].dataPtr();
-        amrex::ParticleReal* const AMREX_RESTRICT part_sx = soa_real[RealSoA::sx].dataPtr();
-        amrex::ParticleReal* const AMREX_RESTRICT part_sy = soa_real[RealSoA::sy].dataPtr();
-        amrex::ParticleReal* const AMREX_RESTRICT part_sz = soa_real[RealSoA::sz].dataPtr();
 
-        uint64_t* const AMREX_RESTRICT part_idcpu = pti.GetStructOfArrays().GetIdCPUData().dataPtr();
+        uint64_t* const AMREX_RESTRICT part_idcpu = soa.GetIdCPUData().dataPtr();
 
         if (spin) {
             if constexpr (std::is_base_of_v<mixin::SpinTransport, std::decay_t<T_Element>>) {
+                amrex::ParticleReal* const AMREX_RESTRICT part_sx = soa_real[RealSoA::sx].dataPtr();
+                amrex::ParticleReal* const AMREX_RESTRICT part_sy = soa_real[RealSoA::sy].dataPtr();
+                amrex::ParticleReal* const AMREX_RESTRICT part_sz = soa_real[RealSoA::sz].dataPtr();
+
                 detail::PushSingleParticleSpin<T_Element> const pushSingleParticle(
                     element, part_x, part_y, part_t, part_px, part_py, part_pt, part_sx, part_sy, part_sz, part_idcpu, ref_part);
 
                 // loop over beam particles in the box
-#ifdef AMREX_USE_SIMD
-                if constexpr (amrex::simd::is_vectorized<T_Element>) {
-                    amrex::ParallelForSIMD<T_Element::simd_width>(np, pushSingleParticle);  // TODO: test 2,4,8, ... and handle remainder
-                } else
-#endif
-                {
-                    amrex::ParallelFor(np, pushSingleParticle);
-                }
+                impactx::ParallelFor<T_Element>(np, pushSingleParticle);
             } else {
-                throw std::runtime_error("Spin transport requested but element ... does not implement the `SpinTransport` interface class!");
+                throw std::runtime_error("Spin transport requested but element does not implement the `SpinTransport` interface class!");
             }
         }
         else {
@@ -403,14 +421,7 @@ namespace detail
                 element, part_x, part_y, part_t, part_px, part_py, part_pt, part_idcpu, ref_part);
 
             // loop over beam particles in the box
-#ifdef AMREX_USE_SIMD
-            if constexpr (amrex::simd::is_vectorized<T_Element>) {
-                amrex::ParallelForSIMD<T_Element::simd_width>(np, pushSingleParticle);  // TODO: test 2,4,8, ... and handle remainder
-            } else
-#endif
-            {
-                amrex::ParallelFor(np, pushSingleParticle);
-            }
+            impactx::ParallelFor<T_Element>(np, pushSingleParticle);
         }
     }
 } // namespace detail


### PR DESCRIPTION
Generalize the SIMD logic for load/store with a bit of meta-programming and perfect forwarding, to avoid duplicate code paths to launch the single/simd particle methods of an element.

Exploring this generalization for reuse of the SIMD patterns in other BLAST codes. Generalized versions of `load_pdata` and `store_pdata` might move into `AMReX_SIMD.H` afterwards.

- [x] generalize in AMReX via https://github.com/AMReX-Codes/amrex/pull/4924

Follow-up to #1002

[test_performance.sh](https://github.com/user-attachments/files/25034084/test_performance.sh)
- [x] validate this is performance neutral on CPU with `-DImpactX_SIMD=ON`
- [x] validate this is performance neutral on CPU with `-DImpactX_SIMD=OFF`
- [x] validate this is performance neutral on GPU

[test_performance.sh](https://github.com/user-attachments/files/25037169/test_performance.sh)