### PR TITLE
Fix: DipEdge K0 Default (Docs)

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -356,7 +356,7 @@ This requires these additional parameters:
 * ``<element_name>.rc`` (``float``, in meters) the bend radius
 * ``<element_name>.g`` (``float``, in meters) the full magnetic gap size
 * ``<element_name>.R`` (``float``, in meters) scale length for the field integrals (default: ``1 m``)
-* ``<element_name>.K0`` (``float``, dimensionless) normalized field integral for fringe field (default: ``pi/6``)
+* ``<element_name>.K0`` (``float``, dimensionless) normalized field integral for fringe field (default: ``pi**2/6``)
 * ``<element_name>.K1`` (``float``, dimensionless) normalized field integral for fringe field (default: ``0``)
 * ``<element_name>.K2`` (``float``, dimensionless) normalized field integral for fringe field (FINT, default: ``1``)
 * ``<element_name>.K3`` (``float``, dimensionless) normalized field integral for fringe field (default: ``1/6``)

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -856,7 +856,7 @@ This module provides elements and methods for the accelerator lattice.
 
       focusing t strength in 1/m
 
-.. py:class:: impactx.elements.DipEdge(psi, rc, g, R=1, K0=pi/6, K1=0, K2=1, K3=1/6, K4=0, K5=0, K6=0, model="linear", location="entry", dx=0, dy=0, rotation=0, name=None)
+.. py:class:: impactx.elements.DipEdge(psi, rc, g, R=1, K0=pi**2/6, K1=0, K2=1, K3=1/6, K4=0, K5=0, K6=0, model="linear", location="entry", dx=0, dy=0, rotation=0, name=None)
 
    Edge focusing associated with bend entry or exit
 


### PR DESCRIPTION
The default of the `DipEdge.K0` parameter is pi**2/6 in the `InitElement.cpp` logic and the paper. This fixes the user-facing docs.