### PR TITLE
Quad Spin Test: One w/o MPI

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1869,7 +1869,7 @@ add_impactx_test(distgen-spinvmf.py
 # without space charge
 add_impactx_test(quad-spin
     examples/spin_tracking/input_quad_spin.in
-    ON   # ImpactX MPI-parallel
+    OFF  # ImpactX MPI-parallel
     examples/spin_tracking/analysis_quad_spin.py
     OFF  # no plot script yet
 )


### PR DESCRIPTION
Allow to run one test sequentially, so MPI is not required for coverage in CI.

Re: https://github.com/BLAST-ImpactX/impactx/pull/1281#issuecomment-3814950255