### PR TITLE
Increase bithermal space charge test resolution

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1005,6 +1005,8 @@ add_impactx_test(bithermal.py
     examples/epac2004_benchmarks/analysis_bithermal.py
     examples/epac2004_benchmarks/plot_bithermal.py
 )
+label_impactx_test(bithermal slow)
+label_impactx_test(bithermal.py slow)
 
 
 # IOTA s-dependent nonlinear lens test ########################################

--- a/examples/epac2004_benchmarks/analysis_bithermal.py
+++ b/examples/epac2004_benchmarks/analysis_bithermal.py
@@ -41,7 +41,7 @@ initial = series.iterations[1].particles["beam"].to_df()
 final = series.iterations[last_step].particles["beam"].to_df()
 
 # compare number of particles
-num_particles = 10000
+num_particles = 1000000
 assert num_particles == len(initial)
 assert num_particles == len(final)
 
@@ -80,7 +80,8 @@ print(
 )
 
 atol = 0.0  # ignored
-rtol = 6000 * num_particles**-0.5  # from random sampling of a smooth distribution
+#rtol = 6000 * num_particles**-0.5  # from random sampling of a smooth distribution
+rtol = 10.0 * num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(

--- a/examples/epac2004_benchmarks/analysis_bithermal.py
+++ b/examples/epac2004_benchmarks/analysis_bithermal.py
@@ -80,7 +80,7 @@ print(
 )
 
 atol = 0.0  # ignored
-#rtol = 6000 * num_particles**-0.5  # from random sampling of a smooth distribution
+# rtol = 6000 * num_particles**-0.5  # from random sampling of a smooth distribution
 rtol = 10.0 * num_particles**-0.5  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 

--- a/examples/epac2004_benchmarks/analysis_bithermal.py
+++ b/examples/epac2004_benchmarks/analysis_bithermal.py
@@ -41,7 +41,7 @@ initial = series.iterations[1].particles["beam"].to_df()
 final = series.iterations[last_step].particles["beam"].to_df()
 
 # compare number of particles
-num_particles = 1000000
+num_particles = 10000
 assert num_particles == len(initial)
 assert num_particles == len(final)
 
@@ -80,8 +80,7 @@ print(
 )
 
 atol = 0.0  # ignored
-# rtol = 6000 * num_particles**-0.5  # from random sampling of a smooth distribution
-rtol = 10.0 * num_particles**-0.5  # from random sampling of a smooth distribution
+rtol = 0.07  # dominated by space-charge modeling, not particle sampling
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 assert np.allclose(

--- a/examples/epac2004_benchmarks/input_bithermal.in
+++ b/examples/epac2004_benchmarks/input_bithermal.in
@@ -1,8 +1,7 @@
 ###############################################################################
 # Particle Beam(s)
 ###############################################################################
-#beam.npart = 100000000  #full resolution
-beam.npart = 10000
+beam.npart = 1000000  #full resolution
 beam.units = static
 beam.kin_energy = 0.1
 beam.charge = 1.4285714285714285714e-10
@@ -29,18 +28,17 @@ constf1.ds = 10.0
 constf1.kx = 6.283185307179586
 constf1.ky = constf1.kx
 constf1.kt = constf1.kx
-#constf1.nslice = 400  #full resolution
-constf1.nslice = 50
+constf1.nslice = 400  #full resolution
 
 ###############################################################################
 # Algorithms
 ###############################################################################
 algo.particle_shape = 2
 algo.space_charge = 3D
+algo.poisson_solver = "fft"
 
-#amr.n_cell = 128 128 128  #full resolution
-amr.n_cell = 64 64 64
-geometry.prob_relative = 3.0
+amr.n_cell = 64 64 64  #full resolution
+geometry.prob_relative = 1.5
 
 ###############################################################################
 # Diagnostics

--- a/examples/epac2004_benchmarks/input_bithermal.in
+++ b/examples/epac2004_benchmarks/input_bithermal.in
@@ -1,7 +1,8 @@
 ###############################################################################
 # Particle Beam(s)
 ###############################################################################
-beam.npart = 1000000  #full resolution
+#beam.npart = 1000000  #full resolution
+beam.npart = 10000
 beam.units = static
 beam.kin_energy = 0.1
 beam.charge = 1.4285714285714285714e-10
@@ -28,7 +29,8 @@ constf1.ds = 10.0
 constf1.kx = 6.283185307179586
 constf1.ky = constf1.kx
 constf1.kt = constf1.kx
-constf1.nslice = 400  #full resolution
+#constf1.nslice = 400  #full resolution
+constf1.nslice = 120
 
 ###############################################################################
 # Algorithms
@@ -37,8 +39,8 @@ algo.particle_shape = 2
 algo.space_charge = 3D
 algo.poisson_solver = "fft"
 
-amr.n_cell = 64 64 64  #full resolution
-geometry.prob_relative = 1.5
+amr.n_cell = 64 64 64
+geometry.prob_relative = 1.1
 
 ###############################################################################
 # Diagnostics

--- a/examples/epac2004_benchmarks/run_bithermal.py
+++ b/examples/epac2004_benchmarks/run_bithermal.py
@@ -16,7 +16,7 @@ sim.particle_shape = 2  # B-spline order
 sim.space_charge = "3D"
 sim.poisson_solver = "fft"
 sim.dynamic_size = True
-sim.prob_relative = [1.5]
+sim.prob_relative = [1.1]
 
 # beam diagnostics
 sim.slice_step_diagnostics = False
@@ -27,7 +27,8 @@ sim.init_grids()
 # beam parameters
 kin_energy_MeV = 0.1  # reference energy
 bunch_charge_C = 1.4285714285714285714e-10  # used with space charge
-npart = 1000000  # full resolution
+# npart = 1000000  # full resolution
+npart = 10000
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
@@ -56,7 +57,8 @@ constf = elements.ConstF(
     kx=6.283185307179586,
     ky=6.283185307179586,
     kt=6.283185307179586,
-    nslice=400,  # full resolution
+    # nslice=400,  # full resolution
+    nslice=120,
 )
 
 sim.lattice.append(constf)

--- a/examples/epac2004_benchmarks/run_bithermal.py
+++ b/examples/epac2004_benchmarks/run_bithermal.py
@@ -11,12 +11,12 @@ from impactx import ImpactX, distribution, elements
 sim = ImpactX()
 
 # set numerical parameters and IO control
-# sim.n_cell = [128, 128, 128]  # full resolution
 sim.n_cell = [64, 64, 64]
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "3D"
+sim.poisson_solver = "fft"
 sim.dynamic_size = True
-sim.prob_relative = [3.0]
+sim.prob_relative = [1.5]
 
 # beam diagnostics
 sim.slice_step_diagnostics = False
@@ -27,8 +27,7 @@ sim.init_grids()
 # beam parameters
 kin_energy_MeV = 0.1  # reference energy
 bunch_charge_C = 1.4285714285714285714e-10  # used with space charge
-# npart = 100000000  # full resolution
-npart = 10000  # number of macro particles
+npart = 1000000  # full resolution
 
 #   reference particle
 ref = sim.particle_container().ref_particle()
@@ -57,8 +56,7 @@ constf = elements.ConstF(
     kx=6.283185307179586,
     ky=6.283185307179586,
     kt=6.283185307179586,
-    # nslice=400,  # full resolution
-    nslice=50,
+    nslice=400,  # full resolution
 )
 
 sim.lattice.append(constf)


### PR DESCRIPTION
This PR increases the resolution of the space charge test in: `examples/epac2004_benchmarks/run_bithermal.py`.  

- [x] adjust numerical resolution and tolerance
- [x] mark test as "slow" -- not needed anymore, now only 3.4x slower than `development`

This fixes #1379, where we had a 6000% tolerance. Now it is 7%.