### PR TITLE
Fix domain segfault before init_grids

### DIFF
--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -166,7 +166,8 @@ void init_ImpactX (py::module& m)
 
                 pp_geometry.add("dynamic_size", false);
 
-                ix.ResizeMesh();
+                if (ix.initialized())
+                    ix.ResizeMesh();
             },
             "The physical extent of the full simulation domain, relative to the reference particle position, in meters."
         )


### PR DESCRIPTION
Fixes #1371 

Note - the modified `prob_lo`/`prob_hi` and `dynamic_size=false` will get correctly picked up by init_grids() when it is called later. We could also throw here, not sure which is better.