### PR TITLE
Spin Examples: Fix .py Consistency with .in Files

### DIFF
--- a/examples/spin_tracking/run_cfbend_spin.py
+++ b/examples/spin_tracking/run_cfbend_spin.py
@@ -13,7 +13,7 @@ sim = ImpactX()
 # set numerical parameters and IO control
 sim.space_charge = False
 sim.spin = True
-sim.slice_step_diagnostics = True
+sim.slice_step_diagnostics = False
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/examples/spin_tracking/run_reversibility_spin.py
+++ b/examples/spin_tracking/run_reversibility_spin.py
@@ -14,7 +14,7 @@ sim = ImpactX()
 # set numerical parameters and IO control
 sim.space_charge = False
 sim.spin = True
-sim.slice_step_diagnostics = True
+sim.slice_step_diagnostics = False
 
 # domain decomposition & space charge mesh
 sim.init_grids()

--- a/examples/spin_tracking/run_sbend_spin.py
+++ b/examples/spin_tracking/run_sbend_spin.py
@@ -71,11 +71,11 @@ print(gamma)
 # length for this test should be one period
 ds_value = 2.0 * np.pi / (gyromagnetic_anomaly * gamma)
 
-quad1 = elements.Sbend(name="bend1", ds=ds_value, rc=rc_value, nslice=ns)
+bend1 = elements.Sbend(name="bend1", ds=ds_value, rc=rc_value, nslice=ns)
 
 # set the lattice
 sim.lattice.append(monitor)
-sim.lattice.append(quad1)
+sim.lattice.append(bend1)
 sim.lattice.append(monitor)
 
 # run simulation


### PR DESCRIPTION
## Summary
- **`run_reversibility_spin.py`** and **`run_cfbend_spin.py`**: set `slice_step_diagnostics = False` to match corresponding `.in` input files (which have `diag.slice_step_diagnostics = false`)
- **`run_sbend_spin.py`**: rename variable `quad1` to `bend1` to match the element name `"bend1"` (the element type was already correctly `Sbend`)

## Test plan
- [x] Existing `reversibility-spin.py`, `cfbend-spin.py`, and `sbend-spin.py` CI tests pass unchanged (the `slice_step_diagnostics` setting does not affect physics, and the variable rename is cosmetic)


🤖 Generated with [Claude Code](https://claude.com/claude-code)