### PR TITLE
[WIP] Element Finalize Logic on Destructor

### DIFF
--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -51,10 +51,6 @@ namespace impactx
          */
         void finalize ();
 
-        /** Finalize elements
-         */
-        void finalize_elements ();
-
         /** Initialize AMReX blocks/grids for domain decomposition & space charge mesh.
          *
          * This must come first, before particle beams and lattice elements are

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -41,11 +41,9 @@ namespace impactx {
 
     void ImpactX::finalize ()
     {
-        // loop over all beamline elements & finalize them
-        finalize_elements();
-
         if (m_grids_initialized)
         {
+            // loop over all beamline elements & finalize them
             m_lattice.clear();
 
             // this one last
@@ -56,17 +54,6 @@ namespace impactx {
 
             // only finalize once
             m_grids_initialized = false;
-        }
-    }
-
-    void ImpactX::finalize_elements ()
-    {
-        // loop over all beamline elements & finalize them
-        for (auto & element_variant : m_lattice)
-        {
-            std::visit([](auto&& element){
-                element.finalize();
-            }, element_variant);
         }
     }
 

--- a/src/elements/ExactCFbend.H
+++ b/src/elements/ExactCFbend.H
@@ -599,7 +599,6 @@ namespace impactx::elements
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();
 
-
         /** Close and deallocate all data and handles.
          */
         void

--- a/src/elements/Programmable.H
+++ b/src/elements/Programmable.H
@@ -120,6 +120,8 @@ namespace impactx::elements
         void
         finalize ();
 
+        ~Programmable () { finalize(); }
+
         amrex::ParticleReal m_ds = 0.0; //! segment length in m
         int m_nslice = 1; //! number of slices used for the application of space charge
 

--- a/src/elements/diagnostics/BeamMonitor.H
+++ b/src/elements/diagnostics/BeamMonitor.H
@@ -175,6 +175,8 @@ namespace detail
         void
         finalize ();
 
+        ~BeamMonitor() { finalize(); }
+
     private:
         /** Open the openPMD series (on first access) */
         void open ();

--- a/src/elements/mixin/beamoptic.H
+++ b/src/elements/mixin/beamoptic.H
@@ -434,6 +434,20 @@ namespace detail
     template<typename T_Element>
     struct BeamOptic
     {
+        /** Close and deallocate all data and handles.
+         *
+         * Some elements manager dynamic device memory for input data.
+         * This ensures their finalize() method is called when they
+         * get destroyed, so device memory is deallocated properly.
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        ~BeamOptic () {
+            AMREX_IF_ON_HOST((
+                T_Element& element = *static_cast<T_Element*>(this);
+                element.finalize();
+            ))
+        }
+
         /** Push first the reference particle, then all other particles
          *
          * @param[inout] pc container of the particles to push

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -76,7 +76,9 @@ namespace
             },
             py::arg("pc"), py::arg("step")=0, py::arg("period")=0,
             "Push first the reference particle, then all other particles."
-        );
+        )
+        .def("finalize", &Element::finalize)
+        ;
     }
 
     /** Registers the mixin LinearTransport::operator method
@@ -396,7 +398,6 @@ void init_elements(py::module& m)
             },
             "Scale factor (in meters^(1/2)) of the IOTA nonlinear magnetic insert element used for computing H and I."
         )
-        .def("finalize", &diagnostics::BeamMonitor::finalize)
     ;
     register_push(py_BeamMonitor);
 


### PR DESCRIPTION
We nove have a few interactive workflows, e.g.,
in `test_benchmark_elements.py`, where we push elements that hold dynamic device data without ever placing them in `sim.lattice`. This revamps the element `finalize` logic to be called automatically on element destruction. The latter is implied in `sim.lattice.clear()` .