### PR TITLE
Lattice: delete & replace

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -754,6 +754,7 @@ This module provides elements and methods for the accelerator lattice.
 
       :param kind: Element type(s) to filter by. Can be a string (e.g., ``"Drift"``), regex pattern (e.g., ``r".*Quad"``), element type (e.g., ``elements.Drift``), or list/tuple of these.
       :param name: Element name(s) to filter by. Can be a string, regex pattern, or ``list``/``tuple`` of these.
+      :rtype: :py:class:`impactx.elements.FilteredElementsList`
 
       **Examples:**
 
@@ -774,6 +775,12 @@ This module provides elements and methods for the accelerator lattice.
 
          # Modify original elements through references
          drift_elements[0].ds = 2.0  # modifies original lattice
+
+         # delete all drifts
+         lattice.select(kind=r".*Drift").delete()
+
+         # replace all Quads with drift equivalents
+         lattice.select(kind=r".*Quad").replace_with_drifts()
 
    .. py:method:: get_kinds()
 
@@ -828,6 +835,92 @@ This module provides elements and methods for the accelerator lattice.
       :param ax: A plotting area in matplotlib (called axes there).
       :param legend: Plot a legend if true.
       :param legend_ncols: Number of columns for lattice element types in the legend.
+
+.. py:class:: impactx.elements.FilteredElementsList
+
+   View returned by :py:meth:`~impactx.elements.KnownElementsList.select` on a
+   :py:class:`~impactx.elements.KnownElementsList` or by chained ``.select()`` on a filtered view.
+   Indexing returns the same element objects as the full lattice; assigning to fields updates the
+   underlying list.
+
+   All mutating operations (``delete``, ``replace_each``, ``replace_with_drifts``) rebuild the
+   lattice using cloned elements. Existing Python references to lattice elements will then point
+   to objects that are **no longer in the lattice**. If you cache element references, re-fetch
+   them from the lattice after any mutation.
+
+   If the selection is empty, ``delete`` is a no-op and ``replace_*`` return
+   an empty ``FilteredElementsList``.
+
+   .. py:method:: select(kind=None, name=None)
+
+      Narrow this view with an additional AND filter. OR logic within a single call matches
+      :py:meth:`~impactx.elements.KnownElementsList.select`.
+
+      :param kind: Same meaning as for :py:meth:`~impactx.elements.KnownElementsList.select`.
+      :param name: Same meaning as for :py:meth:`~impactx.elements.KnownElementsList.select`.
+      :rtype: :py:class:`impactx.elements.FilteredElementsList`
+
+   .. py:method:: delete()
+
+      Remove all elements in the current selection from the underlying lattice. Invalidates this
+      view **and** all other live selections on that lattice.
+      Call :py:meth:`~impactx.elements.KnownElementsList.select` on the underlying lattice again to obtain a new view.
+
+      :rtype: None
+
+   .. py:method:: replace_each(element, *, keep_name=True, keep_ds=False)
+
+      Replace each selected element with a copy of ``element``. Invalidates all **other** live
+      selections on the same lattice; returns a **new** filtered view over the same indices (the
+      returned view is valid).
+
+      :param element: Element to clone at each selected index (names and ``ds`` may be overridden;
+         see below).
+      :param keep_name: If true (default), copy ``name`` from each replaced element when present.
+      :param keep_ds: If true, copy segment length ``ds`` from each replaced element; otherwise
+         ``ds`` comes from the template (default false).
+      :rtype: :py:class:`impactx.elements.FilteredElementsList`
+
+      **Examples:**
+
+      .. code-block:: python
+
+         # Replace quadrupoles; names kept, ds and k from template
+         sim.lattice.select(kind="Quad").replace_each(
+             elements.Quad(name="tpl", ds=0.1, k=1.5)
+         )
+
+         # Same but keep ds from the replaced elements (only k from template)
+         sim.lattice.select(kind="Quad").replace_each(
+             elements.Quad(name="tpl", ds=0.1, k=1.5), keep_ds=True
+         )
+
+   .. py:method:: replace_with_drifts(*, model="match", keep_alignment=True, keep_aperture=False)
+
+      Replace each selected element with a drift of the chosen physics family. Names and ``ds``
+      are always taken from the replaced element. Invalidates all **other** live selections on the
+      same lattice; returns a **new** filtered view over the same indices (the returned view is
+      valid).
+
+      :param model: With ``"match"`` (default), linear elements become ``Drift``, class names
+         starting with ``Chr`` become ``ChrDrift``, and class names starting with ``Exact`` become
+         ``ExactDrift``. With ``"linear"``, ``"paraxial"``, or ``"exact"``, every selected slot
+         uses that drift type.
+      :param keep_alignment: If true (default), copy ``dx``, ``dy``, and ``rotation`` from each
+         replaced element; otherwise zero them.
+      :param keep_aperture: If true, copy ``aperture_x`` and ``aperture_y`` from each replaced
+         element; otherwise zero them (default false).
+      :rtype: :py:class:`impactx.elements.FilteredElementsList`
+
+      **Examples:**
+
+      .. code-block:: python
+
+         # All Quads become drifts of the matching model
+         sim.lattice.select(kind=r".*Quad").replace_with_drifts()
+
+         # Clear alignment errors and apertures
+         sim.lattice.select(kind=r".*Quad").replace_with_drifts(keep_alignment=False)
 
 .. py:class:: impactx.elements.CFbend(ds, rc, k, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, nslice=1, name=None)
 

--- a/src/python/impactx/__init__.py
+++ b/src/python/impactx/__init__.py
@@ -29,6 +29,7 @@ __author__ = impactx_pybind.__author__
 from .distribution_input_helpers import twiss  # noqa
 from .fourier import fourier_coefficients  # noqa
 from .extensions.KnownElementsList import (
+    FilteredElementsList,
     register_KnownElementsList_extension,
 )
 from .extensions.ImpactXParticleContainer import (
@@ -49,6 +50,10 @@ from .extensions.SoftSolenoid import (
 
 # MAD-X file reader for beamline lattice elements
 register_KnownElementsList_extension(impactx_pybind.elements.KnownElementsList)
+
+# Public alias on the elements submodule (same class object as in extensions)
+impactx_pybind.elements.FilteredElementsList = FilteredElementsList
+FilteredElementsList.__module__ = impactx_pybind.elements.__name__
 
 # MAD-X file reader for reference particle
 RefPart.load_file = read_beam  # noqa

--- a/src/python/impactx/dashboard/Input/defaults_helper.py
+++ b/src/python/impactx/dashboard/Input/defaults_helper.py
@@ -97,8 +97,13 @@ class InputDefaultsHelper:
         :return: A list of tuples containing class names.
         """
 
+        # Container / utility classes that are not user-selectable elements.
+        _SKIP_CLASSES = {"KnownElementsList", "FilteredElementsList"}
+
         results = []
         for name in dir(module_name):
+            if name in _SKIP_CLASSES:
+                continue
             attr = getattr(module_name, name)
             if inspect.isclass(attr):
                 results.append((name, attr))
@@ -120,7 +125,8 @@ class InputDefaultsHelper:
             init_method = getattr(cls, "__init__", None)
             if init_method:
                 docstring = cls.__init__.__doc__
-                docstrings[name] = docstring
+                if docstring is not None:
+                    docstrings[name] = docstring
         return docstrings
 
     @staticmethod

--- a/src/python/impactx/extensions/KnownElementsList.py
+++ b/src/python/impactx/extensions/KnownElementsList.py
@@ -8,8 +8,136 @@ License: BSD-3-Clause-LBNL
 
 import os
 import re
+import weakref
 
 from impactx import elements
+
+# All live FilteredElementsList views for a lattice (WeakKeyDictionary: key is KnownElementsList).
+_filtered_views_by_lattice: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+
+FILTERED_ELEMENTS_LIST_INVALID_MSG = (
+    "This lattice selection is no longer valid because the lattice was modified; "
+    "call select() again on the lattice."
+)
+
+# Drift implementation used by ``replace_with_drifts`` for ``model=`` (except ``"match"``).
+# ``model="match"`` picks the same key from the replaced element's class name (see
+# ``_model_key_from_element_typename``).
+_DRIFT_MODEL_CLASSES: dict[str, type] = {
+    "linear": elements.Drift,
+    "paraxial": elements.ChrDrift,
+    "exact": elements.ExactDrift,
+}
+
+
+def _model_key_from_element_typename(type_name: str) -> str:
+    """Return the drift-model key for an element class name (linear / paraxial / exact)."""
+    if type_name.startswith("Exact"):
+        return "exact"
+    if type_name.startswith("Chr"):
+        return "paraxial"
+    return "linear"
+
+
+def _drift_class_for_replace_with_drifts(model: str, old_el) -> type:
+    """Map ``model`` and ``old_el`` to the Drift / ChrDrift / ExactDrift class to insert.
+
+    For ``model=="match"``, the class follows ``_model_key_from_element_typename``; otherwise
+    ``model`` must already be validated against ``_DRIFT_MODEL_CLASSES``."""
+    if model == "match":
+        key = _model_key_from_element_typename(type(old_el).__name__)
+    else:
+        key = model
+    return _DRIFT_MODEL_CLASSES[key]
+
+
+def _commit_lattice_rebuild(original, new_elements) -> None:
+    """Replace lattice contents with ``new_elements`` and invalidate all FilteredElementsList views."""
+    original.clear()
+    original.extend(new_elements)
+    _invalidate_all_registered_views(original)
+
+
+def _registry_for(lattice):
+    """Return the WeakSet of FilteredElementsList instances for this lattice."""
+    rs = _filtered_views_by_lattice.get(lattice)
+    if rs is None:
+        rs = weakref.WeakSet()
+        _filtered_views_by_lattice[lattice] = rs
+    return rs
+
+
+def _invalidate_all_registered_views(lattice) -> None:
+    """Mark every registered FilteredElementsList for this lattice as invalid."""
+    rs = _filtered_views_by_lattice.get(lattice)
+    if rs is None:
+        return
+    for fel in list(rs):
+        fel._invalidated = True
+
+
+def _clone_element(template):
+    """Deep-clone a lattice element via ``to_dict`` (pybind elements are not copy.copy-able)."""
+    d = template.to_dict()
+    type_name = d.pop("type")
+    cls = getattr(elements, type_name)
+    return cls(**d)
+
+
+def _make_drift_from_old(
+    cls,
+    old_el,
+    *,
+    keep_name,
+    keep_ds,
+    keep_alignment,
+    keep_aperture,
+):
+    """Build a drift (``cls`` is Drift / ChrDrift / ExactDrift) from thick-element fields on ``old_el``.
+
+    When ``keep_ds`` is False, ``ds`` is set to 0. When ``keep_name`` is False, ``name`` is None.
+    If ``keep_ds`` is True but ``old_el`` has no ``ds`` attribute (thin element), ``ds`` defaults to 0.
+    When ``keep_alignment`` is True, copy dx/dy/rotation from the old element.
+    When ``keep_aperture`` is True, copy aperture_x/aperture_y from the old element.
+    """
+    nslice = getattr(old_el, "nslice", 1)
+
+    if keep_ds and hasattr(old_el, "ds"):
+        ds = old_el.ds
+    else:
+        ds = 0.0
+
+    name = None
+    if keep_name:
+        if hasattr(old_el, "has_name") and old_el.has_name:
+            name = old_el.name
+
+    if keep_alignment:
+        dx = getattr(old_el, "dx", 0.0)
+        dy = getattr(old_el, "dy", 0.0)
+        rotation = getattr(old_el, "rotation", 0.0)
+    else:
+        dx = 0.0
+        dy = 0.0
+        rotation = 0.0
+
+    if keep_aperture:
+        aperture_x = getattr(old_el, "aperture_x", 0.0)
+        aperture_y = getattr(old_el, "aperture_y", 0.0)
+    else:
+        aperture_x = 0.0
+        aperture_y = 0.0
+
+    return cls(
+        ds=ds,
+        dx=dx,
+        dy=dy,
+        rotation=rotation,
+        aperture_x=aperture_x,
+        aperture_y=aperture_y,
+        nslice=nslice,
+        name=name,
+    )
 
 
 def load_file(self, filename, nslice=1):
@@ -93,29 +221,43 @@ def from_pals(self, pals_beamline, nslice=1):
 
 
 class FilteredElementsList:
-    """A selection result class for ElementsList that maintains references to original elements.
+    """Result of ``KnownElementsList.select(...)`` or chained ``.select()`` calls: a filtered
+    view of the same underlying lattice.
 
-    References to the original elements in a lattice are needed to allow modification of the original elements.
+    Indexing (``self[i]``) returns elements from the original ``KnownElementsList``; changing
+    fields on those elements modifies the lattice in place. You can narrow the filter again with
+    ``.select(...)`` (AND logic between chained calls). After ``delete``, ``replace_each``, or
+    ``replace_with_drifts``, obtain a new selection from the lattice; earlier filter objects must
+    not be used.
     """
 
     def __init__(self, original_list, indices):
         self._original_list = original_list
-        self._indices = indices
+        self._indices = list(indices) if not isinstance(indices, list) else indices
+        self._invalidated = False
+        _registry_for(original_list).add(self)
+
+    def _require_valid(self) -> None:
+        """Raise if this view was invalidated after a lattice mutation."""
+        if self._invalidated:
+            raise RuntimeError(FILTERED_ELEMENTS_LIST_INVALID_MSG)
 
     def __getitem__(self, key):
+        self._require_valid()
         if isinstance(key, int):
             return self._original_list[self._indices[key]]
         elif isinstance(key, slice):
-            # Return a new FilteredElementsList with sliced indices
             sliced_indices = self._indices[key]
             return FilteredElementsList(self._original_list, sliced_indices)
         else:
             raise TypeError(f"Invalid key type: {type(key)}")
 
     def __len__(self):
+        self._require_valid()
         return len(self._indices)
 
     def __iter__(self):
+        self._require_valid()
         for i in self._indices:
             yield self._original_list[i]
 
@@ -170,6 +312,7 @@ class FilteredElementsList:
                 name=r"quad\d+"
             )  # Filter quads by regex pattern
         """
+        self._require_valid()
         # Apply filtering directly to the indices we already have
         if kind is not None or name is not None:
             # Validate parameters
@@ -187,12 +330,107 @@ class FilteredElementsList:
         # If no filtering criteria provided, return all current elements
         return FilteredElementsList(self._original_list, self._indices)
 
+    def delete(self) -> None:
+        """Remove selected elements from the underlying lattice. Invalidates this and all other
+        live selections on the same lattice. Returns None."""
+        self._require_valid()
+        original = self._original_list
+        to_remove = set(self._indices)
+        if not to_remove:
+            _invalidate_all_registered_views(original)
+            return None
+        n = len(original)
+        # Clone kept elements before clear(); clear() destroys C++ objects in the list.
+        new_elems = [
+            _clone_element(original[i]) for i in range(n) if i not in to_remove
+        ]
+        _commit_lattice_rebuild(original, new_elems)
+        return None
+
+    def replace_each(self, element, *, keep_name=True, keep_ds=False):
+        """Replace each selected element with a copy of ``element``, optionally keeping name and
+        ``ds`` from the replaced element (``keep_ds`` defaults to False). Invalidates prior views;
+        returns a new selection over the same indices."""
+        self._require_valid()
+        original = self._original_list
+        indices = self._indices
+        if not indices:
+            _invalidate_all_registered_views(original)
+            return FilteredElementsList(original, [])
+
+        n = len(original)
+        idx_set = set(indices)
+        new_row = [None] * n
+        for i in range(n):
+            if i not in idx_set:
+                new_row[i] = _clone_element(original[i])
+                continue
+            old_el = original[i]
+            new_el = _clone_element(element)
+            if keep_name:
+                if hasattr(old_el, "has_name") and old_el.has_name:
+                    new_el.name = old_el.name
+            if keep_ds and hasattr(old_el, "ds"):
+                new_el.ds = old_el.ds
+            new_row[i] = new_el
+
+        _commit_lattice_rebuild(original, new_row)
+        return FilteredElementsList(original, list(indices))
+
+    def replace_with_drifts(
+        self, *, model="match", keep_alignment=True, keep_aperture=False
+    ):
+        """Replace each selected element with a drift of the matching physics family.
+
+        When ``model="match"``: ``Exact*`` elements become ``ExactDrift``, ``Chr*`` elements
+        become ``ChrDrift``, and all other (linear) elements become ``Drift``. When
+        ``model`` is ``"linear"``, ``"paraxial"``, or ``"exact"``, every selected slot uses
+        that drift model. Names and segment length ``ds`` are always taken from the replaced
+        element.
+
+        By default, alignment errors (dx, dy, rotation) are preserved and apertures are
+        cleared. Use ``keep_alignment=False`` to zero alignment errors, or
+        ``keep_aperture=True`` to preserve aperture_x/aperture_y."""
+        self._require_valid()
+        original = self._original_list
+        indices = self._indices
+        if not indices:
+            _invalidate_all_registered_views(original)
+            return FilteredElementsList(original, [])
+
+        if model != "match" and model not in _DRIFT_MODEL_CLASSES:
+            raise ValueError(
+                f"model must be 'match' or one of {sorted(_DRIFT_MODEL_CLASSES)}, got {model!r}"
+            )
+
+        n = len(original)
+        idx_set = set(indices)
+        new_row = [None] * n
+        for i in range(n):
+            if i not in idx_set:
+                new_row[i] = _clone_element(original[i])
+                continue
+            old_el = original[i]
+            cls = _drift_class_for_replace_with_drifts(model, old_el)
+            new_row[i] = _make_drift_from_old(
+                cls,
+                old_el,
+                keep_name=True,
+                keep_ds=True,
+                keep_alignment=keep_alignment,
+                keep_aperture=keep_aperture,
+            )
+
+        _commit_lattice_rebuild(original, new_row)
+        return FilteredElementsList(original, list(indices))
+
     def get_kinds(self) -> list[type]:
         """Get all unique element kinds in the filtered list.
 
         Returns:
             list[type]: List of unique element types (sorted by name).
         """
+        self._require_valid()
         return get_kinds(self)
 
     def count_by_kind(self, kind_pattern) -> int:
@@ -207,6 +445,7 @@ class FilteredElementsList:
         Returns:
             int: Number of elements of the specified kind.
         """
+        self._require_valid()
         return count_by_kind(self, kind_pattern)
 
     def has_kind(self, kind_pattern) -> bool:
@@ -221,12 +460,15 @@ class FilteredElementsList:
         Returns:
             bool: True if at least one element of the specified kind exists.
         """
+        self._require_valid()
         return has_kind(self, kind_pattern)
 
     def __repr__(self):
+        self._require_valid()
         return f"FilteredElementsList({len(self)} elements)"
 
     def __str__(self):
+        self._require_valid()
         return f"FilteredElementsList({len(self)} elements)"
 
 

--- a/tests/python/test_lattice_select.py
+++ b/tests/python/test_lattice_select.py
@@ -20,6 +20,14 @@ This module tests the select method that supports:
 import pytest
 
 from impactx import elements
+from impactx.extensions.KnownElementsList import (
+    FilteredElementsList as _FilteredElementsList,
+)
+
+
+def test_filtered_elements_list_exported_on_elements_module():
+    assert elements.FilteredElementsList is _FilteredElementsList
+    assert elements.FilteredElementsList.__module__ == elements.__name__
 
 
 def test_basic_indexing():
@@ -811,3 +819,318 @@ def test_select_no_arguments():
     all_then_drift = lattice.select().select(kind="Drift")
     assert len(all_then_drift) == 2
     assert [el.name for el in all_then_drift] == ["drift1", "drift2"]
+
+
+def test_delete_removes_and_returns_none():
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Drift(name="drift1", ds=1.0),
+            elements.Quad(name="quad1", ds=0.5, k=1.0),
+            elements.Drift(name="drift2", ds=2.0),
+        ]
+    )
+    sel = lattice.select(kind="Drift")
+    ret = sel.delete()
+    assert ret is None
+    assert len(lattice) == 1
+    assert type(lattice[0]) is elements.Quad
+    assert lattice[0].name == "quad1"
+
+
+def test_delete_invalidates_chained_filtered_views():
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Drift(name="drift1", ds=1.0),
+            elements.Quad(name="quad1", ds=0.5, k=1.0),
+            elements.Drift(name="drift2", ds=2.0),
+        ]
+    )
+    outer = lattice.select(kind="Drift")
+    inner = outer.select(name="drift1")
+    inner.delete()
+    with pytest.raises(RuntimeError, match="no longer valid"):
+        _ = len(outer)
+    with pytest.raises(RuntimeError, match="no longer valid"):
+        _ = len(inner)
+    assert len(lattice) == 2
+    assert lattice[0].name == "quad1"
+    assert lattice[1].name == "drift2"
+
+
+def test_delete_invalidates_sibling_filtered_views():
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Drift(name="drift1", ds=1.0),
+            elements.Drift(name="drift2", ds=2.0),
+            elements.Quad(name="quad1", ds=0.5, k=1.0),
+        ]
+    )
+    drifts = lattice.select(kind="Drift")
+    branch_a = drifts.select(name="drift1")
+    branch_b = drifts.select(name="drift2")
+    branch_a.delete()
+    with pytest.raises(RuntimeError, match="no longer valid"):
+        _ = len(drifts)
+    with pytest.raises(RuntimeError, match="no longer valid"):
+        _ = len(branch_b)
+    assert len(lattice) == 2
+
+
+def test_replace_each_default_keep_name_not_ds():
+    """Default: keep_name=True, keep_ds=False
+
+    names from replaced elements, ds from template."""
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Drift(name="drift1", ds=1.0),
+            elements.Quad(name="qf1", ds=0.5, k=1.0),
+            elements.Quad(name="qd1", ds=0.25, k=-1.0),
+        ]
+    )
+    template = elements.Quad(name="tpl", ds=0.01, k=99.0)
+    sel = lattice.select(kind="Quad")
+    new_sel = sel.replace_each(template)
+    assert type(lattice[1]) is elements.Quad
+    assert lattice[1].name == "qf1"
+    assert lattice[1].ds == 0.01
+    assert lattice[1].k == 99.0
+    assert lattice[2].name == "qd1"
+    assert lattice[2].ds == 0.01
+    assert len(new_sel) == 2
+    assert new_sel[0].name == "qf1"
+    with pytest.raises(RuntimeError, match="no longer valid"):
+        _ = len(sel)
+
+
+def test_replace_each_keep_ds_true():
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Quad(name="qf1", ds=0.5, k=1.0),
+            elements.Quad(name="qd1", ds=0.25, k=-1.0),
+        ]
+    )
+    template = elements.Quad(name="tpl", ds=0.01, k=99.0)
+    lattice.select(kind="Quad").replace_each(template, keep_ds=True)
+    assert lattice[0].ds == 0.5
+    assert lattice[1].ds == 0.25
+    assert lattice[0].k == 99.0
+
+
+def test_replace_each_keep_name_and_ds_false():
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Quad(name="qf1", ds=0.5, k=1.0),
+        ]
+    )
+    template = elements.Quad(name="tpl", ds=0.01, k=7.0)
+    lattice.select(kind="Quad").replace_each(template, keep_name=False)
+    assert lattice[0].name == "tpl"
+    assert lattice[0].ds == 0.01
+    assert lattice[0].k == 7.0
+
+
+def test_replace_with_drifts_model_match():
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Quad(name="lq", ds=1.0, k=1.0, nslice=2),
+            elements.ChrQuad(name="cq", ds=0.5, k=1.0, nslice=3),
+            elements.ExactQuad(name="eq", ds=0.25, k=1.0, nslice=4),
+        ]
+    )
+    sel = lattice.select(kind=r".*Quad")
+    sel.replace_with_drifts()
+    assert type(lattice[0]) is elements.Drift
+    assert type(lattice[1]) is elements.ChrDrift
+    assert type(lattice[2]) is elements.ExactDrift
+    assert lattice[0].name == "lq"
+    assert lattice[1].name == "cq"
+    assert lattice[2].name == "eq"
+    assert lattice[0].ds == 1.0
+    assert lattice[1].ds == 0.5
+    assert lattice[2].ds == 0.25
+    assert lattice[0].nslice == 2
+    assert lattice[1].nslice == 3
+    assert lattice[2].nslice == 4
+
+
+def test_replace_with_drifts_explicit_model():
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Quad(name="lq", ds=1.0, k=1.0),
+            elements.ExactQuad(name="eq", ds=0.25, k=1.0),
+        ]
+    )
+    lattice.select(kind=r".*Quad").replace_with_drifts(model="paraxial")
+    assert type(lattice[0]) is elements.ChrDrift
+    assert type(lattice[1]) is elements.ChrDrift
+    assert lattice[0].ds == 1.0
+    assert lattice[1].ds == 0.25
+
+    lattice.select(kind=r".*Drift").replace_with_drifts(model="exact")
+    assert type(lattice[0]) is elements.ExactDrift
+    assert type(lattice[1]) is elements.ExactDrift
+
+
+def test_replace_invalid_model_string():
+    lattice = elements.KnownElementsList()
+    lattice.extend([elements.Drift(name="d1", ds=1.0)])
+    sel = lattice.select(kind="Drift")
+    with pytest.raises(ValueError, match="model"):
+        sel.replace_with_drifts(model="not_a_model")
+
+
+def test_replace_with_drifts_keep_alignment():
+    """Test keep_alignment parameter."""
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [elements.Quad(name="q1", ds=0.5, k=1.0, dx=0.01, dy=0.02, rotation=0.5)]
+    )
+
+    # Default: keep_alignment=True
+    lattice.select(kind="Quad").replace_with_drifts()
+    assert lattice[0].dx == 0.01
+    assert lattice[0].dy == 0.02
+    assert lattice[0].rotation == 0.5
+
+    # Reset and test keep_alignment=False
+    lattice.clear()
+    lattice.extend(
+        [elements.Quad(name="q1", ds=0.5, k=1.0, dx=0.01, dy=0.02, rotation=0.5)]
+    )
+    lattice.select(kind="Quad").replace_with_drifts(keep_alignment=False)
+    assert lattice[0].dx == 0.0
+    assert lattice[0].dy == 0.0
+    assert lattice[0].rotation == 0.0
+
+
+def test_replace_with_drifts_keep_aperture():
+    """Test keep_aperture parameter."""
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [elements.Quad(name="q1", ds=0.5, k=1.0, aperture_x=0.05, aperture_y=0.03)]
+    )
+
+    # Default: keep_aperture=False
+    lattice.select(kind="Quad").replace_with_drifts()
+    assert lattice[0].aperture_x == 0.0
+    assert lattice[0].aperture_y == 0.0
+
+    # Reset and test keep_aperture=True
+    lattice.clear()
+    lattice.extend(
+        [elements.Quad(name="q1", ds=0.5, k=1.0, aperture_x=0.05, aperture_y=0.03)]
+    )
+    lattice.select(kind="Quad").replace_with_drifts(keep_aperture=True)
+    assert lattice[0].aperture_x == 0.05
+    assert lattice[0].aperture_y == 0.03
+
+
+def test_chained_replace_each():
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Quad(name="qf1", ds=0.5, k=1.0),
+            elements.Quad(name="qd1", ds=0.25, k=-1.0),
+        ]
+    )
+    q2 = elements.Quad(name="tpl", ds=0.1, k=2.0)
+    new_sel = (
+        lattice.select(kind="Quad")
+        .replace_each(q2)
+        .replace_each(elements.Quad(name="tpl2", ds=0.2, k=3.0))
+    )
+    assert lattice[0].k == 3.0
+    assert lattice[1].k == 3.0
+    assert len(new_sel) == 2
+
+
+def test_delete_empty_selection():
+    """delete() on empty selection is a no-op, returns None."""
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Drift(name="d1", ds=1.0),
+            elements.Quad(name="q1", ds=0.5, k=1.0),
+        ]
+    )
+    sel = lattice.select(name="nonexistent")
+    assert len(sel) == 0
+    ret = sel.delete()
+    assert ret is None
+    assert len(lattice) == 2
+
+
+def test_replace_each_empty_selection():
+    """replace_each on empty selection returns empty FilteredElementsList."""
+    lattice = elements.KnownElementsList()
+    lattice.extend([elements.Drift(name="d1", ds=1.0)])
+    sel = lattice.select(name="nonexistent")
+    new_sel = sel.replace_each(elements.Quad(name="tpl", ds=0.1, k=1.0))
+    assert len(new_sel) == 0
+    assert len(lattice) == 1
+    assert lattice[0].name == "d1"
+
+
+def test_replace_with_drifts_empty_selection():
+    """replace_with_drifts on empty selection returns empty FilteredElementsList."""
+    lattice = elements.KnownElementsList()
+    lattice.extend([elements.Drift(name="d1", ds=1.0)])
+    sel = lattice.select(name="nonexistent")
+    new_sel = sel.replace_with_drifts()
+    assert len(new_sel) == 0
+    assert len(lattice) == 1
+
+
+def test_replace_each_thin_element():
+    """replace_each with keep_ds=True on thin element (Marker has ds=0)."""
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Marker(name="m1"),
+            elements.Drift(name="d1", ds=1.0),
+        ]
+    )
+    # Marker is a thin element with ds=0; keep_ds=True should preserve that
+    sel = lattice.select(kind="Marker")
+    new_sel = sel.replace_each(elements.Drift(name="tpl", ds=0.5), keep_ds=True)
+    assert len(new_sel) == 1
+    assert type(lattice[0]) is elements.Drift
+    assert lattice[0].name == "m1"
+    # Marker has ds=0.0, so with keep_ds=True, the new element gets ds=0.0
+    assert lattice[0].ds == 0.0
+
+    # Now test keep_ds=False: template's ds should be used
+    lattice2 = elements.KnownElementsList()
+    lattice2.extend([elements.Marker(name="m2")])
+    lattice2.select(kind="Marker").replace_each(
+        elements.Drift(name="tpl", ds=0.5), keep_ds=False
+    )
+    assert lattice2[0].ds == 0.5
+
+
+def test_replace_with_drifts_thin_element():
+    """replace_with_drifts on thin element (Marker with ds=0)."""
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Marker(name="m1"),
+            elements.Drift(name="d1", ds=1.0),
+        ]
+    )
+    sel = lattice.select(kind="Marker")
+    new_sel = sel.replace_with_drifts()
+    assert len(new_sel) == 1
+    assert type(lattice[0]) is elements.Drift
+    assert lattice[0].name == "m1"
+    # Marker has ds=0.0 (thin element), so drift gets ds=0.0
+    assert lattice[0].ds == 0.0
+    assert lattice[1].name == "d1"
+    assert lattice[1].ds == 1.0


### PR DESCRIPTION
From Python, expand the [lattice manipulation](https://impactx--1370.org.readthedocs.build/en/1370/usage/python.html#impactx.elements.KnownElementsList.select) with:
- `delete()` to [drop](https://impactx--1370.org.readthedocs.build/en/1370/usage/python.html#impactx.elements.FilteredElementsList.delete) the current selection,
- `replace_each(...)` to [swap each selected element](https://impactx--1370.org.readthedocs.build/en/1370/usage/python.html#impactx.elements.FilteredElementsList.replace_each) for a clone of a template (with optional name and `ds` carry-over), or
- `replace_with_drifts(...)` to turn selections into the [matching drift family](https://impactx--1370.org.readthedocs.build/en/1370/usage/python.html#impactx.elements.FilteredElementsList.replace_with_drifts), a single drift `model` for every slot.

Since lattice-changing operations change the underlying lattice, we safely invalidate earlier filtered views (temporary variables to `.select(...)`) when a deletion or replacement was triggered. Multiple complex manipulations will then simply start again from `sim.lattice.select()` over multiple lines.

Continue lattice manipulation needs as described in #884 #1088