### PR TITLE
Doc: Perlmutter Python Batch Script

### DIFF
--- a/docs/source/install/hpc/lumi-csc/lumi_cpu.sbatch
+++ b/docs/source/install/hpc/lumi-csc/lumi_cpu.sbatch
@@ -17,6 +17,15 @@ INPUTS=run_fodo.py
 #EXE=./impactx
 #INPUTS=input_fodo.in
 
+# enviroment setup
+if [[ -z "${MY_PROFILE}" ]]; then
+    echo "WARNING: FORGOT TO"
+    echo "   source $HOME/lumi_cpu_impactx.profile"
+    echo "before submission. Doing that now."
+
+    source $HOME/lumi_cpu_impactx.profile
+fi
+
 date
 
 # note (12-12-22)

--- a/docs/source/install/hpc/lumi-csc/lumi_cpu.sbatch
+++ b/docs/source/install/hpc/lumi-csc/lumi_cpu.sbatch
@@ -10,12 +10,12 @@
 #SBATCH --ntasks-per-node=16
 #SBATCH --cpus-per-task=8
 
-# executable & inputs file or ...
-EXE=./impactx
-INPUTS=inputs
-# ... python interpreter & PICMI script here
-#EXE=python3
-#INPUTS=run_fodo.py
+# python interpreter & script here
+EXE=python3
+INPUTS=run_fodo.py
+# or executable & inputs file
+#EXE=./impactx
+#INPUTS=input_fodo.in
 
 date
 

--- a/docs/source/install/hpc/lumi-csc/lumi_cpu_impactx.profile.example
+++ b/docs/source/install/hpc/lumi-csc/lumi_cpu_impactx.profile.example
@@ -1,6 +1,10 @@
 # please set your project account
 #export proj="project_..."
 
+# remembers the location of this script
+export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your $MY_PROFILE file! Please edit its line 2 to continue!"; return; fi
+
 # required dependencies
 module load LUMI/24.03  partition/C
 module load PrgEnv-aocc

--- a/docs/source/install/hpc/lumi-csc/lumi_gpu.sbatch
+++ b/docs/source/install/hpc/lumi-csc/lumi_gpu.sbatch
@@ -17,6 +17,15 @@ INPUTS=run_fodo.py
 #EXE=./impactx
 #INPUTS=input_fodo.in
 
+# enviroment setup
+if [[ -z "${MY_PROFILE}" ]]; then
+    echo "WARNING: FORGOT TO"
+    echo "   source $HOME/lumi_gpu_impactx.profile"
+    echo "before submission. Doing that now."
+
+    source $HOME/lumi_gpu_impactx.profile
+fi
+
 date
 
 # note (12-12-22)

--- a/docs/source/install/hpc/lumi-csc/lumi_gpu.sbatch
+++ b/docs/source/install/hpc/lumi-csc/lumi_gpu.sbatch
@@ -10,12 +10,12 @@
 #SBATCH --ntasks-per-node=8
 #SBATCH --gpus-per-node=8
 
-# executable & inputs file or ...
-EXE=./impactx
-INPUTS=inputs
-# ... python interpreter & PICMI script here
-#EXE=python3
-#INPUTS=run_fodo.py
+# python interpreter & script here
+EXE=python3
+INPUTS=run_fodo.py
+# or executable & inputs file
+#EXE=./impactx
+#INPUTS=input_fodo.in
 
 date
 

--- a/docs/source/install/hpc/lumi-csc/lumi_gpu.sbatch
+++ b/docs/source/install/hpc/lumi-csc/lumi_gpu.sbatch
@@ -81,7 +81,9 @@ CPU_BIND="${CPU_BIND},7e00000000,7e0000000000"
 
 export OMP_NUM_THREADS=6
 
+# GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1
+export AMREX_DEFAULT_INIT="amrex.use_gpu_aware_mpi=1"
 
 srun --cpu-bind=${CPU_BIND} ./select_gpu  \
   ${EXE} ${INPUTS}                        \

--- a/docs/source/install/hpc/lumi-csc/lumi_gpu_impactx.profile.example
+++ b/docs/source/install/hpc/lumi-csc/lumi_gpu_impactx.profile.example
@@ -1,6 +1,10 @@
 # please set your project account
 #export proj="project_..."
 
+# remembers the location of this script
+export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your $MY_PROFILE file! Please edit its line 2 to continue!"; return; fi
+
 # required dependencies
 module load LUMI/24.03  partition/G
 module load rocm/6.0.3

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_cpu.sbatch
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_cpu.sbatch
@@ -25,6 +25,15 @@ INPUTS=run_fodo.py
 #EXE=./impactx
 #INPUTS=input_fodo.in
 
+# enviroment setup
+if [[ -z "${MY_PROFILE}" ]]; then
+    echo "WARNING: FORGOT TO"
+    echo "   source $HOME/perlmutter_cpu_impactx.profile"
+    echo "before submission. Doing that now."
+
+    source $HOME/perlmutter_cpu_impactx.profile
+fi
+
 # each CPU node on Perlmutter (NERSC) has 64 hardware cores with
 # 2x Hyperthreading/SMP
 # https://en.wikichip.org/wiki/amd/epyc/7763

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_cpu.sbatch
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_cpu.sbatch
@@ -18,9 +18,12 @@
 #SBATCH -o ImpactX.o%j
 #SBATCH -e ImpactX.e%j
 
-# executable & inputs file or python interpreter & PICMI script here
-EXE=./impactx
-INPUTS=inputs_small
+# python interpreter & script here
+EXE=python3
+INPUTS=run_fodo.py
+# or executable & inputs file
+#EXE=./impactx
+#INPUTS=input_fodo.in
 
 # each CPU node on Perlmutter (NERSC) has 64 hardware cores with
 # 2x Hyperthreading/SMP

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu.sbatch
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu.sbatch
@@ -48,11 +48,11 @@ export MPICH_OFI_NIC_POLICY=GPU
 export SRUN_CPUS_PER_TASK=16
 
 # GPU-aware MPI optimizations
-GPU_AWARE_MPI="amrex.use_gpu_aware_mpi=1"
+export AMREX_DEFAULT_INIT="amrex.use_gpu_aware_mpi=1"
 
 # CUDA visible devices are ordered inverse to local task IDs
 #   Reference: nvidia-smi topo -m
 srun --cpu-bind=cores bash -c "
     export CUDA_VISIBLE_DEVICES=\$((3-SLURM_LOCALID));
-    ${EXE} ${INPUTS} ${GPU_AWARE_MPI}" \
+    ${EXE} ${INPUTS}" \
   > output.txt

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu.sbatch
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu.sbatch
@@ -31,6 +31,15 @@ INPUTS=run_fodo.py
 #EXE=./impactx
 #INPUTS=input_fodo.in
 
+# enviroment setup
+if [[ -z "${MY_PROFILE}" ]]; then
+    echo "WARNING: FORGOT TO"
+    echo "   source $HOME/perlmutter_gpu_impactx.profile"
+    echo "before submission. Doing that now."
+
+    source $HOME/perlmutter_gpu_impactx.profile
+fi
+
 # pin to closest NIC to GPU
 export MPICH_OFI_NIC_POLICY=GPU
 

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu.sbatch
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu.sbatch
@@ -24,9 +24,12 @@
 #SBATCH -o ImpactX.o%j
 #SBATCH -e ImpactX.e%j
 
-# executable & inputs file or python interpreter & PICMI script here
-EXE=./impactx
-INPUTS=inputs
+# python interpreter & script here
+EXE=python3
+INPUTS=run_fodo.py
+# or executable & inputs file
+#EXE=./impactx
+#INPUTS=input_fodo.in
 
 # pin to closest NIC to GPU
 export MPICH_OFI_NIC_POLICY=GPU


### PR DESCRIPTION
Make HPC batch templates portable to Python & executable usage alike.
Put Python first as in the rest of the docs.
Add fallback if a user forgot to source their profile.

- [x] wait for solution in https://github.com/AMReX-Codes/amrex/issues/4947