### PR TITLE
Fix: Python Elements Benchmark (CUDA)

### DIFF
--- a/tests/python/test_benchmark_elements.py
+++ b/tests/python/test_benchmark_elements.py
@@ -103,6 +103,7 @@ def sim(request):
             return self.sim
 
         def __exit__(self, exc_type, exc_value, traceback):
+            self.sim.backup_beam.clear_particles()
             self.sim.finalize()
             del self.sim
 

--- a/tests/python/test_benchmark_elements.py
+++ b/tests/python/test_benchmark_elements.py
@@ -103,7 +103,9 @@ def sim(request):
             return self.sim
 
         def __exit__(self, exc_type, exc_value, traceback):
+            # Work-around for https://github.com/AMReX-Codes/amrex/pull/5270
             self.sim.backup_beam.clear_particles()
+
             self.sim.finalize()
             del self.sim
 


### PR DESCRIPTION
Clean up memory to avoid stale memory on GPU runs.

There is a more general fix proposed in https://github.com/AMReX-Codes/amrex/pull/5270 for the 26.05 release cycle. (ImpactX is still in the 26.04 cycle as of today.)

This is one of the error types that https://github.com/AMReX-Codes/pyamrex/issues/81 describes.