### PR TITLE
Doc: Perlmutter GCC Downgrade

### DIFF
--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
@@ -8,6 +8,7 @@ if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in yo
 # these module versions are current and compatible as of Cray Programming Environment 24.07 (module cpe)
 
 # required dependencies
+module load gcc-native/13.2  # default gcc-native/14 breaks pybind11 builds with NVCC 12.9.41
 module load cmake/3.24.3
 
 # optional: for openPMD and PSATD+RZ support


### PR DESCRIPTION
After the last upgrade, Perlmutter (NERSC) ships CUDA 12.9.0 with NVCC 12.9.41. The default compiler was updated to GCC 14.3.0.

Compiling ImpactX for CUDA breaks the pyAMReX / pybind11 builds, so we downgrade to GCC 13.2 instead.

See also: https://github.com/BLAST-WarpX/warpx/pull/6609