### PR TITLE
CI: Codspeed

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -44,10 +44,9 @@ jobs:
         path: |
           ~/.ccache
           ~/.cache/ccache
-        key: ccache-cuda-nvcc-${{ hashFiles('.github/workflows/cuda.yml') }}-${{ hashFiles('cmake/dependencies/ABLASTR.cmake') }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-cuda-nvcc-${{ hashFiles('.github/workflows/cuda.yml') }}-
-          ccache-cuda-nvcc-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
 
     - name: build ImpactX
       run: |

--- a/.github/workflows/dependencies/gcc.sh
+++ b/.github/workflows/dependencies/gcc.sh
@@ -36,6 +36,7 @@ python3 -m pip install -U -r requirements.txt
 python3 -m pip install -U -r src/python/impactx/dashboard/requirements.txt
 python3 -m pip install -U -r examples/requirements.txt
 python3 -m pip install -U -r tests/python/requirements.txt
+python3 -m pip install -U pytest-codspeed
 
 # extra tests
 python3 -m pip install -U -r examples/requirements_torch_cpu.txt

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -29,10 +29,9 @@ jobs:
         path: |
           ~/.ccache
           ~/.cache/ccache
-        key: ccache-hip-clang-${{ hashFiles('.github/workflows/hip.yml') }}-${{ hashFiles('cmake/dependencies/ABLASTR.cmake') }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-hip-clang-${{ hashFiles('.github/workflows/hip.yml') }}-
-          ccache-hip-clang-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
 
     - name: build ImpactX
       shell: bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,10 +58,9 @@ jobs:
       # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
         path: /Users/runner/Library/Caches/ccache
-        key: ccache-macos-appleclang-${{ hashFiles('.github/workflows/macos.yml') }}-${{ hashFiles('cmake/dependencies/ABLASTR.cmake') }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-macos-appleclang-${{ hashFiles('.github/workflows/macos.yml') }}-
-          ccache-macos-appleclang-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build ImpactX
       run: |
         export CCACHE_COMPRESS=1

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -26,10 +26,9 @@ jobs:
         path: |
           ~/.ccache
           ~/.cache/ccache
-        key: ccache-openmp-clangsan-${{ hashFiles('.github/workflows/tooling.yml') }}-${{ hashFiles('cmake/dependencies/ABLASTR.cmake') }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-openmp-clangsan-${{ hashFiles('.github/workflows/tooling.yml') }}-
-          ccache-openmp-clangsan-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
 
     - name: build ImpactX
       env:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -6,6 +6,10 @@ concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-ubuntu
   cancel-in-progress: true
 
+permissions:
+  contents: read   # required for actions/checkout
+  id-token: write  # required for OIDC authentication with CodSpeed
+
 jobs:
   build_gcc:
     name: GCC w/ MPI w/ Python
@@ -103,7 +107,7 @@ jobs:
 
   build_gcc_python:
     name: GCC w/ SIMD w/o MPI w/ Python
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     env:
       CMAKE_GENERATOR: Ninja
@@ -122,6 +126,11 @@ jobs:
         swap-storage: false
 
     - uses: actions/checkout@v6
+
+    - name: Setup Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
 
     - name: install dependencies
       run: |
@@ -194,3 +203,9 @@ jobs:
           -DImpactX_SIMD=ON            \
           -DImpactX_TEST_CLEANUP=ON
         cmake --build build_sp -j 4
+
+    - name: Python CodSpeedHQ Benchmarks
+      uses: CodSpeedHQ/action@v4
+      with:
+        mode: simulation
+        run: pytest tests/ --codspeed

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -45,10 +45,9 @@ jobs:
         path: |
           ~/.ccache
           ~/.cache/ccache
-        key: ccache-openmp-gcc-${{ hashFiles('.github/workflows/ubuntu.yml') }}-${{ hashFiles('cmake/dependencies/ABLASTR.cmake') }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-openmp-gcc-${{ hashFiles('.github/workflows/ubuntu.yml') }}-
-          ccache-openmp-gcc-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
 
     - name: system info
       run: |
@@ -71,7 +70,7 @@ jobs:
 
     - name: run tests
       run: |
-        ctest --test-dir build --output-on-failure --label-exclude slow
+        ctest --test-dir build --output-on-failure --label-exclude slow -E pytest.AMReX
 
     - name: Upload dashboard screenshots
       if: always()
@@ -144,10 +143,9 @@ jobs:
         path: |
           ~/.ccache
           ~/.cache/ccache
-        key: ccache-openmp-pygcc-${{ hashFiles('.github/workflows/ubuntu.yml') }}-${{ hashFiles('cmake/dependencies/ABLASTR.cmake') }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-openmp-pygcc-${{ hashFiles('.github/workflows/ubuntu.yml') }}-
-          ccache-openmp-pygcc-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
 
     - name: build ImpactX
       run: |
@@ -165,7 +163,7 @@ jobs:
 
     - name: run tests
       run: |
-        ctest --test-dir build --output-on-failure --label-exclude slow
+        ctest --test-dir build --output-on-failure --label-exclude slow -E pytest.AMReX
 
     - name: run installed app
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,10 +25,9 @@ jobs:
         path: |
           ~/.ccache
           ~/.cache/ccache
-        key: ccache-windows-winmsvc-${{ hashFiles('.github/workflows/windows.yml') }}-${{ hashFiles('cmake/dependencies/ABLASTR.cmake') }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-          ccache-windows-winmsvc-${{ hashFiles('.github/workflows/windows.yml') }}-
-          ccache-windows-winmsvc-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Download Dependencies
       run: |
         Invoke-WebRequest http://fftw.org/fftw-3.3.10.tar.gz -OutFile fftw-3.3.10.tar.gz

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![DOI (paper)](https://img.shields.io/badge/DOI%20(paper)-10.18429%2FJACoW--NAPAC2022--TUYE2-blue.svg)](https://doi.org/10.18429/JACoW-NAPAC2022-TUYE2)  
 [![Language: C++17](https://img.shields.io/badge/language-C%2B%2B17-orange.svg)](https://isocpp.org/)
 [![Language: Python](https://img.shields.io/badge/language-Python-orange.svg)](https://python.org/)
+[![ImpactX CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/BLAST-ImpactX/impactx?utm_source=badge)
 
 ImpactX: an s-based beam dynamics code including space charge effects.
 This is the next generation of the [IMPACT-Z](https://github.com/impact-lbl/IMPACT-Z) code.


### PR DESCRIPTION
Add a [dedicated service](https://codspeed.io) to run code performance tests. Leverage existing pytest benchmarks (`pytest-codspeed` is a [compatible drop-in](https://codspeed.io/docs/reference/pytest-codspeed#with-the-benchmark-fixture) for `pytest-benchmark`).

https://codspeed.io/BLAST-ImpactX/impactx