### PR TITLE
Return linear map for simple nonlinear elements.

### DIFF
--- a/src/elements/ChrDrift.H
+++ b/src/elements/ChrDrift.H
@@ -269,7 +269,7 @@ namespace impactx::elements
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1_prt;
 
             // assign linear map matrix elements
             Map6x6 R = Map6x6::Identity();

--- a/src/elements/ChrDrift.H
+++ b/src/elements/ChrDrift.H
@@ -255,6 +255,7 @@ namespace impactx::elements
 
         /** This function returns the linear transport map.
          *
+         * @param[in] refpart reference particle
          * @returns 6x6 transport matrix
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE

--- a/src/elements/ChrDrift.H
+++ b/src/elements/ChrDrift.H
@@ -255,15 +255,29 @@ namespace impactx::elements
 
         /** This function returns the linear transport map.
          *
-         * @param[in] refpart reference particle
          * @returns 6x6 transport matrix
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE
         Map6x6
-        transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
+        transport_map (RefPart const & AMREX_RESTRICT refpart) const
         {
-            throw std::runtime_error(std::string(type) + ": Envelope tracking is not yet implemented!");
-            return Map6x6::Identity();
+            using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
+
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
+            // access reference particle values to find beta*gamma^2
+            amrex::ParticleReal const pt_ref = refpart.pt;
+            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
+
+            // assign linear map matrix elements
+            Map6x6 R = Map6x6::Identity();
+            R(1,2) = slice_ds;
+            R(3,4) = slice_ds;
+            R(5,6) = slice_ds / betgam2;
+
+            return R;
         }
 
       private:

--- a/src/elements/ChrPlasmaLens.H
+++ b/src/elements/ChrPlasmaLens.H
@@ -313,7 +313,7 @@ namespace impactx::elements
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1_prt;
 
             // compute phase advance per unit length in s (in rad/m)
             amrex::ParticleReal const omega = std::sqrt(std::abs(m_k));

--- a/src/elements/ChrPlasmaLens.H
+++ b/src/elements/ChrPlasmaLens.H
@@ -299,11 +299,12 @@ namespace impactx::elements
 
         /** This function returns the linear transport map.
          *
+         * @param[in] refpart reference particle
          * @returns 6x6 transport matrix
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE
         Map6x6
-        transport_map (RefPart const & AMREX_RESTRICT refpart) const  // TODO: update as well, but needs more careful placement of calc_constants
+        transport_map (RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;

--- a/src/elements/ChrPlasmaLens.H
+++ b/src/elements/ChrPlasmaLens.H
@@ -299,15 +299,55 @@ namespace impactx::elements
 
         /** This function returns the linear transport map.
          *
-         * @param[in] refpart reference particle
          * @returns 6x6 transport matrix
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE
         Map6x6
-        transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
+        transport_map (RefPart const & AMREX_RESTRICT refpart) const  // TODO: update as well, but needs more careful placement of calc_constants
         {
-            throw std::runtime_error(std::string(type) + ": Envelope tracking is not yet implemented!");
-            return Map6x6::Identity();
+            using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
+
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
+            // access reference particle values to find beta*gamma^2
+            amrex::ParticleReal const pt_ref = refpart.pt;
+            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
+
+            // compute phase advance per unit length in s (in rad/m)
+            amrex::ParticleReal const omega = std::sqrt(std::abs(m_k));
+
+            // initialize linear map matrix elements
+            Map6x6 R = Map6x6::Identity();
+
+            if (m_k > 0.0) {
+                R(1,1) = std::cos(omega*slice_ds);
+                R(1,2) = std::sin(omega*slice_ds)/omega;
+                R(2,1) = -omega*std::sin(omega*slice_ds);
+                R(2,2) = std::cos(omega*slice_ds);
+                R(3,3) = std::cos(omega*slice_ds);
+                R(3,4) = std::sin(omega*slice_ds)/omega;
+                R(4,3) = -omega*std::sin(omega*slice_ds);
+                R(4,4) = std::cos(omega*slice_ds);
+                R(5,6) = slice_ds/betgam2;
+            } else if (m_k < 0.0) {
+                R(1,1) = std::cosh(omega*slice_ds);
+                R(1,2) = std::sinh(omega*slice_ds)/omega;
+                R(2,1) = omega*std::sinh(omega*slice_ds);
+                R(2,2) = std::cosh(omega*slice_ds);
+                R(3,3) = std::cosh(omega*slice_ds);
+                R(3,4) = std::sinh(omega*slice_ds)/omega;
+                R(4,3) = omega*std::sinh(omega*slice_ds);
+                R(4,4) = std::cosh(omega*slice_ds);
+                R(5,6) = slice_ds/betgam2;
+            } else {
+                R(1,2) = slice_ds;
+                R(3,4) = slice_ds;
+                R(5,6) = slice_ds / betgam2;
+            }
+
+            return R;
         }
 
         amrex::ParticleReal m_k; //! focusing strength in 1/m^2 (or T/m)

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -386,27 +386,27 @@ lambday = -gyro_const * ( px*inv_delta1*(1_prt - cos_omega_ds) + x*omega*sin_ome
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
-                
+
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
-                
+
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
             amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
-            
+
             // compute phase advance per unit length in s (in rad/m)
             amrex::ParticleReal const omega = std::sqrt(std::abs(m_k));
-                
+
             // initialize linear map matrix elements
             Map6x6 R = Map6x6::Identity();
-            
+
             if (m_k > 0.0) {
                 R(1,1) = std::cos(omega*slice_ds);
                 R(1,2) = std::sin(omega*slice_ds)/omega;
                 R(2,1) = -omega*std::sin(omega*slice_ds);
                 R(2,2) = std::cos(omega*slice_ds);
                 R(3,3) = std::cosh(omega*slice_ds);
-                R(3,4) = std::sinh(omega*slice_ds)/omega;   
+                R(3,4) = std::sinh(omega*slice_ds)/omega;
                 R(4,3) = omega*std::sinh(omega*slice_ds);
                 R(4,4) = std::cosh(omega*slice_ds);
                 R(5,6) = slice_ds/betgam2;
@@ -417,7 +417,7 @@ lambday = -gyro_const * ( px*inv_delta1*(1_prt - cos_omega_ds) + x*omega*sin_ome
                 R(2,2) = std::cosh(omega*slice_ds);
                 R(3,3) = std::cos(omega*slice_ds);
                 R(3,4) = std::sin(omega*slice_ds)/omega;
-                R(4,3) = -omega*std::sin(omega*slice_ds);   
+                R(4,3) = -omega*std::sin(omega*slice_ds);
                 R(4,4) = std::cos(omega*slice_ds);
                 R(5,6) = slice_ds/betgam2;
             } else {
@@ -425,7 +425,7 @@ lambday = -gyro_const * ( px*inv_delta1*(1_prt - cos_omega_ds) + x*omega*sin_ome
                 R(3,4) = m_slice_ds;
                 R(5,6) = m_slice_ds / betgam2;
             }
-            
+
             return R;
         }
 

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -375,9 +375,6 @@ lambday = -gyro_const * ( px*inv_delta1*(1_prt - cos_omega_ds) + x*omega*sin_ome
         }
 
 
-        /** This pushes the covariance matrix. */
-        using LinearTransport::operator();
-
         /** This function returns the linear transport map.
          *
          * @param[in] refpart reference particle
@@ -385,11 +382,55 @@ lambday = -gyro_const * ( px*inv_delta1*(1_prt - cos_omega_ds) + x*omega*sin_ome
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE
         Map6x6
-        transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
+        transport_map (RefPart const & AMREX_RESTRICT refpart) const  // TODO: update as well, but needs more careful placement of calc_constants
         {
-            throw std::runtime_error(std::string(type) + ": Envelope tracking is not yet implemented!");
-            return Map6x6::Identity();
+            using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
+                
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+                
+            // access reference particle values to find beta*gamma^2
+            amrex::ParticleReal const pt_ref = refpart.pt;
+            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
+            
+            // compute phase advance per unit length in s (in rad/m)
+            amrex::ParticleReal const omega = std::sqrt(std::abs(m_k));
+                
+            // initialize linear map matrix elements
+            Map6x6 R = Map6x6::Identity();
+            
+            if (m_k > 0.0) {
+                R(1,1) = std::cos(omega*slice_ds);
+                R(1,2) = std::sin(omega*slice_ds)/omega;
+                R(2,1) = -omega*std::sin(omega*slice_ds);
+                R(2,2) = std::cos(omega*slice_ds);
+                R(3,3) = std::cosh(omega*slice_ds);
+                R(3,4) = std::sinh(omega*slice_ds)/omega;   
+                R(4,3) = omega*std::sinh(omega*slice_ds);
+                R(4,4) = std::cosh(omega*slice_ds);
+                R(5,6) = slice_ds/betgam2;
+            } else if (m_k < 0.0) {
+                R(1,1) = std::cosh(omega*slice_ds);
+                R(1,2) = std::sinh(omega*slice_ds)/omega;
+                R(2,1) = omega*std::sinh(omega*slice_ds);
+                R(2,2) = std::cosh(omega*slice_ds);
+                R(3,3) = std::cos(omega*slice_ds);
+                R(3,4) = std::sin(omega*slice_ds)/omega;
+                R(4,3) = -omega*std::sin(omega*slice_ds);   
+                R(4,4) = std::cos(omega*slice_ds);
+                R(5,6) = slice_ds/betgam2;
+            } else {
+                R(1,2) = m_slice_ds;
+                R(3,4) = m_slice_ds;
+                R(5,6) = m_slice_ds / betgam2;
+            }
+            
+            return R;
         }
+
+        /** This pushes the covariance matrix. */
+        using LinearTransport::operator();
 
         amrex::ParticleReal m_k; //! quadrupole strength in 1/m^2 (or T/m)
         int m_unit; //! unit specification for quad strength

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -375,6 +375,9 @@ lambday = -gyro_const * ( px*inv_delta1*(1_prt - cos_omega_ds) + x*omega*sin_ome
         }
 
 
+        /** This pushes the covariance matrix. */
+        using LinearTransport::operator();
+
         /** This function returns the linear transport map.
          *
          * @param[in] refpart reference particle
@@ -428,9 +431,6 @@ lambday = -gyro_const * ( px*inv_delta1*(1_prt - cos_omega_ds) + x*omega*sin_ome
 
             return R;
         }
-
-        /** This pushes the covariance matrix. */
-        using LinearTransport::operator();
 
         amrex::ParticleReal m_k; //! quadrupole strength in 1/m^2 (or T/m)
         int m_unit; //! unit specification for quad strength

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -382,7 +382,7 @@ lambday = -gyro_const * ( px*inv_delta1*(1_prt - cos_omega_ds) + x*omega*sin_ome
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE
         Map6x6
-        transport_map (RefPart const & AMREX_RESTRICT refpart) const  // TODO: update as well, but needs more careful placement of calc_constants
+        transport_map (RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -392,7 +392,7 @@ lambday = -gyro_const * ( px*inv_delta1*(1_prt - cos_omega_ds) + x*omega*sin_ome
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1_prt;
 
             // compute phase advance per unit length in s (in rad/m)
             amrex::ParticleReal const omega = std::sqrt(std::abs(m_k));

--- a/src/elements/ExactDrift.H
+++ b/src/elements/ExactDrift.H
@@ -249,6 +249,7 @@ namespace impactx::elements
 
         /** This function returns the linear transport map.
          *
+         * @param[in] refpart reference particle
          * @returns 6x6 transport matrix
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE

--- a/src/elements/ExactDrift.H
+++ b/src/elements/ExactDrift.H
@@ -244,6 +244,7 @@ namespace impactx::elements
             (*this)(x, y, t, px, py, pt, idcpu, refpart);
         }
 
+
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();
 

--- a/src/elements/ExactDrift.H
+++ b/src/elements/ExactDrift.H
@@ -263,7 +263,7 @@ namespace impactx::elements
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
+            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1_prt;
 
             // assign linear map matrix elements
             Map6x6 R = Map6x6::Identity();

--- a/src/elements/ExactDrift.H
+++ b/src/elements/ExactDrift.H
@@ -244,21 +244,34 @@ namespace impactx::elements
             (*this)(x, y, t, px, py, pt, idcpu, refpart);
         }
 
-
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();
 
         /** This function returns the linear transport map.
          *
-         * @param[in] refpart reference particle
          * @returns 6x6 transport matrix
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE
         Map6x6
-        transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
+        transport_map (RefPart const & AMREX_RESTRICT refpart) const
         {
-            throw std::runtime_error(std::string(type) + ": Envelope tracking is not yet implemented!");
-            return Map6x6::Identity();
+            using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
+
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+
+            // access reference particle values to find beta*gamma^2
+            amrex::ParticleReal const pt_ref = refpart.pt;
+            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
+
+            // assign linear map matrix elements
+            Map6x6 R = Map6x6::Identity();
+            R(1,2) = slice_ds;
+            R(3,4) = slice_ds;
+            R(5,6) = slice_ds / betgam2;
+
+            return R;
         }
 
       private:

--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -311,6 +311,7 @@ namespace impactx::elements
 
         /** This function returns the linear transport map.
          *
+         * @param[in] refpart reference particle
          * @returns 6x6 transport matrix
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE
@@ -325,8 +326,8 @@ namespace impactx::elements
 
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
-            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
-            amrex::ParticleReal const bet = std::sqrt(betgam2/(1.0_prt + betgam2));
+            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1_prt;
+            amrex::ParticleReal const bet = refpart.beta;
 
             // initialize linear map matrix elements
             Map6x6 R = Map6x6::Identity();

--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -319,44 +319,44 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
-               
+
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
-               
+
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
             amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
             amrex::ParticleReal const bet = std::sqrt(betgam2/(1.0_prt + betgam2));
-            
+
             // initialize linear map matrix elements
             Map6x6 R = Map6x6::Identity();
-            
+
             // treat the special case of zero field
             if (m_rc==0.0_prt) {
                R(1,2) = slice_ds;
                R(3,4) = slice_ds;
                R(5,6) = slice_ds / betgam2;
-        
+
             } else {
-         
+
                // calculate expensive terms once
                amrex::ParticleReal const theta = slice_ds/m_rc;
                auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
-        
+
                // assign linear map matrix elements
                R(1,1) = cos_theta;
                R(1,2) = m_rc*sin_theta;
                R(1,6) = - (m_rc/bet)*(1.0_prt - cos_theta);
-               R(2,1) = -sin_theta/m_rc;  
+               R(2,1) = -sin_theta/m_rc;
                R(2,2) = cos_theta;
                R(2,6) = - sin_theta/bet;
                R(3,4) = m_rc*theta;
                R(5,1) = sin_theta/bet;
                R(5,2) = m_rc/bet*(1.0_prt - cos_theta);
                R(5,6) = m_rc*(-theta+sin_theta/(bet*bet));
-            
+
             }
-            
+
             return R;
         }
 

--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -311,15 +311,53 @@ namespace impactx::elements
 
         /** This function returns the linear transport map.
          *
-         * @param[in] refpart reference particle
          * @returns 6x6 transport matrix
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE
         Map6x6
-        transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
+        transport_map (RefPart const & AMREX_RESTRICT refpart) const
         {
-            throw std::runtime_error(std::string(type) + ": Envelope tracking is not yet implemented!");
-            return Map6x6::Identity();
+            using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
+               
+            // length of the current slice
+            amrex::ParticleReal const slice_ds = m_ds / nslice();
+               
+            // access reference particle values to find beta*gamma^2
+            amrex::ParticleReal const pt_ref = refpart.pt;
+            amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
+            amrex::ParticleReal const bet = std::sqrt(betgam2/(1.0_prt + betgam2));
+            
+            // initialize linear map matrix elements
+            Map6x6 R = Map6x6::Identity();
+            
+            // treat the special case of zero field
+            if (m_rc==0.0_prt) {
+               R(1,2) = slice_ds;
+               R(3,4) = slice_ds;
+               R(5,6) = slice_ds / betgam2;
+        
+            } else {
+         
+               // calculate expensive terms once
+               amrex::ParticleReal const theta = slice_ds/m_rc;
+               auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
+        
+               // assign linear map matrix elements
+               R(1,1) = cos_theta;
+               R(1,2) = m_rc*sin_theta;
+               R(1,6) = - (m_rc/bet)*(1.0_prt - cos_theta);
+               R(2,1) = -sin_theta/m_rc;  
+               R(2,2) = cos_theta;
+               R(2,6) = - sin_theta/bet;
+               R(3,4) = m_rc*theta;
+               R(5,1) = sin_theta/bet;
+               R(5,2) = m_rc/bet*(1.0_prt - cos_theta);
+               R(5,6) = m_rc*(-theta+sin_theta/(bet*bet));
+            
+            }
+            
+            return R;
         }
 
         amrex::ParticleReal m_phi; //! bend angle in radians

--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -345,16 +345,15 @@ namespace impactx::elements
 
                // assign linear map matrix elements
                R(1,1) = cos_theta;
-               R(1,2) = m_rc*sin_theta;
-               R(1,6) = - (m_rc/bet)*(1.0_prt - cos_theta);
-               R(2,1) = -sin_theta/m_rc;
+               R(1,2) = m_rc * sin_theta;
+               R(1,6) = - ( m_rc / bet) * (1_prt - cos_theta);
+               R(2,1) = -sin_theta / m_rc;
                R(2,2) = cos_theta;
-               R(2,6) = - sin_theta/bet;
-               R(3,4) = m_rc*theta;
-               R(5,1) = sin_theta/bet;
-               R(5,2) = m_rc/bet*(1.0_prt - cos_theta);
-               R(5,6) = m_rc*(-theta+sin_theta/(bet*bet));
-
+               R(2,6) = - sin_theta / bet;
+               R(3,4) = m_rc * theta;
+               R(5,1) = sin_theta / bet;
+               R(5,2) = m_rc / bet * (1_prt - cos_theta);
+               R(5,6) = m_rc * (-theta + sin_theta / (bet * bet));
             }
 
             return R;

--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -327,7 +327,7 @@ namespace impactx::elements
             // access reference particle values to find beta*gamma^2
             amrex::ParticleReal const pt_ref = refpart.pt;
             amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1_prt;
-            amrex::ParticleReal const bet = refpart.beta;
+            amrex::ParticleReal const bet = refpart.beta();
 
             // initialize linear map matrix elements
             Map6x6 R = Map6x6::Identity();


### PR DESCRIPTION
This PR adds the return of the linear map for several core elements that use nonlinear element models.  Here, this includes:

- [x] ChrQuad
- [x] ChrDrift
- [x] ChrPlasmaLens
- [x] ExactDrift
- [x] ExactSbend
- [ ] simplify: call maps of linear elements -- later because of diverged inputs

The linear maps here are identical to those in the corresponding linear element (Quad, Drift, etc.)

Note that other nonlinear elements, including `ExactQuad`, `ExactMultipole` and `ExactCFbend`, are already supported.
