### PR TITLE
Elements: Compile Push in Separate Translation Units

### DIFF
--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -247,4 +247,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::Aperture)
+
 #endif // IMPACTX_APERTURE_H

--- a/src/elements/Aperture.cpp
+++ b/src/elements/Aperture.cpp
@@ -40,3 +40,5 @@ impactx::elements::Aperture::action_name (Action const & action)
             throw std::runtime_error("Unknown action");
     }
 }
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::Aperture)

--- a/src/elements/Buncher.H
+++ b/src/elements/Buncher.H
@@ -188,4 +188,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::Buncher)
+
 #endif // IMPACTX_BUNCHER_H

--- a/src/elements/Buncher.cpp
+++ b/src/elements/Buncher.cpp
@@ -1,0 +1,3 @@
+#include "Buncher.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::Buncher)

--- a/src/elements/CFbend.H
+++ b/src/elements/CFbend.H
@@ -423,4 +423,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::CFbend)
+
 #endif // IMPACTX_CFBEND_H

--- a/src/elements/CFbend.cpp
+++ b/src/elements/CFbend.cpp
@@ -1,0 +1,3 @@
+#include "CFbend.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::CFbend)

--- a/src/elements/CMakeLists.txt
+++ b/src/elements/CMakeLists.txt
@@ -1,9 +1,40 @@
 target_sources(lib
   PRIVATE
     Aperture.cpp
+    Buncher.cpp
+    CFbend.cpp
+    ChrDrift.cpp
+    ChrPlasmaLens.cpp
+    ChrQuad.cpp
+    ChrUniformAcc.cpp
+    ConstF.cpp
+    DipEdge.cpp
+    Drift.cpp
+    ExactCFbend.cpp
+    ExactDrift.cpp
+    ExactMultipole.cpp
+    ExactQuad.cpp
+    ExactSbend.cpp
+    Kicker.cpp
+    LinearMap.cpp
+    Multipole.cpp
+    NonlinearLens.cpp
+    PlaneXYRot.cpp
     PolygonAperture.cpp
+    PRot.cpp
     Programmable.cpp
+    Quad.cpp
+    QuadEdge.cpp
+    RFCavity.cpp
+    Sbend.cpp
+    ShortRF.cpp
+    SoftQuad.cpp
+    SoftSol.cpp
+    Sol.cpp
     Source.cpp
+    SpinMap.cpp
+    TaperedPL.cpp
+    ThinDipole.cpp
 )
 
 add_subdirectory(diagnostics)

--- a/src/elements/ChrDrift.H
+++ b/src/elements/ChrDrift.H
@@ -292,4 +292,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::ChrDrift)
+
 #endif // IMPACTX_CHRDRIFT_H

--- a/src/elements/ChrDrift.cpp
+++ b/src/elements/ChrDrift.cpp
@@ -1,0 +1,3 @@
+#include "ChrDrift.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::ChrDrift)

--- a/src/elements/ChrPlasmaLens.H
+++ b/src/elements/ChrPlasmaLens.H
@@ -366,4 +366,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::ChrPlasmaLens)
+
 #endif // IMPACTX_CHRPLASMALENS_H

--- a/src/elements/ChrPlasmaLens.cpp
+++ b/src/elements/ChrPlasmaLens.cpp
@@ -1,0 +1,3 @@
+#include "ChrPlasmaLens.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::ChrPlasmaLens)

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -447,4 +447,6 @@ lambday = -gyro_const * ( px*inv_delta1*(1_prt - cos_omega_ds) + x*omega*sin_ome
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::ChrQuad)
+
 #endif // IMPACTX_CHRQUAD_H

--- a/src/elements/ChrQuad.cpp
+++ b/src/elements/ChrQuad.cpp
@@ -1,0 +1,3 @@
+#include "ChrQuad.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::ChrQuad)

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -310,4 +310,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::ChrAcc)
+
 #endif // IMPACTX_CHRACC_H

--- a/src/elements/ChrUniformAcc.cpp
+++ b/src/elements/ChrUniformAcc.cpp
@@ -1,0 +1,3 @@
+#include "ChrUniformAcc.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::ChrAcc)

--- a/src/elements/ConstF.H
+++ b/src/elements/ConstF.H
@@ -365,4 +365,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::ConstF)
+
 #endif // IMPACTX_CONSTF_H

--- a/src/elements/ConstF.cpp
+++ b/src/elements/ConstF.cpp
@@ -1,0 +1,3 @@
+#include "ConstF.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::ConstF)

--- a/src/elements/DipEdge.H
+++ b/src/elements/DipEdge.H
@@ -329,4 +329,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::DipEdge)
+
 #endif // IMPACTX_DIPEDGE_H

--- a/src/elements/DipEdge.cpp
+++ b/src/elements/DipEdge.cpp
@@ -1,0 +1,3 @@
+#include "DipEdge.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::DipEdge)

--- a/src/elements/Drift.H
+++ b/src/elements/Drift.H
@@ -278,4 +278,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::Drift)
+
 #endif // IMPACTX_DRIFT_H

--- a/src/elements/Drift.cpp
+++ b/src/elements/Drift.cpp
@@ -1,0 +1,3 @@
+#include "Drift.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::Drift)

--- a/src/elements/ExactCFbend.H
+++ b/src/elements/ExactCFbend.H
@@ -641,4 +641,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::ExactCFbend)
+
 #endif // IMPACTX_EXACTCFBEND_H

--- a/src/elements/ExactCFbend.cpp
+++ b/src/elements/ExactCFbend.cpp
@@ -1,0 +1,3 @@
+#include "ExactCFbend.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::ExactCFbend)

--- a/src/elements/ExactDrift.H
+++ b/src/elements/ExactDrift.H
@@ -285,4 +285,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::ExactDrift)
+
 #endif // IMPACTX_EXACTDRIFT_H

--- a/src/elements/ExactDrift.cpp
+++ b/src/elements/ExactDrift.cpp
@@ -1,0 +1,3 @@
+#include "ExactDrift.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::ExactDrift)

--- a/src/elements/ExactMultipole.H
+++ b/src/elements/ExactMultipole.H
@@ -550,4 +550,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::ExactMultipole)
+
 #endif // IMPACTX_EXACTMULTIPOLE_H

--- a/src/elements/ExactMultipole.cpp
+++ b/src/elements/ExactMultipole.cpp
@@ -1,0 +1,3 @@
+#include "ExactMultipole.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::ExactMultipole)

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -435,4 +435,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::ExactQuad)
+
 #endif // IMPACTX_EXACTQUAD_H

--- a/src/elements/ExactQuad.cpp
+++ b/src/elements/ExactQuad.cpp
@@ -1,0 +1,3 @@
+#include "ExactQuad.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::ExactQuad)

--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -371,4 +371,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::ExactSbend)
+
 #endif // IMPACTX_EXACTSBEND_H

--- a/src/elements/ExactSbend.cpp
+++ b/src/elements/ExactSbend.cpp
@@ -1,0 +1,3 @@
+#include "ExactSbend.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::ExactSbend)

--- a/src/elements/Kicker.H
+++ b/src/elements/Kicker.H
@@ -192,4 +192,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::Kicker)
+
 #endif // IMPACTX_KICKER_H

--- a/src/elements/Kicker.cpp
+++ b/src/elements/Kicker.cpp
@@ -1,0 +1,3 @@
+#include "Kicker.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::Kicker)

--- a/src/elements/LinearMap.H
+++ b/src/elements/LinearMap.H
@@ -245,4 +245,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::LinearMap)
+
 #endif // IMPACTX_ELEMENT_LINEAR_MAP_H

--- a/src/elements/LinearMap.cpp
+++ b/src/elements/LinearMap.cpp
@@ -1,0 +1,3 @@
+#include "LinearMap.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::LinearMap)

--- a/src/elements/Multipole.H
+++ b/src/elements/Multipole.H
@@ -218,4 +218,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::Multipole)
+
 #endif // IMPACTX_MULTIPOLE_H

--- a/src/elements/Multipole.cpp
+++ b/src/elements/Multipole.cpp
@@ -1,0 +1,3 @@
+#include "Multipole.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::Multipole)

--- a/src/elements/NonlinearLens.H
+++ b/src/elements/NonlinearLens.H
@@ -216,4 +216,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::NonlinearLens)
+
 #endif // IMPACTX_NONLINEARLENS_H

--- a/src/elements/NonlinearLens.cpp
+++ b/src/elements/NonlinearLens.cpp
@@ -1,0 +1,3 @@
+#include "NonlinearLens.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::NonlinearLens)

--- a/src/elements/PRot.H
+++ b/src/elements/PRot.H
@@ -187,4 +187,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::PRot)
+
 #endif // IMPACTX_PROT_H

--- a/src/elements/PRot.cpp
+++ b/src/elements/PRot.cpp
@@ -1,0 +1,3 @@
+#include "PRot.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::PRot)

--- a/src/elements/PlaneXYRot.H
+++ b/src/elements/PlaneXYRot.H
@@ -192,4 +192,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::PlaneXYRot)
+
 #endif // IMPACTX_PLANE_XYROT_H

--- a/src/elements/PlaneXYRot.cpp
+++ b/src/elements/PlaneXYRot.cpp
@@ -1,0 +1,3 @@
+#include "PlaneXYRot.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::PlaneXYRot)

--- a/src/elements/PolygonAperture.H
+++ b/src/elements/PolygonAperture.H
@@ -338,4 +338,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::PolygonAperture)
+
 #endif // IMPACTX_POLYGONAPERTURE_H

--- a/src/elements/PolygonAperture.cpp
+++ b/src/elements/PolygonAperture.cpp
@@ -25,3 +25,5 @@ impactx::elements::PolygonAperture::action_name (Action const & action)
             throw std::runtime_error("Unknown action");
     }
 }
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::PolygonAperture)

--- a/src/elements/Quad.H
+++ b/src/elements/Quad.H
@@ -380,4 +380,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::Quad)
+
 #endif // IMPACTX_QUAD_H

--- a/src/elements/Quad.cpp
+++ b/src/elements/Quad.cpp
@@ -1,0 +1,3 @@
+#include "Quad.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::Quad)

--- a/src/elements/QuadEdge.H
+++ b/src/elements/QuadEdge.H
@@ -225,4 +225,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::QuadEdge)
+
 #endif // IMPACTX_QUADEDGE_H

--- a/src/elements/QuadEdge.cpp
+++ b/src/elements/QuadEdge.cpp
@@ -1,0 +1,3 @@
+#include "QuadEdge.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::QuadEdge)

--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -586,4 +586,6 @@ namespace RFCavityData
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::RFCavity)
+
 #endif // IMPACTX_RFCAVITY_H

--- a/src/elements/RFCavity.cpp
+++ b/src/elements/RFCavity.cpp
@@ -1,0 +1,3 @@
+#include "RFCavity.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::RFCavity)

--- a/src/elements/Sbend.H
+++ b/src/elements/Sbend.H
@@ -414,4 +414,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::Sbend)
+
 #endif // IMPACTX_SBEND_H

--- a/src/elements/Sbend.cpp
+++ b/src/elements/Sbend.cpp
@@ -1,0 +1,3 @@
+#include "Sbend.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::Sbend)

--- a/src/elements/ShortRF.H
+++ b/src/elements/ShortRF.H
@@ -275,4 +275,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::ShortRF)
+
 #endif // IMPACTX_SHORTRF_H

--- a/src/elements/ShortRF.cpp
+++ b/src/elements/ShortRF.cpp
@@ -1,0 +1,3 @@
+#include "ShortRF.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::ShortRF)

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -529,4 +529,6 @@ namespace SoftQuadrupoleData
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::SoftQuadrupole)
+
 #endif // IMPACTX_SOFTQUAD_H

--- a/src/elements/SoftQuad.cpp
+++ b/src/elements/SoftQuad.cpp
@@ -1,0 +1,3 @@
+#include "SoftQuad.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::SoftQuadrupole)

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -604,4 +604,6 @@ namespace SoftSolenoidData
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::SoftSolenoid)
+
 #endif // IMPACTX_SOFTSOL_H

--- a/src/elements/SoftSol.cpp
+++ b/src/elements/SoftSol.cpp
@@ -1,0 +1,3 @@
+#include "SoftSol.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::SoftSolenoid)

--- a/src/elements/Sol.H
+++ b/src/elements/Sol.H
@@ -378,4 +378,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::Sol)
+
 #endif // IMPACTX_SOL_H

--- a/src/elements/Sol.cpp
+++ b/src/elements/Sol.cpp
@@ -1,0 +1,3 @@
+#include "Sol.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::Sol)

--- a/src/elements/SpinMap.H
+++ b/src/elements/SpinMap.H
@@ -228,4 +228,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::SpinMap)
+
 #endif // IMPACTX_ELEMENT_SPIN_MAP_H

--- a/src/elements/SpinMap.cpp
+++ b/src/elements/SpinMap.cpp
@@ -1,0 +1,3 @@
+#include "SpinMap.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::SpinMap)

--- a/src/elements/TaperedPL.H
+++ b/src/elements/TaperedPL.H
@@ -170,4 +170,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::TaperedPL)
+
 #endif // IMPACTX_TAPEREDPL_H

--- a/src/elements/TaperedPL.cpp
+++ b/src/elements/TaperedPL.cpp
@@ -1,0 +1,3 @@
+#include "TaperedPL.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::TaperedPL)

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -214,4 +214,6 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::ThinDipole)
+
 #endif // IMPACTX_THINDIPOLE_H

--- a/src/elements/ThinDipole.cpp
+++ b/src/elements/ThinDipole.cpp
@@ -1,0 +1,3 @@
+#include "ThinDipole.H"
+
+IMPACTX_PUSH_INSTANTIATE(impactx::elements::ThinDipole)

--- a/src/particles/PushAll.H
+++ b/src/particles/PushAll.H
@@ -74,4 +74,18 @@ namespace impactx
 
 } // namespace impactx
 
+/** Suppress implicit instantiation of push_all<T> — use in element headers. */
+#define IMPACTX_PUSH_EXTERN_TEMPLATE(ElementType) \
+    extern template void impactx::push_all<ElementType>( \
+        impactx::ImpactXParticleContainer &, \
+        ElementType &, \
+        int, int, bool);
+
+/** Explicit instantiation of push_all<T> — use in element .cpp files. */
+#define IMPACTX_PUSH_INSTANTIATE(ElementType) \
+    template void impactx::push_all<ElementType>( \
+        impactx::ImpactXParticleContainer &, \
+        ElementType &, \
+        int, int, bool);
+
 #endif // IMPACTX_PUSH_ALL_H


### PR DESCRIPTION
Each element's `push_all<T>` instantiation is now compiled in its own translation unit (`src/elements/<Element>.cpp`), enabling parallel compilation of the 33 GPU-heavy kernel instantiations that were previously all compiled together through `Push.cpp`. Two convenience macros in `PushAll.H`:
* `IMPACTX_PUSH_EXTERN_TEMPLATE` and
* `IMPACTX_PUSH_INSTANTIATE`

keep the boilerplate minimal and centralize the `push_all` signature.                                                                                                                                          
                                                            
Each element header declares `extern template` to suppress implicit instantiation, while the corresponding `.cpp` file provides the explicit instantiation definition. `Push.cpp` is unchanged: it still includes `All.H` and uses `std::visit`, but now only emits function calls to the externally-defined symbols instead of instantiating the full template chain (`push_all` → `push_all_particles` → `PushSingleParticle` → `ParallelFor` + element `operator()`). GPU performance is preserved because each per-element TU is compiled with full visibility of the template chain, so the per-particle physics remains fully inlined into `ParallelFor`.

Elements without `BeamOptic` (`Empty`, `Marker`, `Programmable`, `Source`, `BeamMonitor`) are unaffected.


## To Do?

- [x] CPU/OpenMP: measure per TU and complete compile time before/with this PR (ccache turned off)
- [x] GPU/CUDA: measure per TU and complete compile time before/with this PR (ccache turned off)