### PR TITLE
Warning: openPMD-api 0.17 Steps

### DIFF
--- a/src/elements/diagnostics/BeamMonitor.cpp
+++ b/src/elements/diagnostics/BeamMonitor.cpp
@@ -185,7 +185,6 @@ namespace detail {
 #   if openPMD_HAVE_MPI==1
                 , amrex::ParallelDescriptor::Communicator()
 #   endif
-                , "adios2.engine.usesteps = true"
             );
             series.setSoftware("ImpactX", IMPACTX_VERSION);
             series.setIterationEncoding( series_encoding );


### PR DESCRIPTION
Follow-up to #1252 Fix warning:
```
219: [ADIOS2 backend] WARNING: Parameter `adios2.engine.usesteps` is deprecated since use of steps is now always enabled.
```

cc @guj @franzpoeschel