### PR TITLE
Fix linear map return for nslice > 1

### DIFF
--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -2646,7 +2646,8 @@ void init_elements(py::module& m)
 
                     // extract element transport map, handle fallback
                     Map6x6 element_transport_map = Map6x6::Identity();
-                    std::visit([&ref, &fallback_identity_map, &element_transport_map](auto const & el) {
+                    int element_nslice;
+                    std::visit([&ref, &fallback_identity_map, &element_transport_map, &element_nslice](auto const & el) {
                         using Element = std::decay_t<decltype(el)>;
                         std::string not_impl_msg = "Undefined transfer map in lattice for element ";
                         if (el.has_name()) not_impl_msg += el.name() + " ";
@@ -2655,6 +2656,7 @@ void init_elements(py::module& m)
                         if constexpr (std::is_base_of_v<elements::mixin::LinearTransport<Element>, Element>) {
                             try {
                                 element_transport_map = el.transport_map(ref);
+                                element_nslice = el.nslice();
                             } catch (std::exception const &) {
                                 if (!fallback_identity_map) {
                                     throw std::runtime_error(not_impl_msg);
@@ -2668,7 +2670,9 @@ void init_elements(py::module& m)
                     }, el_v);
 
                     // advance linear transfer map
-                    linear_transfer_map = element_transport_map * linear_transfer_map;
+                    for (int n = 0; n < element_nslice; n++) {
+                        linear_transfer_map = element_transport_map * linear_transfer_map;
+                    }
                 }
                 return linear_transfer_map;
             },

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -1401,7 +1401,7 @@ void init_elements(py::module& m)
                 std::optional<std::string> name
              )
              {
-                 if (unit != "dimensionless" && unit != "T-m") 
+                 if (unit != "dimensionless" && unit != "T-m")
                      throw std::runtime_error(R"(unit must be "dimensionless" or "T-m")");
 
                  Kicker::UnitSystem const u = unit == "dimensionless" ?

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -1401,7 +1401,7 @@ void init_elements(py::module& m)
                 std::optional<std::string> name
              )
              {
-                 if (unit != "dimensionless" && unit != "T-m")
+                 if (unit != "dimensionless" && unit != "T-m") 
                      throw std::runtime_error(R"(unit must be "dimensionless" or "T-m")");
 
                  Kicker::UnitSystem const u = unit == "dimensionless" ?

--- a/tests/python/test_lattice_optics.py
+++ b/tests/python/test_lattice_optics.py
@@ -24,10 +24,10 @@ def test_lattice_linear_map():
     lattice = elements.KnownElementsList()
     lattice.extend(
         [
-            elements.Sbend(name="bend1", ds=1.0, rc=10.0),
-            elements.Drift(name="drift1", ds=2.0),
-            elements.Quad(name="quad1", ds=0.5, k=1.0),
-            elements.Drift(name="drift2", ds=1.0),
+            elements.Sbend(name="bend1", ds=1.0, rc=10.0, nslice=2),
+            elements.Drift(name="drift1", ds=2.0, nslice=2),
+            elements.Quad(name="quad1", ds=0.5, k=1.0, nslice=2),
+            elements.Drift(name="drift2", ds=1.0, nslice=2),
         ]
     )
 


### PR DESCRIPTION
This PR fixes a bug that occurs in the return of the linear map to the user via the function `transfer_map()` when `nslice > 1`.  (This does not affect the particle tracking.)

Closes Issue #1336 