### PR TITLE
Throw Exceptions in Asserts

### DIFF
--- a/docs/source/developers/debugging.rst
+++ b/docs/source/developers/debugging.rst
@@ -48,3 +48,9 @@ See the `AMReX debugger section <https://amrex-codes.github.io/amrex/docs_html/B
 * avoid AMReX-level signal handling
 
 You will need to set those runtime options to work directly with debuggers.
+
+For Python runs, you can use ``gdb`` to catch C++ exceptions and get a backtrace:
+
+.. code-block:: bash
+
+   gdb -ex 'catch throw' -ex run -ex bt --args python run_impactx.py

--- a/src/initialization/InitParser.cpp
+++ b/src/initialization/InitParser.cpp
@@ -18,6 +18,11 @@ namespace impactx::initialization
     {
         amrex::ParmParse pp_amrex("amrex");
 
+        // throw exceptions in asserts, to enable optional error handling, especially in Python
+        // https://amrex-codes.github.io/amrex/docs_html/RuntimeParameters.html#amrex.throw_exception
+        bool throw_exception = true; // AMReX' default: false
+        pp_amrex.queryAdd("throw_exception", throw_exception);
+
         // https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters
         bool abort_on_out_of_gpu_memory = true; // AMReX' default: false
         pp_amrex.queryAdd("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);


### PR DESCRIPTION
Fix #1348: Set AMReX `system::throw_exception` so that in interactive usage we can potentially catch an exception and handle it, instead of terminating the process (Python interpreter).


## To Do

- [x] needs https://github.com/AMReX-Codes/amrex/pull/5219
- [x] check reproducer in #1348 works now
- [x] uncaught exceptions in Python do not generate backtraces
- [x] ensure backtraces are still generated when uncaught (`.in` files)
- [x] [Update tests](https://github.com/search?q=repo%3ABLAST-ImpactX%2Fimpactx%20throw_exception&type=code) to new default (clean/remove)

## How to get a Backtrace Now in Python

`gdb` with a catchpoint is the most direct:
```console                                                                       
  gdb -ex 'catch throw' -ex run -ex bt --args python your_script.py
```                                                                     
This breaks right at the C++ throw site and gives a full C++ stack.