### PR TITLE
Python: `ref.set_species(species_name)`

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -46,7 +46,19 @@ Initial Beam Distributions
   beam current, used only if ``algo.space_charge = "2D"``
 
 * ``beam.particle`` (``string``)
-  particle type: currently either ``electron``, ``positron`` or ``proton``
+  particle type: ``electron``, ``positron``, ``proton``, or ``Hminus``.
+  For other species, please use the :ref:`Python API <usage-python>` or `open an issue <https://github.com/BLAST-ImpactX/impactx/issues>`__.
+
+  .. dropdown:: Species Constants
+     :color: light
+     :icon: info
+     :animate: fade-in-slide-down
+
+     .. literalinclude:: ../../../src/particles/ReferenceParticle.H
+        :language: cpp
+        :dedent: 12
+        :start-after: // [known_species]
+        :end-before: // [/known_species]
 
 * ``beam.distribution`` (``string``)
   Indicates the initial distribution type.

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -578,6 +578,36 @@ Particles
       :param keep_mass: do not reset the reference particle mass
       :param keep_charge: do not reset the reference particle charge
 
+   .. py:method:: set_species(species_name)
+
+      Set reference particle species by name.
+      Sets charge, mass, and gyromagnetic anomaly for a known particle species.
+      Returns the reference particle for chaining.
+
+      Known species: ``electron``, ``positron``, ``proton``, ``Hminus``.
+      For other species, set charge, mass, and gyromagnetic anomaly individually via
+      :py:meth:`set_charge_qe`, :py:meth:`set_mass_MeV`, and :py:meth:`set_gyromagnetic_anomaly`.
+
+      .. dropdown:: Species Constants
+         :color: light
+         :icon: info
+         :animate: fade-in-slide-down
+
+         .. literalinclude:: ../../../src/particles/ReferenceParticle.H
+            :language: cpp
+            :dedent: 12
+            :start-after: // [known_species]
+            :end-before: // [/known_species]
+
+      :param str species_name: particle species name
+
+      Example usage:
+
+      .. code-block:: python
+
+         ref = sim.particle_container().ref_particle()
+         ref.set_species("electron").set_kin_energy_MeV(2.0e3)
+
    .. py:method:: set_charge_qe(charge_qe)
 
       Write-only: Set reference particle charge in (positive) elementary charges.

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -45,43 +45,10 @@ namespace impactx
         std::string particle_type;  // Particle type
         pp_dist.get("particle", particle_type);
 
-        amrex::ParticleReal qe;     // charge (elementary charge)
-        amrex::ParticleReal massE;  // MeV/c^2
-        constexpr amrex::ParticleReal m_e = ablastr::constant::SI::m_e_v<amrex::ParticleReal>;
-        constexpr amrex::ParticleReal m_p = ablastr::constant::SI::m_p_v<amrex::ParticleReal>;
-        constexpr amrex::ParticleReal MeV_inv_c2 = ablastr::constant::SI::MeV_inv_c2_v<amrex::ParticleReal>;
-        amrex::ParticleReal gyromagnetic_anomaly;  // anomalous magnetic dipole moment
-        if (particle_type == "electron") {
-            qe = -1.0;
-            massE = m_e / MeV_inv_c2;
-            gyromagnetic_anomaly = 0.00115965218062;
-        } else if (particle_type == "positron") {
-            qe = 1.0;
-            massE = m_e / MeV_inv_c2;
-            gyromagnetic_anomaly = 0.00115965218062;
-        } else if (particle_type == "proton") {
-            qe = 1.0;
-            massE = m_p / MeV_inv_c2;
-            gyromagnetic_anomaly = 1.7928473446;
-        } else if (particle_type == "Hminus") {
-            qe = -1.0;
-            massE = 939.294308;  // value used in TraceWin
-            gyromagnetic_anomaly = 1.7928473446; // this value is difficult to find, and needs to be checked
-        }
-        else {  // default to electron
-            ablastr::warn_manager::WMRecordWarning(
-                    "ImpactX::initBeamDistributionFromInputs",
-                    "No beam.particle specified, defaulting to electrons.",
-                    ablastr::warn_manager::WarnPriority::low
-            );
-            qe = -1.0;
-            massE = m_e / MeV_inv_c2;
-            gyromagnetic_anomaly = 0.00115965218062;
-        }
-
         // configure a new reference particle
         RefPart ref;
-        ref.set_charge_qe(qe).set_mass_MeV(massE).set_kin_energy_MeV(kin_energy).set_gyromagnetic_anomaly(gyromagnetic_anomaly);
+        ref.set_species(particle_type);
+        ref.set_kin_energy_MeV(kin_energy);
         return ref;
     }
 

--- a/src/particles/ReferenceParticle.H
+++ b/src/particles/ReferenceParticle.H
@@ -20,6 +20,8 @@
 #include <AMReX_SmallMatrix.H>
 
 #include <cmath>
+#include <stdexcept>
+#include <string>
 
 
 namespace impactx
@@ -72,6 +74,59 @@ namespace impactx
 
             if (keep_mass) { mass = old_mass; }
             if (keep_charge) { charge = old_charge; }
+        }
+
+        /** Set reference particle species by name
+         *
+         * Sets charge, mass, and gyromagnetic anomaly for a known particle species.
+         *
+         * @param species_name particle species name
+         * @returns reference to this RefPart for chaining
+         */
+        RefPart &
+        set_species (std::string const & species_name)
+        {
+            constexpr amrex::ParticleReal m_e = ablastr::constant::SI::m_e_v<amrex::ParticleReal>;
+            constexpr amrex::ParticleReal m_p = ablastr::constant::SI::m_p_v<amrex::ParticleReal>;
+            constexpr amrex::ParticleReal MeV_inv_c2 = ablastr::constant::SI::MeV_inv_c2_v<amrex::ParticleReal>;
+
+            amrex::ParticleReal qe;
+            amrex::ParticleReal massE;
+            amrex::ParticleReal g_anomaly;
+
+            // [known_species]
+            if (species_name == "electron") {
+                qe = -1.0;
+                massE = m_e / MeV_inv_c2;
+                g_anomaly = 0.00115965218062;
+            } else if (species_name == "positron") {
+                qe = 1.0;
+                massE = m_e / MeV_inv_c2;
+                g_anomaly = 0.00115965218062;
+            } else if (species_name == "proton") {
+                qe = 1.0;
+                massE = m_p / MeV_inv_c2;
+                g_anomaly = 1.7928473446;
+            } else if (species_name == "Hminus") {
+                qe = -1.0;
+                massE = (m_p + 2.0 * m_e) / MeV_inv_c2;  // neglect ~14 eV/c^2 binding energy
+                g_anomaly = 1.7928473446;
+            }
+            // [/known_species]
+            else {
+                throw std::runtime_error(
+                    "Unknown species: '" + species_name +
+                    "'. Known species: electron, positron, proton, Hminus. "
+                    "For other species, set charge, mass, and gyromagnetic anomaly "
+                    "individually via set_charge_qe(), set_mass_MeV(), and "
+                    "set_gyromagnetic_anomaly()."
+                );
+            }
+
+            set_charge_qe(qe);
+            set_mass_MeV(massE);
+            set_gyromagnetic_anomaly(g_anomaly);
+            return *this;
         }
 
         /** Get reference particle relativistic gamma

--- a/src/python/ReferenceParticle.cpp
+++ b/src/python/ReferenceParticle.cpp
@@ -62,5 +62,11 @@ void init_refparticle(py::module& m)
         .def("set_gyromagnetic_anomaly", &RefPart::set_gyromagnetic_anomaly,
              py::return_value_policy::reference_internal,
              "Set reference particle gyromagnetic anomaly value (for spin tracking)", py::arg("gyromagnetic_anomaly"))
+        .def("set_species", &RefPart::set_species,
+             py::return_value_policy::reference_internal,
+             "Set reference particle species by name.\n\n"
+             "Sets charge, mass, and gyromagnetic anomaly for a known particle species.\n"
+             "Returns self for chaining, e.g.: ref.set_species(\"electron\").set_kin_energy_MeV(2.0e3)",
+             py::arg("species_name"))
     ;
 }


### PR DESCRIPTION
Simplify reference particle generation in Python by sharing the same lookup table of charge, mass and gyromagnetic anomaly as the `.in` parameter files logic.

- [x] non-breaking change, everything still works as before if desired
- [x] follow-up PR: update all examples & tests #1385
- [x] show internally used constants in docs ([Python](https://impactx--1384.org.readthedocs.build/en/1384/usage/python.html#impactx.RefPart.set_species), [Inputs file](https://impactx--1384.org.readthedocs.build/en/1384/usage/parameters.html#initial-beam-distributions))
- [x] clarify `Hminus` treatment