### PR TITLE
Elements Lifetime (GPU)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,15 @@ set_target_properties(lib PROPERTIES
     WINDOWS_EXPORT_ALL_SYMBOLS ON
 )
 
+include(GenerateExportHeader)
+generate_export_header(lib
+    BASE_NAME impactx
+    EXPORT_FILE_NAME src/impactx_export.H
+)
+if(NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(lib PUBLIC IMPACTX_STATIC_DEFINE)
+endif()
+
 # Optional: build only a single TU
 if(ImpactX_UNITY_BUILD)
     set_target_properties(lib PROPERTIES

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -8,6 +8,7 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "ImpactX.H"
+#include "elements/mixin/dynamicdata.H"
 #include "initialization/InitAmrCore.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/Push.H"

--- a/src/elements/ExactCFbend.H
+++ b/src/elements/ExactCFbend.H
@@ -1,4 +1,4 @@
-/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
  *           Berkeley National Laboratory (subject to receipt of any required
  *           approvals from the U.S. Dept. of Energy). All rights reserved.
  *
@@ -13,12 +13,14 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/integrators/Integrators.H"
 #include "mixin/alignment.H"
-#include "mixin/pipeaperture.H"
 #include "mixin/beamoptic.H"
-#include "mixin/thick.H"
+#include "mixin/dynamicdata.H"
+#include "mixin/lineartransport.H"
 #include "mixin/named.H"
 #include "mixin/nofinalize.H"
-#include "mixin/lineartransport.H"
+#include "mixin/pipeaperture.H"
+#include "mixin/thick.H"
+#include "mixin/TrackedVector.H"
 
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
@@ -27,35 +29,23 @@
 #include <AMReX_Math.H>
 
 #include <cmath>
+#include <memory>
 #include <stdexcept>
 #include <vector>
 
 namespace impactx::elements
 {
 
-    /** Dynamic data for the ExactCFbend elements
+    /** CFbend multipole coefficients for magnetic field.
      *
-     * Since we copy the element to the device, we cannot store this data on the element itself.
-     * But we can store pointers to this data with the element and keep a lookup table here,
-     * which we clean up in the end.
+     * Host data persists across simulations; device data is uploaded
+     * on-demand "lazily" on first use and released when AMReX shuts down.
      */
-    namespace ExactCFbendData
+    struct CFbendCoefficients
     {
-        //! last used id for a created ExactCFbend
-        inline int next_id = 0;
-
-        //! host: normal multipole coefficients of the magnetic field
-        inline std::map<int, std::vector<amrex::ParticleReal>> h_k_normal = {};
-        //! host: skew multipole coefficients of the magnetic field
-        inline std::map<int, std::vector<amrex::ParticleReal>> h_k_skew = {};
-
-        //! device: normal multipole coefficients of the magnetic field
-        inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_k_normal = {};
-        //! device: skew multipole coefficients of the magnetic field
-        inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_k_skew = {};
-
-    } // namespace ExactCFbendData
-
+        mixin::TrackedVector<amrex::ParticleReal> k_normal;
+        mixin::TrackedVector<amrex::ParticleReal> k_skew;
+    };
 
     struct ExactCFbend
     : public mixin::Named,
@@ -63,11 +53,13 @@ namespace impactx::elements
       public mixin::LinearTransport<ExactCFbend>,
       public mixin::Thick,
       public mixin::Alignment,
-      public mixin::PipeAperture,
-      public mixin::NoFinalize
+      public mixin::NoFinalize,
+      public mixin::PipeAperture
     {
         static constexpr auto type = "ExactCFbend";
         using PType = ImpactXParticleContainer::ParticleType;
+
+        using DynamicData = mixin::GPUDataRegistry<CFbendCoefficients>;
 
         /** A general (thick) combined-function sector dipole whose field consists
          *  of a superposition of ideal curvilinear hard-edge multipoles.
@@ -113,41 +105,23 @@ namespace impactx::elements
           Thick(ds, nslice),
           Alignment(dx, dy, rotation_degree),
           PipeAperture(aperture_x, aperture_y),
-          m_unit(unit),m_int_order(int_order),m_mapsteps(mapsteps),m_id(ExactCFbendData::next_id)
+          m_unit(unit), m_int_order(int_order), m_mapsteps(mapsteps),
+          m_id(DynamicData::allocate_id())
         {
-            // next created ExactCFbend has another id for its data
-            ExactCFbendData::next_id++;
-
-            // validate symplectic integration order is implemented
             if (m_int_order != 2 && m_int_order != 4 && m_int_order != 6)
                 throw std::runtime_error("ExactCFbend: The order used for symplectic integration must be 2, 4 or 6.");
 
-            // validate normal and skew coefficients are the same length
             m_ncoef = int(k_normal.size());
             if (m_ncoef != int(k_skew.size()))
-                throw std::runtime_error("ExactMultipole: normal and skew coefficient arrays must have same length!");
+                throw std::runtime_error("ExactCFbend: normal and skew coefficient arrays must have same length!");
 
-            // host data
-            ExactCFbendData::h_k_normal[m_id] = k_normal;
-            ExactCFbendData::h_k_skew[m_id] = k_skew;
-            m_k_normal_h_data = ExactCFbendData::h_k_normal[m_id].data();
-            m_k_skew_h_data = ExactCFbendData::h_k_skew[m_id].data();
-
-            // device data
-            ExactCFbendData::d_k_normal.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
-            ExactCFbendData::d_k_skew.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
-            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                                  k_normal.begin(), k_normal.end(),
-                                  ExactCFbendData::d_k_normal[m_id].begin());
-            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                                  k_skew.begin(), k_skew.end(),
-                                  ExactCFbendData::d_k_skew[m_id].begin());
-            amrex::Gpu::streamSynchronize();
-
-            // low-level objects we can use on device
-            m_k_normal_d_data = ExactCFbendData::d_k_normal[m_id].data();
-            m_k_skew_d_data = ExactCFbendData::d_k_skew[m_id].data();
-
+            auto& coef = DynamicData::emplace(
+                m_id,
+                std::move(k_normal),
+                std::move(k_skew)
+            );
+            m_k_normal_h_data = coef.k_normal.host_const().data();
+            m_k_skew_h_data = coef.k_skew.host_const().data();
         }
 
         /** Push all particles */
@@ -166,13 +140,18 @@ namespace impactx::elements
 
             Alignment::compute_constants(refpart);
 
+            // Ensure dynamic coefficient data is on GPU and we have fresh pointers to it
+            auto const & coef = *DynamicData::get(m_id);
+            m_k_normal_d_data = coef.k_normal.device_const().data();
+            m_k_skew_d_data = coef.k_skew.device_const().data();
+
             // access reference particle values to find relativistic factors
             m_beta = refpart.beta();
             m_ibeta = 1_prt / m_beta;
             m_ibetgam2 = 1_prt / amrex::Math::powi<2>(refpart.beta_gamma());
             m_brho = refpart.rigidity_Tm();
 
-            amrex::ParticleReal* k_normal = m_k_normal_h_data;
+            amrex::ParticleReal const * k_normal = m_k_normal_h_data;
 
             // find magnetic field and curvature; normalize units to MAD-X convention if needed
             amrex::ParticleReal curvature = m_unit == 1 ? k_normal[0] / m_brho : k_normal[0];
@@ -378,8 +357,8 @@ namespace impactx::elements
             amrex::ParticleReal tout = t;
             amrex::ParticleReal ptout = pt;
 
-            amrex::ParticleReal* k_normal = m_k_normal_d_data;
-            amrex::ParticleReal* k_skew = m_k_skew_d_data;
+            amrex::ParticleReal const * k_normal = m_k_normal_d_data;
+            amrex::ParticleReal const * k_skew = m_k_skew_d_data;
 
             // defined dimensionless variables scaled by radius of curvature
             amrex::ParticleReal rho = 1_prt + x / m_rc;
@@ -480,9 +459,9 @@ namespace impactx::elements
             amrex::ParticleReal const brho = refpart.rigidity_Tm();
 
 #if AMREX_DEVICE_COMPILE
-            amrex::ParticleReal* k_normal = m_k_normal_d_data;
+            amrex::ParticleReal const * k_normal = m_k_normal_d_data;
 #else
-            amrex::ParticleReal* k_normal = m_k_normal_h_data;
+            amrex::ParticleReal const * k_normal = m_k_normal_h_data;
 #endif
             // find magnetic field and curvature; normalize units to MAD-X convention if needed
             amrex::ParticleReal const curvature = m_unit == 1 ? k_normal[0] / brho : k_normal[0];
@@ -546,7 +525,7 @@ namespace impactx::elements
             amrex::ParticleReal const bet = refpart.beta();
             amrex::ParticleReal const ibetgam2 = 1_prt / betgam2;
 
-            amrex::ParticleReal* k_normal = m_k_normal_h_data;
+            amrex::ParticleReal const * k_normal = m_k_normal_h_data;
 
             // find magnetic field and curvature; normalize units to MAD-X convention if needed
             amrex::ParticleReal const curvature = m_unit == 1 ? k_normal[0] / m_brho : k_normal[0];
@@ -600,33 +579,16 @@ namespace impactx::elements
         using LinearTransport::operator();
 
 
-        /** Close and deallocate all data and handles.
-         */
-        void
-        finalize ()
-        {
-            // remove from unique data map
-            if (ExactCFbendData::h_k_normal.count(m_id) != 0u)
-                ExactCFbendData::h_k_normal.erase(m_id);
-            if (ExactCFbendData::h_k_skew.count(m_id) != 0u)
-                ExactCFbendData::h_k_skew.erase(m_id);
-
-            if (ExactCFbendData::d_k_normal.count(m_id) != 0u)
-                ExactCFbendData::d_k_normal.erase(m_id);
-            if (ExactCFbendData::d_k_skew.count(m_id) != 0u)
-                ExactCFbendData::d_k_skew.erase(m_id);
-        }
-
         int m_unit; //! unit specification for Multipole strength
         int m_int_order; //! order used for the symplectic integration (2 or 4)
         int m_mapsteps; //! number of integration steps per slice
         int m_id; //! unique ExactMultipole id used for data lookup map
 
         int m_ncoef = 0; //! number of Fourier coefficients
-        amrex::ParticleReal* m_k_normal_h_data = nullptr; //! non-owning pointer to host cosine coefficients
-        amrex::ParticleReal* m_k_skew_h_data = nullptr; //! non-owning pointer to host sine coefficients
-        amrex::ParticleReal* m_k_normal_d_data = nullptr; //! non-owning pointer to device cosine coefficients
-        amrex::ParticleReal* m_k_skew_d_data = nullptr; //! non-owning pointer to device sine coefficients
+        amrex::ParticleReal const * m_k_normal_h_data = nullptr; //! non-owning pointer to host cosine coefficients
+        amrex::ParticleReal const * m_k_skew_h_data = nullptr; //! non-owning pointer to host sine coefficients
+        amrex::ParticleReal const * m_k_normal_d_data = nullptr; //! non-owning pointer to device cosine coefficients
+        amrex::ParticleReal const * m_k_skew_d_data = nullptr; //! non-owning pointer to device sine coefficients
 
     private:
         // constants that are independent of the individually tracked particle,
@@ -641,6 +603,7 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_GPUDATA_EXTERN(impactx::elements::ExactCFbend)
 IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::ExactCFbend)
 
 #endif // IMPACTX_EXACTCFBEND_H

--- a/src/elements/ExactCFbend.H
+++ b/src/elements/ExactCFbend.H
@@ -585,10 +585,10 @@ namespace impactx::elements
         int m_id; //! unique ExactMultipole id used for data lookup map
 
         int m_ncoef = 0; //! number of Fourier coefficients
-        amrex::ParticleReal const * m_k_normal_h_data = nullptr; //! non-owning pointer to host cosine coefficients
-        amrex::ParticleReal const * m_k_skew_h_data = nullptr; //! non-owning pointer to host sine coefficients
-        amrex::ParticleReal const * m_k_normal_d_data = nullptr; //! non-owning pointer to device cosine coefficients
-        amrex::ParticleReal const * m_k_skew_d_data = nullptr; //! non-owning pointer to device sine coefficients
+        amrex::ParticleReal const * m_k_normal_h_data = nullptr; //! non-owning pointer to host normal coefficients
+        amrex::ParticleReal const * m_k_skew_h_data = nullptr; //! non-owning pointer to host skew coefficients
+        amrex::ParticleReal const * m_k_normal_d_data = nullptr; //! non-owning pointer to device normal coefficients
+        amrex::ParticleReal const * m_k_skew_d_data = nullptr; //! non-owning pointer to device skew coefficients
 
     private:
         // constants that are independent of the individually tracked particle,

--- a/src/elements/ExactCFbend.cpp
+++ b/src/elements/ExactCFbend.cpp
@@ -1,3 +1,4 @@
 #include "ExactCFbend.H"
 
+IMPACTX_GPUDATA_INSTANTIATE(impactx::elements::ExactCFbend)
 IMPACTX_PUSH_INSTANTIATE(impactx::elements::ExactCFbend)

--- a/src/elements/ExactMultipole.H
+++ b/src/elements/ExactMultipole.H
@@ -1,4 +1,4 @@
-/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
  *           Berkeley National Laboratory (subject to receipt of any required
  *           approvals from the U.S. Dept. of Energy). All rights reserved.
  *
@@ -13,11 +13,14 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/integrators/Integrators.H"
 #include "mixin/alignment.H"
-#include "mixin/pipeaperture.H"
 #include "mixin/beamoptic.H"
-#include "mixin/thick.H"
-#include "mixin/named.H"
+#include "mixin/dynamicdata.H"
 #include "mixin/lineartransport.H"
+#include "mixin/named.H"
+#include "mixin/nofinalize.H"
+#include "mixin/pipeaperture.H"
+#include "mixin/thick.H"
+#include "mixin/TrackedVector.H"
 
 #include <AMReX_Extension.H>
 #include <AMReX_GpuComplex.H>
@@ -26,6 +29,7 @@
 #include <AMReX_SIMD.H>
 
 #include <cmath>
+#include <memory>
 #include <stdexcept>
 #include <vector>
 
@@ -33,29 +37,16 @@
 namespace impactx::elements
 {
 
-    /** Dynamic data for the ExactMultipole elements
+    /** Multipole coefficients for magnetic field.
      *
-     * Since we copy the element to the device, we cannot store this data on the element itself.
-     * But we can store pointers to this data with the element and keep a lookup table here,
-     * which we clean up in the end.
+     * Host data persists across simulations; device data is uploaded
+     * on-demand "lazily" on first use and released when AMReX shuts down.
      */
-    namespace MultipoleData
+    struct MultipoleCoefficients
     {
-        //! last used id for a created ExactMultipole
-        inline int next_id = 0;
-
-        //! host: normal multipole coefficients of the magnetic field
-        inline std::map<int, std::vector<amrex::ParticleReal>> h_k_normal = {};
-        //! host: skew multipole coefficients of the magnetic field
-        inline std::map<int, std::vector<amrex::ParticleReal>> h_k_skew = {};
-
-        //! device: normal multipole coefficients of the magnetic field
-        inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_k_normal = {};
-        //! device: skew multipole coefficients of the magnetic field
-        inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_k_skew = {};
-
-    } // namespace MultipoleData
-
+        mixin::TrackedVector<amrex::ParticleReal> k_normal;
+        mixin::TrackedVector<amrex::ParticleReal> k_skew;
+    };
 
     struct ExactMultipole
     : public mixin::Named,
@@ -63,6 +54,7 @@ namespace impactx::elements
       public mixin::LinearTransport<ExactMultipole>,
       public mixin::Thick,
       public mixin::Alignment,
+      public mixin::NoFinalize,
       public mixin::PipeAperture
 #ifndef _WIN32
       // https://github.com/AMReX-Codes/amrex/issues/4609
@@ -71,6 +63,8 @@ namespace impactx::elements
     {
         static constexpr auto type = "ExactMultipole";
         using PType = ImpactXParticleContainer::ParticleType;
+
+        using DynamicData = mixin::GPUDataRegistry<MultipoleCoefficients>;
 
         /** A general (thick) straight-axis magnetic element whose field consists
          *  of a superposition of ideal hard-edge multipoles.  Like the element
@@ -117,36 +111,19 @@ namespace impactx::elements
           Alignment(dx, dy, rotation_degree),
           PipeAperture(aperture_x, aperture_y),
           m_unit(unit), m_int_order(int_order), m_mapsteps(mapsteps),
-          m_id(MultipoleData::next_id)
+          m_id(DynamicData::allocate_id())
         {
-            // next created ExactMultipole has another id for its data
-            MultipoleData::next_id++;
-
-            // validate normal and skew coefficients are the same length
             m_ncoef = int(k_normal.size());
             if (m_ncoef != int(k_skew.size()))
                 throw std::runtime_error("ExactMultipole: normal and skew coefficient arrays must have same length!");
 
-            // host data
-            MultipoleData::h_k_normal[m_id] = k_normal;
-            MultipoleData::h_k_skew[m_id] = k_skew;
-            m_k_normal_h_data = MultipoleData::h_k_normal[m_id].data();
-            m_k_skew_h_data = MultipoleData::h_k_skew[m_id].data();
-
-            // device data
-            MultipoleData::d_k_normal.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
-            MultipoleData::d_k_skew.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
-            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                                  k_normal.begin(), k_normal.end(),
-                                  MultipoleData::d_k_normal[m_id].begin());
-            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                                  k_skew.begin(), k_skew.end(),
-                                  MultipoleData::d_k_skew[m_id].begin());
-            amrex::Gpu::streamSynchronize();
-
-            // low-level objects we can use on device
-            m_k_normal_d_data = MultipoleData::d_k_normal[m_id].data();
-            m_k_skew_d_data = MultipoleData::d_k_skew[m_id].data();
+            auto& coef = DynamicData::emplace(
+                m_id,
+                std::move(k_normal),
+                std::move(k_skew)
+            );
+            m_k_normal_h_data = coef.k_normal.host_const().data();
+            m_k_skew_h_data = coef.k_skew.host_const().data();
         }
 
         /** Push all particles */
@@ -165,6 +142,11 @@ namespace impactx::elements
             using amrex::Math::powi;
 
             Alignment::compute_constants(refpart);
+
+            // Ensure dynamic coefficient data is on GPU and we have fresh pointers to it
+            auto const & coef = *DynamicData::get(m_id);
+            m_k_normal_d_data = coef.k_normal.device_const().data();
+            m_k_skew_d_data = coef.k_skew.device_const().data();
 
             // length of the current slice
             m_slice_ds = m_ds / nslice();
@@ -342,11 +324,11 @@ namespace impactx::elements
             T_Real ptout = pt;
 
 #if AMREX_DEVICE_COMPILE
-            amrex::ParticleReal* k_normal = m_k_normal_d_data;
-            amrex::ParticleReal* k_skew = m_k_skew_d_data;
+            amrex::ParticleReal const * k_normal = m_k_normal_d_data;
+            amrex::ParticleReal const * k_skew = m_k_skew_d_data;
 #else
-            amrex::ParticleReal* k_normal = m_k_normal_h_data;
-            amrex::ParticleReal* k_skew = m_k_skew_h_data;
+            amrex::ParticleReal const * k_normal = m_k_normal_h_data;
+            amrex::ParticleReal const * k_skew = m_k_skew_h_data;
 #endif
 
             // a complex type with two T_Real
@@ -451,11 +433,11 @@ namespace impactx::elements
             // pick the right data depending if we are on the host side
             // (reference particle push) or device side (particles):
 #if AMREX_DEVICE_COMPILE
-            amrex::ParticleReal* k_normal = m_k_normal_d_data;
-            amrex::ParticleReal* k_skew = m_k_skew_d_data;
+            amrex::ParticleReal const * k_normal = m_k_normal_d_data;
+            amrex::ParticleReal const * k_skew = m_k_skew_d_data;
 #else
-            amrex::ParticleReal* k_normal = m_k_normal_h_data;
-            amrex::ParticleReal* k_skew = m_k_skew_h_data;
+            amrex::ParticleReal const * k_normal = m_k_normal_h_data;
+            amrex::ParticleReal const * k_skew = m_k_skew_h_data;
 #endif
 
             // normalize quad units to MAD-X convention if needed
@@ -509,33 +491,16 @@ namespace impactx::elements
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();
 
-        /** Close and deallocate all data and handles.
-         */
-        void
-        finalize ()
-        {
-            // remove from unique data map
-            if (MultipoleData::h_k_normal.count(m_id) != 0u)
-                MultipoleData::h_k_normal.erase(m_id);
-            if (MultipoleData::h_k_skew.count(m_id) != 0u)
-                MultipoleData::h_k_skew.erase(m_id);
-
-            if (MultipoleData::d_k_normal.count(m_id) != 0u)
-                MultipoleData::d_k_normal.erase(m_id);
-            if (MultipoleData::d_k_skew.count(m_id) != 0u)
-                MultipoleData::d_k_skew.erase(m_id);
-        }
-
         int m_unit; //! unit specification for Multipole strength
         int m_int_order; //! order used for the symplectic integration (2 or 4)
         int m_mapsteps; //! number of integration steps per slice
         int m_id; //! unique ExactMultipole id used for data lookup map
 
         int m_ncoef = 0; //! number of Fourier coefficients
-        amrex::ParticleReal* m_k_normal_h_data = nullptr; //! non-owning pointer to host cosine coefficients
-        amrex::ParticleReal* m_k_skew_h_data = nullptr; //! non-owning pointer to host sine coefficients
-        amrex::ParticleReal* m_k_normal_d_data = nullptr; //! non-owning pointer to device cosine coefficients
-        amrex::ParticleReal* m_k_skew_d_data = nullptr; //! non-owning pointer to device sine coefficients
+        amrex::ParticleReal const * m_k_normal_h_data = nullptr; //! non-owning pointer to host cosine coefficients
+        amrex::ParticleReal const * m_k_skew_h_data = nullptr; //! non-owning pointer to host sine coefficients
+        amrex::ParticleReal const * m_k_normal_d_data = nullptr; //! non-owning pointer to device cosine coefficients
+        amrex::ParticleReal const * m_k_skew_d_data = nullptr; //! non-owning pointer to device sine coefficients
 
     private:
         // constants that are independent of the individually tracked particle,
@@ -550,6 +515,7 @@ namespace impactx::elements
 
 } // namespace impactx
 
+IMPACTX_GPUDATA_EXTERN(impactx::elements::ExactMultipole)
 IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::ExactMultipole)
 
 #endif // IMPACTX_EXACTMULTIPOLE_H

--- a/src/elements/ExactMultipole.H
+++ b/src/elements/ExactMultipole.H
@@ -497,10 +497,10 @@ namespace impactx::elements
         int m_id; //! unique ExactMultipole id used for data lookup map
 
         int m_ncoef = 0; //! number of Fourier coefficients
-        amrex::ParticleReal const * m_k_normal_h_data = nullptr; //! non-owning pointer to host cosine coefficients
-        amrex::ParticleReal const * m_k_skew_h_data = nullptr; //! non-owning pointer to host sine coefficients
-        amrex::ParticleReal const * m_k_normal_d_data = nullptr; //! non-owning pointer to device cosine coefficients
-        amrex::ParticleReal const * m_k_skew_d_data = nullptr; //! non-owning pointer to device sine coefficients
+        amrex::ParticleReal const * m_k_normal_h_data = nullptr; //! non-owning pointer to host normal coefficients
+        amrex::ParticleReal const * m_k_skew_h_data = nullptr; //! non-owning pointer to host skew coefficients
+        amrex::ParticleReal const * m_k_normal_d_data = nullptr; //! non-owning pointer to device normal coefficients
+        amrex::ParticleReal const * m_k_skew_d_data = nullptr; //! non-owning pointer to device skew coefficients
 
     private:
         // constants that are independent of the individually tracked particle,

--- a/src/elements/ExactMultipole.cpp
+++ b/src/elements/ExactMultipole.cpp
@@ -1,3 +1,4 @@
 #include "ExactMultipole.H"
 
+IMPACTX_GPUDATA_INSTANTIATE(impactx::elements::ExactMultipole)
 IMPACTX_PUSH_INSTANTIATE(impactx::elements::ExactMultipole)

--- a/src/elements/PolygonAperture.H
+++ b/src/elements/PolygonAperture.H
@@ -1,4 +1,4 @@
-/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
  *           Berkeley National Laboratory (subject to receipt of any required
  *           approvals from the U.S. Dept. of Energy). All rights reserved.
  *
@@ -14,9 +14,12 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/alignment.H"
 #include "mixin/beamoptic.H"
-#include "mixin/thin.H"
+#include "mixin/dynamicdata.H"
 #include "mixin/lineartransport.H"
 #include "mixin/named.H"
+#include "mixin/nofinalize.H"
+#include "mixin/thin.H"
+#include "mixin/TrackedVector.H"
 
 #include <ablastr/constant.H>
 
@@ -27,6 +30,7 @@
 
 #include <cmath>
 #include <map>
+#include <memory>
 #include <stdexcept>
 #include <vector>
 
@@ -34,39 +38,30 @@
 namespace impactx::elements
 {
 
-    /** Dynamic data for the PolygonAperture elements
+    /** Polygon vertices for aperture boundary definition.
      *
-     * Since we copy the element to the device, we cannot store this data on the element itself.
-     * But we can store pointers to this data with the element and keep a lookup table here,
-     * which we clean up in the end.
+     * Host data persists across simulations; device data is uploaded
+     * on-demand "lazily" on first use and released when AMReX shuts down.
      */
-    namespace PolygonApertureData
+    struct PolygonVertices
     {
-        //! last used id for a created ExactMultipole
-        inline int next_id = 0;
-
-        //! host: normal multipole coefficients of the magnetic field
-        inline std::map<int, std::vector<amrex::ParticleReal>> h_vertices_x = {};
-        //! host: skew multipole coefficients of the magnetic field
-        inline std::map<int, std::vector<amrex::ParticleReal>> h_vertices_y = {};
-
-        //! device: normal multipole coefficients of the magnetic field
-        inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_vertices_x = {};
-        //! device: skew multipole coefficients of the magnetic field
-        inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_vertices_y = {};
-
-    } // namespace PolygonApertureData
+        mixin::TrackedVector<amrex::ParticleReal> x;
+        mixin::TrackedVector<amrex::ParticleReal> y;
+    };
 
     struct PolygonAperture
     : public mixin::Named,
       public mixin::BeamOptic<PolygonAperture>,
       public mixin::LinearTransport<PolygonAperture>,
       public mixin::Thin,
-      public mixin::Alignment
+      public mixin::Alignment,
+      public mixin::NoFinalize
       // public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
     {
         static constexpr auto type = "PolygonAperture";
         using PType = ImpactXParticleContainer::ParticleType;
+
+        using DynamicData = mixin::GPUDataRegistry<PolygonVertices>;
 
         enum Action
         {
@@ -109,7 +104,7 @@ namespace impactx::elements
         : Named(std::move(name)),
           Alignment(dx, dy, rotation_degree),
           m_action(action), m_repeat_x(repeat_x), m_repeat_y(repeat_y), m_shift_odd_x(shift_odd_x),
-          m_id(PolygonApertureData::next_id),
+          m_id(DynamicData::allocate_id()),
           m_min_radius2(min_radius2)
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -118,41 +113,23 @@ namespace impactx::elements
                 throw std::runtime_error("PolygonAperture: shift_odd_x can only be used if repeat_y is set, too!");
             }
 
-            // next created MulPolygonAperture has another id for its data
-            PolygonApertureData::next_id++;
-
             m_nvert = vertices_x.size();
-            // there must be the same number of horizontal and vertical vertices
             if (m_nvert != vertices_y.size()) {
                 throw std::runtime_error("PolygonAperture: horizontal and vertical vertices arrays must have same length!");
             }
 
-            // verify that first and last vertices are the same
             if ((vertices_x[0] != vertices_x[m_nvert-1]) ||
                 (vertices_y[0] != vertices_y[m_nvert-1])) {
-                    throw std::runtime_error("PolygonAperture: first and last vertex must be exactly equal!");
+                throw std::runtime_error("PolygonAperture: first and last vertex must be exactly equal!");
             }
 
-            // host data
-            PolygonApertureData::h_vertices_x[m_id] = vertices_x;
-            PolygonApertureData::h_vertices_y[m_id] = vertices_y;
-            m_vertices_x_h_data = PolygonApertureData::h_vertices_x[m_id].data();
-            m_vertices_y_h_data = PolygonApertureData::h_vertices_y[m_id].data();
-
-            // device data
-            PolygonApertureData::d_vertices_x.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_nvert));
-            PolygonApertureData::d_vertices_y.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_nvert));
-            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                                  vertices_x.begin(), vertices_x.end(),
-                                  PolygonApertureData::d_vertices_x[m_id].begin());
-            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                                  vertices_y.begin(), vertices_y.end(),
-                                  PolygonApertureData::d_vertices_y[m_id].begin());
-            amrex::Gpu::streamSynchronize();
-
-            // low-level objects we can use on device
-            m_vertices_x_d_data = PolygonApertureData::d_vertices_x[m_id].data();
-            m_vertices_y_d_data = PolygonApertureData::d_vertices_y[m_id].data();
+            auto& vert = DynamicData::emplace(
+                m_id,
+                std::move(vertices_x),
+                std::move(vertices_y)
+            );
+            m_vertices_x_h_data = vert.x.host_const().data();
+            m_vertices_y_h_data = vert.y.host_const().data();
         }
 
         /** Push all particles */
@@ -168,6 +145,11 @@ namespace impactx::elements
         void compute_constants ([[maybe_unused]] RefPart const & refpart)
         {
             Alignment::compute_constants(refpart);
+
+            // Ensure dynamic vertex data is on GPU and we have fresh pointers to it
+            auto const & vert = *DynamicData::get(m_id);
+            m_vertices_x_d_data = vert.x.device_const().data();
+            m_vertices_y_d_data = vert.y.device_const().data();
         }
 
         /** This is an aperture functor, so that a variable of this type can be used like an
@@ -238,11 +220,11 @@ namespace impactx::elements
             } else{
 
 #if AMREX_DEVICE_COMPILE
-                amrex::ParticleReal* vertices_x = m_vertices_x_d_data;
-                amrex::ParticleReal* vertices_y = m_vertices_y_d_data;
+                amrex::ParticleReal const * vertices_x = m_vertices_x_d_data;
+                amrex::ParticleReal const * vertices_y = m_vertices_y_d_data;
 #else
-                amrex::ParticleReal* vertices_x = m_vertices_x_h_data;
-                amrex::ParticleReal* vertices_y = m_vertices_y_h_data;
+                amrex::ParticleReal const * vertices_x = m_vertices_x_h_data;
+                amrex::ParticleReal const * vertices_y = m_vertices_y_h_data;
 #endif
 
                 // no, we have to do the polygon calculation
@@ -302,23 +284,6 @@ namespace impactx::elements
             return Map6x6::Identity();
         }
 
-        /** Close and deallocate all data and handles.
-         */
-        void
-        finalize ()
-        {
-            // remove from unique data map
-            if (PolygonApertureData::h_vertices_x.count(m_id) != 0u)
-                PolygonApertureData::h_vertices_x.erase(m_id);
-            if (PolygonApertureData::h_vertices_y.count(m_id) != 0u)
-                PolygonApertureData::h_vertices_y.erase(m_id);
-
-            if (PolygonApertureData::d_vertices_x.count(m_id) != 0u)
-                PolygonApertureData::d_vertices_x.erase(m_id);
-            if (PolygonApertureData::d_vertices_y.count(m_id) != 0u)
-                PolygonApertureData::d_vertices_y.erase(m_id);
-        }
-
         Action m_action; //! action type (transmit, absorb)
         amrex::ParticleReal m_repeat_x; //! horizontal period for repeated masking
         amrex::ParticleReal m_repeat_y; //! vertical period for repeated masking
@@ -329,15 +294,16 @@ namespace impactx::elements
         amrex::ParticleReal m_min_radius2; // minimum radius in which all pass squared
 
         std::vector<double>::size_type m_nvert = 0; //! number of vertices
-        amrex::ParticleReal* m_vertices_x_h_data = nullptr; //! non-owning pointer to host x vertices
-        amrex::ParticleReal* m_vertices_y_h_data = nullptr; //! non-owning pointer to host vertices
-        amrex::ParticleReal* m_vertices_x_d_data = nullptr; //! non-owning pointer to device x vertices
-        amrex::ParticleReal* m_vertices_y_d_data = nullptr; //! non-owning pointer to device y vertices
+        amrex::ParticleReal const * m_vertices_x_h_data = nullptr; //! non-owning pointer to host x vertices
+        amrex::ParticleReal const * m_vertices_y_h_data = nullptr; //! non-owning pointer to host vertices
+        amrex::ParticleReal const * m_vertices_x_d_data = nullptr; //! non-owning pointer to device x vertices
+        amrex::ParticleReal const * m_vertices_y_d_data = nullptr; //! non-owning pointer to device y vertices
 
     };
 
 } // namespace impactx
 
+IMPACTX_GPUDATA_EXTERN(impactx::elements::PolygonAperture)
 IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::PolygonAperture)
 
 #endif // IMPACTX_POLYGONAPERTURE_H

--- a/src/elements/PolygonAperture.cpp
+++ b/src/elements/PolygonAperture.cpp
@@ -12,6 +12,8 @@
 #include <stdexcept>
 #include <string>
 
+IMPACTX_GPUDATA_INSTANTIATE(impactx::elements::PolygonAperture)
+
 std::string
 impactx::elements::PolygonAperture::action_name (Action const & action)
 {

--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -1,4 +1,4 @@
-/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
  *           Berkeley National Laboratory (subject to receipt of any required
  *           approvals from the U.S. Dept. of Energy). All rights reserved.
  *
@@ -13,11 +13,14 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/integrators/Integrators.H"
 #include "mixin/alignment.H"
-#include "mixin/pipeaperture.H"
 #include "mixin/beamoptic.H"
+#include "mixin/dynamicdata.H"
 #include "mixin/lineartransport.H"
 #include "mixin/named.H"
+#include "mixin/nofinalize.H"
+#include "mixin/pipeaperture.H"
 #include "mixin/thick.H"
+#include "mixin/TrackedVector.H"
 
 #include <ablastr/constant.H>
 
@@ -29,6 +32,7 @@
 #include <AMReX_SmallMatrix.H>
 
 #include <cmath>
+#include <memory>
 #include <stdexcept>
 #include <tuple>
 #include <vector>
@@ -82,28 +86,16 @@ namespace impactx::elements
         };
     };
 
-/** Dynamic data for the RFCavity elements
- *
- * Since we copy the element to the device, we cannot store this data on the element itself.
- * But we can store pointers to this data with the element and keep a lookup table here,
- * which we clean up in the end.
- */
-namespace RFCavityData
-{
-    //! last used id for a created RF cavity
-    inline int next_id = 0;
-
-    //! host: cosine coefficients in Fourier expansion of on-axis electric field Ez
-    inline std::map<int, std::vector<amrex::ParticleReal>> h_cos_coef = {};
-    //! host: sine coefficients in Fourier expansion of on-axis electric field Ez
-    inline std::map<int, std::vector<amrex::ParticleReal>> h_sin_coef = {};
-
-    //! device: cosine coefficients in Fourier expansion of on-axis electric field Ez
-    inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_cos_coef = {};
-    //! device: sine coefficients in Fourier expansion of on-axis electric field Ez
-    inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_sin_coef = {};
-
-} // namespace RFCavityData
+    /** Fourier coefficients for on-axis RF electric field Ez.
+     *
+     * Host data persists across simulations; device data is uploaded
+     * on-demand "lazily" on first use and released when AMReX shuts down.
+     */
+    struct CavityFourierCoefficients
+    {
+        mixin::TrackedVector<amrex::ParticleReal> cos;
+        mixin::TrackedVector<amrex::ParticleReal> sin;
+    };
 
     struct RFCavity
     : public mixin::Named,
@@ -111,11 +103,14 @@ namespace RFCavityData
       public mixin::LinearTransport<RFCavity>,
       public mixin::Thick,
       public mixin::Alignment,
+      public mixin::NoFinalize,
       public mixin::PipeAperture,
       public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
     {
         static constexpr auto type = "RFCavity";
         using PType = ImpactXParticleContainer::ParticleType;
+
+        using DynamicData = mixin::GPUDataRegistry<CavityFourierCoefficients>;
 
         /** An RF cavity
          *
@@ -155,36 +150,20 @@ namespace RFCavityData
             Thick(ds, nslice),
             Alignment(dx, dy, rotation_degree),
             PipeAperture(aperture_x, aperture_y),
-            m_escale(escale), m_freq(freq), m_phase(phase), m_mapsteps(mapsteps), m_id(RFCavityData::next_id)
+            m_escale(escale), m_freq(freq), m_phase(phase), m_mapsteps(mapsteps),
+            m_id(DynamicData::allocate_id())
         {
-            // next created RF cavity has another id for its data
-            RFCavityData::next_id++;
-
-            // validate sin and cos coefficients are the same length
             m_ncoef = int(cos_coef.size());
             if (m_ncoef != int(sin_coef.size()))
                 throw std::runtime_error("RFCavity: cos and sin coefficients must have same length!");
 
-            // host data
-            RFCavityData::h_cos_coef[m_id] = cos_coef;
-            RFCavityData::h_sin_coef[m_id] = sin_coef;
-            m_cos_h_data = RFCavityData::h_cos_coef[m_id].data();
-            m_sin_h_data = RFCavityData::h_sin_coef[m_id].data();
-
-            // device data
-            RFCavityData::d_cos_coef.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
-            RFCavityData::d_sin_coef.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
-            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                                  cos_coef.begin(), cos_coef.end(),
-                                  RFCavityData::d_cos_coef[m_id].begin());
-            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                                  sin_coef.begin(), sin_coef.end(),
-                                  RFCavityData::d_sin_coef[m_id].begin());
-            amrex::Gpu::streamSynchronize();
-
-            // low-level objects we can use on device
-            m_cos_d_data = RFCavityData::d_cos_coef[m_id].data();
-            m_sin_d_data = RFCavityData::d_sin_coef[m_id].data();
+            auto& coef = DynamicData::emplace(
+                m_id,
+                std::move(cos_coef),
+                std::move(sin_coef)
+            );
+            m_cos_h_data = coef.cos.host_const().data();
+            m_sin_h_data = coef.sin.host_const().data();
         }
 
         /** Push all particles */
@@ -202,6 +181,10 @@ namespace RFCavityData
             using namespace amrex::literals; // for _rt and _prt
 
             Alignment::compute_constants(refpart);
+
+            auto const & coef = *DynamicData::get(m_id);
+            m_cos_d_data = coef.cos.device_const().data();
+            m_sin_d_data = coef.sin.device_const().data();
         }
 
         /** This is an RF cavity functor, so that a variable of this type can be used like
@@ -371,11 +354,11 @@ namespace RFCavityData
             // pick the right data depending if we are on the host side
             // (reference particle push) or device side (particles):
 #if AMREX_DEVICE_COMPILE
-            amrex::ParticleReal* cos_data = m_cos_d_data;
-            amrex::ParticleReal* sin_data = m_sin_d_data;
+            amrex::ParticleReal const * cos_data = m_cos_d_data;
+            amrex::ParticleReal const * sin_data = m_sin_d_data;
 #else
-            amrex::ParticleReal* cos_data = m_cos_h_data;
-            amrex::ParticleReal* sin_data = m_sin_h_data;
+            amrex::ParticleReal const * cos_data = m_cos_h_data;
+            amrex::ParticleReal const * sin_data = m_sin_h_data;
 #endif
 
             // specify constants
@@ -554,23 +537,6 @@ namespace RFCavityData
             refpart.map(6,6) = M*R(5,6) + R(6,6);
         }
 
-        /** Close and deallocate all data and handles.
-         */
-        void
-        finalize ()
-        {
-            // remove from unique data map
-            if (RFCavityData::h_cos_coef.count(m_id) != 0u)
-                RFCavityData::h_cos_coef.erase(m_id);
-            if (RFCavityData::h_sin_coef.count(m_id) != 0u)
-                RFCavityData::h_sin_coef.erase(m_id);
-
-            if (RFCavityData::d_cos_coef.count(m_id) != 0u)
-                RFCavityData::d_cos_coef.erase(m_id);
-            if (RFCavityData::d_sin_coef.count(m_id) != 0u)
-                RFCavityData::d_sin_coef.erase(m_id);
-        }
-
         amrex::ParticleReal m_escale; //! scaling factor for RF electric field
         amrex::ParticleReal m_freq; //! RF frequency in Hz
         amrex::ParticleReal m_phase; //! RF driven phase in deg
@@ -578,14 +544,15 @@ namespace RFCavityData
         int m_id; //! unique RF cavity id used for data lookup map
 
         int m_ncoef = 0; //! number of Fourier coefficients
-        amrex::ParticleReal* m_cos_h_data = nullptr; //! non-owning pointer to host cosine coefficients
-        amrex::ParticleReal* m_sin_h_data = nullptr; //! non-owning pointer to host sine coefficients
-        amrex::ParticleReal* m_cos_d_data = nullptr; //! non-owning pointer to device cosine coefficients
-        amrex::ParticleReal* m_sin_d_data = nullptr; //! non-owning pointer to device sine coefficients
+        amrex::ParticleReal const * m_cos_h_data = nullptr; //! non-owning pointer to host cosine coefficients
+        amrex::ParticleReal const * m_sin_h_data = nullptr; //! non-owning pointer to host sine coefficients
+        amrex::ParticleReal const * m_cos_d_data = nullptr; //! non-owning pointer to device cosine coefficients
+        amrex::ParticleReal const * m_sin_d_data = nullptr; //! non-owning pointer to device sine coefficients
     };
 
 } // namespace impactx
 
+IMPACTX_GPUDATA_EXTERN(impactx::elements::RFCavity)
 IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::RFCavity)
 
 #endif // IMPACTX_RFCAVITY_H

--- a/src/elements/RFCavity.cpp
+++ b/src/elements/RFCavity.cpp
@@ -1,3 +1,4 @@
 #include "RFCavity.H"
 
+IMPACTX_GPUDATA_INSTANTIATE(impactx::elements::RFCavity)
 IMPACTX_PUSH_INSTANTIATE(impactx::elements::RFCavity)

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -1,4 +1,4 @@
-/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
  *           Berkeley National Laboratory (subject to receipt of any required
  *           approvals from the U.S. Dept. of Energy). All rights reserved.
  *
@@ -13,11 +13,14 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/integrators/Integrators.H"
 #include "mixin/alignment.H"
-#include "mixin/pipeaperture.H"
 #include "mixin/beamoptic.H"
+#include "mixin/dynamicdata.H"
 #include "mixin/lineartransport.H"
 #include "mixin/named.H"
+#include "mixin/nofinalize.H"
+#include "mixin/pipeaperture.H"
 #include "mixin/thick.H"
+#include "mixin/TrackedVector.H"
 
 #include <ablastr/constant.H>
 
@@ -29,6 +32,7 @@
 #include <AMReX_SmallMatrix.H>
 
 #include <cmath>
+#include <memory>
 #include <stdexcept>
 #include <tuple>
 #include <vector>
@@ -91,28 +95,16 @@ namespace impactx::elements
             };
     };
 
-/** Dynamic data for the SoftQuadrupole elements
- *
- * Since we copy the element to the device, we cannot store this data on the element itself.
- * But we can store pointers to this data with the element and keep a lookup table here,
- * which we clean up in the end.
- */
-namespace SoftQuadrupoleData
-{
-    //! last used id for a created soft quad
-    inline int next_id = 0;
-
-    //! host: cosine coefficients in Fourier expansion of on-axis magnetic field Bz
-    inline std::map<int, std::vector<amrex::ParticleReal>> h_cos_coef = {};
-    //! host: sine coefficients in Fourier expansion of on-axis magnetic field Bz
-    inline std::map<int, std::vector<amrex::ParticleReal>> h_sin_coef = {};
-
-    //! device: cosine coefficients in Fourier expansion of on-axis magnetic field Bz
-    inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_cos_coef = {};
-    //! device: sine coefficients in Fourier expansion of on-axis magnetic field Bz
-    inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_sin_coef = {};
-
-} // namespace SoftQuadrupoleData
+    /** Fourier coefficients for on-axis quadrupole field gradient.
+     *
+     * Host data persists across simulations; device data is uploaded
+     * on-demand "lazily" on first use and released when AMReX shuts down.
+     */
+    struct QuadrupoleFourierCoefficients
+    {
+        mixin::TrackedVector<amrex::ParticleReal> cos;
+        mixin::TrackedVector<amrex::ParticleReal> sin;
+    };
 
     struct SoftQuadrupole
     : public mixin::Named,
@@ -120,11 +112,14 @@ namespace SoftQuadrupoleData
       public mixin::LinearTransport<SoftQuadrupole>,
       public mixin::Thick,
       public mixin::Alignment,
+      public mixin::NoFinalize,
       public mixin::PipeAperture,
       public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
     {
         static constexpr auto type = "SoftQuadrupole";
         using PType = ImpactXParticleContainer::ParticleType;
+
+        using DynamicData = mixin::GPUDataRegistry<QuadrupoleFourierCoefficients>;
 
         /** A soft-edge quadrupole
          *
@@ -160,37 +155,21 @@ namespace SoftQuadrupoleData
             Thick(ds, nslice),
             Alignment(dx, dy, rotation_degree),
             PipeAperture(aperture_x, aperture_y),
-            m_gscale(gscale), m_mapsteps(mapsteps), m_id(SoftQuadrupoleData::next_id)
+            m_gscale(gscale), m_mapsteps(mapsteps),
+            m_id(DynamicData::allocate_id())
         {
-            // next created soft quad has another id for its data
-            SoftQuadrupoleData::next_id++;
-
-            // validate sin and cos coefficients are the same length
             m_ncoef = int(cos_coef.size());
             if (m_ncoef != int(sin_coef.size()))
                 throw std::runtime_error("SoftQuadrupole: cos and sin coefficients must have same length!");
 
-            // host data
-            SoftQuadrupoleData::h_cos_coef[m_id] = cos_coef;
-            SoftQuadrupoleData::h_sin_coef[m_id] = sin_coef;
-            m_cos_h_data = SoftQuadrupoleData::h_cos_coef[m_id].data();
-            m_sin_h_data = SoftQuadrupoleData::h_sin_coef[m_id].data();
-
-            // device data
-            SoftQuadrupoleData::d_cos_coef.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
-            SoftQuadrupoleData::d_sin_coef.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
-            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                                  cos_coef.begin(), cos_coef.end(),
-                                  SoftQuadrupoleData::d_cos_coef[m_id].begin());
-            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                                  sin_coef.begin(), sin_coef.end(),
-                                  SoftQuadrupoleData::d_sin_coef[m_id].begin());
-            amrex::Gpu::streamSynchronize();
-
-            // low-level objects we can use on device
-            m_cos_d_data = SoftQuadrupoleData::d_cos_coef[m_id].data();
-            m_sin_d_data = SoftQuadrupoleData::d_sin_coef[m_id].data();
-       }
+            auto& coef = DynamicData::emplace(
+                m_id,
+                std::move(cos_coef),
+                std::move(sin_coef)
+            );
+            m_cos_h_data = coef.cos.host_const().data();
+            m_sin_h_data = coef.sin.host_const().data();
+        }
 
         /** Push all particles */
         using BeamOptic::operator();
@@ -207,6 +186,11 @@ namespace SoftQuadrupoleData
             using namespace amrex::literals; // for _rt and _prt
 
             Alignment::compute_constants(refpart);
+
+            // Ensure dynamic coefficient data is on GPU and we have fresh pointers to it
+            auto const & coef = *DynamicData::get(m_id);
+            m_cos_d_data = coef.cos.device_const().data();
+            m_sin_d_data = coef.sin.device_const().data();
         }
 
         /** This is a soft-edge quadrupole functor, so that a variable of this type can be used
@@ -369,11 +353,11 @@ namespace SoftQuadrupoleData
             // pick the right data depending if we are on the host side
             // (reference particle push) or device side (particles):
 #if AMREX_DEVICE_COMPILE
-            amrex::ParticleReal* cos_data = m_cos_d_data;
-            amrex::ParticleReal* sin_data = m_sin_d_data;
+            amrex::ParticleReal const * cos_data = m_cos_d_data;
+            amrex::ParticleReal const * sin_data = m_sin_d_data;
 #else
-            amrex::ParticleReal* cos_data = m_cos_h_data;
-            amrex::ParticleReal* sin_data = m_sin_h_data;
+            amrex::ParticleReal const * cos_data = m_cos_h_data;
+            amrex::ParticleReal const * sin_data = m_sin_h_data;
 #endif
 
             // specify constants
@@ -499,36 +483,20 @@ namespace SoftQuadrupoleData
 
         }
 
-        /** Close and deallocate all data and handles.
-         */
-        void
-        finalize ()
-        {
-            // remove from unique data map
-            if (SoftQuadrupoleData::h_cos_coef.count(m_id) != 0u)
-                SoftQuadrupoleData::h_cos_coef.erase(m_id);
-            if (SoftQuadrupoleData::h_sin_coef.count(m_id) != 0u)
-                SoftQuadrupoleData::h_sin_coef.erase(m_id);
-
-            if (SoftQuadrupoleData::d_cos_coef.count(m_id) != 0u)
-                SoftQuadrupoleData::d_cos_coef.erase(m_id);
-            if (SoftQuadrupoleData::d_sin_coef.count(m_id) != 0u)
-                SoftQuadrupoleData::d_sin_coef.erase(m_id);
-        }
-
         amrex::ParticleReal m_gscale; //! scaling factor for quad field gradient
         int m_mapsteps; //! number of map integration steps per slice
         int m_id; //! unique soft quad id used for data lookup map
 
         int m_ncoef = 0; //! number of Fourier coefficients
-        amrex::ParticleReal* m_cos_h_data = nullptr; //! non-owning pointer to host cosine coefficients
-        amrex::ParticleReal* m_sin_h_data = nullptr; //! non-owning pointer to host sine coefficients
-        amrex::ParticleReal* m_cos_d_data = nullptr; //! non-owning pointer to device cosine coefficients
-        amrex::ParticleReal* m_sin_d_data = nullptr; //! non-owning pointer to device sine coefficients
+        amrex::ParticleReal const * m_cos_h_data = nullptr; //! non-owning pointer to host cosine coefficients
+        amrex::ParticleReal const * m_sin_h_data = nullptr; //! non-owning pointer to host sine coefficients
+        amrex::ParticleReal const * m_cos_d_data = nullptr; //! non-owning pointer to device cosine coefficients
+        amrex::ParticleReal const * m_sin_d_data = nullptr; //! non-owning pointer to device sine coefficients
     };
 
 } // namespace impactx
 
+IMPACTX_GPUDATA_EXTERN(impactx::elements::SoftQuadrupole)
 IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::SoftQuadrupole)
 
 #endif // IMPACTX_SOFTQUAD_H

--- a/src/elements/SoftQuad.cpp
+++ b/src/elements/SoftQuad.cpp
@@ -1,3 +1,4 @@
 #include "SoftQuad.H"
 
+IMPACTX_GPUDATA_INSTANTIATE(impactx::elements::SoftQuadrupole)
 IMPACTX_PUSH_INSTANTIATE(impactx::elements::SoftQuadrupole)

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -1,4 +1,4 @@
-/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
  *           Berkeley National Laboratory (subject to receipt of any required
  *           approvals from the U.S. Dept. of Energy). All rights reserved.
  *
@@ -13,11 +13,14 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/integrators/Integrators.H"
 #include "mixin/alignment.H"
-#include "mixin/pipeaperture.H"
 #include "mixin/beamoptic.H"
+#include "mixin/dynamicdata.H"
 #include "mixin/lineartransport.H"
 #include "mixin/named.H"
+#include "mixin/nofinalize.H"
+#include "mixin/pipeaperture.H"
 #include "mixin/thick.H"
+#include "mixin/TrackedVector.H"
 
 #include <ablastr/constant.H>
 
@@ -29,6 +32,7 @@
 #include <AMReX_SmallMatrix.H>
 
 #include <cmath>
+#include <memory>
 #include <stdexcept>
 #include <tuple>
 #include <vector>
@@ -96,28 +100,16 @@ namespace impactx::elements
             };
     };
 
-/** Dynamic data for the SoftSolenoid elements
- *
- * Since we copy the element to the device, we cannot store this data on the element itself.
- * But we can store pointers to this data with the element and keep a lookup table here,
- * which we clean up in the end.
- */
-namespace SoftSolenoidData
-{
-    //! last used id for a created soft solenoid
-    inline int next_id = 0;
-
-    //! host: cosine coefficients in Fourier expansion of on-axis magnetic field Bz
-    inline std::map<int, std::vector<amrex::ParticleReal>> h_cos_coef = {};
-    //! host: sine coefficients in Fourier expansion of on-axis magnetic field Bz
-    inline std::map<int, std::vector<amrex::ParticleReal>> h_sin_coef = {};
-
-    //! device: cosine coefficients in Fourier expansion of on-axis magnetic field Bz
-    inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_cos_coef = {};
-    //! device: sine coefficients in Fourier expansion of on-axis magnetic field Bz
-    inline std::map<int, amrex::Gpu::DeviceVector<amrex::ParticleReal>> d_sin_coef = {};
-
-} // namespace SoftSolenoidData
+    /** Fourier coefficients for on-axis solenoid field Bz(z).
+     *
+     * Host data persists across simulations; device data is uploaded
+     * on-demand "lazily" on first use and released when AMReX shuts down.
+     */
+    struct SolenoidFourierCoefficients
+    {
+        mixin::TrackedVector<amrex::ParticleReal> cos;
+        mixin::TrackedVector<amrex::ParticleReal> sin;
+    };
 
     struct SoftSolenoid
     : public mixin::Named,
@@ -125,11 +117,14 @@ namespace SoftSolenoidData
       public mixin::LinearTransport<SoftSolenoid>,
       public mixin::Thick,
       public mixin::Alignment,
+      public mixin::NoFinalize,
       public mixin::PipeAperture,
       public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
     {
         static constexpr auto type = "SoftSolenoid";
         using PType = ImpactXParticleContainer::ParticleType;
+
+        using DynamicData = mixin::GPUDataRegistry<SolenoidFourierCoefficients>;
 
         /** A soft-edge solenoid
          *
@@ -171,36 +166,20 @@ namespace SoftSolenoidData
             Thick(ds, nslice),
             Alignment(dx, dy, rotation_degree),
             PipeAperture(aperture_x, aperture_y),
-            m_bscale(bscale), m_unit(unit), m_mapsteps(mapsteps), m_id(SoftSolenoidData::next_id)
-       {
-           // next created soft solenoid has another id for its data
-           SoftSolenoidData::next_id++;
+            m_bscale(bscale), m_unit(unit), m_mapsteps(mapsteps),
+            m_id(DynamicData::allocate_id())
+        {
+            m_ncoef = int(cos_coef.size());
+            if (m_ncoef != int(sin_coef.size()))
+                throw std::runtime_error("SoftSolenoid: cos and sin coefficients must have same length!");
 
-           // validate sin and cos coefficients are the same length
-           m_ncoef = int(cos_coef.size());
-           if (m_ncoef != int(sin_coef.size()))
-               throw std::runtime_error("SoftSolenoid: cos and sin coefficients must have same length!");
-
-           // host data
-           SoftSolenoidData::h_cos_coef[m_id] = cos_coef;
-           SoftSolenoidData::h_sin_coef[m_id] = sin_coef;
-           m_cos_h_data = SoftSolenoidData::h_cos_coef[m_id].data();
-           m_sin_h_data = SoftSolenoidData::h_sin_coef[m_id].data();
-
-           // device data
-           SoftSolenoidData::d_cos_coef.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
-           SoftSolenoidData::d_sin_coef.emplace(m_id, amrex::Gpu::DeviceVector<amrex::ParticleReal>(m_ncoef));
-           amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                                 cos_coef.begin(), cos_coef.end(),
-                                 SoftSolenoidData::d_cos_coef[m_id].begin());
-           amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
-                                 sin_coef.begin(), sin_coef.end(),
-                                 SoftSolenoidData::d_sin_coef[m_id].begin());
-           amrex::Gpu::streamSynchronize();
-
-           // low-level objects we can use on device
-           m_cos_d_data = SoftSolenoidData::d_cos_coef[m_id].data();
-           m_sin_d_data = SoftSolenoidData::d_sin_coef[m_id].data();
+            auto& coef = DynamicData::emplace(
+                m_id,
+                std::move(cos_coef),
+                std::move(sin_coef)
+            );
+            m_cos_h_data = coef.cos.host_const().data();
+            m_sin_h_data = coef.sin.host_const().data();
         }
 
         /** Push all particles */
@@ -218,6 +197,11 @@ namespace SoftSolenoidData
             using namespace amrex::literals; // for _rt and _prt
 
             Alignment::compute_constants(refpart);
+
+            // Ensure dynamic coefficient data is on GPU and we have fresh pointers to it
+            auto const & coef = *DynamicData::get(m_id);
+            m_cos_d_data = coef.cos.device_const().data();
+            m_sin_d_data = coef.sin.device_const().data();
         }
 
         /** This is a soft-edge solenoid functor, so that a variable of this type can be used
@@ -378,11 +362,11 @@ namespace SoftSolenoidData
             // pick the right data depending if we are on the host side
             // (reference particle push) or device side (particles):
 #if AMREX_DEVICE_COMPILE
-            amrex::ParticleReal* cos_data = m_cos_d_data;
-            amrex::ParticleReal* sin_data = m_sin_d_data;
+            amrex::ParticleReal const * cos_data = m_cos_d_data;
+            amrex::ParticleReal const * sin_data = m_sin_d_data;
 #else
-            amrex::ParticleReal* cos_data = m_cos_h_data;
-            amrex::ParticleReal* sin_data = m_sin_h_data;
+            amrex::ParticleReal const * cos_data = m_cos_h_data;
+            amrex::ParticleReal const * sin_data = m_sin_h_data;
 #endif
 
             // specify constants
@@ -573,37 +557,21 @@ namespace SoftSolenoidData
 
         }
 
-        /** Close and deallocate all data and handles.
-         */
-        void
-        finalize ()
-        {
-            // remove from unique data map
-            if (SoftSolenoidData::h_cos_coef.count(m_id) != 0u)
-                SoftSolenoidData::h_cos_coef.erase(m_id);
-            if (SoftSolenoidData::h_sin_coef.count(m_id) != 0u)
-                SoftSolenoidData::h_sin_coef.erase(m_id);
-
-            if (SoftSolenoidData::d_cos_coef.count(m_id) != 0u)
-                SoftSolenoidData::d_cos_coef.erase(m_id);
-            if (SoftSolenoidData::d_sin_coef.count(m_id) != 0u)
-                SoftSolenoidData::d_sin_coef.erase(m_id);
-        }
-
         amrex::ParticleReal m_bscale; //! scaling factor for solenoid Bz field
         int m_unit; //! unit specification for quad strength
         int m_mapsteps; //! number of map integration steps per slice
         int m_id; //! unique soft solenoid id used for data lookup map
 
         int m_ncoef = 0; //! number of Fourier coefficients
-        amrex::ParticleReal* m_cos_h_data = nullptr; //! non-owning pointer to host cosine coefficients
-        amrex::ParticleReal* m_sin_h_data = nullptr; //! non-owning pointer to host sine coefficients
-        amrex::ParticleReal* m_cos_d_data = nullptr; //! non-owning pointer to device cosine coefficients
-        amrex::ParticleReal* m_sin_d_data = nullptr; //! non-owning pointer to device sine coefficients
+        amrex::ParticleReal const * m_cos_h_data = nullptr; //! non-owning pointer to host cosine coefficients
+        amrex::ParticleReal const * m_sin_h_data = nullptr; //! non-owning pointer to host sine coefficients
+        amrex::ParticleReal const * m_cos_d_data = nullptr; //! non-owning pointer to device cosine coefficients
+        amrex::ParticleReal const * m_sin_d_data = nullptr; //! non-owning pointer to device sine coefficients
     };
 
 } // namespace impactx
 
+IMPACTX_GPUDATA_EXTERN(impactx::elements::SoftSolenoid)
 IMPACTX_PUSH_EXTERN_TEMPLATE(impactx::elements::SoftSolenoid)
 
 #endif // IMPACTX_SOFTSOL_H

--- a/src/elements/SoftSol.cpp
+++ b/src/elements/SoftSol.cpp
@@ -1,3 +1,4 @@
 #include "SoftSol.H"
 
+IMPACTX_GPUDATA_INSTANTIATE(impactx::elements::SoftSolenoid)
 IMPACTX_PUSH_INSTANTIATE(impactx::elements::SoftSolenoid)

--- a/src/elements/mixin/TrackedVector.H
+++ b/src/elements/mixin/TrackedVector.H
@@ -1,0 +1,318 @@
+/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+*           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * FIXME: SHOULD BE REPLACED WITH amrex::Gpu::TrackedVector in v26.05+, see
+ *        https://github.com/AMReX-Codes/amrex/pull/5253
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_TRACKED_VECTOR_H
+#define IMPACTX_TRACKED_VECTOR_H
+
+#include <AMReX.H>
+#include <AMReX_GpuContainers.H>
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+
+namespace impactx::elements::mixin
+{
+    /** Base for element data with dynamic host vectors mirrored lazily to GPU.
+     *
+     * Provides lifetimes independent of AMReX initialize/finalize cycles,
+     * synchronization tracking, and data release APIs.
+     *
+     * This object is primarily for input handling, allowing to initialize
+     * data even before AMReX was initialized and enabling workflows crossing
+     * AMReX init/finalize cycles. GPU memory will always be bound to an
+     * AMReX session, but CPU memory can be allocated and live arbitrarily long.
+     *
+     * For AMReX CPU builds, the host and device members point to the *same* memory
+     * and the status will always be up to date.
+     *
+     * Usage contract:
+     *   - Device data can only be allocated after AMReX initialize and before finalize.
+     *   - You can call `release_gpu()` anytime, but we will call it during AMReX finalize
+     *     to invalidate device().
+     *   - Always access data via host/device[_const](). Do not cache references/pointers to
+     *     host/device memory managed by this object, or you run the risk of stale memory access.
+     */
+    template <class T>
+    struct TrackedVector
+    {
+        static_assert(std::is_trivially_copyable<T>(), "TrackedVector can only hold trivially copyable types");
+        using value_type      = T;
+        using size_type       = std::size_t;
+
+    private:
+        void register_finalize () {
+#ifdef AMREX_USE_GPU
+            if (*m_finalize_registered) { return; }
+            *m_finalize_registered = true;
+
+            std::weak_ptr<std::vector<T>> weak_host = m_host;
+            std::weak_ptr<amrex::Gpu::DeviceVector<T>> weak_device = m_device;
+            std::weak_ptr<Status> weak_status = m_status;
+            std::weak_ptr<bool> weak_registered = m_finalize_registered;
+
+            amrex::ExecOnFinalize([weak_host, weak_device, weak_status, weak_registered]() {
+                // see: release_gpu()
+                auto host   = weak_host.lock();
+                auto device = weak_device.lock();
+                auto status = weak_status.lock();
+                if (host && device && status
+                    && *status == Status::device_dirty
+                    && !device->empty())
+                {
+                    // see: to_host()
+                    host->resize(device->size());
+                    amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                        device->begin(), device->end(), host->begin());
+                }
+                if (device) {
+                    device->clear();
+                    device->shrink_to_fit();
+                }
+                if (status) {
+                    *status = Status::host_dirty;
+                }
+                if (auto reg = weak_registered.lock()) {
+                    *reg = false;
+                }
+            });
+#endif
+        }
+    public:
+
+        TrackedVector () = default;
+
+        explicit TrackedVector (size_type a_size)
+            : m_host(std::make_shared<std::vector<T>>(a_size))
+        {
+#ifdef AMREX_USE_GPU
+            *m_status = Status::host_dirty;
+#endif
+        }
+
+        TrackedVector (size_type a_size, value_type const & a_value)
+            : m_host(std::make_shared<std::vector<T>>(a_size, a_value))
+        {
+#ifdef AMREX_USE_GPU
+            *m_status = Status::host_dirty;
+#endif
+        }
+
+        TrackedVector (std::initializer_list<T> a_initializer_list)
+            : m_host(std::make_shared<std::vector<T>>(a_initializer_list))
+        {
+#ifdef AMREX_USE_GPU
+            *m_status = Status::host_dirty;
+#endif
+        }
+
+        TrackedVector (std::vector<T> a_vector)
+            : m_host(std::make_shared<std::vector<T>>(std::move(a_vector)))
+        {
+#ifdef AMREX_USE_GPU
+            *m_status = Status::host_dirty;
+#endif
+        }
+
+        TrackedVector (TrackedVector const & a_vector)
+            : m_host(std::make_shared<std::vector<T>>(*a_vector.m_host))
+        {
+            *m_status = *a_vector.m_status;
+#ifdef AMREX_USE_GPU
+            *m_device = *a_vector.m_device;
+#endif
+        }
+
+        /** Swap data of this and a_vector */
+        TrackedVector (TrackedVector && a_vector) noexcept
+        {
+            std::swap(m_status, a_vector.m_status);
+            std::swap(m_host, a_vector.m_host);
+#ifdef AMREX_USE_GPU
+            std::swap(m_device, a_vector.m_device);
+            std::swap(m_finalize_registered, a_vector.m_finalize_registered);
+#endif
+        }
+
+        TrackedVector& operator= (TrackedVector const & a_vector) {
+            if (this != &a_vector) {
+                *m_status = *a_vector.m_status;
+                *m_host = *a_vector.m_host;
+#ifdef AMREX_USE_GPU
+                *m_device = *a_vector.m_device;
+#endif
+            }
+            return *this;
+        }
+
+        /** Swap the data of this and a_vector */
+        TrackedVector& operator= (TrackedVector && a_vector) noexcept {
+            if (this != &a_vector) {
+                std::swap(m_host, a_vector.m_host);
+                std::swap(m_status, a_vector.m_status);
+#ifdef AMREX_USE_GPU
+                std::swap(m_device, a_vector.m_device);
+                std::swap(m_finalize_registered, a_vector.m_finalize_registered);
+#endif
+            }
+            return *this;
+        }
+
+        ~TrackedVector () = default;
+
+        enum class Status {
+            up_to_date,    //!< host and device data are in sync
+            device_dirty,  //!< host data needs an update
+            host_dirty     //!< device data needs an update
+        };
+
+        [[nodiscard]] Status status () const { return *m_status; }
+
+        /** Return writable host data
+         *
+         * If device data is newer, syncs device-to-host first (GPU builds).
+         * Marks host as dirty so the next device access will sync back.
+         */
+        [[nodiscard]] std::vector<T> &
+        host () {
+#ifdef AMREX_USE_GPU
+            if (*m_status == Status::device_dirty) {
+                to_host();
+            }
+            *m_status = Status::host_dirty;
+#endif
+            return *m_host;
+        }
+
+        /** Return read-only host data
+         *
+         * If device data is newer, syncs device-to-host first (GPU builds).
+         */
+        [[nodiscard]] std::vector<T> const &
+        host_const () const {
+#ifdef AMREX_USE_GPU
+            if (*m_status == Status::device_dirty) {
+                to_host();
+            }
+#endif
+            return *m_host;
+        }
+
+#ifdef AMREX_USE_GPU
+        /** Return writable device data
+         *
+         * If host data is newer, syncs host-to-device first.
+         * Marks device as dirty so the next host access will sync back.
+         */
+        [[nodiscard]] amrex::Gpu::DeviceVector<T> &
+        device () {
+            if (!amrex::Initialized()) {
+                throw std::runtime_error("TrackedVector::device() called before AMReX initialize/after AMReX finalize");
+            }
+            register_finalize();
+            if (*m_status == Status::host_dirty) {
+                to_device();
+            }
+            *m_status = Status::device_dirty;
+            return *m_device;
+        }
+
+        /** Return read-only device data
+         *
+         * If host data is newer, syncs host-to-device first.
+         */
+        [[nodiscard]] amrex::Gpu::DeviceVector<T> const &
+        device_const () const {
+            if (!amrex::Initialized()) {
+                throw std::runtime_error("TrackedVector::device_const() called before AMReX initialize/after AMReX finalize");
+            }
+            const_cast<TrackedVector*>(this)->register_finalize();
+            if (*m_status == Status::host_dirty) {
+                to_device();
+            }
+            return *m_device;
+        }
+#else
+        /** Return writable device (==host) data, up to date by definition */
+        [[nodiscard]] std::vector<T> &
+        device () { return *m_host; }
+
+        /** Return read-only device (==host) data */
+        [[nodiscard]] std::vector<T> const &
+        device_const () const { return *m_host; }
+#endif
+
+        /** Release GPU memory
+         *
+         * If the device side was modified (device_dirty), syncs device data
+         * back to the host first so no updates are lost.
+         * Host data preserved for reuse until destructor.
+         * This enables use outside of and across AMReX init/finalize cycles.
+         */
+        void release_gpu ()
+        {
+#ifdef AMREX_USE_GPU
+            if (*m_status == Status::device_dirty) {
+                to_host();
+            }
+            m_device->clear();
+            m_device->shrink_to_fit();
+            *m_status = Status::host_dirty;
+#endif
+        }
+
+    private:
+
+        /** Synchronize host data to device */
+        void to_device () const {
+#ifdef AMREX_USE_GPU
+            if (!amrex::Initialized()) {
+                throw std::runtime_error("TrackedVector::to_device() called outside of AMReX initialize/finalize");
+            }
+            auto const size = m_host->size();
+            if (size > 0U) {
+                m_device->resize(size);
+                amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                    m_host->begin(), m_host->end(), m_device->begin());
+            } else {
+                m_device->clear();
+            }
+            *m_status = Status::up_to_date;
+#endif
+        }
+
+        /** Synchronize device data to host */
+        void to_host () const {
+#ifdef AMREX_USE_GPU
+            if (!amrex::Initialized()) {
+                throw std::runtime_error("TrackedVector::to_host() called outside of AMReX initialize/finalize");
+            }
+            m_host->resize(m_device->size());
+            amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                m_device->begin(), m_device->end(), m_host->begin());
+            *m_status = Status::up_to_date;
+#endif
+        }
+
+        mutable std::shared_ptr<Status> m_status = std::make_shared<Status>();
+        mutable std::shared_ptr<std::vector<T>> m_host = std::make_shared<std::vector<T>>();
+#ifdef AMREX_USE_GPU
+        mutable std::shared_ptr<amrex::Gpu::DeviceVector<T>> m_device = std::make_shared<amrex::Gpu::DeviceVector<T>>();
+        mutable std::shared_ptr<bool> m_finalize_registered = std::make_shared<bool>(false);
+#endif
+    };
+
+}
+
+#endif

--- a/src/elements/mixin/dynamicdata.H
+++ b/src/elements/mixin/dynamicdata.H
@@ -1,0 +1,143 @@
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_ELEMENTS_MIXIN_DYNAMICDATA_H
+#define IMPACTX_ELEMENTS_MIXIN_DYNAMICDATA_H
+
+#include <AMReX_Gpu.H>
+
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+
+namespace impactx::elements::mixin
+{
+
+    /** Registry for element data that outlives value-copied elements.
+     *
+     * Beamline elements are stored by value in std::variant and may be copied.
+     * E.g., element data coefficient arrays live here in shared_ptr so all copies
+     * share data.
+     *
+     * Example (in MyElement.H):
+     * @code
+     * struct MyCoefficients { ... };
+     * using MyElementData = GPUDataRegistry<MyCoefficients>;
+     * @endcode
+     *
+     * @warning This template uses function-local static variables. To avoid ODR
+     *          violations (separate registry instances per translation unit), you
+     *          MUST add explicit instantiation control:
+     *          - In the element header: `IMPACTX_GPUDATA_EXTERN(impactx::elements::MyElement)`
+     *          - In the element .cpp:   `IMPACTX_GPUDATA_INSTANTIATE(impactx::elements::MyElement)`
+     *
+     * @tparam T element data struct with to_device() method
+     */
+    template<typename T>
+    struct GPUDataRegistry
+    {
+        using DataType = T;  //!< The coefficient/data type stored in this registry
+
+        static int& next_id () {
+            static int id = 0;
+            return id;
+        }
+
+        static std::map<int, std::shared_ptr<T>>& registry () {
+            static std::map<int, std::shared_ptr<T>> reg;
+            return reg;
+        }
+
+        /** Allocate unique ID for a new element instance. */
+        static int allocate_id () { return next_id()++; }
+
+        /** Retrieve data by element ID.
+         *
+         * @param[in] id Element ID assigned at construction
+         * @return Shared pointer to coefficient data
+         * @throws std::runtime_error if ID not found
+         */
+        static std::shared_ptr<T> const &
+        get (int id)
+        {
+            auto& reg = registry();
+            auto it = reg.find(id);
+            if (it == reg.end() || !it->second)
+                throw std::runtime_error(
+                    "GPUDataRegistry::get failed for id=" + std::to_string(id));
+            return it->second;
+        }
+
+        /** Store data for a new element.
+         *
+         * @param[in] id Element ID from allocate_id()
+         * @param[in] data Shared pointer to coefficient data
+         */
+        static void store (int id, std::shared_ptr<T> data)
+        {
+            registry()[id] = std::move(data);
+        }
+
+        /** Construct and store data for a new element.
+         *
+         * @param[in] id Element ID from allocate_id()
+         * @param[in] args Constructor arguments forwarded to T
+         * @return Reference to the stored data
+         */
+        template<typename... Args>
+        static T& emplace (int id, Args&&... args)
+        {
+            auto ptr = std::shared_ptr<T>(new T{std::forward<Args>(args)...});  // NOLINT(modernize-make-shared)
+            registry()[id] = ptr;
+            return *ptr;
+        }
+
+        /** Full teardown: clear all data including host. */
+        static void clear ()
+        {
+            registry().clear();
+            next_id() = 0;
+        }
+    };
+
+} // namespace impactx::elements::mixin
+
+
+/** Suppress implicit instantiation of GPUDataRegistry for an element type.
+ *
+ * GPUDataRegistry uses function-local static variables for its registry map and
+ * ID counter. Without explicit instantiation control, different translation units
+ * may each get their own copy of these statics, causing elements to be registered
+ * in one registry instance but looked up in another (ODR violation).
+ *
+ * Use IMPACTX_GPUDATA_EXTERN in headers and IMPACTX_GPUDATA_INSTANTIATE in the
+ * corresponding .cpp file to ensure a single shared registry across the program.
+ *
+ * @param ElementType The element class (must define `using DynamicData = ...`)
+ */
+#define IMPACTX_GPUDATA_EXTERN(ElementType) \
+    extern template struct impactx::elements::mixin::GPUDataRegistry< \
+        ElementType::DynamicData::DataType>;
+
+/** Explicit instantiation of GPUDataRegistry for an element type.
+ *
+ * Provides the single definition of the registry's static variables.
+ * Pair with IMPACTX_GPUDATA_EXTERN in the header.
+ *
+ * @param ElementType The element class (must define `using DynamicData = ...`)
+ */
+#define IMPACTX_GPUDATA_INSTANTIATE(ElementType) \
+    template struct impactx::elements::mixin::GPUDataRegistry< \
+        ElementType::DynamicData::DataType>;
+
+#endif // IMPACTX_ELEMENTS_MIXIN_DYNAMICDATA_H

--- a/src/elements/mixin/dynamicdata.H
+++ b/src/elements/mixin/dynamicdata.H
@@ -10,6 +10,8 @@
 #ifndef IMPACTX_ELEMENTS_MIXIN_DYNAMICDATA_H
 #define IMPACTX_ELEMENTS_MIXIN_DYNAMICDATA_H
 
+#include "impactx_export.H"
+
 #include <AMReX_Gpu.H>
 
 #include <map>
@@ -48,12 +50,12 @@ namespace impactx::elements::mixin
     {
         using DataType = T;  //!< The coefficient/data type stored in this registry
 
-        static int& next_id () {
+        IMPACTX_EXPORT static int& next_id () {
             static int id = 0;
             return id;
         }
 
-        static std::map<int, std::shared_ptr<T>>& registry () {
+        IMPACTX_EXPORT static std::map<int, std::shared_ptr<T>>& registry () {
             static std::map<int, std::shared_ptr<T>> reg;
             return reg;
         }

--- a/src/elements/mixin/nofinalize.H
+++ b/src/elements/mixin/nofinalize.H
@@ -15,8 +15,8 @@ namespace impactx::elements::mixin
 {
     /** This is a helper class for lattice elements that need no finalize function.
      *
-     * Finalize helpers are used to clean up static/shared data, usually dynamic
-     * memory from parameters or state from external libraries.
+     * Finalize helpers are used to clean up static/shared data, usually
+     * state from external libraries.
      */
     struct NoFinalize
     {

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -2241,8 +2241,8 @@ void init_elements(py::module& m)
                     soft_sol,
                     std::make_pair("bscale", soft_sol.m_bscale),
                     std::make_pair("unit", soft_sol.m_unit),
-                    std::make_pair("cos_coefficients", SoftSolenoidData::h_cos_coef[soft_sol.m_id]),
-                    std::make_pair("sin_coefficients", SoftSolenoidData::h_sin_coef[soft_sol.m_id]),
+                    std::make_pair("cos_coefficients", SoftSolenoid::DynamicData::get(soft_sol.m_id)->cos.host_const()),
+                    std::make_pair("sin_coefficients", SoftSolenoid::DynamicData::get(soft_sol.m_id)->sin.host_const()),
                     std::make_pair("mapsteps", soft_sol.m_mapsteps)
                 );
             }
@@ -2282,8 +2282,36 @@ void init_elements(py::module& m)
             [](SoftSolenoid & soft_sol, amrex::ParticleReal bscale) { soft_sol.m_bscale = bscale; },
             "Scaling factor for on-axis magnetic field Bz in inverse meters (if unit = 0) or magnetic field Bz in T (SI units, if unit = 1)"
         )
-        // TODO cos_coefficients
-        // TODO sin_coefficients
+        /* TODO Before we can expose this we need to ensure that sim.lattice takes a list of shared pointers
+         *    and not copies of elements. Otherwise, users can invalidate their cached host pointers with
+         *      sol = SoftSolenoid(...)
+         *      sim.lattice.append(sol)  # copy in lattice has same m_id
+         *      sol.cos_coef = new_values  # updates data of m_id and sol.m_cos_h_data, but NOT the lattice copy
+        .def_property("cos_coefficients",
+            [](SoftSolenoid & soft_sol) {
+                return SoftSolenoid::DynamicData::get(soft_sol.m_id)->h_cos;
+            },
+            [](SoftSolenoid & soft_sol, std::vector<amrex::ParticleReal> v) {
+                auto & coef = *SoftSolenoid::DynamicData::get(soft_sol.m_id);
+                coef.h_cos = std::move(v);
+                coef.mark_dirty();
+                soft_sol.m_cos_h_data = coef.h_cos.data();
+            },
+            "cosine coefficients in Fourier expansion of on-axis magnetic field Bz"
+        )
+        .def_property("sin_coefficients",
+            [](SoftSolenoid & soft_sol) {
+                return SoftSolenoid::DynamicData::get(soft_sol.m_id)->h_sin;
+            },
+            [](SoftSolenoid & soft_sol, std::vector<amrex::ParticleReal> v) {
+                auto & coef = *SoftSolenoid::DynamicData::get(soft_sol.m_id);
+                coef.h_sin = std::move(v);
+                coef.mark_dirty();
+                soft_sol.m_sin_h_data = coef.h_sin.data();
+            },
+            "sine coefficients in Fourier expansion of on-axis magnetic field Bz"
+        )
+        */
         .def_property("unit",
             [](SoftSolenoid & soft_sol) { return soft_sol.m_unit; },
             [](SoftSolenoid & soft_sol, amrex::ParticleReal unit) { soft_sol.m_unit = unit; },

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -1154,8 +1154,8 @@ void init_elements(py::module& m)
                  return element_dict(
                      exact_multipole,
                      std::make_pair("unit", exact_multipole.m_unit),
-                     std::make_pair("k_normal", MultipoleData::h_k_normal[exact_multipole.m_id]),
-                     std::make_pair("k_skew", MultipoleData::h_k_skew[exact_multipole.m_id]),
+                     std::make_pair("k_normal", ExactMultipole::DynamicData::get(exact_multipole.m_id)->k_normal.host_const()),
+                     std::make_pair("k_skew", ExactMultipole::DynamicData::get(exact_multipole.m_id)->k_skew.host_const()),
                      std::make_pair("mapsteps", exact_multipole.m_mapsteps),
                      std::make_pair("int_order", exact_multipole.m_int_order)
                  );
@@ -1224,8 +1224,8 @@ void init_elements(py::module& m)
                  return element_dict(
                      exact_cfbend,
                      std::make_pair("unit", exact_cfbend.m_unit),
-                     std::make_pair("k_normal", ExactCFbendData::h_k_normal[exact_cfbend.m_id]),
-                     std::make_pair("k_skew", ExactCFbendData::h_k_skew[exact_cfbend.m_id]),
+                     std::make_pair("k_normal", ExactCFbend::DynamicData::get(exact_cfbend.m_id)->k_normal.host_const()),
+                     std::make_pair("k_skew", ExactCFbend::DynamicData::get(exact_cfbend.m_id)->k_skew.host_const()),
                      std::make_pair("mapsteps", exact_cfbend.m_mapsteps),
                      std::make_pair("int_order", exact_cfbend.m_int_order)
                  );
@@ -1736,8 +1736,8 @@ void init_elements(py::module& m)
                 using namespace amrex::literals;
                 return element_dict(
                     polygon_aperture,
-                    std::make_pair("vertices_x", PolygonApertureData::h_vertices_x[polygon_aperture.m_id]),
-                    std::make_pair("vertices_y", PolygonApertureData::h_vertices_y[polygon_aperture.m_id]),
+                    std::make_pair("vertices_x", PolygonAperture::DynamicData::get(polygon_aperture.m_id)->x.host_const()),
+                    std::make_pair("vertices_y", PolygonAperture::DynamicData::get(polygon_aperture.m_id)->y.host_const()),
                     std::make_pair("min_radius2", polygon_aperture.m_min_radius2),
                     std::make_pair("action", polygon_aperture.action_name(polygon_aperture.m_action)),
                     std::make_pair("repeat_x", polygon_aperture.m_repeat_x),
@@ -1951,8 +1951,8 @@ void init_elements(py::module& m)
                     std::make_pair("escale", rfc.m_escale),
                     std::make_pair("freq", rfc.m_freq),
                     std::make_pair("phase", rfc.m_phase),
-                    std::make_pair("cos_coefficients", RFCavityData::h_cos_coef[rfc.m_id]),
-                    std::make_pair("sin_coefficients", RFCavityData::h_sin_coef[rfc.m_id]),
+                    std::make_pair("cos_coefficients", RFCavity::DynamicData::get(rfc.m_id)->cos.host_const()),
+                    std::make_pair("sin_coefficients", RFCavity::DynamicData::get(rfc.m_id)->sin.host_const()),
                     std::make_pair("mapsteps", rfc.m_mapsteps)
                 );
             }
@@ -2513,8 +2513,8 @@ void init_elements(py::module& m)
                 return element_dict(
                     soft_quad,
                     std::make_pair("gscale", soft_quad.m_gscale),
-                    std::make_pair("cos_coefficients", SoftQuadrupoleData::h_cos_coef[soft_quad.m_id]),
-                    std::make_pair("sin_coefficients", SoftQuadrupoleData::h_sin_coef[soft_quad.m_id]),
+                    std::make_pair("cos_coefficients", SoftQuadrupole::DynamicData::get(soft_quad.m_id)->cos.host_const()),
+                    std::make_pair("sin_coefficients", SoftQuadrupole::DynamicData::get(soft_quad.m_id)->sin.host_const()),
                     std::make_pair("mapsteps", soft_quad.m_mapsteps)
                 );
             }

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -18,8 +18,20 @@ else:
 basepath = os.getcwd()
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "manages_amrex: test manages its own AMReX init/finalize lifecycle"
+    )
+
+
 @pytest.fixture(autouse=True, scope="function")
-def amrex_init(tmpdir):
+def amrex_init(request, tmpdir):
+    # Allow tests to manage their own AMReX lifecycle
+    if request.node.get_closest_marker("manages_amrex"):
+        with tmpdir.as_cwd():
+            yield
+        return
+
     with tmpdir.as_cwd():
         # warning: with an external AMReX initialize, our ImpactX overwrite_amrex_parser_defaults is never called!
         amr.initialize(

--- a/tests/python/test_element_lifetime.py
+++ b/tests/python/test_element_lifetime.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+"""
+Tests for element lifetime management with dynamic GPU data.
+
+These tests verify that elements with dynamic GPU data (like SoftSolenoid,
+RFCavity, etc.) can be:
+1. Created before AMReX/ImpactX is initialized
+2. Cleaned up properly even if never added to a lattice
+3. Reused across multiple simulations (with AMReX finalize/init cycles)
+"""
+
+import pytest
+
+from impactx import ImpactX, distribution, elements
+
+
+def run_minimal_simulation(sim, lattice_elements):
+    """
+    Run a minimal simulation with given lattice elements.
+
+    Parameters
+    ----------
+    sim : ImpactX
+        The simulation object (must be initialized with init_grids)
+    lattice_elements : list
+        List of beamline elements to add to the lattice
+    """
+    kin_energy_MeV = 250.0
+    bunch_charge_C = 1.0e-9
+    npart = 100
+
+    ref = sim.particle_container().ref_particle()
+    ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
+
+    distr = distribution.Waterbag(
+        lambdaX=1.0e-3,
+        lambdaY=1.0e-3,
+        lambdaT=1.0e-3,
+        lambdaPx=1.0e-4,
+        lambdaPy=1.0e-4,
+        lambdaPt=1.0e-3,
+    )
+    sim.add_particles(bunch_charge_C, distr, npart)
+
+    sim.lattice.extend(lattice_elements)
+    sim.track_particles()
+
+
+def create_soft_solenoid(name="sol"):
+    """Create a SoftSolenoid element with minimal coefficients."""
+    return elements.SoftSolenoid(
+        name=name,
+        ds=1.0,
+        bscale=0.1,
+        cos_coefficients=[0.5, 0.3, 0.1],
+        sin_coefficients=[0.0, 0.0, 0.0],
+        mapsteps=10,
+        nslice=1,
+    )
+
+
+def create_soft_quadrupole(name="quad"):
+    """Create a SoftQuadrupole element with minimal coefficients."""
+    return elements.SoftQuadrupole(
+        name=name,
+        ds=0.5,
+        gscale=1.0,
+        cos_coefficients=[1.0, 0.5],
+        sin_coefficients=[0.0, 0.0],
+        mapsteps=10,
+        nslice=1,
+    )
+
+
+@pytest.mark.manages_amrex
+def test_element_creation_before_amrex_init():
+    """
+    Test that elements with dynamic GPU data can be created before AMReX init.
+
+    This verifies that host-side data storage works without AMReX being
+    initialized, and that the element can be used once AMReX is started.
+    """
+    # Create element BEFORE AMReX/ImpactX is initialized
+    sol = create_soft_solenoid("sol_pre_init")
+    quad = create_soft_quadrupole("quad_pre_init")
+
+    # Now initialize ImpactX (which initializes AMReX) and run simulation
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.diagnostics = False
+    sim.slice_step_diagnostics = False
+    sim.init_grids()
+
+    run_minimal_simulation(sim, [sol, quad])
+
+    # Verify simulation completed
+    ref = sim.particle_container().ref_particle()
+    assert ref.s == pytest.approx(1.5, rel=1e-6)
+
+    sim.finalize()
+
+
+@pytest.mark.manages_amrex
+def test_unused_element_cleanup():
+    """
+    Test that elements never added to lattice are cleaned up without error.
+
+    This verifies that sim.finalize() handles elements that were created
+    but never used in a simulation.
+    """
+    # Create elements before ImpactX init
+    unused_sol = create_soft_solenoid("unused_sol")
+    unused_quad = create_soft_quadrupole("unused_quad")
+
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.diagnostics = False
+    sim.slice_step_diagnostics = False
+    sim.init_grids()
+
+    # Create more elements after ImpactX init
+    another_unused = create_soft_solenoid("another_unused")
+
+    # Run simulation with DIFFERENT element, not the ones created above
+    used_sol = create_soft_solenoid("used_sol")
+    run_minimal_simulation(sim, [used_sol])
+
+    # finalize() should NOT error even though unused_sol, unused_quad,
+    # and another_unused were never added to lattice
+    sim.finalize()
+
+    # Keep references alive to ensure they weren't prematurely destroyed
+    assert unused_sol is not None
+    assert unused_quad is not None
+    assert another_unused is not None
+
+
+@pytest.mark.manages_amrex
+def test_element_reuse_across_simulations():
+    """
+    Test that elements can be reused across multiple simulations.
+
+    This verifies that release_gpu_data() preserves host data, allowing
+    elements to be uploaded to GPU again in a subsequent simulation.
+    """
+    # Create element before first simulation
+    reusable_sol = create_soft_solenoid("reusable_sol")
+
+    # First simulation
+    sim1 = ImpactX()
+    sim1.particle_shape = 2
+    sim1.space_charge = False
+    sim1.diagnostics = False
+    sim1.slice_step_diagnostics = False
+    sim1.init_grids()
+
+    run_minimal_simulation(sim1, [reusable_sol])
+
+    ref1 = sim1.particle_container().ref_particle()
+    s_after_sim1 = ref1.s
+    assert s_after_sim1 == pytest.approx(1.0, rel=1e-6)
+
+    sim1.finalize()
+
+    # Second simulation - reuse the same element
+    sim2 = ImpactX()
+    sim2.particle_shape = 2
+    sim2.space_charge = False
+    sim2.diagnostics = False
+    sim2.slice_step_diagnostics = False
+    sim2.init_grids()
+
+    # Use the SAME element again - its host data should still be valid
+    run_minimal_simulation(sim2, [reusable_sol])
+
+    ref2 = sim2.particle_container().ref_particle()
+    s_after_sim2 = ref2.s
+    assert s_after_sim2 == pytest.approx(1.0, rel=1e-6)
+
+    sim2.finalize()

--- a/tests/python/test_element_lifetime.py
+++ b/tests/python/test_element_lifetime.py
@@ -102,10 +102,6 @@ def test_element_creation_before_amrex_init():
 
     run_minimal_simulation(sim, [sol, quad])
 
-    # Verify simulation completed
-    ref = sim.particle_container().ref_particle()
-    assert ref.s == pytest.approx(1.5, rel=1e-6)
-
     sim.finalize()
 
 
@@ -166,10 +162,6 @@ def test_element_reuse_across_simulations():
 
     run_minimal_simulation(sim1, [reusable_sol])
 
-    ref1 = sim1.particle_container().ref_particle()
-    s_after_sim1 = ref1.s
-    assert s_after_sim1 == pytest.approx(1.0, rel=1e-6)
-
     sim1.finalize()
 
     # Second simulation - reuse the same element
@@ -182,9 +174,5 @@ def test_element_reuse_across_simulations():
 
     # Use the SAME element again - its host data should still be valid
     run_minimal_simulation(sim2, [reusable_sol])
-
-    ref2 = sim2.particle_container().ref_particle()
-    s_after_sim2 = ref2.s
-    assert s_after_sim2 == pytest.approx(1.0, rel=1e-6)
 
     sim2.finalize()


### PR DESCRIPTION
On GPU, we have to more carefully deal with the lifetime of dynamic (array) data in elements. This PR is an infrastructure update for complex elements that have such dynamic GPU data, to address multiple usage bugs on GPU.

## Part 1: This PR
- [x] ensure we can create elements before an initialized simulation object
- [x] add unit tests
- [x] clean them up more carefully after a simulation ends, incl. no error for elements that were _never added_ to `sim.lattice`
- [x] we can even reuse the same elements between different simulations (with AMReX finalize and another init in between!)
- [x] similar logic for beam monitor/source: do not over-eagerly open files, but lazily on first use. Close on finalize (even if not in lattice): already done in #1178

## Part 2: Follow-up PR

- make `sim.lattice` behave like a Python list: shared instead of copied elements #1381