### PR TITLE
FODO Channel Python w/o Slice Diags

### DIFF
--- a/examples/fodo_channel/run_fodo.py
+++ b/examples/fodo_channel/run_fodo.py
@@ -13,7 +13,7 @@ sim = ImpactX()
 # set numerical parameters and IO control
 sim.space_charge = False
 # sim.diagnostics = False  # benchmarking
-sim.slice_step_diagnostics = True
+sim.slice_step_diagnostics = False
 
 # domain decomposition & space charge mesh
 sim.init_grids()


### PR DESCRIPTION
The inputs file version does not use slice diagnostics, so the Python test should set the same. Speed up by ~2.5x.