### PR TITLE
Python 3.11+

### DIFF
--- a/docs/source/install/hpc/lumi.rst
+++ b/docs/source/install/hpc/lumi.rst
@@ -291,7 +291,7 @@ Post-Processing
 LUMI provides a `Jupyter Lab service <https://docs.lumi-supercomputer.eu/runjobs/webui/jupyter/>`__ that can be used for interactive post-processing.
 
 You can reuse your CPU ImpactX virtual environment for post-processing in Jupyter Lab:
-* Python: ``Cray-python (3.10.10)``
+* Python: ``Cray-python (3.11.7)``
 * Virtual environment path: ``${HOME}/sw/lumi/cpu/venvs/impactx-cpu-lumi/`` (replace ``${HOME}`` with the output of ``echo ${HOME}``)
 
 

--- a/setup.py
+++ b/setup.py
@@ -272,7 +272,7 @@ setup(
     ext_modules=cxx_modules,
     cmdclass=cmdclass,
     zip_safe=False,
-    python_requires=">=3.8",  # left for CI, truly ">=3.9"
+    python_requires=">=3.8",  # left for CI, truly ">=3.11"
     tests_require=["numpy", "pandas", "pytest", "pytest-benchmark", "scipy"],
     install_requires=install_requires,
     # cmdclass={'test': PyTest},
@@ -290,11 +290,10 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Programming Language :: C++",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         (
             "License :: OSI Approved :: BSD License"
         ),  # TODO: use real SPDX: BSD-3-Clause-LBNL


### PR DESCRIPTION
Python 3.10 is EOL in Oct 2026.
Supporting 3.11-3.14 reduces CI & maintainer burden and enables using modern typing hints without fallbacks. Upgrade across the BLAST sw stack right now.