### PR TITLE
Add example of RF cavity phase optimization.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -720,6 +720,19 @@ add_impactx_test(rfcavity-ref-part-hook.py
     OFF  # no plot script yet
 )
 
+# Proton acceleration by RF Cavities (using phase optimization) #####################
+#
+file(COPY ${ImpactX_SOURCE_DIR}/examples/rfcavity/onaxis_data.in
+     DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rfcavity-ref-part-opt.py)
+file(COPY ${ImpactX_SOURCE_DIR}/examples/rfcavity/phase_opt.py
+     DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rfcavity-ref-part-opt.py)
+add_impactx_test(rfcavity-ref-part-opt.py
+    examples/rfcavity/run_rfcavity_ref_part_opt.py
+    OFF   # ImpactX MPI-parallel
+    examples/rfcavity/analysis_rfcavity_ref_part_opt.py
+    OFF  # no plot script yet
+)     
+
 # Ideal, Hard-Edge Solenoid ###################################################
 #
 add_impactx_test(solenoid

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -731,7 +731,7 @@ add_impactx_test(rfcavity-ref-part-opt.py
     OFF   # ImpactX MPI-parallel
     examples/rfcavity/analysis_rfcavity_ref_part_opt.py
     OFF  # no plot script yet
-)     
+)
 
 # Ideal, Hard-Edge Solenoid ###################################################
 #

--- a/examples/rfcavity/README.rst
+++ b/examples/rfcavity/README.rst
@@ -160,3 +160,52 @@ We run the following script to analyze correctness:
    .. literalinclude:: analysis_rfcavity_ref_part_hook.py
       :language: python3
       :caption: You can copy this file from ``examples/rfcavity/analysis_rfcavity_ref_part_hook.py``.
+
+
+
+.. _examples-rfcavity-ref-part-opt:
+
+Proton acceleration by RF Cavities (Using RF phase optimization)
+================================================================
+   
+This test is similar to the :ref:`test above <examples-rfcavity-ref-part-hook>`, except that the test is performed for protons (at the same energy).  As a result, there is a large variation of relativistic
+beta (in the first RF cavity), and the analytical methods of the previous example cannot be used.  
+
+To treat this case, the callback hook feature :py:attr:`~impactx.ImpactX.hook` is combined with an optimization loop (using scipy.minimize_scalar) to determine, for each RF cavity, the input phase setting
+that results in maximum energy gain.  The phase is reset to this value (for each cavity).
+
+The functions used for optimization of the RF phase are contained in the file ``phase_opt.py``.
+   
+In this test, the initial and final reference values of :math:`s` and :math:`\gamma` must agree with nominal values.
+          
+
+Run
+---       
+
+This example can be run as:
+
+* **Python** script: ``python3 run_rfcavity_ref_part_opt.py``
+          
+For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+
+.. tab-set::
+
+   .. tab-item:: Python: Script
+
+       .. literalinclude:: run_rfcavity_ref_part_opt.py
+          :language: python3
+          :caption: You can copy this file from ``examples/rfcavity/run_rfcavity_ref_part_opt.py``.
+      
+   
+Analyze
+-------
+          
+We run the following script to analyze correctness:
+
+.. dropdown:: Script ``analysis_rfcavity_ref_part_opt.py``
+
+   .. literalinclude:: analysis_rfcavity_ref_part_opt.py
+      :language: python3
+      :caption: You can copy this file from ``examples/rfcavity/analysis_rfcavity_ref_part_opt.py``.
+
+

--- a/examples/rfcavity/README.rst
+++ b/examples/rfcavity/README.rst
@@ -196,6 +196,15 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
           :language: python3
           :caption: You can copy this file from ``examples/rfcavity/run_rfcavity_ref_part_opt.py``.
 
+This script makes use of functions defined in the script ``phase_opt.py`` below, which can be re-used by the user:
+
+.. tab-set::
+
+   .. tab-item:: Python: Script
+
+       .. literalinclude:: phase_opt.py
+          :language: python3
+          :caption: You can copy this file from ``examples/rfcavity/phase_opt.py``.
 
 Analyze
 -------

--- a/examples/rfcavity/README.rst
+++ b/examples/rfcavity/README.rst
@@ -167,25 +167,25 @@ We run the following script to analyze correctness:
 
 Proton acceleration by RF Cavities (Using RF phase optimization)
 ================================================================
-   
+
 This test is similar to the :ref:`test above <examples-rfcavity-ref-part-hook>`, except that the test is performed for protons (at the same energy).  As a result, there is a large variation of relativistic
-beta (in the first RF cavity), and the analytical methods of the previous example cannot be used.  
+beta (in the first RF cavity), and the analytical methods of the previous example cannot be used.
 
 To treat this case, the callback hook feature :py:attr:`~impactx.ImpactX.hook` is combined with an optimization loop (using scipy.minimize_scalar) to determine, for each RF cavity, the input phase setting
 that results in maximum energy gain.  The phase is reset to this value (for each cavity).
 
 The functions used for optimization of the RF phase are contained in the file ``phase_opt.py``.
-   
+
 In this test, the initial and final reference values of :math:`s` and :math:`\gamma` must agree with nominal values.
-          
+
 
 Run
----       
+---
 
 This example can be run as:
 
 * **Python** script: ``python3 run_rfcavity_ref_part_opt.py``
-          
+
 For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
 
 .. tab-set::
@@ -195,11 +195,11 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
        .. literalinclude:: run_rfcavity_ref_part_opt.py
           :language: python3
           :caption: You can copy this file from ``examples/rfcavity/run_rfcavity_ref_part_opt.py``.
-      
-   
+
+
 Analyze
 -------
-          
+
 We run the following script to analyze correctness:
 
 .. dropdown:: Script ``analysis_rfcavity_ref_part_opt.py``
@@ -207,5 +207,3 @@ We run the following script to analyze correctness:
    .. literalinclude:: analysis_rfcavity_ref_part_opt.py
       :language: python3
       :caption: You can copy this file from ``examples/rfcavity/analysis_rfcavity_ref_part_opt.py``.
-
-

--- a/examples/rfcavity/analysis_rfcavity_ref_part_opt.py
+++ b/examples/rfcavity/analysis_rfcavity_ref_part_opt.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+import glob
+import re
+
+import numpy as np
+import pandas as pd
+
+
+def read_file(file_pattern):
+    for filename in glob.glob(file_pattern):
+        df = pd.read_csv(filename, delimiter=r"\s+")
+        if "step" not in df.columns:
+            step = int(re.findall(r"[0-9]+", filename)[0])
+            df["step"] = step
+        yield df
+
+
+def read_time_series(file_pattern):
+    """Read in all CSV files from each MPI rank (and potentially OpenMP
+    thread). Concatenate into one Pandas dataframe.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    return pd.concat(
+        read_file(file_pattern),
+        axis=0,
+        ignore_index=True,
+    )  # .set_index('id')
+
+
+# read reference particle data
+rbc = read_time_series("diags/ref_particle.*")
+
+s = rbc["s"]
+gamma = rbc["gamma"]
+
+si = s.iloc[0]
+gammai = gamma.iloc[0]
+
+sf = s.iloc[-1]
+gammaf = gamma.iloc[-1]
+
+print("")
+print("Initial Beam:")
+print(f"  s_ref={si:e} gamma_ref={gammai:e}")
+
+atol = 1.0e-4  # ignored
+print(f"  atol={atol}")
+
+assert np.allclose(
+    [si, gammai],
+    [
+        0.000000,
+        1.2451314527015738,
+    ],
+    atol=atol,
+)
+
+
+print("")
+print("Final Beam:")
+print(f"  s_ref={sf:e} gamma_ref={gammaf:e}")
+
+atol = 1.0e-4  # ignored
+print(f"  atol={atol}")
+
+assert np.allclose(
+    [sf, gammaf],
+    [
+        5.9391682799999987,
+        39.858859594214152,
+    ],
+    atol=atol,
+)

--- a/examples/rfcavity/phase_opt.py
+++ b/examples/rfcavity/phase_opt.py
@@ -41,6 +41,10 @@ def objective(parameter, ref, element):
 
 def optimize(ref, element):
 
+    # This function is designed to maximize the energy gain of a reference particle
+    #  (ref) in an RFCavity (element).  Optimization is performed by minimizing 
+    #  -(change in kinetic energy in MeV).
+    
     # optimizer specific options
     options = {"maxiter": 2000, "disp": 1}
 

--- a/examples/rfcavity/phase_opt.py
+++ b/examples/rfcavity/phase_opt.py
@@ -1,0 +1,64 @@
+import numpy as np
+from scipy.optimize import minimize_scalar
+
+from impactx import ImpactX, elements, push
+
+
+def objective(parameter, ref, element):
+    """
+    A function that is evaluated by the optimizer.
+
+    Parameters
+    ----------
+    parameter:
+      rf cavity phase
+
+    Returns
+    -------
+    Negative of the RF cavity energy gain in MeV (to minimize).
+    """
+
+    # adjust the RF cavity phase
+    phase_opt = parameter
+    element.phase = phase_opt
+
+    # store the incoming energy and copy the reference particle
+    KE_in = ref.kin_energy_MeV
+    ref_copy = ref.copy()
+
+    # push the copy of the reference particle
+    push(ref_copy,element)
+    KE_fin = ref_copy.kin_energy_MeV
+
+    # evaluate the objective
+    loss = KE_in - KE_fin
+
+    if np.isnan(loss):
+        loss = 1.0e99
+    
+    return loss
+
+def optimize(ref,element):
+
+    # optimizer specific options
+    options = {
+        "maxiter": 2000,
+        "disp": 1
+    }
+    
+    # Call the optimizer
+    res = minimize_scalar(
+        objective,
+        method="bounded",
+        args=(ref,element),
+        tol=1.0e-8,
+        options=options,
+        bounds=(-180, 180),
+    )
+    
+    # Optimization result
+    phase_opt = res.x
+    e_gain = -1.0*res.fun
+
+    return phase_opt, e_gain    
+

--- a/examples/rfcavity/phase_opt.py
+++ b/examples/rfcavity/phase_opt.py
@@ -42,7 +42,7 @@ def objective(parameter, ref, element):
 def optimize(ref, element):
     """
     Maximize the energy gain of a reference particle
-    
+
     Using (ref) in an RFCavity (element): the optimization is performed by minimizing
     -(change in kinetic energy in MeV).
     """

--- a/examples/rfcavity/phase_opt.py
+++ b/examples/rfcavity/phase_opt.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy.optimize import minimize_scalar
 
-from impactx import ImpactX, elements, push
+from impactx import push
 
 
 def objective(parameter, ref, element):
@@ -27,7 +27,7 @@ def objective(parameter, ref, element):
     ref_copy = ref.copy()
 
     # push the copy of the reference particle
-    push(ref_copy,element)
+    push(ref_copy, element)
     KE_fin = ref_copy.kin_energy_MeV
 
     # evaluate the objective
@@ -35,30 +35,27 @@ def objective(parameter, ref, element):
 
     if np.isnan(loss):
         loss = 1.0e99
-    
+
     return loss
 
-def optimize(ref,element):
+
+def optimize(ref, element):
 
     # optimizer specific options
-    options = {
-        "maxiter": 2000,
-        "disp": 1
-    }
-    
+    options = {"maxiter": 2000, "disp": 1}
+
     # Call the optimizer
     res = minimize_scalar(
         objective,
         method="bounded",
-        args=(ref,element),
+        args=(ref, element),
         tol=1.0e-8,
         options=options,
         bounds=(-180, 180),
     )
-    
+
     # Optimization result
     phase_opt = res.x
-    e_gain = -1.0*res.fun
+    e_gain = -1.0 * res.fun
 
-    return phase_opt, e_gain    
-
+    return phase_opt, e_gain

--- a/examples/rfcavity/phase_opt.py
+++ b/examples/rfcavity/phase_opt.py
@@ -45,6 +45,17 @@ def optimize(ref, element):
 
     Using (ref) in an RFCavity (element): the optimization is performed by minimizing
     -(change in kinetic energy in MeV).
+
+    Parameters
+    ----------
+    ref:
+      the reference particle at RF entry
+    element:
+      the RF cavity element
+
+    Returns
+    -------
+    The optimized phase and energy gain at that phase (phase_opt, e_gain).
     """
 
     # optimizer specific options

--- a/examples/rfcavity/phase_opt.py
+++ b/examples/rfcavity/phase_opt.py
@@ -42,9 +42,9 @@ def objective(parameter, ref, element):
 def optimize(ref, element):
 
     # This function is designed to maximize the energy gain of a reference particle
-    #  (ref) in an RFCavity (element).  Optimization is performed by minimizing 
+    #  (ref) in an RFCavity (element).  Optimization is performed by minimizing
     #  -(change in kinetic energy in MeV).
-    
+
     # optimizer specific options
     options = {"maxiter": 2000, "disp": 1}
 

--- a/examples/rfcavity/phase_opt.py
+++ b/examples/rfcavity/phase_opt.py
@@ -40,10 +40,12 @@ def objective(parameter, ref, element):
 
 
 def optimize(ref, element):
-
-    # This function is designed to maximize the energy gain of a reference particle
-    #  (ref) in an RFCavity (element).  Optimization is performed by minimizing
-    #  -(change in kinetic energy in MeV).
+    """
+    Maximize the energy gain of a reference particle
+    
+    Using (ref) in an RFCavity (element): the optimization is performed by minimizing
+    -(change in kinetic energy in MeV).
+    """
 
     # optimizer specific options
     options = {"maxiter": 2000, "disp": 1}

--- a/examples/rfcavity/run_rfcavity_ref_part_opt.py
+++ b/examples/rfcavity/run_rfcavity_ref_part_opt.py
@@ -80,7 +80,7 @@ sim.lattice.extend(
 
 def hook_before_element(sim):
     element = sim.tracking_element
-    if element.name == "rf":
+    if type(element) is elements.RFCavity:
         beam = sim.particle_container()
         ref = beam.ref_particle()
         print(

--- a/examples/rfcavity/run_rfcavity_ref_part_opt.py
+++ b/examples/rfcavity/run_rfcavity_ref_part_opt.py
@@ -7,10 +7,9 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-from scipy import constants as sconst
-
-from impactx import ImpactX, elements, fourier_coefficients
 from phase_opt import optimize
+
+from impactx import ImpactX, elements
 
 sim = ImpactX()
 
@@ -93,7 +92,7 @@ def hook_before_element(sim):
         phase_shift = element.phase
 
         # Find RF phase that maximizes energy gain:
-        phase_opt, e_gain = optimize(ref,element)
+        phase_opt, e_gain = optimize(ref, element)
 
         # Reset input RF phase to appropriate value for tracking:
         element.phase = phase_opt + phase_shift

--- a/examples/rfcavity/run_rfcavity_ref_part_opt.py
+++ b/examples/rfcavity/run_rfcavity_ref_part_opt.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Marco Garten, Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from scipy import constants as sconst
+
+from impactx import ImpactX, elements, fourier_coefficients
+from phase_opt import optimize
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.space_charge = False
+sim.slice_step_diagnostics = True
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# reference kinetic energy (initial)
+kin_energy_MeV = 230.0  # reference energy
+
+#   reference particle
+ref = sim.particle_container().ref_particle()
+ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
+
+# design the accelerator lattice
+
+# access RF cavity on-axis field data
+data_in = np.loadtxt("onaxis_data.in")
+z = data_in[:, 0]
+ez_onaxis = data_in[:, 1]
+ncoef = 25
+
+#   Drift elements
+dr1 = elements.Drift(name="dr1", ds=0.4, nslice=1)
+dr2 = elements.Drift(name="dr2", ds=0.032997, nslice=1)
+
+#   RF cavity element
+rf = elements.RFCavity(
+    name="rf",
+    ds=1.31879807,
+    escale=20.0,
+    z=z,
+    field_on_axis=ez_onaxis,
+    ncoef=ncoef,
+    freq=1.3e9,
+    phase=0.0,
+    mapsteps=100,
+    nslice=4,
+)
+
+
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+
+sim.lattice.extend(
+    [
+        monitor,
+        dr1,
+        dr2,
+        rf,
+        dr2,
+        dr2,
+        rf,
+        dr2,
+        dr2,
+        rf,
+        dr2,
+        dr2,
+        rf,
+        dr2,
+        monitor,
+    ]
+)
+
+
+def hook_before_element(sim):
+    element = sim.tracking_element
+    if element.name == "rf":
+        beam = sim.particle_container()
+        ref = beam.ref_particle()
+        print(
+            f"  Beam at s={ref.s:.2f}m, t={ref.t:.2f}s, gamma at entry={ref.gamma:.2f}",
+            flush=True,
+        )
+
+        # Interpret input RF phase as measured relative to max accelerating phase:
+        phase_shift = element.phase
+
+        # Find RF phase that maximizes energy gain:
+        phase_opt, e_gain = optimize(ref,element)
+
+        # Reset input RF phase to appropriate value for tracking:
+        element.phase = phase_opt + phase_shift
+        print(
+            f"  RF cavity updated (reset) values of phase={phase_opt:.2f}, energy gain (MeV) ={e_gain:.2f}",
+            flush=True,
+        )
+
+
+sim.hook["before_element"] = hook_before_element
+
+# run simulation
+sim.track_reference(ref)
+
+# clean shutdown
+sim.finalize()


### PR DESCRIPTION
This PR adds an example that illustrates how to set the RF phase values for thick RFCavity elements by using a combination of the hook callback feature and a small optimization loop (using reference particle tracking) in Python to find the phase of maximum energy gain.