### PR TITLE
Fix Dashboard Test Race Conditions

### DIFF
--- a/src/python/impactx/dashboard/Toolbar/file_imports/ui_populator.py
+++ b/src/python/impactx/dashboard/Toolbar/file_imports/ui_populator.py
@@ -31,13 +31,29 @@ def on_import_file_change(import_file, **kwargs):
 def _apply_distribution_inputs():
     """
     Push any cached distribution parameters into the UI.
+
+    Updates all parameters in a single batch to avoid repeated
+    state.dirty() calls that can disrupt trame state synchronisation.
     """
+    from ...Input.utils import GeneralFunctions
+    from ...Input.validation import DashboardValidation, errors_tracker
 
     imported_params = getattr(state, "imported_distribution_parameters", None)
     if imported_params:
+        updated = False
         for param_name, raw_value in imported_params.items():
-            if param_name in state.selected_distribution_parameters:
-                ctrl.update_distribution_parameter(param_name, raw_value)
+            parameter = state.selected_distribution_parameters.get(param_name)
+            if parameter:
+                numeric_input = GeneralFunctions.convert_to_numeric(raw_value)
+                error_message = DashboardValidation.validate(
+                    param_name, numeric_input, category="distribution"
+                )
+                parameter["value"] = numeric_input
+                parameter["error_message"] = error_message
+                updated = True
+        if updated:
+            errors_tracker.update_simulation_validation_status()
+            state.dirty("selected_distribution_parameters")
         state.imported_distribution_parameters = None
 
 

--- a/tests/python/dashboard/test_lattice_variable_handler.py
+++ b/tests/python/dashboard/test_lattice_variable_handler.py
@@ -127,10 +127,13 @@ def test_lattice_variable_handler(dashboard):
     assert_lattice_param_sim_input(dashboard, 0, "ds", 0.500194828041958)
     assert_lattice_param_sim_input(dashboard, 0, "rc", -10.346228368619553)
 
-    variables = dashboard.get_state("variables")
-    assert all(var["name"] != "ns" for var in variables), (
-        "Variable 'ns' was not deleted"
-    )
+    for i in range(TIMEOUT):
+        variables = dashboard.get_state("variables")
+        if variables is not None and all(var["name"] != "ns" for var in variables):
+            break
+        time.sleep(1)
+    else:
+        raise AssertionError("Variable 'ns' was not deleted")
 
     # Wait for nslice parameter to have 'ns' as sim_input (non-numeric after variable deletion)
     assert_lattice_param_sim_input(dashboard, 0, "nslice", "ns")

--- a/tests/python/dashboard/test_python_import.py
+++ b/tests/python/dashboard/test_python_import.py
@@ -6,9 +6,11 @@ Authors: Parthib Roy
 License: BSD-3-Clause-LBNL
 """
 
+import time
+
 import pytest
 
-from .utils import APPROX_TOL
+from .utils import APPROX_TOL, TIMEOUT
 
 
 def test_python_import(dashboard):
@@ -72,17 +74,24 @@ def test_python_import(dashboard):
     ):
         dashboard.assert_state(param_name, expected_value)
 
-    # Check input values
+    # Check input values using get_attribute (does not require element
+    # visibility, unlike get_value which fails for scrollable containers).
     for element_id, expected_value in DISTRIBUTION_VALUES + LATTICE_CONFIGURATION:
-        actual_value = dashboard.sb.get_value(element_id)
+        for i in range(TIMEOUT):
+            actual_value = dashboard.sb.get_attribute(element_id, "value")
+            if actual_value is not None and actual_value != "":
+                break
+            time.sleep(1)
+        else:
+            raise AssertionError(
+                f"{element_id}: value was still empty after {TIMEOUT} seconds"
+            )
 
         if isinstance(expected_value, str):
-            # Compare strings directly
             assert actual_value == expected_value, (
                 f"{element_id}: expected '{expected_value}', got '{actual_value}'"
             )
         else:
-            # Compare numbers with tolerance
             actual_value = float(actual_value)
             assert actual_value == pytest.approx(expected_value, **APPROX_TOL), (
                 f"{element_id}: expected {expected_value}, got {actual_value}"


### PR DESCRIPTION
Fix two dashboard tests that fail on my local Ubuntu and Conda-Forge.

##  Dashboard: batch distribution parameter updates in file import

_apply_distribution_inputs() called ctrl.update_distribution_parameter()
per parameter, which triggered state.dirty() on each iteration. The
repeated dirty calls during a state.flush() cycle disrupted trame's
state synchronisation, causing only the first parameter to be applied.

Update all parameter dicts in-place in a single loop, then call
state.dirty() and errors_tracker once at the end.

##  Dashboard test: add retry for variable deletion assertion

After clicking the delete button, get_state("variables") was checked
immediately without waiting for the state update to propagate. This
caused a race condition where the assertion failed on slower machines.

Add a polling loop that waits for the variable to be removed from state,
matching the retry pattern already used by assert_lattice_param_sim_input
in the same file.

##  Dashboard test: use get_attribute to read input values

sb.get_value() requires elements to be visible in the viewport, which
fails for distribution parameter fields inside a scrollable container
with max-height: 50vh. Replace with sb.get_attribute(id, "value") which
reads via JS without a visibility requirement, and add a retry loop to
wait for values to be populated after the async file import.

Thanks, Claude :crossed_fingers: 