### PR TITLE
Require R>0 for nonlinear DipEdge input

### DIFF
--- a/src/elements/DipEdge.H
+++ b/src/elements/DipEdge.H
@@ -131,7 +131,7 @@ namespace impactx::elements
             if (m_R == 0_prt) {
                 warning_message.append(
                  "In DipEdge user has set R = 0.  This must be a positive value.  Setting R=1. "
-                );  
+                );
                ablastr::warn_manager::WMRecordWarning(
                 "elements::DipEdge",
                    warning_message,

--- a/src/elements/DipEdge.H
+++ b/src/elements/DipEdge.H
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <stdexcept>
 
+
 namespace impactx::elements
 {
     namespace dipedge

--- a/src/elements/DipEdge.H
+++ b/src/elements/DipEdge.H
@@ -26,7 +26,7 @@
 
 #include <cmath>
 #include <stdexcept>
-
+#include <ablastr/warn_manager/WarnManager.H>
 
 namespace impactx::elements
 {
@@ -125,6 +125,20 @@ namespace impactx::elements
             using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
+
+            // verify that the length scale constant R > 0
+            std::string warning_message;
+            if (m_R == 0_prt) {
+                warning_message.append(
+                 "In DipEdge user set R = 0.  This must be a positiv value.  Setting R=1. "
+                );  
+               ablastr::warn_manager::WMRecordWarning(
+                "elements::DipEdge",
+                   warning_message,
+                   ablastr::warn_manager::WarnPriority::medium
+               );
+               m_R = 1_prt;
+            }
 
             // constants for linear map:
 

--- a/src/elements/DipEdge.H
+++ b/src/elements/DipEdge.H
@@ -26,7 +26,6 @@
 
 #include <cmath>
 #include <stdexcept>
-#include <ablastr/warn_manager/WarnManager.H>
 
 namespace impactx::elements
 {
@@ -125,20 +124,6 @@ namespace impactx::elements
             using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
-
-            // verify that the length scale constant R > 0
-            std::string warning_message;
-            if (m_R == 0_prt) {
-                warning_message.append(
-                 "In DipEdge user has set R = 0.  This must be a positive value.  Setting R=1. "
-                );
-               ablastr::warn_manager::WMRecordWarning(
-                "elements::DipEdge",
-                   warning_message,
-                   ablastr::warn_manager::WarnPriority::medium
-               );
-               m_R = 1_prt;
-            }
 
             // constants for linear map:
 

--- a/src/elements/DipEdge.H
+++ b/src/elements/DipEdge.H
@@ -130,7 +130,7 @@ namespace impactx::elements
             std::string warning_message;
             if (m_R == 0_prt) {
                 warning_message.append(
-                 "In DipEdge user set R = 0.  This must be a positiv value.  Setting R=1. "
+                 "In DipEdge user has set R = 0.  This must be a positive value.  Setting R=1. "
                 );  
                ablastr::warn_manager::WMRecordWarning(
                 "elements::DipEdge",

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -215,13 +215,8 @@ namespace detail
             pp_element.queryAdd("location", location_str);
             dipedge::Location const location = amrex::getEnum<dipedge::Location>(location_str);
 
-            if (R < 0) {
-                ablastr::warn_manager::WMRecordWarning(
-                    "ImpactX::read_element",
-                    element_name + " User passed R < 0 to DipEdge.  Please set R > 0. ",
-                    ablastr::warn_manager::WarnPriority::high
-                    );
-                    R = 1;
+            if (R <= 0) {
+                throw std::runtime_error(element_name + ".R must be >0 but is: " + std::to_string(R));
             }
 
             m_lattice.emplace_back( DipEdge(psi, rc, g, R, K0, K1, K2, K3, K4, K5, K6, model, location, a["dx"], a["dy"], a["rotation_degree"], element_name) );

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -215,6 +215,15 @@ namespace detail
             pp_element.queryAdd("location", location_str);
             dipedge::Location const location = amrex::getEnum<dipedge::Location>(location_str);
 
+            if (R < 0) {
+                ablastr::warn_manager::WMRecordWarning(
+                    "ImpactX::read_element",
+                    element_name + " User passed R < 0 to DipEdge.  Please set R > 0. ",
+                    ablastr::warn_manager::WarnPriority::high
+                    );
+                    R = 1;
+            }
+
             m_lattice.emplace_back( DipEdge(psi, rc, g, R, K0, K1, K2, K3, K4, K5, K6, model, location, a["dx"], a["dy"], a["rotation_degree"], element_name) );
         } else if (element_type == "quadedge")
         {

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -864,7 +864,7 @@ void init_elements(py::module& m)
             {
                  if (R < 0.0)
                      throw std::runtime_error(R"(DipEdge parameter R must be > 0.)");
-                     R = 1
+                     R = 1;
 
                 dipedge::Model const fm = amrex::getEnum<dipedge::Model>(model);
                 dipedge::Location const fl = amrex::getEnum<dipedge::Location>(location);

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -862,7 +862,7 @@ void init_elements(py::module& m)
             std::optional<std::string> name
             )
             {
-                 if (R < 0.0)
+                 if (R <= 0.0)
                      throw std::runtime_error(R"(DipEdge parameter R must be > 0.)");
 
                 dipedge::Model const fm = amrex::getEnum<dipedge::Model>(model);

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -864,7 +864,6 @@ void init_elements(py::module& m)
             {
                  if (R < 0.0)
                      throw std::runtime_error(R"(DipEdge parameter R must be > 0.)");
-                     R = 1;
 
                 dipedge::Model const fm = amrex::getEnum<dipedge::Model>(model);
                 dipedge::Location const fl = amrex::getEnum<dipedge::Location>(location);

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -864,7 +864,7 @@ void init_elements(py::module& m)
             {
                  if (R < 0.0)
                      throw std::runtime_error(R"(DipEdge parameter R must be > 0.)");
-                     R = 1                
+                     R = 1
 
                 dipedge::Model const fm = amrex::getEnum<dipedge::Model>(model);
                 dipedge::Location const fl = amrex::getEnum<dipedge::Location>(location);

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -905,7 +905,11 @@ void init_elements(py::module& m)
         )
         .def_property("R",
             [](DipEdge & dip_edge) { return dip_edge.m_R; },
-            [](DipEdge & dip_edge, amrex::ParticleReal R) { dip_edge.m_R = R; },
+            [](DipEdge & dip_edge, amrex::ParticleReal R) {
+                if (R <= 0.0)
+                     throw std::runtime_error(R"(DipEdge parameter R must be > 0.)");
+                dip_edge.m_R = R;
+            },
             "Length scale for field integrals in m"
         )
         .def_property("K0",

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -862,6 +862,10 @@ void init_elements(py::module& m)
             std::optional<std::string> name
             )
             {
+                 if (R < 0.0)
+                     throw std::runtime_error(R"(DipEdge parameter R must be > 0.)");
+                     R = 1                
+
                 dipedge::Model const fm = amrex::getEnum<dipedge::Model>(model);
                 dipedge::Location const fl = amrex::getEnum<dipedge::Location>(location);
                 return new DipEdge(psi, rc, g, R, K0, K1, K2, K3, K4, K5, K6, fm, fl, dx, dy, rotation_degree, name);


### PR DESCRIPTION
The DipEdge element requires a strict R>0 when the nonlinear model is chosen.