### PR TITLE
Move spin calculations to compute_constants

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1925,20 +1925,18 @@ add_impactx_test(fodo-spin.py
     examples/spin_tracking/analysis_fodo_channel_spin.py
     examples/spin_tracking/plot_fodo_polarization.py
 )
-    
+
 # Element Reversibility with Spin ###################
 # without space charge
 add_impactx_test(reversibility-spin
     examples/spin_tracking/input_reversibility_spin.in
     ON   # ImpactX MPI-parallel
     examples/spin_tracking/analysis_reversibility_spin.py
-    OFF  # no plot script yet 
+    OFF  # no plot script yet
 )
 add_impactx_test(reversibility-spin.py
     examples/spin_tracking/run_reversibility_spin.py
     ON    # ImpactX MPI-parallel
     examples/spin_tracking/analysis_reversibility_spin.py
-    OFF  # no plot script yet  
-)   
-
-
+    OFF  # no plot script yet
+)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1925,3 +1925,20 @@ add_impactx_test(fodo-spin.py
     examples/spin_tracking/analysis_fodo_channel_spin.py
     examples/spin_tracking/plot_fodo_polarization.py
 )
+    
+# Element Reversibility with Spin ###################
+# without space charge
+add_impactx_test(reversibility-spin
+    examples/spin_tracking/input_reversibility_spin.in
+    ON   # ImpactX MPI-parallel
+    examples/spin_tracking/analysis_reversibility_spin.py
+    OFF  # no plot script yet 
+)
+add_impactx_test(reversibility-spin.py
+    examples/spin_tracking/run_reversibility_spin.py
+    ON    # ImpactX MPI-parallel
+    examples/spin_tracking/analysis_reversibility_spin.py
+    OFF  # no plot script yet  
+)   
+
+

--- a/examples/spin_tracking/README.rst
+++ b/examples/spin_tracking/README.rst
@@ -150,3 +150,58 @@ The analysis can be run using:
    .. literalinclude:: analysis_sbend_spin.py
       :language: python3
       :caption: You can copy this file from ``examples/spin_tracking/analysis_sbend_spin.py``.
+
+
+
+.. _examples-reversibility-spin:
+
+Element Reversibility with Spin
+====================================
+
+In the case of linear elements, including spin, the joint spin-orbit map has the following exact reversibility property.
+
+The effect of setting ds -> -ds is equivalent to replacing the map by its inverse.
+
+In this test, a beam is propagated forward through an element of length ds, following by the corresponding element with length -ds.  As a result, the composite map is the identity.  This provides a non-trivial test for consistency between the spin map and the orbit map.
+
+In this test, the initial and final spin components :math:`s_x`, :math:`s_y`, and :math:`s_z` are compared.  The norm of the change in the spin vector must lie within a very small tolerance.
+
+
+Run
+---
+
+This example can be run **either** as:
+
+* **Python** script: ``python3 run_reversibility_spin.py`` or
+* ImpactX **executable** using an input file: ``impactx input_reversibility_spin.in``
+
+For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+
+.. tab-set::
+
+   .. tab-item:: Python: Script
+
+       .. literalinclude:: run_reversibility_spin.py
+          :language: python3
+          :caption: You can copy this file from ``examples/spin_tracking/run_reversibility_spin.py``.
+
+   .. tab-item:: Executable: Input File
+
+       .. literalinclude:: input_reversibility_spin.in
+          :language: ini
+          :caption: You can copy this file from ``examples/spin_tracking/input_reversibility_spin.in``.
+
+
+
+Analyze
+-------
+
+The analysis can be run using:
+
+
+.. dropdown:: Script ``analysis_reversibility_spin.py``
+
+   .. literalinclude:: analysis_reversibility_spin.py
+      :language: python3
+      :caption: You can copy this file from ``examples/spin_tracking/analysis_reversibility_spin.py``.
+

--- a/examples/spin_tracking/README.rst
+++ b/examples/spin_tracking/README.rst
@@ -204,4 +204,3 @@ The analysis can be run using:
    .. literalinclude:: analysis_reversibility_spin.py
       :language: python3
       :caption: You can copy this file from ``examples/spin_tracking/analysis_reversibility_spin.py``.
-

--- a/examples/spin_tracking/analysis_fodo_channel_spin.py
+++ b/examples/spin_tracking/analysis_fodo_channel_spin.py
@@ -71,9 +71,9 @@ print(f"  atol={atol}")
 assert np.allclose(
     [polarization_x, polarization_y, polarization_z],
     [
-        0.02,
-        0.05,
-        0.01,
+        0.035,
+        0.085,
+        0.077,
     ],
     atol=atol,
 )

--- a/examples/spin_tracking/analysis_fodo_channel_spin.py
+++ b/examples/spin_tracking/analysis_fodo_channel_spin.py
@@ -72,7 +72,7 @@ assert np.allclose(
     [polarization_x, polarization_y, polarization_z],
     [
         0.02,
-        0.02,
+        0.05,
         0.01,
     ],
     atol=atol,

--- a/examples/spin_tracking/analysis_reversibility_spin.py
+++ b/examples/spin_tracking/analysis_reversibility_spin.py
@@ -5,7 +5,6 @@
 # License: BSD-3-Clause-LBNL
 #
 
-import math
 
 import numpy as np
 import openpmd_api as io
@@ -25,7 +24,7 @@ sxf = final["spin_x"]
 syf = final["spin_y"]
 szf = final["spin_z"]
 
-dspin2 = (sxf - sxi)**2 + (syf - syi)**2 + (szf - szi)**2
+dspin2 = (sxf - sxi) ** 2 + (syf - syi) ** 2 + (szf - szi) ** 2
 dspin = np.sqrt(dspin2)
 dspinmax = dspin.max()
 

--- a/examples/spin_tracking/analysis_reversibility_spin.py
+++ b/examples/spin_tracking/analysis_reversibility_spin.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+import math
+
+import numpy as np
+import openpmd_api as io
+
+# initial/final beam
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+last_step = list(series.iterations)[-1]
+initial = series.iterations[1].particles["beam"].to_df()
+beam_final = series.iterations[last_step].particles["beam"]
+final = beam_final.to_df()
+
+sxi = initial["spin_x"]
+syi = initial["spin_y"]
+szi = initial["spin_z"]
+
+sxf = final["spin_x"]
+syf = final["spin_y"]
+szf = final["spin_z"]
+
+dspin2 = (sxf - sxi)**2 + (syf - syi)**2 + (szf - szi)**2
+dspin = np.sqrt(dspin2)
+dspinmax = dspin.max()
+
+print("Change in the spin:")
+print("||delta s||_max", dspinmax)
+
+atol = 1.5e-9
+print(f"  atol={atol}")
+
+assert np.allclose(
+    [dspinmax],
+    [
+        0.0,
+    ],
+    atol=atol,
+)

--- a/examples/spin_tracking/input_reversibility_spin.in
+++ b/examples/spin_tracking/input_reversibility_spin.in
@@ -1,0 +1,67 @@
+###############################################################################
+# Particle Beam(s)
+###############################################################################
+beam.npart = 100000
+beam.units = static
+beam.kin_energy = 2.0e3  #2 GeV
+beam.charge = 1.0e-9
+beam.particle = electron
+beam.distribution = waterbag
+beam.lambdaX = 5.0e-6            # 5 um
+beam.lambdaY = 8.0e-6            # 8 um
+beam.lambdaT = 0.0599584916      # 200 ps
+beam.lambdaPx = 2.5543422003e-9  # exn = 50 pm-rad
+beam.lambdaPy = 1.5964638752e-9  # eyn = 50 pm-rad
+beam.lambdaPt = 9.0e-4           # approximately dE/E
+beam.muxpx = 0.0
+beam.muypy = 0.0
+beam.mutpt = 0.0
+beam.polarization_x = 0.4
+beam.polarization_y = 0.9
+beam.polarization_z = 0.1
+
+###############################################################################
+# Beamline: lattice elements and segments
+###############################################################################
+lattice.elements = monitor quad1 iquad1 sol1 isol1 quad2 iquad2 monitor
+
+lattice.nslice = 1
+
+iquad1.type = quad  #inverse quad
+iquad1.ds = -1.5
+iquad1.k = 60.0
+
+quad1.type = quad
+quad1.ds = 1.5
+quad1.k = 60.0
+
+isol1.type = solenoid  #inverse solenoid
+isol1.ds = -1.5
+isol1.ks = 1.0
+
+sol1.type = solenoid
+sol1.ds = 1.5
+sol1.ks = 1.0
+
+iquad2.type = quad_chromatic  #inverse quad
+iquad2.ds = -1.5
+iquad2.k = -60.0
+
+quad2.type = quad_chromatic
+quad2.ds = 1.5  
+quad2.k = -60.0
+
+monitor.type = beam_monitor
+monitor.backend = h5
+
+
+###############################################################################
+# Algorithms
+###############################################################################
+algo.space_charge = false
+algo.spin = true
+
+###############################################################################
+# Diagnostics
+###############################################################################
+diag.slice_step_diagnostics = false

--- a/examples/spin_tracking/input_reversibility_spin.in
+++ b/examples/spin_tracking/input_reversibility_spin.in
@@ -48,7 +48,7 @@ iquad2.ds = -1.5
 iquad2.k = -60.0
 
 quad2.type = quad_chromatic
-quad2.ds = 1.5  
+quad2.ds = 1.5
 quad2.k = -60.0
 
 monitor.type = beam_monitor

--- a/examples/spin_tracking/run_reversibility_spin.py
+++ b/examples/spin_tracking/run_reversibility_spin.py
@@ -6,7 +6,6 @@
 #
 # -*- coding: utf-8 -*-
 
-import numpy as np
 
 from impactx import ImpactX, distribution, elements
 

--- a/examples/spin_tracking/run_reversibility_spin.py
+++ b/examples/spin_tracking/run_reversibility_spin.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+from impactx import ImpactX, distribution, elements
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.space_charge = False
+sim.spin = True
+sim.slice_step_diagnostics = True
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# basic beam parameters
+kin_energy_MeV = 2.0e3  # reference energy (kinetic)
+mass_MeV = 0.510998950  # particle mass
+bunch_charge_C = 1.0e-9  # used with space charge
+gyromagnetic_anomaly = 0.00115965218062  # value for an electron
+npart = 100000  # number of macro particles
+
+# set reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(-1.0).set_mass_MeV(mass_MeV).set_kin_energy_MeV(
+    kin_energy_MeV
+).set_gyromagnetic_anomaly(gyromagnetic_anomaly)
+
+#   particle bunch
+distr = distribution.Gaussian(
+    lambdaX=5.0e-6,
+    lambdaY=8.0e-6,
+    lambdaT=0.0599584916,
+    lambdaPx=2.5543422003e-9,
+    lambdaPy=1.5964638752e-9,
+    lambdaPt=9.0e-4,
+    muxpx=0.0,
+    muypy=0.0,
+    mutpt=0.0,
+)
+spin = distribution.SpinvMF(
+    0.4,
+    0.9,
+    0.1,
+)
+
+sim.add_particles(bunch_charge_C, distr, npart, spin)
+
+# design the accelerator lattice
+ns = 1  # number of slices per ds in the element
+
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+
+# parameters
+L = 1.5
+kquad = 60.0
+ksol = 1.0
+
+quad1 = elements.Quad(name="quad1", ds=L, k=kquad, nslice=ns)
+iquad1 = elements.Quad(name="iquad1", ds=-L, k=kquad, nslice=ns)
+quad2 = elements.ChrQuad(name="quad2", ds=L, k=-kquad, nslice=ns)
+iquad2 = elements.ChrQuad(name="iquad2", ds=-L, k=-kquad, nslice=ns)
+sol1 = elements.Sol(name="sol1", ds=L, ks=ksol, nslice=ns)
+isol1 = elements.Sol(name="isol1", ds=-L, ks=ksol, nslice=ns)
+
+# set the lattice
+sim.lattice.append(monitor)
+sim.lattice.append(quad1)
+sim.lattice.append(iquad1)
+sim.lattice.append(sol1)
+sim.lattice.append(isol1)
+sim.lattice.append(quad2)
+sim.lattice.append(iquad2)
+sim.lattice.append(monitor)
+
+# run simulation
+sim.track_particles()
+
+# clean shutdown
+sim.finalize()

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -116,10 +116,6 @@ namespace impactx::elements
             m_g = m_unit == 1 ? m_k / refpart.rigidity_Tm() : m_k;
 
             m_const1 = 1_prt / (2_prt * powi<3>(m_beta) * powi<2>(m_gamma));
-
-            // used for spin push
-            m_gryo = refpart.gyromagnetic_anomaly;
-
         }
 
         /** This is a chrquad functor, so that a variable of this type can be used like a chrquad function.
@@ -340,7 +336,7 @@ namespace impactx::elements
 
             // compute particle relativistic gamma
             T_Real const gamma = m_gamma * (1_prt - m_beta*pt);
-            T_Real const gyro_const = 1_prt + m_gryo * gamma;
+            T_Real const gyro_const = 1_prt + refpart.gyromagnetic_anomaly * gamma;
 
             // compute phase advance per unit length in s (in rad/m)
             // chromatic dependence on delta is included
@@ -406,7 +402,6 @@ lambday = -gyro_const * ( px*inv_delta1*(1_prt - cos_omega_ds) + x*omega*sin_ome
         amrex::ParticleReal m_gamma;
         amrex::ParticleReal m_g;
         amrex::ParticleReal m_const1;
-        amrex::ParticleReal m_gryo;     //! gryomagnetic anomaly (for spin push)
     };
 
 } // namespace impactx

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -338,7 +338,7 @@ namespace impactx::elements
             T_Real const delta1 = sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
 
             // compute particle relativistic gamma
-            T_Real const gamma = m_gamma * (1_prt - m_beta*m_gamma*pt);
+            T_Real const gamma = m_gamma * (1_prt - m_beta*pt);
             T_Real const gyro_const = 1_prt + m_gryo * gamma;
 
             // compute phase advance per unit length in s (in rad/m)

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -336,6 +336,7 @@ namespace impactx::elements
 
             // compute particle momentum deviation delta + 1
             T_Real const delta1 = sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
+            T_Real const inv_delta1 = 1_prt / delta1;
 
             // compute particle relativistic gamma
             T_Real const gamma = m_gamma * (1_prt - m_beta*pt);
@@ -343,7 +344,7 @@ namespace impactx::elements
 
             // compute phase advance per unit length in s (in rad/m)
             // chromatic dependence on delta is included
-            T_Real const omega = sqrt(abs(m_g)/delta1);
+            T_Real const omega = sqrt(abs(m_g)*inv_delta1);
 
             // compute trigonometric quantities
             auto const [sin_omega_ds, cos_omega_ds] = amrex::Math::sincos(omega*m_slice_ds);
@@ -355,14 +356,15 @@ namespace impactx::elements
 
                 // horizontally focusing quad case
                 lambdax = -gyro_const * ( py/delta1*(cosh_omega_ds - 1_prt) + y*omega*sinh_omega_ds );
-                lambday = -gyro_const * ( px/delta1*(1_prt - cos_omega_ds) + x*omega*sin_omega_ds );
+lambdax = -gyro_const * ( py*inv_delta1*(cosh_omega_ds - 1_prt) + y*omega*sinh_omega_ds );
+lambday = -gyro_const * ( px*inv_delta1*(1_prt - cos_omega_ds) + x*omega*sin_omega_ds );
 
             } else if (m_g < 0.0_prt)
             {
 
                 // horizontally defocusing quad case
-                lambdax = gyro_const * ( py/delta1*(1_prt - cos_omega_ds) + y*omega*sin_omega_ds );
-                lambday = gyro_const * ( px/delta1*(cosh_omega_ds - 1_prt) + x*omega*sinh_omega_ds );
+                lambdax = gyro_const * ( py*inv_delta1*(1_prt - cos_omega_ds) + y*omega*sin_omega_ds );
+                lambday = gyro_const * ( px*inv_delta1*(cosh_omega_ds - 1_prt) + x*omega*sinh_omega_ds );
 
             } else {
                 // treat as a drift

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -116,6 +116,10 @@ namespace impactx::elements
             m_g = m_unit == 1 ? m_k / refpart.rigidity_Tm() : m_k;
 
             m_const1 = 1_prt / (2_prt * powi<3>(m_beta) * powi<2>(m_gamma));
+
+            // used for spin push
+            m_gryo = refpart.gyromagnetic_anomaly;
+
         }
 
         /** This is a chrquad functor, so that a variable of this type can be used like a chrquad function.
@@ -330,29 +334,21 @@ namespace impactx::elements
             T_Real lambday = 0_prt;
             T_Real lambdaz = 0_prt;
 
-            // access reference particle values
-            amrex::ParticleReal G = refpart.gyromagnetic_anomaly;
-            amrex::ParticleReal beta_ref = refpart.beta();
-            amrex::ParticleReal gamma_ref = refpart.gamma();
-
-            // length of the current slice
-            amrex::ParticleReal const slice_ds = m_ds / nslice();
-
             // compute particle momentum deviation delta + 1
-            T_Real const delta1 = sqrt(1_prt - 2_prt*pt/beta_ref + powi<2>(pt));
+            T_Real const delta1 = sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
 
             // compute particle relativistic gamma
-            T_Real const gamma = gamma_ref * (1_prt - beta_ref*gamma_ref*pt);
-            T_Real const gyro_const = 1_prt + G * gamma;
+            T_Real const gamma = m_gamma * (1_prt - m_beta*m_gamma*pt);
+            T_Real const gyro_const = 1_prt + m_gryo * gamma;
 
             // compute phase advance per unit length in s (in rad/m)
             // chromatic dependence on delta is included
             T_Real const omega = sqrt(abs(m_g)/delta1);
 
             // compute trigonometric quantities
-            auto const [sin_omega_ds, cos_omega_ds] = amrex::Math::sincos(omega*slice_ds);
-            T_Real const sinh_omega_ds = sinh(omega*slice_ds);
-            T_Real const cosh_omega_ds = cosh(omega*slice_ds);
+            auto const [sin_omega_ds, cos_omega_ds] = amrex::Math::sincos(omega*m_slice_ds);
+            T_Real const sinh_omega_ds = sinh(omega*m_slice_ds);
+            T_Real const cosh_omega_ds = cosh(omega*m_slice_ds);
 
             if (m_g > 0.0_prt)
             {
@@ -365,8 +361,8 @@ namespace impactx::elements
             {
 
                 // horizontally defocusing quad case
-                lambdax = -gyro_const * ( px/delta1*(1_prt - cos_omega_ds) + x*omega*sin_omega_ds );
-                lambday = -gyro_const * ( py/delta1*(cosh_omega_ds - 1_prt) + y*omega*sinh_omega_ds );
+                lambdax = gyro_const * ( py/delta1*(1_prt - cos_omega_ds) + y*omega*sin_omega_ds );
+                lambday = gyro_const * ( px/delta1*(cosh_omega_ds - 1_prt) + x*omega*sinh_omega_ds );
 
             } else {
                 // treat as a drift
@@ -408,6 +404,7 @@ namespace impactx::elements
         amrex::ParticleReal m_gamma;
         amrex::ParticleReal m_g;
         amrex::ParticleReal m_const1;
+        amrex::ParticleReal m_gryo;     //! gryomagnetic anomaly (for spin push)
     };
 
 } // namespace impactx

--- a/src/elements/Quad.H
+++ b/src/elements/Quad.H
@@ -113,6 +113,10 @@ namespace impactx::elements
             m_cos_omega_ds = std::cos(m_omega*m_slice_ds);
             m_sinh_omega_ds = std::sinh(m_omega*m_slice_ds);
             m_cosh_omega_ds = std::cosh(m_omega*m_slice_ds);
+
+            // gyromagnetic constant (used during spin push)
+            amrex::ParticleReal G = refpart.gyromagnetic_anomaly;
+            m_gyro_const = 1_prt + G * refpart.gamma();
         }
 
         /** This is a quad functor, so that a variable of this type can be used like a quad function.
@@ -328,34 +332,19 @@ namespace impactx::elements
             T_Real lambday = 0_prt;
             T_Real lambdaz = 0_prt;
 
-            // access reference particle values
-            amrex::ParticleReal G = refpart.gyromagnetic_anomaly;
-            amrex::ParticleReal const gyro_const = 1_prt + G * refpart.gamma();
-
-            // length of the current slice
-            amrex::ParticleReal const slice_ds = m_ds / nslice();
-
-            // compute phase advance per unit length in s (in rad/m)
-            amrex::ParticleReal const omega = std::sqrt(std::abs(m_k));
-
-            // compute trigonometric quantities
-            auto const [sin_omega_ds, cos_omega_ds] = amrex::Math::sincos(omega*slice_ds);
-            amrex::ParticleReal const sinh_omega_ds = std::sinh(omega*slice_ds);
-            amrex::ParticleReal const cosh_omega_ds = std::cosh(omega*slice_ds);
-
             if (m_k > 0.0_prt)
             {
 
                 // horizontally focusing quad case
-                lambdax = -gyro_const * ( py*(cosh_omega_ds - 1_prt) + y*omega*sinh_omega_ds );
-                lambday = -gyro_const * ( px*(1_prt - cos_omega_ds) + x*omega*sin_omega_ds );
+                lambdax = -m_gyro_const * ( py*(m_cosh_omega_ds - 1_prt) + y*m_omega*m_sinh_omega_ds );
+                lambday = -m_gyro_const * ( px*(1_prt - m_cos_omega_ds) + x*m_omega*m_sin_omega_ds );
 
             } else if (m_k < 0.0_prt)
             {
 
                 // horizontally defocusing quad case
-                lambdax = -gyro_const * ( px*(1_prt - cos_omega_ds) + x*omega*sin_omega_ds );
-                lambday = -gyro_const * ( py*(cosh_omega_ds - 1_prt) + y*omega*sinh_omega_ds );
+                lambdax = m_gyro_const * ( py*(1_prt - m_cos_omega_ds) + y*m_omega*m_sin_omega_ds );
+                lambday = m_gyro_const * ( px*(m_cosh_omega_ds - 1_prt) + x*m_omega*m_sinh_omega_ds );
 
             } else {
                 // treat as a drift
@@ -385,6 +374,8 @@ namespace impactx::elements
         amrex::ParticleReal m_cos_omega_ds;   //! std::cos(omega*slice_ds)
         amrex::ParticleReal m_sinh_omega_ds;  //! std::sinh(omega*slice_ds)
         amrex::ParticleReal m_cosh_omega_ds;  //! std::cosh(omega*slice_ds)
+        amrex::ParticleReal m_gyro_const;     //! (1 + G*gamma) for spin calculation
+
     };
 
 } // namespace impactx

--- a/src/elements/Sbend.H
+++ b/src/elements/Sbend.H
@@ -118,12 +118,12 @@ namespace impactx::elements
             auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
 
             // nonvanishing linear matrix elements (if h = 0, this is equivalent to a drift)
-            m_R11 = (h == 0_prt) ? 1.0_prt : cos_theta;
+            m_R11 = (h == 0_prt) ? 1_prt : cos_theta;
             m_R12 = (h == 0_prt) ? slice_ds : m_rc * sin_theta;
-            m_R16 = (h == 0_prt) ? 0.0_prt : -m_rc * ibet * (1.0_prt - cos_theta);
-            m_R21 = (h == 0_prt) ? 0.0_prt :-sin_theta * h;
+            m_R16 = (h == 0_prt) ? 0_prt : -m_rc * ibet * (1_prt - cos_theta);
+            m_R21 = (h == 0_prt) ? 0_prt :-sin_theta * h;
             // m_R22 = m_R11
-            m_R26 = (h == 0_prt) ? 0.0_prt : -sin_theta * ibet;
+            m_R26 = (h == 0_prt) ? 0_prt : -sin_theta * ibet;
             m_R34 = (h == 0_prt) ? slice_ds : m_rc * theta;
             // m_R51 = -m_R26
             // m_R52 = -m_R16
@@ -143,11 +143,11 @@ namespace impactx::elements
             m_lambday = -spin_ref_angle;
 
             // elements of the spin-orbit coupling matrix
-            m_A14 = (gamma - 1.0_prt)/gamma * (1.0_prt - cos_Gtheta);
+            m_A14 = (gamma - 1_prt)/gamma * (1_prt - cos_Gtheta);
             m_A21 = -gyro_const * h * sin_theta;
-            m_A22 = -gyro_const * (1.0_prt - cos_theta);
+            m_A22 = -gyro_const * (1_prt - cos_theta);
             m_A26 = -gyro_const * ibet * sin_theta + G * beta * gamma * theta;
-            m_A34 = (gamma - 1.0_prt)/gamma * sin_Gtheta;
+            m_A34 = (gamma - 1_prt)/gamma * sin_Gtheta;
 
         }
 

--- a/src/elements/Sbend.H
+++ b/src/elements/Sbend.H
@@ -112,33 +112,43 @@ namespace impactx::elements
             amrex::ParticleReal const ibet = 1.0_prt / refpart.beta();
             amrex::ParticleReal const ibetagam2 = 1_prt / powi<2>(refpart.beta_gamma());
 
-            // treat the special case of zero field (equivalent to a drift)
-            if (m_rc==0_prt) {
-               m_R11 = 1.0_prt;
-               m_R12 = slice_ds;
-               m_R16 = 0.0_prt;
-               m_R21 = 0.0_prt;
-               m_R26 = 0.0_prt;
-               m_R34 = slice_ds;
-               m_R56 = slice_ds * ibetagam2;
+            // compute intermediate constants (curvature, bend angle, trigonometry)
+            amrex::ParticleReal const h = (m_rc == 0_prt) ? 0_prt : 1_prt/m_rc;
+            amrex::ParticleReal const theta = h * slice_ds;
+            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
 
-            } else {
+            // nonvanishing linear matrix elements (if h = 0, this is equivalent to a drift)
+            m_R11 = (h == 0_prt) ? 1.0_prt : cos_theta;
+            m_R12 = (h == 0_prt) ? slice_ds : m_rc * sin_theta;
+            m_R16 = (h == 0_prt) ? 0.0_prt : -m_rc * ibet * (1.0_prt - cos_theta);
+            m_R21 = (h == 0_prt) ? 0.0_prt :-sin_theta * h;
+            // m_R22 = m_R11
+            m_R26 = (h == 0_prt) ? 0.0_prt : -sin_theta * ibet;
+            m_R34 = (h == 0_prt) ? slice_ds : m_rc * theta;
+            // m_R51 = -m_R26
+            // m_R52 = -m_R16
+            m_R56 = (h == 0_prt) ? slice_ds * ibetagam2 : m_rc * (-theta + sin_theta * ibet * ibet);
 
-               // calculate expensive terms once
-               amrex::ParticleReal const theta = slice_ds / m_rc;
-               auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
+            // access reference particle values for spin calculation
+            amrex::ParticleReal G = refpart.gyromagnetic_anomaly;
+            amrex::ParticleReal const gamma = refpart.gamma();
+            amrex::ParticleReal const beta = refpart.beta();
+            amrex::ParticleReal const gyro_const = 1_prt + G * gamma;
 
-               m_R11 = cos_theta;
-               m_R12 = m_rc * sin_theta;
-               m_R16 = -m_rc * ibet * (1.0_prt - cos_theta);
-               m_R21 = -sin_theta / m_rc;
-               // m_R22 = m_R11
-               m_R26 = -sin_theta * ibet;
-               m_R34 = m_rc * theta;
-               // m_R51 = -m_R26
-               // m_R52 = -m_R16
-               m_R56 = m_rc * (-theta + sin_theta * ibet * ibet);
-           }
+            // trigonometry for spin calculation
+            amrex::ParticleReal const spin_ref_angle = G * gamma * theta;
+            auto const [sin_Gtheta, cos_Gtheta] = amrex::Math::sincos(spin_ref_angle);
+
+            // nonvanishing components of spin rotation at the design point
+            m_lambday = -spin_ref_angle;
+
+            // elements of the spin-orbit coupling matrix
+            m_A14 = (gamma - 1.0_prt)/gamma * (1.0_prt - cos_Gtheta);
+            m_A21 = -gyro_const * h * sin_theta;
+            m_A22 = -gyro_const * (1.0_prt - cos_theta);
+            m_A26 = -gyro_const * ibet * sin_theta + G * beta * gamma * theta;
+            m_A34 = (gamma - 1.0_prt)/gamma * sin_Gtheta;
+
         }
 
         /** This is a sbend functor, so that a variable of this type can be used like a sbend function.
@@ -367,39 +377,23 @@ namespace impactx::elements
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-            using amrex::Math::powi;
-
-            // length of the current slice
-            amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // initialize the three components of the axis-angle vector
             T_Real lambdax = 0_prt;
             T_Real lambday = 0_prt;
             T_Real lambdaz = 0_prt;
 
-            // access reference particle values
-            amrex::ParticleReal const beta = refpart.beta();
-            amrex::ParticleReal const gamma = refpart.gamma();
-            amrex::ParticleReal G = refpart.gyromagnetic_anomaly;
-            amrex::ParticleReal const gyro_const = 1_prt + G * gamma;
-
-            // compute trigonometric quantities
-            amrex::ParticleReal const h = 1.0_prt/m_rc;
-            amrex::ParticleReal const theta = slice_ds * h;
-            auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
-            auto const [sin_Gtheta, cos_Gtheta] = amrex::Math::sincos(G*gamma*theta);
-
-            // axis-angle vector components generating the remainder spin map
-            lambdax = py * (gamma - 1.0_prt)/gamma * (1.0_prt - cos_Gtheta);
-            lambday = -gyro_const * (px*(1.0_prt - cos_theta) + (pt/beta + h*x)*sin_theta) + pt*G*beta*gamma*theta;
-            lambdaz = py * (gamma - 1.0_prt)/gamma * sin_Gtheta;
+            // set the angle-axis generator based on the phase space variables
+            lambdax = m_A14 * py;
+            lambday = m_A21 * x + m_A22 * px + m_A26 * pt;
+            lambdaz = m_A34 * py;
 
             // push the spin vector using the generator just determined
             rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);
 
             // axis-angle vector components generating the reference spin map
             lambdax = 0.0_prt;
-            lambday = -theta*G*gamma;
+            lambday = m_lambday;
             lambdaz = 0.0_prt;
 
             // push the spin vector using the generator just determined
@@ -415,6 +409,7 @@ namespace impactx::elements
         // constants that are independent of the individually tracked particle,
         // see: compute_constants() to refresh
         amrex::ParticleReal m_R11, m_R12, m_R16, m_R21, m_R26, m_R34, m_R56;
+        amrex::ParticleReal m_lambday, m_A14, m_A21, m_A22, m_A26, m_A34;
     };
 
 } // namespace impactx

--- a/src/elements/Sol.H
+++ b/src/elements/Sol.H
@@ -117,7 +117,7 @@ namespace impactx::elements
 
             // access reference particle values required for spin push
             amrex::ParticleReal G = refpart.gyromagnetic_anomaly;
-            amrex::ParticleReal const beta = refpart.beta();   
+            amrex::ParticleReal const beta = refpart.beta();
             amrex::ParticleReal const gamma = refpart.gamma();
             m_rel_const = 0.5_prt * (gamma - 1_prt);
             auto const [sin_G, cos_G] = amrex::Math::sincos(2_prt * G * theta);

--- a/src/elements/Sol.H
+++ b/src/elements/Sol.H
@@ -286,8 +286,8 @@ namespace impactx::elements
             T_Real lambdaz = 0_prt;
 
             // axis-angle vector components generating the remainder spin map
-            lambdax = m_rel_const * ((2*px + m_ks*y)*m_sin_G - (2*py - m_ks*x)*(1-m_cos_G));
-            lambday = m_rel_const * ((2*py - m_ks*x)*m_sin_G + (2*px + m_ks*y)*(1-m_cos_G));
+            lambdax = m_rel_const * ((2_prt*px + m_ks*y)*m_sin_G - (2_prt*py - m_ks*x)*(1_prt-m_cos_G));
+            lambday = m_rel_const * ((2_prt*py - m_ks*x)*m_sin_G + (2_prt*px + m_ks*y)*(1_prt-m_cos_G));
             lambdaz = -2_prt * m_theta_1pG * pt * m_ibeta;
 
             // push the spin vector using the generator just determined

--- a/src/elements/Sol.H
+++ b/src/elements/Sol.H
@@ -121,8 +121,8 @@ namespace impactx::elements
             m_rel_const = 0.5_prt * (gamma - 1_prt);
             auto const [sin_G, cos_G] = amrex::Math::sincos(2_prt * G * theta);
             m_sin_G = sin_G;
-            m_cos_G = cos_G;
-            m_theta_1pG = theta * (1_prt + G);
+            m_1cos_G = 1_prt - cos_G;
+            m_neg2_theta_1pG = -2_prt * theta * (1_prt + G);
 
         }
 
@@ -286,9 +286,9 @@ namespace impactx::elements
             T_Real lambdaz = 0_prt;
 
             // axis-angle vector components generating the remainder spin map
-            lambdax = m_rel_const * ((2_prt*px + m_ks*y)*m_sin_G - (2_prt*py - m_ks*x)*(1_prt-m_cos_G));
-            lambday = m_rel_const * ((2_prt*py - m_ks*x)*m_sin_G + (2_prt*px + m_ks*y)*(1_prt-m_cos_G));
-            lambdaz = -2_prt * m_theta_1pG * pt * m_ibeta;
+            lambdax = m_rel_const * ((2_prt*px + m_ks*y)*m_sin_G - (2_prt*py - m_ks*x)*m_1cos_G);
+            lambday = m_rel_const * ((2_prt*py - m_ks*x)*m_sin_G + (2_prt*px + m_ks*y)*m_1cos_G);
+            lambdaz = m_neg2_theta_1pG * pt * m_ibeta;
 
             // push the spin vector using the generator just determined
             rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);
@@ -296,7 +296,7 @@ namespace impactx::elements
             // axis-angle vector components generating the reference spin map
             lambdax = 0.0_prt;
             lambday = 0.0_prt;
-            lambdaz = -2_prt * m_theta_1pG;
+            lambdaz = m_neg2_theta_1pG;
 
             // push the spin vector using the generator just determined
             rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);
@@ -373,7 +373,7 @@ namespace impactx::elements
         // constants that are independent of the individually tracked particle,
         // see: compute_constants() to refresh
         amrex::ParticleReal m_ds_bg2, m_cos_theta, m_sin_theta, m_sin_theta_ialpha, m_neg_alpha_sin_theta;
-        amrex::ParticleReal m_rel_const, m_sin_G, m_cos_G, m_theta_1pG, m_ibeta;
+        amrex::ParticleReal m_rel_const, m_sin_G, m_1cos_G, m_neg2_theta_1pG, m_ibeta;
     };
 
 } // namespace impactx

--- a/src/elements/Sol.H
+++ b/src/elements/Sol.H
@@ -101,6 +101,7 @@ namespace impactx::elements
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const betgam2 = powi<2>(refpart.pt) - 1.0_prt;
+            m_ibeta = 1.0_prt / refpart.beta();
 
             // compute phase advance per unit length (in rad/m) and
             // rotation angle (in rad)
@@ -113,6 +114,17 @@ namespace impactx::elements
             m_sin_theta_ialpha = sin_theta / alpha;
             m_neg_alpha_sin_theta = -alpha * sin_theta;
             m_ds_bg2 = slice_ds / betgam2;
+
+            // access reference particle values required for spin push
+            amrex::ParticleReal G = refpart.gyromagnetic_anomaly;
+            amrex::ParticleReal const beta = refpart.beta();   
+            amrex::ParticleReal const gamma = refpart.gamma();
+            m_rel_const = 0.5_prt * (gamma - 1_prt);
+            auto const [sin_G, cos_G] = amrex::Math::sincos(2_prt * G * theta);
+            m_sin_G = sin_G;
+            m_cos_G = cos_G;
+            m_theta_1pG = theta * (1_prt + G);
+
         }
 
         /** This is a sol functor, so that a variable of this type can be used like a sol function.
@@ -274,27 +286,10 @@ namespace impactx::elements
             T_Real lambday = 0_prt;
             T_Real lambdaz = 0_prt;
 
-            // access reference particle values
-            amrex::ParticleReal G = refpart.gyromagnetic_anomaly;
-            amrex::ParticleReal const beta = refpart.beta();
-            amrex::ParticleReal const gamma = refpart.gamma();
-            amrex::ParticleReal const rel_const = 0.5_prt * (gamma - 1_prt);
-
-            // length of the current slice
-            amrex::ParticleReal const slice_ds = m_ds / nslice();
-
-            // compute phase advance per unit length (in rad/m) and
-            // rotation angle (in rad)
-            amrex::ParticleReal const alpha = m_ks * 0.5_prt;
-            amrex::ParticleReal const theta = alpha*slice_ds;
-
-            // compute trigonometric quantities
-            auto const [sin_G, cos_G] = amrex::Math::sincos(2_prt * G * theta);
-
             // axis-angle vector components generating the remainder spin map
-            lambdax = rel_const * ((2*px + m_ks*y)*sin_G - (2*py - m_ks*x)*(1-cos_G));
-            lambday = rel_const * ((2*py - m_ks*x)*sin_G + (2*px + m_ks*y)*(1-cos_G));
-            lambdaz = -2_prt * theta * (1_prt + G) * pt / beta;
+            lambdax = m_rel_const * ((2*px + m_ks*y)*m_sin_G - (2*py - m_ks*x)*(1-m_cos_G));
+            lambday = m_rel_const * ((2*py - m_ks*x)*m_sin_G + (2*px + m_ks*y)*(1-m_cos_G));
+            lambdaz = -2_prt * m_theta_1pG * pt * m_ibeta;
 
             // push the spin vector using the generator just determined
             rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);
@@ -302,7 +297,7 @@ namespace impactx::elements
             // axis-angle vector components generating the reference spin map
             lambdax = 0.0_prt;
             lambday = 0.0_prt;
-            lambdaz = -2_prt * theta * (1_prt + G);
+            lambdaz = -2_prt * m_theta_1pG;
 
             // push the spin vector using the generator just determined
             rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);
@@ -379,6 +374,7 @@ namespace impactx::elements
         // constants that are independent of the individually tracked particle,
         // see: compute_constants() to refresh
         amrex::ParticleReal m_ds_bg2, m_cos_theta, m_sin_theta, m_sin_theta_ialpha, m_neg_alpha_sin_theta;
+        amrex::ParticleReal m_rel_const, m_sin_G, m_cos_G, m_theta_1pG, m_ibeta;
     };
 
 } // namespace impactx

--- a/src/elements/Sol.H
+++ b/src/elements/Sol.H
@@ -117,7 +117,6 @@ namespace impactx::elements
 
             // access reference particle values required for spin push
             amrex::ParticleReal G = refpart.gyromagnetic_anomaly;
-            amrex::ParticleReal const beta = refpart.beta();
             amrex::ParticleReal const gamma = refpart.gamma();
             m_rel_const = 0.5_prt * (gamma - 1_prt);
             auto const [sin_G, cos_G] = amrex::Math::sincos(2_prt * G * theta);


### PR DESCRIPTION
This PR moves many computations for the spin push outside the particle loop into `compute_constants`, to improve performance.

- [x] Quad (note that a typo was fixed in the k < 0 case)
- [x] ChrQuad
- [x] Sbend
- [x] Sol
- [x] Add benchmark test

Close #1288