### PR TITLE
Fix prob_relative getter for multi-level lists

### DIFF
--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -173,7 +173,10 @@ void init_ImpactX (py::module& m)
 
         .def_property("prob_relative",
               [](ImpactX & /* ix */) {
-                  return detail::get_or_throw<amrex::Real>("geometry", "prob_relative");
+                  amrex::ParmParse const pp_geometry("geometry");
+                  std::vector<amrex::Real> frac;
+                  pp_geometry.getarr("prob_relative", frac);
+                  return frac;
               },
               [](ImpactX & /* ix */, std::vector<amrex::Real> frac) {
                   amrex::ParmParse pp_geometry("geometry");


### PR DESCRIPTION
Use getarr to return a vector, matching the setter and documentation. The scalar get_or_throw concatenated array entries into a single unparseable string.

Fixes #1373 