### PR TITLE
Lattice Element (De)Serialization Round-Trip

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -823,6 +823,14 @@ This module provides elements and methods for the accelerator lattice.
       Each element is converted to a dictionary using its ``to_dict()`` method.
       The resulting list can be serialized to JSON, YAML, or other formats.
 
+      .. note::
+
+         This transforms the buggy ``.to_dict()`` keys of
+         ``ExactSbend``, ``PlaneXYRot``, ``PRot`` and ``ThinDipole``
+         to degrees, which by accident are written in radians.
+         See this comment in
+         `issue #1367 <https://github.com/BLAST-ImpactX/impactx/issues/1367#issuecomment-4160236826>`__.
+
       :return: List of element dictionaries
       :rtype: list[dict]
 
@@ -848,13 +856,6 @@ This module provides elements and methods for the accelerator lattice.
 
       Each dictionary should be in the format produced by ``to_dict()``,
       containing at minimum a ``type`` key identifying the element class.
-
-      .. note::
-
-         This transforms the dict keys of ``ExactSbend``, ``PlaneXYRot``,
-         ``PRot`` and ``ThinDipole`` to degrees, which by accident are written
-         in radians. See this comment in
-         `issue #1367 <https://github.com/BLAST-ImpactX/impactx/issues/1367#issuecomment-4160236826>`__.
 
       :param dicts: List of element dictionaries
       :type dicts: list[dict]
@@ -883,8 +884,9 @@ This module provides elements and methods for the accelerator lattice.
 
       .. note::
 
-         Like ``from_dicts()``, this transforms the dict keys of ``ExactSbend``,
-         ``PlaneXYRot``, ``PRot`` and ``ThinDipole`` angles from radians to degrees.
+         Like ``to_dicts()``, this transforms the buggy ``.to_dict()`` keys of
+         ``ExactSbend``, ``PlaneXYRot``, ``PRot`` and ``ThinDipole``
+         from radians to degrees.
 
       :return: Python source code
       :rtype: str

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -816,6 +816,63 @@ This module provides elements and methods for the accelerator lattice.
       :return: The transfer map of all elements in the list.
       :rtype: Map6x6
 
+   .. py:method:: to_dicts()
+
+      Serialize the lattice to a list of dictionaries.
+
+      Each element is converted to a dictionary using its ``to_dict()`` method.
+      The resulting list can be serialized to JSON, YAML, or other formats.
+
+      :return: List of element dictionaries
+      :rtype: list[dict]
+
+      **Example:**
+
+      .. code-block:: python
+
+         import json
+         from impactx import elements
+
+         lattice = elements.KnownElementsList([
+             elements.Drift(ds=1.0, name="d1"),
+             elements.Quad(ds=0.5, k=2.0, name="q1"),
+         ])
+
+         # Serialize to JSON
+         with open("lattice.impactx.json", "w") as f:
+             json.dump(lattice.to_dicts(), f, indent=2)
+
+   .. py:method:: from_dicts(dicts)
+
+      Load and append elements from a list of dictionaries.
+
+      Each dictionary should be in the format produced by ``to_dict()``,
+      containing at minimum a ``type`` key identifying the element class.
+
+      .. note::
+
+         This transforms the dict keys of `ExactSbend`, `PlanXYRot`,
+         `PRot` and `ThinDipole` to degrees, which by accident are written
+         in radians. See this comment in
+         `issue #1367 <https://github.com/BLAST-ImpactX/impactx/issues/1367#issuecomment-4160236826>`__.
+
+      :param dicts: List of element dictionaries
+      :type dicts: list[dict]
+
+      **Example:**
+
+      .. code-block:: python
+
+         import json
+         from impactx import elements
+
+         # Load from JSON
+         with open("lattice.impactx.json") as f:
+             data = json.load(f)
+
+         lattice = elements.KnownElementsList()
+         lattice.from_dicts(data)
+
    .. py:method:: plot_survey(ref=None, ax=None, legend=True, legend_ncols=5)
 
       Plot over s of all elements in the KnownElementsList.

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -851,8 +851,8 @@ This module provides elements and methods for the accelerator lattice.
 
       .. note::
 
-         This transforms the dict keys of `ExactSbend`, `PlanXYRot`,
-         `PRot` and `ThinDipole` to degrees, which by accident are written
+         This transforms the dict keys of ``ExactSbend``, ``PlaneXYRot``,
+         ``PRot`` and ``ThinDipole`` to degrees, which by accident are written
          in radians. See this comment in
          `issue #1367 <https://github.com/BLAST-ImpactX/impactx/issues/1367#issuecomment-4160236826>`__.
 
@@ -872,6 +872,45 @@ This module provides elements and methods for the accelerator lattice.
 
          lattice = elements.KnownElementsList()
          lattice.from_dicts(data)
+
+   .. py:method:: to_py()
+
+      Generate Python code that recreates this lattice.
+
+      Returns a string containing a complete Python script with imports
+      and a ``get_lattice()`` function that returns a KnownElementsList
+      with all elements.
+
+      .. note::
+
+         Like ``from_dicts()``, this transforms the dict keys of ``ExactSbend``,
+         ``PlaneXYRot``, ``PRot`` and ``ThinDipole`` angles from radians to degrees.
+
+      :return: Python source code
+      :rtype: str
+
+      **Example:**
+
+      .. code-block:: python
+
+         from impactx import elements
+
+         lattice = elements.KnownElementsList([
+             elements.Drift(ds=1.0, name="d1"),
+             elements.Quad(ds=0.5, k=2.0, name="q1"),
+         ])
+
+         # Generate Python code
+         code = lattice.to_py()
+         print(code)
+
+         # Save to file
+         with open("my_lattice.py", "w") as f:
+             f.write(code)
+
+         # Later, use the generated file:
+         # from my_lattice import get_lattice
+         # lattice = get_lattice()
 
    .. py:method:: plot_survey(ref=None, ax=None, legend=True, legend_ncols=5)
 

--- a/src/elements/diagnostics/BeamMonitor.H
+++ b/src/elements/diagnostics/BeamMonitor.H
@@ -164,6 +164,18 @@ namespace detail
         AMREX_FORCE_INLINE
         bool has_name () const { return true; }
 
+        /** openPMD backend string passed at construction (e.g. "default", "bp4", "h5") */
+        AMREX_FORCE_INLINE
+        std::string backend () const { return m_OpenPMDFileType; }
+
+        /** openPMD iteration encoding: "v", "f", or "g" */
+        AMREX_FORCE_INLINE
+        std::string encoding () const { return m_encoding; }
+
+        /** For periodic lattices, only output every Nth period (turn or cycle) */
+        AMREX_FORCE_INLINE
+        int period_sample_intervals () const { return m_period_sample_intervals; }
+
         /** track all m_series_name instances
          *
          * Ensure m_series is the same for the same name.

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -1372,6 +1372,7 @@ void init_elements(py::module& m)
                 return element_dict(
                     exact_sbend,
                     std::make_pair("phi", exact_sbend.m_phi),  // BUG: needs / ExactSbend::degree2rad),
+                                                                 // once fixed, update src/python/impactx/extensions/KnownElementsList.py
                     std::make_pair("B", exact_sbend.m_B)
                 );
             }
@@ -1652,6 +1653,7 @@ void init_elements(py::module& m)
                 return element_dict(
                     plane_xyrot,
                     std::make_pair("angle", plane_xyrot.m_phi)  // BUG: / PlaneXYRot::degree2rad)
+                                                                  // once fixed, update src/python/impactx/extensions/KnownElementsList.py
                 );
             }
         )
@@ -2379,6 +2381,7 @@ void init_elements(py::module& m)
                     prot,
                     std::make_pair("phi_in", prot.m_phi_in),   // BUG: needs / PRot::degree2rad),
                     std::make_pair("phi_out", prot.m_phi_out)  // BUG: needs / PRot::degree2rad)
+                                                                 // once fixed, update src/python/impactx/extensions/KnownElementsList.py
                 );
             }
         )
@@ -2497,6 +2500,7 @@ void init_elements(py::module& m)
                 return element_dict(
                     thin_dp,
                     std::make_pair("theta", thin_dp.m_theta),  // BUG: needs / ThinDipole::degree2rad),
+                                                                 // once fixed, update src/python/impactx/extensions/KnownElementsList.py
                     std::make_pair("rc", thin_dp.m_rc)
                 );
             }

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -184,6 +184,7 @@ namespace
         amrex::ParticleReal,
         int,
         long,
+        bool,
         std::string,
         std::vector<amrex::ParticleReal>,
         std::vector<int>,
@@ -194,7 +195,22 @@ namespace
         py::none
     >;
 
-    /** Create a map (for a Python dictionary) of properties of an element */
+    /** Create a map (for a Python dictionary) of properties of an element
+     *
+     * The values are meant to align with the element type's Python constructor keyword
+     * arguments where possible, used internally for copies and (de)serialization.
+     *
+     * The dict always includes a ``type`` string (the element class name) for dispatch;
+     * we also include ``ds`` as 0.0 for thin elements for simplicity (plots, etc.);
+     * ``type`` is not a constructor argument and neither is ``ds`` for thin elements,
+     * and must be omitted when unpacking, e.g.:
+     * ```py
+     * dr = elements.Drift(name="drift1", ds=1.0)
+     * d = dr.to_dict()
+     * kwargs = {k: v for k, v in d.items() if k != "type" and (k != "ds" or v != 0.0)}
+     * dr2 = elements.Drift(**kwargs)
+     * ```
+     */
     template<typename T_Element, typename... ExtraArgs>
     std::map<std::string, ElementPropertyTypes>
     element_dict (T_Element const & el, std::pair<char const *, ExtraArgs> const &... args)
@@ -210,11 +226,15 @@ namespace
             {"type", type},
             {"name", name},
             // Thin / Thick properties
-            {"ds", el.ds()},
-            {"nslice", el.nslice()}
+            {"ds", el.ds()}
         };
 
         // properties of mixin classes
+        if (el.nslice() != 1) {
+            // for thick elements, nslice default is 1 and can be omitted
+            // for thin elements, nslice is 1 by definition and not a constructor argument
+            ret.insert(std::make_pair("nslice", el.nslice()));
+        }
         if constexpr (std::is_base_of_v<elements::mixin::Alignment, std::decay_t<T_Element>>) {
             ret.insert(std::make_pair("dx", el.dx()));
             ret.insert(std::make_pair("dy", el.dy()));
@@ -345,7 +365,12 @@ void init_elements(py::module& m)
         )
         .def("to_dict",
              [](diagnostics::BeamMonitor const & bm) {
-                 return element_dict(bm);
+                 return element_dict(
+                     bm,
+                     std::make_pair("backend", bm.backend()),
+                     std::make_pair("encoding", bm.encoding()),
+                     std::make_pair("period_sample_intervals", bm.period_sample_intervals())
+                 );
              }
         )
         .def(py::init<std::string, std::string, std::string, int>(),
@@ -360,6 +385,18 @@ void init_elements(py::module& m)
             "name of the series"
         )
         .def_property_readonly("has_name", &diagnostics::BeamMonitor::has_name)
+        .def_property_readonly("backend",
+            &diagnostics::BeamMonitor::backend,
+            "openPMD file backend (e.g. default, bp4, h5)"
+        )
+        .def_property_readonly("encoding",
+            &diagnostics::BeamMonitor::encoding,
+            R"(openPMD iteration encoding: "v" variable-based, "f" file-based, "g" group-based)"
+        )
+        .def_property_readonly("period_sample_intervals",
+            &diagnostics::BeamMonitor::period_sample_intervals,
+            "for periodic lattices, only output every Nth period (turn or cycle)"
+        )
         .def_property("nonlinear_lens_invariants",
             [](diagnostics::BeamMonitor & bm) { return detail::get_or_throw<bool>(bm.name(), "nonlinear_lens_invariants"); },
             [](diagnostics::BeamMonitor & bm, bool nonlinear_lens_invariants) {
@@ -423,8 +460,8 @@ void init_elements(py::module& m)
                 using namespace amrex::literals;
                 return element_dict(
                     ap,
-                    std::make_pair("shape", ap.m_shape),
-                    std::make_pair("action", ap.m_action),
+                    std::make_pair("shape", ap.shape_name(ap.m_shape)),
+                    std::make_pair("action", ap.action_name(ap.m_action)),
                     std::make_pair("aperture_x", 1_prt / ap.m_inv_aperture_x),
                     std::make_pair("aperture_y", 1_prt / ap.m_inv_aperture_y),
                     std::make_pair("repeat_x", ap.m_repeat_x),
@@ -982,11 +1019,13 @@ void init_elements(py::module& m)
         )
         .def("to_dict",
             [](QuadEdge const & quadedge) {
+                std::string const flag_str = quadedge.m_flag == QuadEdge::Location::entry ?
+                    "entry" : "exit";
                 return element_dict(
                     quadedge,
                     std::make_pair("k", quadedge.m_k),
                     std::make_pair("unit", quadedge.m_unit),
-                    std::make_pair("flag", quadedge.m_flag)
+                    std::make_pair("flag", flag_str)
                 );
             }
         )
@@ -1323,7 +1362,7 @@ void init_elements(py::module& m)
              [](ExactSbend const & exact_sbend) {
                  return element_name(
                      exact_sbend,
-                     std::make_pair("phi", exact_sbend.m_phi),
+                     std::make_pair("phi", exact_sbend.m_phi),  // BUG: needs / ExactSbend::degree2rad),
                      std::make_pair("B", exact_sbend.m_B)
                  );
              }
@@ -1332,7 +1371,7 @@ void init_elements(py::module& m)
             [](ExactSbend const & exact_sbend) {
                 return element_dict(
                     exact_sbend,
-                    std::make_pair("phi", exact_sbend.m_phi),
+                    std::make_pair("phi", exact_sbend.m_phi),  // BUG: needs / ExactSbend::degree2rad),
                     std::make_pair("B", exact_sbend.m_B)
                 );
             }
@@ -1368,8 +1407,17 @@ void init_elements(py::module& m)
         .def_property("phi",
             [](ExactSbend & exact_sbend) { return exact_sbend.m_phi; },
             [](ExactSbend & exact_sbend, amrex::ParticleReal phi) { exact_sbend.m_phi = phi; },
+            "Bend angle in radian"
+        )
+        /* BUG, should be in degrees like this:
+        .def_property("phi",
+            [](ExactSbend & exact_sbend) { return exact_sbend.m_phi / ExactSbend::degree2rad; },
+            [](ExactSbend & exact_sbend, amrex::ParticleReal phi_deg) {
+                exact_sbend.m_phi = phi_deg * ExactSbend::degree2rad;
+            },
             "Bend angle in degrees"
         )
+        */
         .def_property("B",
             [](ExactSbend & exact_sbend) { return exact_sbend.m_B; },
             [](ExactSbend & exact_sbend, amrex::ParticleReal B) { exact_sbend.m_B = B; },
@@ -1391,11 +1439,13 @@ void init_elements(py::module& m)
         )
         .def("to_dict",
             [](Kicker const & kicker) {
+                std::string const unit_str = kicker.m_unit == Kicker::UnitSystem::Tm ?
+                    "T-m" : "dimensionless";
                 return element_dict(
                     kicker,
                     std::make_pair("xkick", kicker.m_xkick),
                     std::make_pair("ykick", kicker.m_ykick),
-                    std::make_pair("unit", kicker.m_unit)
+                    std::make_pair("unit", unit_str)
                 );
             }
         )
@@ -1593,7 +1643,7 @@ void init_elements(py::module& m)
              [](PlaneXYRot const & plane_xyrot) {
                  return element_name(
                      plane_xyrot,
-                     std::make_pair("angle", plane_xyrot.m_phi)
+                     std::make_pair("angle", plane_xyrot.m_phi)  // BUG: needs / PlaneXYRot::degree2rad)
                  );
              }
         )
@@ -1601,7 +1651,7 @@ void init_elements(py::module& m)
             [](PlaneXYRot const & plane_xyrot) {
                 return element_dict(
                     plane_xyrot,
-                    std::make_pair("angle", plane_xyrot.m_phi)
+                    std::make_pair("angle", plane_xyrot.m_phi)  // BUG: / PlaneXYRot::degree2rad)
                 );
             }
         )
@@ -1624,6 +1674,15 @@ void init_elements(py::module& m)
             [](PlaneXYRot & plane_xyrot, amrex::ParticleReal phi) { plane_xyrot.m_phi = phi; },
             "Rotation angle (rad)."
         )
+        /* BUG: should be in degrees
+        .def_property("angle",
+            [](PlaneXYRot & plane_xyrot) { return plane_xyrot.m_phi / PlaneXYRot::degree2rad; },
+            [](PlaneXYRot & plane_xyrot, amrex::ParticleReal phi_deg) {
+                plane_xyrot.m_phi = phi_deg * PlaneXYRot::degree2rad;
+            },
+            "Rotation angle in degrees (in the x-y plane about the reference trajectory)."
+        )
+        */
     ;
     register_push(py_PlaneXYRot);
 
@@ -1645,7 +1704,7 @@ void init_elements(py::module& m)
                     std::make_pair("vertices_x", PolygonApertureData::h_vertices_x[polygon_aperture.m_id]),
                     std::make_pair("vertices_y", PolygonApertureData::h_vertices_y[polygon_aperture.m_id]),
                     std::make_pair("min_radius2", polygon_aperture.m_min_radius2),
-                    std::make_pair("action", polygon_aperture.m_action),
+                    std::make_pair("action", polygon_aperture.action_name(polygon_aperture.m_action)),
                     std::make_pair("repeat_x", polygon_aperture.m_repeat_x),
                     std::make_pair("repeat_y", polygon_aperture.m_repeat_y),
                     std::make_pair("shift_odd_x", polygon_aperture.m_shift_odd_x)
@@ -1737,7 +1796,11 @@ void init_elements(py::module& m)
         )
         .def("to_dict",
             [](Programmable const & prg) {
-                return element_dict(prg);
+                return element_dict(
+                    prg,
+                    std::make_pair("ds", prg.m_ds),
+                    std::make_pair("nslice", prg.m_nslice)
+                );
             }
         )
         .def(py::init<
@@ -1853,8 +1916,8 @@ void init_elements(py::module& m)
                     std::make_pair("escale", rfc.m_escale),
                     std::make_pair("freq", rfc.m_freq),
                     std::make_pair("phase", rfc.m_phase),
-                    std::make_pair("cos_coef", RFCavityData::h_cos_coef[rfc.m_id]),
-                    std::make_pair("sin_coef", RFCavityData::h_sin_coef[rfc.m_id]),
+                    std::make_pair("cos_coefficients", RFCavityData::h_cos_coef[rfc.m_id]),
+                    std::make_pair("sin_coefficients", RFCavityData::h_sin_coef[rfc.m_id]),
                     std::make_pair("mapsteps", rfc.m_mapsteps)
                 );
             }
@@ -2143,8 +2206,8 @@ void init_elements(py::module& m)
                     soft_sol,
                     std::make_pair("bscale", soft_sol.m_bscale),
                     std::make_pair("unit", soft_sol.m_unit),
-                    std::make_pair("cos_coef", SoftSolenoidData::h_cos_coef[soft_sol.m_id]),
-                    std::make_pair("sin_coef", SoftSolenoidData::h_sin_coef[soft_sol.m_id]),
+                    std::make_pair("cos_coefficients", SoftSolenoidData::h_cos_coef[soft_sol.m_id]),
+                    std::make_pair("sin_coefficients", SoftSolenoidData::h_sin_coef[soft_sol.m_id]),
                     std::make_pair("mapsteps", soft_sol.m_mapsteps)
                 );
             }
@@ -2206,7 +2269,7 @@ void init_elements(py::module& m)
                  return element_name(
                      src,
                      std::make_pair("distribution", src.m_distribution),
-                     std::make_pair("path", src.m_series_name),
+                     std::make_pair("openpmd_path", src.m_series_name),
                      std::make_pair("active_once", src.m_active_once)
                  );
              }
@@ -2216,7 +2279,7 @@ void init_elements(py::module& m)
                 return element_dict(
                     src,
                     std::make_pair("distribution", src.m_distribution),
-                    std::make_pair("path", src.m_series_name),
+                    std::make_pair("openpmd_path", src.m_series_name),
                     std::make_pair("active_once", src.m_active_once)
                 );
             }
@@ -2305,8 +2368,8 @@ void init_elements(py::module& m)
              [](PRot const & prot) {
                  return element_name(
                      prot,
-                     std::make_pair("phi_in", prot.m_phi_in),
-                     std::make_pair("phi_out", prot.m_phi_out)
+                     std::make_pair("phi_in", prot.m_phi_in),   // BUG: needs / PRot::degree2rad),
+                     std::make_pair("phi_out", prot.m_phi_out)  // BUG needs / PRot::degree2rad)
                  );
              }
         )
@@ -2314,8 +2377,8 @@ void init_elements(py::module& m)
             [](PRot const & prot) {
                 return element_dict(
                     prot,
-                    std::make_pair("phi_in", prot.m_phi_in),
-                    std::make_pair("phi_out", prot.m_phi_out)
+                    std::make_pair("phi_in", prot.m_phi_in),   // BUG: needs / PRot::degree2rad),
+                    std::make_pair("phi_out", prot.m_phi_out)  // BUG: needs / PRot::degree2rad)
                 );
             }
         )
@@ -2332,13 +2395,25 @@ void init_elements(py::module& m)
         .def_property("phi_in",
             [](PRot & prot) { return prot.m_phi_in; },
             [](PRot & prot, amrex::ParticleReal phi_in) { prot.m_phi_in = phi_in; },
-            "angle of the reference particle with respect to the longitudinal (z) axis in the original frame in degrees"
+            "angle of the reference particle with respect to the longitudinal (z) axis in the original frame in radian"
         )
         .def_property("phi_out",
             [](PRot & prot) { return prot.m_phi_out; },
             [](PRot & prot, amrex::ParticleReal phi_out) { prot.m_phi_out = phi_out; },
+            "angle of the reference particle with respect to the longitudinal (z) axis in the rotated frame in radian"
+        )
+        /* BUG: this should be in degree
+        .def_property("phi_in",
+            [](PRot & prot) { return prot.m_phi_in / PRot::degree2rad; },
+            [](PRot & prot, amrex::ParticleReal phi_in_deg) { prot.m_phi_in = phi_in_deg * PRot::degree2rad; },
+            "angle of the reference particle with respect to the longitudinal (z) axis in the original frame in degrees"
+        )
+        .def_property("phi_out",
+            [](PRot & prot) { return prot.m_phi_out / PRot::degree2rad; },
+            [](PRot & prot, amrex::ParticleReal phi_out_deg) { prot.m_phi_out = phi_out_deg * PRot::degree2rad; },
             "angle of the reference particle with respect to the longitudinal (z) axis in the rotated frame in degrees"
         )
+        */
     ;
     register_push(py_PRot);
 
@@ -2357,8 +2432,8 @@ void init_elements(py::module& m)
                 return element_dict(
                     soft_quad,
                     std::make_pair("gscale", soft_quad.m_gscale),
-                    std::make_pair("cos_coef", SoftQuadrupoleData::h_cos_coef[soft_quad.m_id]),
-                    std::make_pair("sin_coef", SoftQuadrupoleData::h_sin_coef[soft_quad.m_id]),
+                    std::make_pair("cos_coefficients", SoftQuadrupoleData::h_cos_coef[soft_quad.m_id]),
+                    std::make_pair("sin_coefficients", SoftQuadrupoleData::h_sin_coef[soft_quad.m_id]),
                     std::make_pair("mapsteps", soft_quad.m_mapsteps)
                 );
             }
@@ -2412,7 +2487,7 @@ void init_elements(py::module& m)
              [](ThinDipole const & thin_dp) {
                  return element_name(
                      thin_dp,
-                     std::make_pair("theta", thin_dp.m_theta),
+                     std::make_pair("theta", thin_dp.m_theta),  // BUG: needs / ThinDipole::degree2rad),
                      std::make_pair("rc", thin_dp.m_rc)
                  );
              }
@@ -2421,7 +2496,7 @@ void init_elements(py::module& m)
             [](ThinDipole const & thin_dp) {
                 return element_dict(
                     thin_dp,
-                    std::make_pair("theta", thin_dp.m_theta),
+                    std::make_pair("theta", thin_dp.m_theta),  // BUG: needs / ThinDipole::degree2rad),
                     std::make_pair("rc", thin_dp.m_rc)
                 );
             }
@@ -2445,6 +2520,14 @@ void init_elements(py::module& m)
         .def_property("theta",
             [](ThinDipole & thin_dp) { return thin_dp.m_theta; },
             [](ThinDipole & thin_dp, amrex::ParticleReal theta) { thin_dp.m_theta = theta; },
+            "Bend angle (radian)"
+        )
+        /* BUG: this should be in degree
+        .def_property("theta",
+            [](ThinDipole & thin_dp) { return thin_dp.m_theta / ThinDipole::degree2rad; },
+            [](ThinDipole & thin_dp, amrex::ParticleReal theta_deg) {
+                thin_dp.m_theta = theta_deg * ThinDipole::degree2rad;
+            },
             "Bend angle (degrees)"
         )
         .def_property("rc",
@@ -2452,6 +2535,7 @@ void init_elements(py::module& m)
             [](ThinDipole & thin_dp, amrex::ParticleReal rc) { thin_dp.m_rc = rc; },
             "Effective curvature radius (meters)"
         )
+        */
     ;
     register_push(py_ThinDipole);
 
@@ -2530,7 +2614,8 @@ void init_elements(py::module& m)
             [](LinearMap const & linearmap) {
                 return element_dict(
                     linearmap,
-                    std::make_pair("transport_map", linearmap.m_transport_map)
+                    std::make_pair("ds", linearmap.m_ds),
+                    std::make_pair("R", linearmap.m_transport_map)
                 );
             }
         )
@@ -2574,15 +2659,16 @@ void init_elements(py::module& m)
                  return element_name(spinmap);
              }
         )
-/*        .def("to_dict",
+        .def("to_dict",
             [](SpinMap const & spinmap) {
                 return element_dict(
                     spinmap,
+                    std::make_pair("ds", spinmap.m_ds),
                     std::make_pair("v", spinmap.m_spin_rotation_vector),
                     std::make_pair("A", spinmap.m_spin_orbit_coupling)
                 );
             }
-        ) */
+        )
         .def(py::init<
                 Vector3,
                 Map3x6,

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -1368,14 +1368,31 @@ void init_elements(py::module& m)
              }
         )
         .def("to_dict",
-            [](ExactSbend const & exact_sbend) {
-                return element_dict(
-                    exact_sbend,
-                    std::make_pair("phi", exact_sbend.m_phi),  // BUG: needs / ExactSbend::degree2rad),
-                                                                 // once fixed, update src/python/impactx/extensions/KnownElementsList.py
-                    std::make_pair("B", exact_sbend.m_B)
-                );
-            }
+            [](ExactSbend const & exact_sbend, bool in_degrees) {
+                if (in_degrees) {
+                    return element_dict(
+                        exact_sbend,
+                        std::make_pair("phi", exact_sbend.m_phi / ExactSbend::degree2rad),
+                                                                   // once fixed, update src/python/impactx/extensions/KnownElementsList.py
+                        std::make_pair("B", exact_sbend.m_B)
+                    );
+                } else {
+                    // legacy: buggy radians instead of degrees
+                    py::warnings::warn(
+                        "Warning: ExactSbend.to_dict() has a known bug, "
+                        "returning phi in radians than degrees. "
+                        "Please use ExactSbend.to_dict(in_degrees=True) instead.",
+                        PyExc_RuntimeWarning,
+                        2
+                    );
+                    return element_dict(
+                        exact_sbend,
+                        std::make_pair("phi", exact_sbend.m_phi),  // BUG: constructor is in degrees
+                        std::make_pair("B", exact_sbend.m_B)
+                    );
+                }
+            },
+            py::arg("in_degrees") = false
         )
         .def(py::init<
                 amrex::ParticleReal,
@@ -1649,13 +1666,29 @@ void init_elements(py::module& m)
              }
         )
         .def("to_dict",
-            [](PlaneXYRot const & plane_xyrot) {
-                return element_dict(
-                    plane_xyrot,
-                    std::make_pair("angle", plane_xyrot.m_phi)  // BUG: / PlaneXYRot::degree2rad)
-                                                                  // once fixed, update src/python/impactx/extensions/KnownElementsList.py
-                );
-            }
+            [](PlaneXYRot const & plane_xyrot, bool in_degrees) {
+                if (in_degrees) {
+                    return element_dict(
+                        plane_xyrot,
+                        std::make_pair("angle", plane_xyrot.m_phi / PlaneXYRot::degree2rad)
+                                                                      // once fixed, update src/python/impactx/extensions/KnownElementsList.py
+                    );
+                } else {
+                    // legacy: buggy radians instead of degrees
+                    py::warnings::warn(
+                        "Warning: PlaneXYRot.to_dict() has a known bug, "
+                        "returning angle in radians than degrees. "
+                        "Please use PlaneXYRot.to_dict(in_degrees=True) instead.",
+                        PyExc_RuntimeWarning,
+                        2
+                    );
+                    return element_dict(
+                        plane_xyrot,
+                        std::make_pair("angle", plane_xyrot.m_phi)  // BUG: constructor is in degrees
+                    );
+                }
+            },
+            py::arg("in_degrees") = false
         )
         .def(py::init<
                 amrex::ParticleReal,
@@ -2376,14 +2409,31 @@ void init_elements(py::module& m)
              }
         )
         .def("to_dict",
-            [](PRot const & prot) {
-                return element_dict(
-                    prot,
-                    std::make_pair("phi_in", prot.m_phi_in),   // BUG: needs / PRot::degree2rad),
-                    std::make_pair("phi_out", prot.m_phi_out)  // BUG: needs / PRot::degree2rad)
-                                                                 // once fixed, update src/python/impactx/extensions/KnownElementsList.py
-                );
-            }
+            [](PRot const & prot, bool in_degrees) {
+                if (in_degrees) {
+                    return element_dict(
+                        prot,
+                        std::make_pair("phi_in", prot.m_phi_in / PRot::degree2rad),
+                                                                     // once fixed, update src/python/impactx/extensions/KnownElementsList.py
+                        std::make_pair("phi_out", prot.m_phi_out / PRot::degree2rad)
+                    );
+                } else {
+                    // legacy: buggy radians instead of degrees
+                    py::warnings::warn(
+                        "Warning: PRot.to_dict() has a known bug, "
+                        "returning phi_in and phi_out in radians than degrees. "
+                        "Please use PRot.to_dict(in_degrees=True) instead.",
+                        PyExc_RuntimeWarning,
+                        2
+                    );
+                    return element_dict(
+                        prot,
+                        std::make_pair("phi_in", prot.m_phi_in),   // BUG: constructor is in degrees
+                        std::make_pair("phi_out", prot.m_phi_out)  // BUG: constructor is in degrees
+                    );
+                }
+            },
+            py::arg("in_degrees") = false
         )
         .def(py::init<
                 amrex::ParticleReal,
@@ -2496,14 +2546,31 @@ void init_elements(py::module& m)
              }
         )
         .def("to_dict",
-            [](ThinDipole const & thin_dp) {
-                return element_dict(
-                    thin_dp,
-                    std::make_pair("theta", thin_dp.m_theta),  // BUG: needs / ThinDipole::degree2rad),
-                                                                 // once fixed, update src/python/impactx/extensions/KnownElementsList.py
-                    std::make_pair("rc", thin_dp.m_rc)
-                );
-            }
+            [](ThinDipole const & thin_dp, bool in_degrees) {
+                if (in_degrees) {
+                    return element_dict(
+                        thin_dp,
+                        std::make_pair("theta", thin_dp.m_theta / ThinDipole::degree2rad),
+                                                                     // once fixed, update src/python/impactx/extensions/KnownElementsList.py
+                        std::make_pair("rc", thin_dp.m_rc)
+                    );
+                } else {
+                    // legacy: buggy radians instead of degrees
+                    py::warnings::warn(
+                        "Warning: ThinDipole.to_dict() has a known bug, "
+                        "returning theta in radians than degrees. "
+                        "Please use ThinDipole.to_dict(in_degrees=True) instead.",
+                        PyExc_RuntimeWarning,
+                        2
+                    );
+                    return element_dict(
+                        thin_dp,
+                        std::make_pair("theta", thin_dp.m_theta),  // BUG: constructor is in degrees
+                        std::make_pair("rc", thin_dp.m_rc)
+                    );
+                }
+            },
+            py::arg("in_degrees") = false
         )
         .def(py::init<
                 amrex::ParticleReal,

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -1362,7 +1362,7 @@ void init_elements(py::module& m)
              [](ExactSbend const & exact_sbend) {
                  return element_name(
                      exact_sbend,
-                     std::make_pair("phi", exact_sbend.m_phi),  // BUG: needs / ExactSbend::degree2rad),
+                     std::make_pair("phi", exact_sbend.m_phi / ExactSbend::degree2rad),
                      std::make_pair("B", exact_sbend.m_B)
                  );
              }
@@ -1644,7 +1644,7 @@ void init_elements(py::module& m)
              [](PlaneXYRot const & plane_xyrot) {
                  return element_name(
                      plane_xyrot,
-                     std::make_pair("angle", plane_xyrot.m_phi)  // BUG: needs / PlaneXYRot::degree2rad)
+                     std::make_pair("angle", plane_xyrot.m_phi / PlaneXYRot::degree2rad)
                  );
              }
         )
@@ -2370,8 +2370,8 @@ void init_elements(py::module& m)
              [](PRot const & prot) {
                  return element_name(
                      prot,
-                     std::make_pair("phi_in", prot.m_phi_in),   // BUG: needs / PRot::degree2rad),
-                     std::make_pair("phi_out", prot.m_phi_out)  // BUG needs / PRot::degree2rad)
+                     std::make_pair("phi_in", prot.m_phi_in / PRot::degree2rad),
+                     std::make_pair("phi_out", prot.m_phi_out / PRot::degree2rad)
                  );
              }
         )
@@ -2490,7 +2490,7 @@ void init_elements(py::module& m)
              [](ThinDipole const & thin_dp) {
                  return element_name(
                      thin_dp,
-                     std::make_pair("theta", thin_dp.m_theta),  // BUG: needs / ThinDipole::degree2rad),
+                     std::make_pair("theta", thin_dp.m_theta / ThinDipole::degree2rad),
                      std::make_pair("rc", thin_dp.m_rc)
                  );
              }

--- a/src/python/impactx/extensions/KnownElementsList.py
+++ b/src/python/impactx/extensions/KnownElementsList.py
@@ -544,21 +544,18 @@ def _rad2deg(radians: float) -> float:
     return radians * 180.0 / math.pi
 
 
-def _element_from_dict(d: dict):
-    """Create an element from its to_dict() representation.
+def _prepare_kwargs(d: dict) -> tuple[str, dict]:
+    """Prepare constructor kwargs from a to_dict() result.
+
+    Applies workarounds for known radian/degree mismatches.
 
     Args:
         d: Dictionary from element.to_dict(), must include 'type' key
 
     Returns:
-        Element instance of the appropriate type
-
-    Raises:
-        KeyError: If 'type' key is missing
-        AttributeError: If element type is not found in elements module
+        tuple[str, dict]: (element_type, kwargs) ready for construction
     """
     element_type = d["type"]
-    element_class = getattr(elements, element_type)
     kwargs = _filter_kwargs(d)
 
     # Workaround: some elements output angles in radians but expect degrees
@@ -575,6 +572,24 @@ def _element_from_dict(d: dict):
     elif element_type == "ThinDipole" and "theta" in kwargs:
         kwargs["theta"] = _rad2deg(kwargs["theta"])
 
+    return element_type, kwargs
+
+
+def _element_from_dict(d: dict):
+    """Create an element from its to_dict() representation.
+
+    Args:
+        d: Dictionary from element.to_dict(), must include 'type' key
+
+    Returns:
+        Element instance of the appropriate type
+
+    Raises:
+        KeyError: If 'type' key is missing
+        AttributeError: If element type is not found in elements module
+    """
+    element_type, kwargs = _prepare_kwargs(d)
+    element_class = getattr(elements, element_type)
     return element_class(**kwargs)
 
 
@@ -612,6 +627,108 @@ def to_dicts(self) -> list[dict]:
         of such elements.
     """
     return [el.to_dict() for el in self]
+
+
+def _format_value(v):
+    """Format a value for Python code generation.
+
+    Converts AMReX SmallMatrix objects to lists.
+    Returns a tuple of (formatted_value, matrix_dims) where matrix_dims
+    is (rows, cols) from the SmallMatrix type, or None otherwise.
+    """
+    if hasattr(v, "to_numpy") and hasattr(v, "row_size"):
+        rows = v.row_size
+        cols = v.column_size
+        arr = v.to_numpy()
+        # Column vectors (Nx1) use flat list, matrices use nested list
+        if cols == 1:
+            return arr.flatten().tolist(), (rows, cols)
+        else:
+            return arr.T.tolist(), (rows, cols)
+    return v, None
+
+
+def to_py(self) -> str:
+    """Generate Python code that recreates this lattice.
+
+    Returns a string containing a complete Python script with imports
+    and a ``get_lattice()`` function that returns a KnownElementsList
+    with all elements.
+
+    Returns:
+        str: Python source code
+
+    Example:
+        .. code-block:: python
+
+            from impactx import elements
+
+            lattice = elements.KnownElementsList(
+                [
+                    elements.Drift(ds=1.0, name="d1"),
+                    elements.Quad(ds=0.5, k=2.0, name="q1"),
+                ]
+            )
+
+            # Generate Python code
+            code = lattice.to_py()
+            print(code)
+
+            # Save to file
+            with open("my_lattice.py", "w") as f:
+                f.write(code)
+
+            # Later, use the generated file:
+            # from my_lattice import get_lattice
+            # lattice = get_lattice()
+    """
+    # Check if we need amrex import for matrix types
+    needs_amrex = False
+    for d in self.to_dicts():
+        _, kwargs = _prepare_kwargs(d)
+        for v in kwargs.values():
+            if hasattr(v, "to_numpy") and hasattr(v, "row_size"):
+                needs_amrex = True
+                break
+        if needs_amrex:
+            break
+
+    lines = ["from impactx import elements"]
+    if needs_amrex:
+        lines.append("import amrex.space3d as amr")
+
+    lines.extend(
+        [
+            "",
+            "",
+            "def get_lattice():",
+            '    """Return the lattice as a KnownElementsList."""',
+            "    lattice = elements.KnownElementsList()",
+            "    lattice.extend([",
+        ]
+    )
+
+    for d in self.to_dicts():
+        element_type, kwargs = _prepare_kwargs(d)
+        formatted_parts = []
+
+        for k, v in kwargs.items():
+            formatted_v, matrix_dims = _format_value(v)
+            if matrix_dims:
+                rows, cols = matrix_dims
+                matrix_cls = f"amr.SmallMatrix_{rows}x{cols}_F_SI1_double"
+                formatted_parts.append(f"{k}={matrix_cls}({repr(formatted_v)})")
+            else:
+                formatted_parts.append(f"{k}={repr(formatted_v)}")
+
+        args_str = ", ".join(formatted_parts)
+        lines.append(f"        elements.{element_type}({args_str}),")
+
+    lines.append("    ])")
+    lines.append("    return lattice")
+    lines.append("")
+
+    return "\n".join(lines)
 
 
 def from_dicts(self, dicts: list[dict]):
@@ -656,6 +773,7 @@ def register_KnownElementsList_extension(kel):
 
     # Serialization methods
     kel.to_dicts = to_dicts
+    kel.to_py = to_py
     kel.from_dicts = from_dicts
 
     # Enhanced element selection methods

--- a/src/python/impactx/extensions/KnownElementsList.py
+++ b/src/python/impactx/extensions/KnownElementsList.py
@@ -521,6 +521,130 @@ def has_kind(self, kind_pattern) -> bool:
     return False
 
 
+import math
+
+
+def _filter_kwargs(d: dict) -> dict:
+    """Filter a to_dict() result into valid constructor kwargs.
+
+    Removes 'type' (not a constructor argument) and 'ds' when zero
+    (thin elements don't accept ds).
+
+    Args:
+        d: Dictionary from element.to_dict()
+
+    Returns:
+        dict: Filtered dictionary suitable for element constructor
+    """
+    return {k: v for k, v in d.items() if k != "type" and (k != "ds" or v != 0.0)}
+
+
+def _rad2deg(radians: float) -> float:
+    """Convert radians to degrees."""
+    return radians * 180.0 / math.pi
+
+
+def _element_from_dict(d: dict):
+    """Create an element from its to_dict() representation.
+
+    Args:
+        d: Dictionary from element.to_dict(), must include 'type' key
+
+    Returns:
+        Element instance of the appropriate type
+
+    Raises:
+        KeyError: If 'type' key is missing
+        AttributeError: If element type is not found in elements module
+    """
+    element_type = d["type"]
+    element_class = getattr(elements, element_type)
+    kwargs = _filter_kwargs(d)
+
+    # Workaround: some elements output angles in radians but expect degrees
+    # BUG: fix these in elements.cpp: to_dict() and remove these workarounds
+    if element_type == "ExactSbend" and "phi" in kwargs:
+        kwargs["phi"] = _rad2deg(kwargs["phi"])
+    elif element_type == "PlaneXYRot" and "angle" in kwargs:
+        kwargs["angle"] = _rad2deg(kwargs["angle"])
+    elif element_type == "PRot":
+        if "phi_in" in kwargs:
+            kwargs["phi_in"] = _rad2deg(kwargs["phi_in"])
+        if "phi_out" in kwargs:
+            kwargs["phi_out"] = _rad2deg(kwargs["phi_out"])
+    elif element_type == "ThinDipole" and "theta" in kwargs:
+        kwargs["theta"] = _rad2deg(kwargs["theta"])
+
+    return element_class(**kwargs)
+
+
+def to_dicts(self) -> list[dict]:
+    """Serialize the lattice to a list of dictionaries.
+
+    Each element is converted to a dictionary using its to_dict() method.
+    The resulting list can be serialized to JSON, YAML, or other formats.
+
+    Returns:
+        list[dict]: List of element dictionaries
+
+    Example:
+        .. code-block:: python
+
+            import json
+            from impactx import elements
+
+            lattice = elements.KnownElementsList(
+                [
+                    elements.Drift(ds=1.0, name="d1"),
+                    elements.Quad(ds=0.5, k=2.0, name="q1"),
+                ]
+            )
+
+            # Serialize to JSON
+            data = lattice.to_dicts()
+            with open("lattice.impactx.json", "w") as f:
+                json.dump(data, f, indent=2)
+
+    Note:
+        Elements with matrix parameters (LinearMap, SpinMap) contain
+        AMReX SmallMatrix objects that require custom JSON encoding.
+        Use :func:`impactx.extensions.ImpactXEncoder` for JSON serialization
+        of such elements.
+    """
+    return [el.to_dict() for el in self]
+
+
+def from_dicts(self, dicts: list[dict]):
+    """Load and append elements from a list of dictionaries.
+
+    Each dictionary should be in the format produced by element.to_dict(),
+    containing at minimum a 'type' key identifying the element class.
+
+    Args:
+        dicts: List of element dictionaries
+
+    Example:
+        .. code-block:: python
+
+            import json
+            from impactx import elements
+
+            # Load from JSON
+            with open("lattice.impactx.json") as f:
+                data = json.load(f)
+
+            lattice = elements.KnownElementsList()
+            lattice.from_dicts(data)
+
+    Note:
+        Elements with matrix parameters (LinearMap, SpinMap) require
+        the matrices to be AMReX SmallMatrix objects. Use
+        :func:`impactx.extensions.matrix_hook` as a JSON object_hook
+        when loading such elements.
+    """
+    self.extend([_element_from_dict(d) for d in dicts])
+
+
 def register_KnownElementsList_extension(kel):
     """KnownElementsList helper methods"""
     from ..plot.Survey import plot_survey
@@ -529,6 +653,10 @@ def register_KnownElementsList_extension(kel):
     kel.from_pals = from_pals
     kel.load_file = load_file
     kel.plot_survey = plot_survey
+
+    # Serialization methods
+    kel.to_dicts = to_dicts
+    kel.from_dicts = from_dicts
 
     # Enhanced element selection methods
     kel.select = select

--- a/src/python/impactx/extensions/KnownElementsList.py
+++ b/src/python/impactx/extensions/KnownElementsList.py
@@ -544,37 +544,6 @@ def _rad2deg(radians: float) -> float:
     return radians * 180.0 / math.pi
 
 
-def _prepare_kwargs(d: dict) -> tuple[str, dict]:
-    """Prepare constructor kwargs from a to_dict() result.
-
-    Applies workarounds for known radian/degree mismatches.
-
-    Args:
-        d: Dictionary from element.to_dict(), must include 'type' key
-
-    Returns:
-        tuple[str, dict]: (element_type, kwargs) ready for construction
-    """
-    element_type = d["type"]
-    kwargs = _filter_kwargs(d)
-
-    # Workaround: some elements output angles in radians but expect degrees
-    # BUG: fix these in elements.cpp: to_dict() and remove these workarounds
-    if element_type == "ExactSbend" and "phi" in kwargs:
-        kwargs["phi"] = _rad2deg(kwargs["phi"])
-    elif element_type == "PlaneXYRot" and "angle" in kwargs:
-        kwargs["angle"] = _rad2deg(kwargs["angle"])
-    elif element_type == "PRot":
-        if "phi_in" in kwargs:
-            kwargs["phi_in"] = _rad2deg(kwargs["phi_in"])
-        if "phi_out" in kwargs:
-            kwargs["phi_out"] = _rad2deg(kwargs["phi_out"])
-    elif element_type == "ThinDipole" and "theta" in kwargs:
-        kwargs["theta"] = _rad2deg(kwargs["theta"])
-
-    return element_type, kwargs
-
-
 def _element_from_dict(d: dict):
     """Create an element from its to_dict() representation.
 
@@ -588,7 +557,8 @@ def _element_from_dict(d: dict):
         KeyError: If 'type' key is missing
         AttributeError: If element type is not found in elements module
     """
-    element_type, kwargs = _prepare_kwargs(d)
+    element_type = d["type"]
+    kwargs = _filter_kwargs(d)
     element_class = getattr(elements, element_type)
     return element_class(**kwargs)
 
@@ -626,7 +596,22 @@ def to_dicts(self) -> list[dict]:
         Use :func:`impactx.extensions.ImpactXEncoder` for JSON serialization
         of such elements.
     """
-    return [el.to_dict() for el in self]
+    # simple implementation:
+    # return [el.to_dict() for el in self]
+
+    # work-around for ExactSbend, PlaneXYRot, PRot, ThinDipole .to_dict() returning radians not degrees
+    results = []
+    for el in self:
+        if type(el) in [
+            elements.ExactSbend,
+            elements.PlaneXYRot,
+            elements.PRot,
+            elements.ThinDipole,
+        ]:
+            results.append(el.to_dict(in_degrees=True))
+        else:
+            results.append(el.to_dict())
+    return results
 
 
 def _format_value(v):
@@ -685,7 +670,7 @@ def to_py(self) -> str:
     # Check if we need amrex import for matrix types
     needs_amrex = False
     for d in self.to_dicts():
-        _, kwargs = _prepare_kwargs(d)
+        kwargs = _filter_kwargs(d)
         for v in kwargs.values():
             if hasattr(v, "to_numpy") and hasattr(v, "row_size"):
                 needs_amrex = True
@@ -709,7 +694,8 @@ def to_py(self) -> str:
     )
 
     for d in self.to_dicts():
-        element_type, kwargs = _prepare_kwargs(d)
+        element_type = d["type"]
+        kwargs = _filter_kwargs(d)
         formatted_parts = []
 
         for k, v in kwargs.items():

--- a/src/python/impactx/plot/Survey.py
+++ b/src/python/impactx/plot/Survey.py
@@ -69,6 +69,7 @@ def plot_survey(
     for i, element in enumerate(self):
         el_dict = element.to_dict()
         el_type = el_dict["type"]
+        el_ds = el_dict["ds"]
         if el_type in skip_names:
             continue
 
@@ -89,7 +90,7 @@ def plot_survey(
             else:  # guess
                 if el_type == "Sbend":
                     el_dict["phi"] = (
-                        el_dict["ds"] / (2 * np.pi * el_dict["rc"]) * 360
+                        el_ds / (2 * np.pi * el_dict["rc"]) * 360
                     )  # calculate bending angle (in degrees) and add to dict
                 height = copysign(0.8, el_dict["phi"])
         # TODO: sign dependent, read m_p_scale

--- a/tests/python/test_element_serialization.py
+++ b/tests/python/test_element_serialization.py
@@ -1,0 +1,709 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+"""
+Test that all elements can be serialized via to_dicts() and reconstructed via from_dicts().
+"""
+
+import re
+
+import numpy as np
+import pytest
+
+import amrex.space3d as amr
+from impactx import elements
+
+
+def get_constructor_params(element_class):
+    """
+    Extract constructor parameter names from pybind11 docstring.
+
+    Returns a set of parameter names, or None if parsing fails.
+    """
+    doc = element_class.__init__.__doc__
+    if not doc:
+        return None
+
+    # Find the signature line: __init__(self: ..., param1: type, ...) -> None
+    match = re.search(r"__init__\(self:[^,]+,\s*(.+?)\)\s*->", doc)
+    if not match:
+        match = re.search(r"__init__\(self:[^,]+,\s*(.+?)\)\s*$", doc, re.MULTILINE)
+    if not match:
+        match = re.search(r"__init__\(self:[^)]+\)", doc)
+        if match:
+            return set()
+        return None
+
+    params_str = match.group(1) if match.lastindex else ""
+    if not params_str.strip():
+        return set()
+
+    # Parse individual parameters, handling nested types like dict[str, int]
+    params = []
+    depth = 0
+    current = ""
+    for char in params_str:
+        if char in "[(":
+            depth += 1
+        elif char in "])":
+            depth -= 1
+        elif char == "," and depth == 0:
+            if current.strip():
+                params.append(current.strip())
+            current = ""
+            continue
+        current += char
+    if current.strip():
+        params.append(current.strip())
+
+    param_names = set()
+    for p in params:
+        name = p.split(":")[0].strip()
+        if name:
+            param_names.add(name)
+
+    return param_names
+
+
+def dicts_equal(d1: dict, d2: dict, rtol: float = 1e-12) -> bool:
+    """
+    Compare two element dicts for equality.
+
+    Handles floating point comparison with relative tolerance and
+    compares AMReX SmallMatrix objects element-wise.
+    """
+    if set(d1.keys()) != set(d2.keys()):
+        return False
+
+    for key in d1:
+        v1, v2 = d1[key], d2[key]
+
+        if isinstance(v1, float) and isinstance(v2, float):
+            if v1 == 0.0 and v2 == 0.0:
+                continue
+            if v1 == 0.0 or v2 == 0.0:
+                return False
+            if abs(v1 - v2) / max(abs(v1), abs(v2)) > rtol:
+                return False
+        elif isinstance(v1, list) and isinstance(v2, list):
+            if len(v1) != len(v2):
+                return False
+            for a, b in zip(v1, v2):
+                if isinstance(a, float) and isinstance(b, float):
+                    if a == 0.0 and b == 0.0:
+                        continue
+                    if a == 0.0 or b == 0.0:
+                        return False
+                    if abs(a - b) / max(abs(a), abs(b)) > rtol:
+                        return False
+                elif a != b:
+                    return False
+        elif hasattr(v1, "to_numpy") and hasattr(v2, "to_numpy"):
+            arr1 = v1.to_numpy()
+            arr2 = v2.to_numpy()
+            if not np.allclose(arr1, arr2, rtol=rtol, atol=0):
+                return False
+        elif v1 != v2:
+            return False
+
+    return True
+
+
+# Elements that cannot be roundtripped
+SKIP_ELEMENTS = {
+    "Source",  # Requires a valid openPMD file path
+    "Empty",  # BUG: to_dict returns type='None' instead of 'Empty'
+}
+
+
+@pytest.fixture
+def all_elements():
+    """Create a KnownElementsList with one instance of each element type."""
+    lattice = elements.KnownElementsList()
+
+    lattice.append(
+        elements.Aperture(
+            aperture_x=0.01,
+            aperture_y=0.02,
+            repeat_x=0.0,
+            repeat_y=0.0,
+            shape="rectangular",
+            action="transmit",
+            dx=0.001,
+            dy=0.002,
+            rotation=0.1,
+            name="test_aperture",
+        )
+    )
+
+    monitor = elements.BeamMonitor(
+        name="test_monitor", backend="h5", encoding="g", period_sample_intervals=2
+    )
+    lattice.append(monitor)
+
+    lattice.append(
+        elements.Buncher(
+            V=0.5, k=10.0, dx=0.001, dy=0.002, rotation=0.05, name="test_buncher"
+        )
+    )
+
+    lattice.append(
+        elements.CFbend(
+            ds=0.5,
+            rc=2.0,
+            k=0.5,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.03,
+            aperture_y=0.04,
+            nslice=3,
+            name="test_cfbend",
+        )
+    )
+
+    lattice.append(
+        elements.ChrAcc(
+            ds=1.0,
+            ez=1e6,
+            bz=0.5,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            nslice=2,
+            name="test_chracc",
+        )
+    )
+
+    lattice.append(
+        elements.ChrDrift(
+            ds=1.0,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.03,
+            aperture_y=0.04,
+            nslice=2,
+            name="test_chrdrift",
+        )
+    )
+
+    lattice.append(
+        elements.ChrPlasmaLens(
+            ds=0.2,
+            k=100.0,
+            unit=0,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.01,
+            aperture_y=0.01,
+            nslice=2,
+            name="test_chrplasmalens",
+        )
+    )
+
+    lattice.append(
+        elements.ChrQuad(
+            ds=0.3,
+            k=2.0,
+            unit=0,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.02,
+            aperture_y=0.02,
+            nslice=2,
+            name="test_chrquad",
+        )
+    )
+
+    lattice.append(
+        elements.ConstF(
+            ds=0.5,
+            kx=1.0,
+            ky=1.5,
+            kt=0.5,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.02,
+            aperture_y=0.02,
+            nslice=2,
+            name="test_constf",
+        )
+    )
+
+    lattice.append(
+        elements.DipEdge(
+            psi=0.1,
+            rc=5.0,
+            g=0.01,
+            K2=0.0,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            name="test_dipedge",
+        )
+    )
+
+    lattice.append(
+        elements.Drift(
+            ds=1.0,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.03,
+            aperture_y=0.04,
+            nslice=2,
+            name="test_drift",
+        )
+    )
+
+    lattice.append(
+        elements.ExactCFbend(
+            ds=0.5,
+            k_normal=[1.0, 0.5],
+            k_skew=[0.0, 0.1],
+            unit=0,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.02,
+            aperture_y=0.02,
+            int_order=4,
+            mapsteps=5,
+            nslice=2,
+            name="test_exactcfbend",
+        )
+    )
+
+    lattice.append(
+        elements.ExactDrift(
+            ds=1.0,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.03,
+            aperture_y=0.04,
+            nslice=2,
+            name="test_exactdrift",
+        )
+    )
+
+    lattice.append(
+        elements.ExactMultipole(
+            ds=0.5,
+            k_normal=[1.0, 0.5],
+            k_skew=[0.0, 0.1],
+            unit=0,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.02,
+            aperture_y=0.02,
+            int_order=4,
+            mapsteps=5,
+            nslice=2,
+            name="test_exactmultipole",
+        )
+    )
+
+    lattice.append(
+        elements.ExactQuad(
+            ds=0.3,
+            k=2.0,
+            unit=0,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.02,
+            aperture_y=0.02,
+            nslice=2,
+            mapsteps=10,
+            int_order=4,
+            name="test_exactquad",
+        )
+    )
+
+    lattice.append(
+        elements.ExactSbend(
+            ds=0.5,
+            phi=15.0,
+            B=0.5,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.03,
+            aperture_y=0.04,
+            nslice=2,
+            name="test_exactsbend",
+        )
+    )
+
+    lattice.append(
+        elements.Kicker(
+            xkick=0.001,
+            ykick=0.002,
+            unit="dimensionless",
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            name="test_kicker",
+        )
+    )
+
+    R = amr.SmallMatrix_6x6_F_SI1_double.identity()
+    lattice.append(
+        elements.LinearMap(
+            R=R, ds=0.5, dx=0.001, dy=0.002, rotation=0.05, name="test_linearmap"
+        )
+    )
+
+    lattice.append(elements.Marker(name="test_marker"))
+
+    lattice.append(
+        elements.Multipole(
+            multipole=2,
+            K_normal=0.1,
+            K_skew=0.05,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            name="test_multipole",
+        )
+    )
+
+    lattice.append(
+        elements.NonlinearLens(
+            knll=0.5,
+            cnll=0.01,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            name="test_nonlinearlens",
+        )
+    )
+
+    lattice.append(
+        elements.PlaneXYRot(
+            angle=45.0, dx=0.001, dy=0.002, rotation=0.05, name="test_planexyrot"
+        )
+    )
+
+    vertices_x = [0.01, 0.01, -0.01, -0.01, 0.01]
+    vertices_y = [0.01, -0.01, -0.01, 0.01, 0.01]
+    lattice.append(
+        elements.PolygonAperture(
+            vertices_x=vertices_x,
+            vertices_y=vertices_y,
+            min_radius2=1e-6,
+            repeat_x=0.0,
+            repeat_y=0.0,
+            action="transmit",
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            name="test_polygonaperture",
+        )
+    )
+
+    lattice.append(elements.Programmable(ds=0.5, nslice=2, name="test_programmable"))
+
+    lattice.append(elements.PRot(phi_in=0.1, phi_out=-0.1, name="test_prot"))
+
+    lattice.append(
+        elements.Quad(
+            ds=0.3,
+            k=2.5,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.02,
+            aperture_y=0.02,
+            nslice=2,
+            name="test_quad",
+        )
+    )
+
+    lattice.append(
+        elements.QuadEdge(
+            k=2.0,
+            unit=0,
+            flag="entry",
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            name="test_quadedge",
+        )
+    )
+
+    lattice.append(
+        elements.RFCavity(
+            ds=0.5,
+            escale=1e6,
+            freq=1.3e9,
+            phase=-90.0,
+            cos_coefficients=[1.0],
+            sin_coefficients=[0.0],
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.02,
+            aperture_y=0.02,
+            nslice=2,
+            mapsteps=10,
+            name="test_rfcavity",
+        )
+    )
+
+    lattice.append(
+        elements.Sbend(
+            ds=0.5,
+            rc=5.0,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.03,
+            aperture_y=0.04,
+            nslice=2,
+            name="test_sbend",
+        )
+    )
+
+    lattice.append(
+        elements.ShortRF(
+            V=0.5,
+            freq=1.3e9,
+            phase=-90.0,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            name="test_shortrf",
+        )
+    )
+
+    lattice.append(
+        elements.Sol(
+            ds=0.5,
+            ks=1.0,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.02,
+            aperture_y=0.02,
+            nslice=2,
+            name="test_sol",
+        )
+    )
+
+    lattice.append(
+        elements.SoftQuadrupole(
+            ds=0.5,
+            gscale=1.0,
+            cos_coefficients=[1.0, 0.5],
+            sin_coefficients=[0.0, 0.1],
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.02,
+            aperture_y=0.02,
+            mapsteps=5,
+            nslice=2,
+            name="test_softquadrupole",
+        )
+    )
+
+    lattice.append(
+        elements.SoftSolenoid(
+            ds=0.5,
+            bscale=1.0,
+            cos_coefficients=[1.0, 0.5],
+            sin_coefficients=[0.0, 0.1],
+            unit=0,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            aperture_x=0.02,
+            aperture_y=0.02,
+            mapsteps=5,
+            nslice=2,
+            name="test_softsolenoid",
+        )
+    )
+
+    v = amr.SmallMatrix_3x1_F_SI1_double()
+    v.set_val(0.1)
+    A = amr.SmallMatrix_3x6_F_SI1_double()
+    A.set_val(0.01)
+    lattice.append(
+        elements.SpinMap(
+            v=v, A=A, ds=0.5, dx=0.001, dy=0.002, rotation=0.05, name="test_spinmap"
+        )
+    )
+
+    lattice.append(
+        elements.TaperedPL(
+            k=100.0,
+            taper=10.0,
+            unit=0,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            name="test_taperedpl",
+        )
+    )
+
+    lattice.append(
+        elements.ThinDipole(
+            theta=0.05,
+            rc=10.0,
+            dx=0.001,
+            dy=0.002,
+            rotation=0.05,
+            name="test_thindipole",
+        )
+    )
+
+    yield lattice, monitor
+    monitor.finalize()
+
+
+def test_to_dicts_from_dicts_roundtrip(all_elements):
+    """
+    Test that lattice serialization via to_dicts()/from_dicts() roundtrips correctly.
+    """
+    lattice, _ = all_elements
+
+    # Serialize
+    dicts = lattice.to_dicts()
+    assert len(dicts) == len(lattice)
+
+    # Verify each dict has required 'type' key
+    for d in dicts:
+        assert "type" in d
+
+    # Reconstruct
+    lattice2 = elements.KnownElementsList()
+    lattice2.from_dicts(dicts)
+    assert len(lattice2) == len(lattice)
+
+    # Serialize again and compare
+    dicts2 = lattice2.to_dicts()
+
+    for i, (d1, d2) in enumerate(zip(dicts, dicts2)):
+        assert dicts_equal(d1, d2), (
+            f"Dict mismatch at index {i} ({d1.get('type')}):\n"
+            f"  Original: {d1}\n"
+            f"  Reconstructed: {d2}"
+        )
+
+
+def test_element_dict_has_constructor_params(all_elements):
+    """
+    Test that to_dict() returns all constructor parameters for each element.
+    """
+    lattice, _ = all_elements
+
+    for element in lattice:
+        element_type = type(element).__name__
+
+        if element_type in SKIP_ELEMENTS:
+            continue
+
+        d = element.to_dict()
+        constructor_params = get_constructor_params(type(element))
+
+        if constructor_params is None:
+            continue
+
+        dict_keys = set(d.keys())
+        dict_keys.discard("type")
+        if d.get("ds") == 0.0 and "ds" not in constructor_params:
+            dict_keys.discard("ds")
+
+        missing = constructor_params - dict_keys
+        extra = dict_keys - constructor_params
+
+        assert not missing, f"{element_type}: to_dict() missing params: {missing}"
+        assert not extra, f"{element_type}: to_dict() has extra keys: {extra}"
+
+
+def test_individual_element_roundtrip(all_elements):
+    """
+    Test each element type individually for roundtrip consistency.
+    """
+    lattice, _ = all_elements
+
+    for element in lattice:
+        element_type = type(element).__name__
+
+        if element_type in SKIP_ELEMENTS:
+            continue
+
+        # work-around for .to_dict() returning radians
+        # where contructor expects degrees
+        buggy_rad_angle_types = [
+            "ExactSbend",
+            "PlaneXYRot",
+            "PRot",
+            "ThinDipole",
+        ]
+        extra_kwargs = {}
+        if element_type in buggy_rad_angle_types:
+            extra_kwargs = {"in_degrees": True}
+
+        # Roundtrip single element
+        d1 = element.to_dict(**extra_kwargs)
+        temp_lattice = elements.KnownElementsList()
+        temp_lattice.from_dicts([d1])
+        element2 = temp_lattice[0]
+        d2 = element2.to_dict(**extra_kwargs)
+
+        assert dicts_equal(d1, d2), (
+            f"Roundtrip failed for {element_type}:\n"
+            f"  Original: {d1}\n"
+            f"  Reconstructed: {d2}"
+        )
+
+
+def test_to_py_roundtrip(all_elements):
+    """
+    Test that to_py() generates executable code that recreates the lattice.
+    """
+    lattice, _ = all_elements
+
+    # Generate Python code
+    code = lattice.to_py()
+
+    # Verify code structure
+    assert "from impactx import elements" in code
+    assert "def get_lattice():" in code
+    assert "return lattice" in code
+
+    # Execute the generated code
+    namespace = {}
+    exec(code, namespace)
+
+    # Get the reconstructed lattice
+    get_lattice = namespace["get_lattice"]
+    lattice2 = get_lattice()
+
+    assert len(lattice2) == len(lattice)
+
+    # Compare all elements
+    dicts1 = lattice.to_dicts()
+    dicts2 = lattice2.to_dicts()
+
+    for i, (d1, d2) in enumerate(zip(dicts1, dicts2)):
+        assert dicts_equal(d1, d2), (
+            f"to_py() roundtrip failed at index {i} ({d1.get('type')}):\n"
+            f"  Original: {d1}\n"
+            f"  Reconstructed: {d2}"
+        )


### PR DESCRIPTION
## Add lattice serialization with `to_dicts()` and `from_dicts()`
    
`KnownElementsList` now supports JSON/YAML-compatible [serialization](https://impactx--1366.org.readthedocs.build/en/1366/usage/python.html#impactx.elements.KnownElementsList.to_dicts):
- to_dicts(): serialize lattice elements to list of dictionaries
- from_dicts(): reconstruct lattice from dictionaries

`from_dicts()` works around known radian/degree `.to_dict()` bugs in four elements, see below.

## Add lattice code generation with `to_py()`

`KnownElementsList.to_py()` generates [executable Python code](https://impactx--1366.org.readthedocs.build/en/1366/usage/python.html#impactx.elements.KnownElementsList.to_py):
- Returns complete script with `get_lattice()` function
- Handles `SmallMatrix` parameters for `LinearMap`/`SpinMap`
- Applies radian-to-degree fixes for affected elements (see below)

When do you need this? After importing an external file format (MAD-X, PALS), you might want to save into a ImpactX Python lattice file for further inspection and manipulation. Basically for one-time imports to ImpactX.

# Bug Fixes

Follow-up to #1365 and #1332:
Ensure we expose enough properties in `to_dict` to rebuild elements in the constructor.

## (Loudly) Breaking Changes to `.to_dict()` Results to better match constructor arguments

These breaks cause visible asserts and are thus easy to fix without a silent error / mismatch being introduced:
- `Aperture`: `shape` and `action` are now properly returned as string, not as int
- `QuadEdge`: `flag` is now properly returned as a string, not as int
- `Kicker`: `unit` is now properly returned as a string, not as int
- `PolygonAperture`: `action` is now properly returned as a string, not as int
- `RFCavity`: `cos_coef`/`sin_coef` are now the `cos_coefficients`/`sin_coefficients` keys to match the constructor arguments
- `SoftQuadrupole`: `cos_coef`/`sin_coef` are now the `cos_coefficients`/`sin_coefficients` keys to match the constructor arguments
- `SoftSolenoid`: `cos_coef`/`sin_coef` are now the `cos_coefficients`/`sin_coefficients` keys to match the constructor arguments
- `Source`: `path` is now the `openpmd_path` key to match the constructor argument
- `LinearMap`: `transport_map` is now the `R` key to match the constructor argument
- for thin elements, `nslice` (==1) is omitted, to match that it does not appear in constructor arguments
- for thick elements, `nslice` is omitted if `1` because that is anyway the default argument in constructors

## Known Bugs with Backwards Compatible Fixes

Elements that take an angle in degrees in their constructor but expose radian #1367 in their `.to_dict()` and `.property` accessors:
- `ExactSbend`: `phi`
- `PlaneXYRot`: `angle`
- `PRot`: `phi_in`, `phi_out`
- `ThinDipole`: `theta`

The new higher-level  `sim.lattice` functions `.to_dicts()` and `.to_py()` address this already, by using underneath for these four classes the new `.to_dicts(in_degrees=True)` argument. The default of this argument is, for backwards compatibility, `False` - but if users use it with that they now get a `RuntimeWarning` and are advised of the inconsistency.

We have to fix them in a separate PR, potentially renaming the keys to cause a visible break instead of a silent translation that will lead to wrong results if we change degrees/rad, and implementing fallbacks where possible.

## Not fixed here

- `unit` is inconsistently handled as int or as string in various elements