### PR TITLE
CI: macOS w/ MPI w/ SIMD

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,6 +35,13 @@ jobs:
         brew install open-mpi
         brew install pkg-config
         set -e
+    - name: install vir-simd
+      run: |
+        wget https://github.com/mattkretz/vir-simd/archive/refs/tags/v0.4.4.tar.gz
+        tar -xvf v0.4.4.tar.gz
+        rm -rf v0.4.4.tar.gz
+        cmake -S vir-simd-0.4.4 -B vir-simd-build
+        sudo cmake --build vir-simd-build --target install
     - name: install pip dependencies
       run: |
         python3 -m pip install --upgrade pip
@@ -69,6 +76,7 @@ jobs:
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DImpactX_FFT=ON             \
           -DImpactX_PYTHON=ON          \
+          -DImpactX_SIMD=ON            \
           -DImpactX_TEST_CLEANUP=ON
         cmake --build build -j 3
 


### PR DESCRIPTION
Adjust the MPI macOS test to incldue SIMD.
Before this, we only had a no-MPI SIMD test in our test matrix.

Re: https://github.com/BLAST-ImpactX/impactx/pull/1281#issuecomment-3814950255