### PR TITLE
Fix t-update in ExactQuad.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1970,7 +1970,7 @@ add_impactx_test(spin-map.py
 # Symplectic integration in an ExactQuad on Reference ###################
 add_impactx_test(exact-quad-on-reference.py
     examples/symplectic_integration/run_exact_quad_on_reference.py
-    ON   # ImpactX MPI-parallel
+    OFF   # ImpactX MPI-parallel
     examples/symplectic_integration/analysis_exact_quad_on_reference.py
     OFF  # no additional analysis script needed
 )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1966,3 +1966,11 @@ add_impactx_test(spin-map.py
     examples/spin_tracking/analysis_spin_map.py
     OFF  # no plot script yet
 )
+
+# Symplectic integration in an ExactQuad on Reference ###################
+add_impactx_test(exact-quad-on-reference.py
+    examples/symplectic_integration/run_exact_quad_on_reference.py
+    ON   # ImpactX MPI-parallel
+    examples/symplectic_integration/analysis_exact_quad_on_reference.py
+    OFF  # no additional analysis script needed
+)

--- a/examples/symplectic_integration/README.rst
+++ b/examples/symplectic_integration/README.rst
@@ -178,3 +178,33 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
        .. literalinclude:: input_exact_cfbend.in
           :language: ini
           :caption: You can copy this file from ``examples/symplectic_integration/input_exact_cfbend.in``.
+
+
+.. _examples-exact-quad-on-reference:
+
+Symplectic Integration in an Exact Quadrupole on Reference
+===========================================================
+
+This benchmark tests the use of the ExactQuad (quadrupole_exact) element to verify that particles which coincide with the reference trajectory before tracking coincide with the reference trajectory after tracking.  The same test is performed using a Quad and an ExactMultiple of equivalent quadrupole gradient.
+
+The test is performed for 400 MeV protons.
+
+In this test, the final values of :math:`x`, :math:`y`, :math:`t`, :math:`p_x`, :math:`p_y`, and :math:`p_t` must vanish (to machine precision).
+
+
+Run and Analyze
+----------------
+
+This example can be run as:
+
+* **Python** script: ``python3 run_exact_quad_on_reference.py``
+
+For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+
+.. tab-set::
+
+   .. tab-item:: Python: Script
+
+       .. literalinclude:: run_exact_quad.py
+          :language: python3
+          :caption: You can copy this file from ``examples/symplectic_integration/run_exact_quad_on_reference.py``.

--- a/examples/symplectic_integration/analysis_exact_quad_on_reference.py
+++ b/examples/symplectic_integration/analysis_exact_quad_on_reference.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+# Analysis is done in-situ.  No additional analysis is required.

--- a/examples/symplectic_integration/analysis_exact_quad_on_reference.py
+++ b/examples/symplectic_integration/analysis_exact_quad_on_reference.py
@@ -5,4 +5,85 @@
 # License: BSD-3-Clause-LBNL
 #
 
-# Analysis is done in-situ.  No additional analysis is required.
+import numpy as np
+import openpmd_api as io
+import pandas as pd
+
+# initial/final beam
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+last_step = list(series.iterations)[-1]
+initial = series.iterations[1].particles["beam"].to_df()
+beam_final = series.iterations[last_step].particles["beam"]
+final = beam_final.to_df()
+
+# compare number of particles
+num_particles = 1
+assert num_particles == len(initial)
+assert num_particles == len(final)
+
+# compute differences
+error_xi = initial["position_x"].abs().max()
+error_pxi = initial["momentum_x"].abs().max()
+error_yi = initial["position_y"].abs().max()
+error_pyi = initial["momentum_y"].abs().max()
+error_ti = initial["position_t"].abs().max()
+error_pti = initial["momentum_t"].abs().max()
+
+error_xf = final["position_x"].abs().max()
+error_pxf = final["momentum_x"].abs().max()
+error_yf = final["position_y"].abs().max()
+error_pyf = final["momentum_y"].abs().max()
+error_tf = final["position_t"].abs().max()
+error_ptf = final["momentum_t"].abs().max()
+
+print("Initial beam, maximum absolute difference in each coordinate:")
+print("Difference x, px, y, py, t, pt:")
+print(error_xi)
+print(error_pxi)
+print(error_yi)
+print(error_pyi)
+print(error_ti)
+print(error_pti)
+
+atol = 1.0e-13
+print(f"  atol={atol}")
+
+assert np.allclose(
+    [error_xi, error_pxi, error_yi, error_pyi, error_ti, error_pti],
+    [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+    ],
+    atol=atol,
+)
+
+print("")
+print("Final beam, maximum absolute difference in each coordinate:")
+print("Difference x, px, y, py, t, pt:")
+print(error_xf)
+print(error_pxf)
+print(error_yf)
+print(error_pyf)
+print(error_tf)
+print(error_ptf)
+
+atol = 1.0e-13  
+print(f"  atol={atol}")
+
+assert np.allclose(   
+    [error_xf, error_pxf, error_yf, error_pyf, error_tf, error_ptf],
+    [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+    ],
+    atol=atol,
+)
+

--- a/examples/symplectic_integration/analysis_exact_quad_on_reference.py
+++ b/examples/symplectic_integration/analysis_exact_quad_on_reference.py
@@ -7,7 +7,6 @@
 
 import numpy as np
 import openpmd_api as io
-import pandas as pd
 
 # initial/final beam
 series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
@@ -71,10 +70,10 @@ print(error_pyf)
 print(error_tf)
 print(error_ptf)
 
-atol = 1.0e-13  
+atol = 1.0e-13
 print(f"  atol={atol}")
 
-assert np.allclose(   
+assert np.allclose(
     [error_xf, error_pxf, error_yf, error_pyf, error_tf, error_ptf],
     [
         0.0,
@@ -86,4 +85,3 @@ assert np.allclose(
     ],
     atol=atol,
 )
-

--- a/examples/symplectic_integration/run_exact_quad_on_reference.py
+++ b/examples/symplectic_integration/run_exact_quad_on_reference.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright 2022-2023 ImpactX contributors
-# Authors: Axel Huebl, Chad Mitchell
+# Authors: Nikita Kuklev, Axel Huebl, Chad Mitchell
 # License: BSD-3-Clause-LBNL
 #
 # -*- coding: utf-8 -*-

--- a/examples/symplectic_integration/run_exact_quad_on_reference.py
+++ b/examples/symplectic_integration/run_exact_quad_on_reference.py
@@ -1,0 +1,80 @@
+import numpy as np
+import amrex.space3d as amr
+
+from impactx import Config, ImpactX, elements
+
+
+KIN_ENERGY_MEV = 400.0
+MASS_MEV = 938.27208816
+QM_EEV = 1.0 / (MASS_MEV * 1.0e6)
+
+
+def make_vec(values):
+    vec_cls = amr.PODVector_real_arena if Config.have_gpu else amr.PODVector_real_std
+    out = vec_cls()
+    for vv in values:
+        out.push_back(float(vv))
+    return out
+
+
+def run_one(element):
+    sim = ImpactX()
+    sim.space_charge = False
+    sim.diagnostics = False
+    sim.slice_step_diagnostics = False
+    sim.verbose = 0
+    sim.init_grids()
+
+    pc = sim.particle_container()
+    ref = pc.ref_particle()
+    ref.set_charge_qe(1.0).set_mass_MeV(MASS_MEV).set_kin_energy_MeV(KIN_ENERGY_MEV)
+
+    # One particle exactly on the reference trajectory
+    pc.add_n_particles(
+        make_vec([0.0]),  # x
+        make_vec([0.0]),  # y
+        make_vec([0.0]),  # t
+        make_vec([0.0]),  # px
+        make_vec([0.0]),  # py
+        make_vec([0.0]),  # pt
+        QM_EEV,
+        bunch_charge=0.0,
+    )
+
+    sim.lattice.append(element)
+    sim.track_particles()
+
+    df = pc.to_df(local=True)
+    x = df["position_x"]
+    px = df["momentum_x"]
+    y = df["position_y"]
+    py = df["momentum_y"]
+    t = df["position_t"]
+    pt = df["momentum_t"]
+    
+    print(x, px, y, py, t, pt)
+
+    atol = 1.0e-13
+    assert np.allclose(  
+        [x, px, y, py, t, pt],
+        [
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ],
+        atol=atol,
+    )
+
+    sim.finalize()
+
+print("Quad")
+run_one(elements.Quad(name="q", ds=0.5, k=1.2))
+
+print("\nExactQuad")
+run_one(elements.ExactQuad(name="eq",ds=0.5,k=1.2))
+
+print("\nExactMultipole")
+run_one(elements.ExactMultipole(name="em",ds=0.5,k_normal=[0,1.2],k_skew=[0.0,0.0]))

--- a/examples/symplectic_integration/run_exact_quad_on_reference.py
+++ b/examples/symplectic_integration/run_exact_quad_on_reference.py
@@ -6,7 +6,6 @@
 #
 # -*- coding: utf-8 -*-
 
-import pandas as pd
 
 import amrex.space3d as amr
 from impactx import Config, ImpactX, elements
@@ -64,7 +63,7 @@ for p_dpx in dpx:
 for p_dpy in dpy:
     dpy_podv.push_back(p_dpy)
 for p_dpt in dpt:
-    dpt_podv.push_back(p_dpt) 
+    dpt_podv.push_back(p_dpt)
 
 pc.add_n_particles(
     dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, bunch_charge_C

--- a/examples/symplectic_integration/run_exact_quad_on_reference.py
+++ b/examples/symplectic_integration/run_exact_quad_on_reference.py
@@ -1,8 +1,7 @@
 import numpy as np
+
 import amrex.space3d as amr
-
 from impactx import Config, ImpactX, elements
-
 
 KIN_ENERGY_MEV = 400.0
 MASS_MEV = 938.27208816
@@ -51,11 +50,11 @@ def run_one(element):
     py = df["momentum_y"]
     t = df["position_t"]
     pt = df["momentum_t"]
-    
+
     print(x, px, y, py, t, pt)
 
     atol = 1.0e-13
-    assert np.allclose(  
+    assert np.allclose(
         [x, px, y, py, t, pt],
         [
             0.0,
@@ -70,11 +69,14 @@ def run_one(element):
 
     sim.finalize()
 
+
 print("Quad")
 run_one(elements.Quad(name="q", ds=0.5, k=1.2))
 
 print("\nExactQuad")
-run_one(elements.ExactQuad(name="eq",ds=0.5,k=1.2))
+run_one(elements.ExactQuad(name="eq", ds=0.5, k=1.2))
 
 print("\nExactMultipole")
-run_one(elements.ExactMultipole(name="em",ds=0.5,k_normal=[0,1.2],k_skew=[0.0,0.0]))
+run_one(
+    elements.ExactMultipole(name="em", ds=0.5, k_normal=[0, 1.2], k_skew=[0.0, 0.0])
+)

--- a/examples/symplectic_integration/run_exact_quad_on_reference.py
+++ b/examples/symplectic_integration/run_exact_quad_on_reference.py
@@ -1,3 +1,11 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Nikita Kuklev, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
 import numpy as np
 
 import amrex.space3d as amr

--- a/examples/symplectic_integration/run_exact_quad_on_reference.py
+++ b/examples/symplectic_integration/run_exact_quad_on_reference.py
@@ -1,90 +1,112 @@
 #!/usr/bin/env python3
 #
 # Copyright 2022-2023 ImpactX contributors
-# Authors: Nikita Kuklev, Chad Mitchell
+# Authors: Axel Huebl, Chad Mitchell
 # License: BSD-3-Clause-LBNL
 #
 # -*- coding: utf-8 -*-
 
-import numpy as np
+import pandas as pd
 
 import amrex.space3d as amr
 from impactx import Config, ImpactX, elements
 
-KIN_ENERGY_MEV = 400.0
-MASS_MEV = 938.27208816
-QM_EEV = 1.0 / (MASS_MEV * 1.0e6)
+sim = ImpactX()
 
+# set numerical parameters and IO control
+sim.space_charge = False
+sim.slice_step_diagnostics = True
 
-def make_vec(values):
-    vec_cls = amr.PODVector_real_arena if Config.have_gpu else amr.PODVector_real_std
-    out = vec_cls()
-    for vv in values:
-        out.push_back(float(vv))
-    return out
+# domain decomposition & space charge mesh
+sim.init_grids()
 
+# load initial beam parameters
+kin_energy_MeV = 0.8e3  # reference energy
+bunch_charge_C = 1.0e-9  # used with space charge
+npart = 10000  # number of macro particles
 
-def run_one(element):
-    sim = ImpactX()
-    sim.space_charge = False
-    sim.diagnostics = False
-    sim.slice_step_diagnostics = False
-    sim.verbose = 0
-    sim.init_grids()
+#   reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
+qm_eev = 1.0 / 938.27208816 / 1e6  # electron charge/mass in e / eV
 
-    pc = sim.particle_container()
-    ref = pc.ref_particle()
-    ref.set_charge_qe(1.0).set_mass_MeV(MASS_MEV).set_kin_energy_MeV(KIN_ENERGY_MEV)
+pc = sim.particle_container()
 
-    # One particle exactly on the reference trajectory
-    pc.add_n_particles(
-        make_vec([0.0]),  # x
-        make_vec([0.0]),  # y
-        make_vec([0.0]),  # t
-        make_vec([0.0]),  # px
-        make_vec([0.0]),  # py
-        make_vec([0.0]),  # pt
-        QM_EEV,
-        bunch_charge=0.0,
-    )
+dx = [0.0]
+dpx = [0.0]
+dy = [0.0]
+dpy = [0.0]
+dt = [0.0]
+dpt = [0.0]
+if not Config.have_gpu:  # initialize using cpu-based PODVectors
+    dx_podv = amr.PODVector_real_std()
+    dy_podv = amr.PODVector_real_std()
+    dt_podv = amr.PODVector_real_std()
+    dpx_podv = amr.PODVector_real_std()
+    dpy_podv = amr.PODVector_real_std()
+    dpt_podv = amr.PODVector_real_std()
+else:  # initialize on device using arena/gpu-based PODVectors
+    dx_podv = amr.PODVector_real_arena()
+    dy_podv = amr.PODVector_real_arena()
+    dt_podv = amr.PODVector_real_arena()
+    dpx_podv = amr.PODVector_real_arena()
+    dpy_podv = amr.PODVector_real_arena()
+    dpt_podv = amr.PODVector_real_arena()
 
-    sim.lattice.append(element)
-    sim.track_particles()
+for p_dx in dx:
+    dx_podv.push_back(p_dx)
+for p_dy in dy:
+    dy_podv.push_back(p_dy)
+for p_dt in dt:
+    dt_podv.push_back(p_dt)
+for p_dpx in dpx:
+    dpx_podv.push_back(p_dpx)
+for p_dpy in dpy:
+    dpy_podv.push_back(p_dpy)
+for p_dpt in dpt:
+    dpt_podv.push_back(p_dpt) 
 
-    df = pc.to_df(local=True)
-    x = df["position_x"]
-    px = df["momentum_x"]
-    y = df["position_y"]
-    py = df["momentum_y"]
-    t = df["position_t"]
-    pt = df["momentum_t"]
-
-    print(x, px, y, py, t, pt)
-
-    atol = 1.0e-13
-    assert np.allclose(
-        [x, px, y, py, t, pt],
-        [
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-        ],
-        atol=atol,
-    )
-
-    sim.finalize()
-
-
-print("Quad")
-run_one(elements.Quad(name="q", ds=0.5, k=1.2))
-
-print("\nExactQuad")
-run_one(elements.ExactQuad(name="eq", ds=0.5, k=1.2))
-
-print("\nExactMultipole")
-run_one(
-    elements.ExactMultipole(name="em", ds=0.5, k_normal=[0, 1.2], k_skew=[0.0, 0.0])
+pc.add_n_particles(
+    dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, bunch_charge_C
 )
+
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+
+# design the accelerator lattice)
+ns = 1  # number of slices per ds in the element
+line = [
+    monitor,
+    elements.Quad(
+        name="q",
+        ds=0.5,
+        k=1.2,
+        nslice=ns,
+    ),
+    elements.ExactQuad(
+        name="eq",
+        ds=0.5,
+        k=1.2,
+        nslice=ns,
+    ),
+    elements.ExactMultipole(
+        name="em",
+        ds=0.5,
+        k_normal=[0.0, 1.2],
+        k_skew=[0.0, 0.0],
+        unit=0,
+        int_order=4,
+        mapsteps=5,
+        nslice=ns,
+    ),
+    monitor,
+]
+
+# assign a fodo segment
+sim.lattice.extend(line)
+
+# run simulation
+sim.track_particles()
+
+# clean shutdown
+sim.finalize()

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -316,7 +316,7 @@ namespace impactx::elements
             particle(2) = px;
             particle(3) = y + tau * py * (-1_prt + inv_pzden);
             particle(4) = py;
-            particle(5) = t + tau * (-m_ibeta - m_ibetgam2*pt + inv_pzden*(1_prt - pt*m_beta));
+            particle(5) = t + tau * (-m_ibeta - m_ibetgam2*pt + inv_pzden*(1_prt - pt*m_beta)*m_ibeta);
             particle(6) = pt;
 
             zeval += tau;


### PR DESCRIPTION
This PR fixes a bug in the longitudinal _t_-update in the element ExactQuad, resulting from a missing factor of relativistic beta.  The transverse update is not affected.  The effect becomes large when $\beta<<1$. 

- [x] add bug fix
- [x] add benchmark example

This closes Issue #1343.  Thanks to @nikitakuklev.