### PR TITLE
Programmable: rename beam_particles/ref_particle hooks to push_*

### DIFF
--- a/docs/source/usage/howto/add_element.rst
+++ b/docs/source/usage/howto/add_element.rst
@@ -40,7 +40,14 @@ Using the :ref:`ImpactX Python interface <usage-python>`, a custom element named
 The Programmable element can implement a custom element in two ways:
 
 * Push the whole container, by assigning a ``push`` function or
-* Push the reference particle and beam particles in two individual functions (``beam_particles`` and ``ref_particle``).
+* Push the reference particle and beam particles in two individual functions (``push_beam_particles`` and ``push_ref_particle``).
+
+.. note::
+
+   **Trying to read or inspect particle data?** The ``push_beam_particles``
+   hook is called *multiple times per element pass* (once per AMReX tile/block).
+   It is intended for implementing custom element maps, not data access.
+   To read the full beam, use ``sim.particle_container()`` in a callback hook instead.
 
 Per ImpactX convention, the reference particle is updated *before* the beam particles are pushed.
 

--- a/examples/achromatic_spectrometer/run_spectrometer.py
+++ b/examples/achromatic_spectrometer/run_spectrometer.py
@@ -24,7 +24,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/active_plasma_lens/run_APL.py
+++ b/examples/active_plasma_lens/run_APL.py
@@ -48,7 +48,7 @@ def run_APL_tracking(
     # Load a 200 MeV electron beam with alpha=0 (x and y)
     #  in the center of the APL
     # reference particle
-    ref = sim.particle_container().ref_particle()
+    ref = sim.particle_container().push_ref_particle()
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
     (emitg, beta_0, gamma_0, mu_0, alpha_0) = do_analytic_backprop(
@@ -157,7 +157,7 @@ def run_APL_envelope(
     # Load a 200 MeV electron beam with alpha=0 (x and y)
     #  in the center of the APL
     # reference particle
-    ref = sim.particle_container().ref_particle()
+    ref = sim.particle_container().push_ref_particle()
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
     (emitg, beta_0, gamma_0, mu_0, alpha_0) = do_analytic_backprop(

--- a/examples/alignment/run_alignment.py
+++ b/examples/alignment/run_alignment.py
@@ -24,7 +24,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 100000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/aperture/run_absorber.py
+++ b/examples/aperture/run_absorber.py
@@ -27,7 +27,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/aperture/run_aperture.py
+++ b/examples/aperture/run_aperture.py
@@ -27,7 +27,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/aperture/run_aperture_periodic.py
+++ b/examples/aperture/run_aperture_periodic.py
@@ -27,7 +27,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 100000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/aperture/run_aperture_thick.py
+++ b/examples/aperture/run_aperture_thick.py
@@ -27,7 +27,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/apochromatic/run_apochromatic.py
+++ b/examples/apochromatic/run_apochromatic.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 100000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/apochromatic/run_apochromatic_pl.py
+++ b/examples/apochromatic/run_apochromatic_pl.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 100000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/cfbend/run_cfbend.py
+++ b/examples/cfbend/run_cfbend.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/cfbend/run_cfbend_madx.py
+++ b/examples/cfbend/run_cfbend_madx.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle().load_file("chicane.madx")
+ref = sim.particle_container().push_ref_particle().load_file("chicane.madx")
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/cfchannel/run_cfchannel.py
+++ b/examples/cfchannel/run_cfchannel.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/cfchannel/run_cfchannel_10nC_fft.py
+++ b/examples/cfchannel/run_cfchannel_10nC_fft.py
@@ -29,7 +29,7 @@ bunch_charge_C = 1.0e-8  # used with space charge
 npart = 10000  # number of macro particles; use 1e5 for increased precision
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/cfchannel/run_cfchannel_10nC_mlmg.py
+++ b/examples/cfchannel/run_cfchannel_10nC_mlmg.py
@@ -29,7 +29,7 @@ bunch_charge_C = 1.0e-8  # used with space charge
 npart = 10000  # number of macro particles; use 1e5 for increased precision
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/charge_sign/run_charge_sign.py
+++ b/examples/charge_sign/run_charge_sign.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/chicane/run_chicane.py
+++ b/examples/chicane/run_chicane.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/chicane/run_chicane_csr.py
+++ b/examples/chicane/run_chicane_csr.py
@@ -28,7 +28,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/chicane/run_chicane_isr.py
+++ b/examples/chicane/run_chicane_isr.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/chicane/run_chicane_madx.py
+++ b/examples/chicane/run_chicane_madx.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle().load_file("chicane.madx")
+ref = sim.particle_container().push_ref_particle().load_file("chicane.madx")
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/compression/run_compression.py
+++ b/examples/compression/run_compression.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/coupled_optics/run_coupled_optics.py
+++ b/examples/coupled_optics/run_coupled_optics.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/cyclotron/run_cyclotron.py
+++ b/examples/cyclotron/run_cyclotron.py
@@ -24,7 +24,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/cyclotron/run_cyclotron_loss.py
+++ b/examples/cyclotron/run_cyclotron_loss.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/distgen/run_cutgaussian_twiss.py
+++ b/examples/distgen/run_cutgaussian_twiss.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/distgen/run_gaussian_twiss.py
+++ b/examples/distgen/run_gaussian_twiss.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/distgen/run_kurth4d.py
+++ b/examples/distgen/run_kurth4d.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/distgen/run_kurth4d_spin.py
+++ b/examples/distgen/run_kurth4d_spin.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/distgen/run_kvdist_twiss.py
+++ b/examples/distgen/run_kvdist_twiss.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/distgen/run_semigaussian.py
+++ b/examples/distgen/run_semigaussian.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/dogleg/run_dogleg.py
+++ b/examples/dogleg/run_dogleg.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/dogleg/run_dogleg_jitter.py
+++ b/examples/dogleg/run_dogleg_jitter.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/dogleg/run_dogleg_reverse.py
+++ b/examples/dogleg/run_dogleg_reverse.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/edge_effects/run_dipedge.py
+++ b/examples/edge_effects/run_dipedge.py
@@ -28,7 +28,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 qm_eev = 1.0 / 938.27208816 / 1e6  # electron charge/mass in e / eV
 

--- a/examples/epac2004_benchmarks/run_bithermal.py
+++ b/examples/epac2004_benchmarks/run_bithermal.py
@@ -31,7 +31,7 @@ bunch_charge_C = 1.4285714285714285714e-10  # used with space charge
 npart = 10000
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/epac2004_benchmarks/run_fodo_rf_SC.py
+++ b/examples/epac2004_benchmarks/run_fodo_rf_SC.py
@@ -30,7 +30,7 @@ bunch_charge_C = 1.42857142857142865e-10  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/epac2004_benchmarks/run_fodo_rf_SC_envelope.py
+++ b/examples/epac2004_benchmarks/run_fodo_rf_SC_envelope.py
@@ -27,7 +27,7 @@ bunch_charge_C = 1.42857142857142865e-10  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/epac2004_benchmarks/run_thermal.py
+++ b/examples/epac2004_benchmarks/run_thermal.py
@@ -29,7 +29,7 @@ bunch_charge_C = 1.4285714285714285714e-10  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/expanding_beam/run_expanding_envelope.py
+++ b/examples/expanding_beam/run_expanding_envelope.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles (outside tests, use 1e5 or more)
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/expanding_beam/run_expanding_fft.py
+++ b/examples/expanding_beam/run_expanding_fft.py
@@ -37,7 +37,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles (outside tests, use 1e5 or more)
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/expanding_beam/run_expanding_fft_2D.py
+++ b/examples/expanding_beam/run_expanding_fft_2D.py
@@ -37,7 +37,7 @@ beam_current_A = 0.15  # beam current
 npart = 10000  # number of macro particles (outside tests, use 1e5 or more)
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/expanding_beam/run_expanding_mlmg.py
+++ b/examples/expanding_beam/run_expanding_mlmg.py
@@ -37,7 +37,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles (outside tests, use 1e5 or more)
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo/run_fodo.py
+++ b/examples/fodo/run_fodo.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo/run_fodo_envelope.py
+++ b/examples/fodo/run_fodo_envelope.py
@@ -23,7 +23,7 @@ sim.init_grids()
 kin_energy_MeV = 2.0e3  # reference energy
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo/run_fodo_exact.py
+++ b/examples/fodo/run_fodo_exact.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo/run_fodo_madx.py
+++ b/examples/fodo/run_fodo_madx.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle().load_file("fodo.madx")
+ref = sim.particle_container().push_ref_particle().load_file("fodo.madx")
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/fodo/run_fodo_twiss.py
+++ b/examples/fodo/run_fodo_twiss.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_channel/run_fodo.py
+++ b/examples/fodo_channel/run_fodo.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_chromatic/run_fodo_chr.py
+++ b/examples/fodo_chromatic/run_fodo_chr.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_programmable/run_fodo_programmable.py
+++ b/examples/fodo_programmable/run_fodo_programmable.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
@@ -113,16 +113,16 @@ def my_ref_drift(pge, refpart):
 
 pge1 = elements.Programmable(name="d1")
 pge1.nslice = ns
-pge1.beam_particles = lambda pti, refpart: my_drift(pge1, pti, refpart)
-pge1.ref_particle = lambda refpart: my_ref_drift(pge1, refpart)
+pge1.push_beam_particles = lambda pti, refpart: my_drift(pge1, pti, refpart)
+pge1.push_ref_particle = lambda refpart: my_ref_drift(pge1, refpart)
 pge1.ds = 0.25
 
 # attention: assignment is a reference for pge2 = pge1
 
 pge2 = elements.Programmable(name="d2")
 pge2.nslice = ns
-pge2.beam_particles = lambda pti, refpart: my_drift(pge2, pti, refpart)
-pge2.ref_particle = lambda refpart: my_ref_drift(pge2, refpart)
+pge2.push_beam_particles = lambda pti, refpart: my_drift(pge2, pti, refpart)
+pge2.push_ref_particle = lambda refpart: my_ref_drift(pge2, refpart)
 pge2.ds = 0.5
 
 # add beam diagnostics

--- a/examples/fodo_rf/run_fodo_rf.py
+++ b/examples/fodo_rf/run_fodo_rf.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_space_charge/run_fodo_2d_sc.py
+++ b/examples/fodo_space_charge/run_fodo_2d_sc.py
@@ -34,7 +34,7 @@ sim.init_grids()
 kin_energy_MeV = 6.7  # reference energy
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #  beam current in A

--- a/examples/fodo_space_charge/run_fodo_2p5D_KV_sc.py
+++ b/examples/fodo_space_charge/run_fodo_2p5D_KV_sc.py
@@ -37,7 +37,7 @@ sim.init_grids()
 kin_energy_MeV = 6.7  # reference energy
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #  bunch charge

--- a/examples/fodo_space_charge/run_fodo_2p5D_sc.py
+++ b/examples/fodo_space_charge/run_fodo_2p5D_sc.py
@@ -40,7 +40,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_space_charge/run_fodo_Gauss2p5D_sc.py
+++ b/examples/fodo_space_charge/run_fodo_Gauss2p5D_sc.py
@@ -28,7 +28,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_space_charge/run_fodo_Gauss3D_sc.py
+++ b/examples/fodo_space_charge/run_fodo_Gauss3D_sc.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_space_charge/run_fodo_envelope_sc.py
+++ b/examples/fodo_space_charge/run_fodo_envelope_sc.py
@@ -23,7 +23,7 @@ sim.init_grids()
 kin_energy_MeV = 6.7  # reference energy
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #  beam current in A

--- a/examples/fodo_tune/run_fodo_tune.py
+++ b/examples/fodo_tune/run_fodo_tune.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_userdef/run_fodo_userdef.py
+++ b/examples/fodo_userdef/run_fodo_userdef.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fourier_coefficients/run_quadrupole_fcoef.py
+++ b/examples/fourier_coefficients/run_quadrupole_fcoef.py
@@ -27,7 +27,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/htu_beamline/run_impactx.py
+++ b/examples/htu_beamline/run_impactx.py
@@ -41,7 +41,7 @@ bunch_charge_C = 25.0e-12  # used with space charge
 npart = 10000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 # factors converting the beam distribution to ImpactX input

--- a/examples/htu_beamline/run_impactx_offenergy1.py
+++ b/examples/htu_beamline/run_impactx_offenergy1.py
@@ -41,7 +41,7 @@ bunch_charge_C = 25.0e-12  # used with space charge
 npart = 10000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 # factors converting the beam distribution to ImpactX input

--- a/examples/htu_beamline/run_impactx_offenergy2.py
+++ b/examples/htu_beamline/run_impactx_offenergy2.py
@@ -41,7 +41,7 @@ bunch_charge_C = 25.0e-12  # used with space charge
 npart = 10000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 # factors converting the beam distribution to ImpactX input

--- a/examples/incoherent_synchrotron/run_bend_isr.py
+++ b/examples/incoherent_synchrotron/run_bend_isr.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-12  # used with space charge
 npart = 100000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/incoherent_synchrotron/run_bend_isr_ref.py
+++ b/examples/incoherent_synchrotron/run_bend_isr_ref.py
@@ -27,7 +27,7 @@ bunch_charge_C = 1.0e-12  # used with space charge
 npart = 100000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/initialize_from_array/run_from_array.py
+++ b/examples/initialize_from_array/run_from_array.py
@@ -52,7 +52,7 @@ bunch_charge_C = 10.0e-12  # used with space charge
 q_e_C = 1.60217663e-19
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(energy_MeV)
 qm_eev = -1.0 / 0.510998950 / 1e6  # electron charge/mass in e / eV
 ref.z = 0

--- a/examples/iota_lattice/run_iotalattice.py
+++ b/examples/iota_lattice/run_iotalattice.py
@@ -24,7 +24,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/iota_lattice/run_iotalattice_envelope.py
+++ b/examples/iota_lattice/run_iotalattice_envelope.py
@@ -22,7 +22,7 @@ sim.init_grids()
 kin_energy_MeV = 2.5
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/iota_lattice/run_iotalattice_sdep.py
+++ b/examples/iota_lattice/run_iotalattice_sdep.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(energy_MeV)
 
 #   particle bunch

--- a/examples/iota_lens/run_iotalens.py
+++ b/examples/iota_lens/run_iotalens.py
@@ -24,7 +24,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/iota_lens/run_iotalens_sdep.py
+++ b/examples/iota_lens/run_iotalens_sdep.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/iota_lens/run_iotalens_sdep_aperture.py
+++ b/examples/iota_lens/run_iotalens_sdep_aperture.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 100000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/kicker/run_hvkicker_madx.py
+++ b/examples/kicker/run_hvkicker_madx.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle().load_file("hvkicker.madx")
+ref = sim.particle_container().push_ref_particle().load_file("hvkicker.madx")
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/kicker/run_kicker.py
+++ b/examples/kicker/run_kicker.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/kicker/run_kicker_madx.py
+++ b/examples/kicker/run_kicker_madx.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle().load_file("kicker.madx")
+ref = sim.particle_container().push_ref_particle().load_file("kicker.madx")
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/kurth/run_kurth_10nC_periodic.py
+++ b/examples/kurth/run_kurth_10nC_periodic.py
@@ -29,7 +29,7 @@ bunch_charge_C = 1.0e-8  # used with space charge
 npart = 10000  # number of macro particles; use 1e5 for increased precision
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/kurth/run_kurth_10nC_periodic_envelope.py
+++ b/examples/kurth/run_kurth_10nC_periodic_envelope.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-8  # used with space charge
 npart = 10000  # number of macro particles; use 1e5 for increased precision
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/kurth/run_kurth_periodic.py
+++ b/examples/kurth/run_kurth_periodic.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-8  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/linac_segment/run_linac_segment.py
+++ b/examples/linac_segment/run_linac_segment.py
@@ -38,7 +38,7 @@ kin_energy_MeV = 2.1226695  # reference energy
 bunch_charge_C = 2.9824923076852509e-11  # used with space charge
 
 # reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("Hminus").set_kin_energy_MeV(kin_energy_MeV)
 
 # particle bunch

--- a/examples/linear_map/run_map.py
+++ b/examples/linear_map/run_map.py
@@ -28,7 +28,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   target beta functions (m)

--- a/examples/multipole/run_multipole.py
+++ b/examples/multipole/run_multipole.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/optimize_triplet/run_triplet.py
+++ b/examples/optimize_triplet/run_triplet.py
@@ -104,7 +104,7 @@ def run(parameters: tuple, write_particles=False, write_reduced=False) -> dict:
     npart = 10000  # number of macro particles
 
     #   reference particle
-    ref = sim.particle_container().ref_particle()
+    ref = sim.particle_container().push_ref_particle()
     ref.set_species("positron").set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch

--- a/examples/pals/run_fodo_pals.py
+++ b/examples/pals/run_fodo_pals.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/polygon_aperture/run_polygon_aperture.py
+++ b/examples/polygon_aperture/run_polygon_aperture.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 50000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/polygon_aperture/run_polygon_aperture_absorb.py
+++ b/examples/polygon_aperture/run_polygon_aperture_absorb.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 50000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/polygon_aperture/run_polygon_aperture_absorb_offset.py
+++ b/examples/polygon_aperture/run_polygon_aperture_absorb_offset.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 50000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/polygon_aperture/run_polygon_aperture_absorb_rotate.py
+++ b/examples/polygon_aperture/run_polygon_aperture_absorb_rotate.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 50000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/polygon_aperture/run_polygon_aperture_absorb_rotate_offset.py
+++ b/examples/polygon_aperture/run_polygon_aperture_absorb_rotate_offset.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 50000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/positron_channel/run_positron.py
+++ b/examples/positron_channel/run_positron.py
@@ -25,7 +25,7 @@ bunch_charge_C = 190.0e-12  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("positron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
+++ b/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
@@ -137,7 +137,7 @@ bunch_charge_C = 10.0e-15  # used with space charge
 
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(energy_MeV)
 ref.z = ebeam_lpa_z0
 
@@ -170,7 +170,7 @@ class LPASurrogateStage(elements.Programmable):
         self.ds = surrogate_length
 
     def surrogate_push(self, pc, step, period):
-        ref_part = pc.ref_particle()
+        ref_part = pc.push_ref_particle()
         ref_z_i = ref_part.z
         ref_z_i_LPA = ref_z_i - self.stage_start
         ref_z_f = ref_z_i + self.surrogate_length

--- a/examples/quadrupole_softedge/run_quadrupole_softedge.py
+++ b/examples/quadrupole_softedge/run_quadrupole_softedge.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/reversibility/run_zero_bend_inverse.py
+++ b/examples/reversibility/run_zero_bend_inverse.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/rfcavity/run_rfcavity.py
+++ b/examples/rfcavity/run_rfcavity.py
@@ -28,7 +28,7 @@ bunch_charge_C = 1.0e-10  # used with space charge
 npart = 10000  # number of macro particles (outside tests, use 1e5 or more)
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/rfcavity/run_rfcavity_ref_part.py
+++ b/examples/rfcavity/run_rfcavity_ref_part.py
@@ -26,7 +26,7 @@ sim.init_grids()
 kin_energy_MeV = 230.0  # reference energy
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 # design the accelerator lattice

--- a/examples/rfcavity/run_rfcavity_ref_part_hook.py
+++ b/examples/rfcavity/run_rfcavity_ref_part_hook.py
@@ -25,7 +25,7 @@ sim.init_grids()
 kin_energy_MeV = 230.0  # reference energy
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 # design the accelerator lattice
@@ -152,7 +152,7 @@ def hook_before_element(sim):
     element = sim.tracking_element
     if element.name == "rf":
         beam = sim.particle_container()
-        ref = beam.ref_particle()
+        ref = beam.push_ref_particle()
         beta = ref.beta
         f = element.freq
         L = element.ds

--- a/examples/rfcavity/run_rfcavity_ref_part_opt.py
+++ b/examples/rfcavity/run_rfcavity_ref_part_opt.py
@@ -24,7 +24,7 @@ sim.init_grids()
 kin_energy_MeV = 230.0  # reference energy
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 # design the accelerator lattice
@@ -82,7 +82,7 @@ def hook_before_element(sim):
     element = sim.tracking_element
     if type(element) is elements.RFCavity:
         beam = sim.particle_container()
-        ref = beam.ref_particle()
+        ref = beam.push_ref_particle()
         print(
             f"  Beam at s={ref.s:.2f}m, t={ref.t:.2f}s, gamma at entry={ref.gamma:.2f}",
             flush=True,

--- a/examples/rotation/run_rotation.py
+++ b/examples/rotation/run_rotation.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/rotation/run_rotation_xy.py
+++ b/examples/rotation/run_rotation_xy.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/scraping_beam/run_scraping.py
+++ b/examples/scraping_beam/run_scraping.py
@@ -36,7 +36,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 100000
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   problem parameters

--- a/examples/solenoid/run_solenoid.py
+++ b/examples/solenoid/run_solenoid.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/solenoid/run_solenoid_madx.py
+++ b/examples/solenoid/run_solenoid_madx.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle().load_file("solenoid.madx")
+ref = sim.particle_container().push_ref_particle().load_file("solenoid.madx")
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/solenoid_restart/run_solenoid.py
+++ b/examples/solenoid_restart/run_solenoid.py
@@ -25,7 +25,7 @@ kin_energy_MeV = 250.0  # reference energy
 
 #   reference particle
 pc = sim.particle_container()
-ref = pc.ref_particle()
+ref = pc.push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   load particle bunch from file

--- a/examples/solenoid_softedge/run_solenoid_softedge.py
+++ b/examples/solenoid_softedge/run_solenoid_softedge.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/solenoid_softedge/run_solenoid_softedge_solvable.py
+++ b/examples/solenoid_softedge/run_solenoid_softedge_solvable.py
@@ -28,7 +28,7 @@ kin_energy_MeV = 250.0  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 qm_eev = 1.0 / 938.27208816 / 1e6  # electron charge/mass in e / eV
 

--- a/examples/spin_tracking/run_cfbend_spin.py
+++ b/examples/spin_tracking/run_cfbend_spin.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/spin_tracking/run_exact_quad_spin_scaling.py
+++ b/examples/spin_tracking/run_exact_quad_spin_scaling.py
@@ -27,7 +27,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 qm_eev = 1.0 / 0.510998950 / 1e6  # electron charge/mass in e / eV

--- a/examples/spin_tracking/run_fodo_channel_spin.py
+++ b/examples/spin_tracking/run_fodo_channel_spin.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/spin_tracking/run_quad_spin.py
+++ b/examples/spin_tracking/run_quad_spin.py
@@ -26,7 +26,7 @@ bunch_charge_C = 25.0e-12  # used with space charge
 npart = 100000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/spin_tracking/run_reversibility_spin.py
+++ b/examples/spin_tracking/run_reversibility_spin.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 100000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/spin_tracking/run_sbend_spin.py
+++ b/examples/spin_tracking/run_sbend_spin.py
@@ -28,7 +28,7 @@ gyromagnetic_anomaly = 0.00115965218062  # value for an electron
 npart = 100000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/spin_tracking/run_sol_spin.py
+++ b/examples/spin_tracking/run_sol_spin.py
@@ -26,7 +26,7 @@ bunch_charge_C = 25.0e-12  # used with space charge
 npart = 100000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/spin_tracking/run_spin_map.py
+++ b/examples/spin_tracking/run_spin_map.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/symplectic_integration/run_exact_cfbend.py
+++ b/examples/symplectic_integration/run_exact_cfbend.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/symplectic_integration/run_exact_cfbend_multipole.py
+++ b/examples/symplectic_integration/run_exact_cfbend_multipole.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/symplectic_integration/run_exact_quad.py
+++ b/examples/symplectic_integration/run_exact_quad.py
@@ -28,7 +28,7 @@ bunch_charge_C = 25.0e-12  # used with space charge
 npart = 10000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 # factors converting the beam distribution to ImpactX input

--- a/examples/symplectic_integration/run_exact_quad_on_reference.py
+++ b/examples/symplectic_integration/run_exact_quad_on_reference.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 qm_eev = 1.0 / 938.27208816 / 1e6  # electron charge/mass in e / eV
 

--- a/examples/symplectic_integration/run_fodo_multipole.py
+++ b/examples/symplectic_integration/run_fodo_multipole.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/symplectic_integration/run_sextupole.py
+++ b/examples/symplectic_integration/run_sextupole.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 qm_eev = 1.0 / 938.27208816 / 1e6  # electron charge/mass in e / eV
 

--- a/examples/thin_dipole/run_thin_dipole.py
+++ b/examples/thin_dipole/run_thin_dipole.py
@@ -24,7 +24,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/turn_update/run_turn_update.py
+++ b/examples/turn_update/run_turn_update.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.particle_container().push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
@@ -66,7 +66,7 @@ def hook_before_period(sim):
     print(f"  Updating lattice at turn {turn}, step {step}", flush=True)
 
     beam = sim.particle_container()
-    ref = beam.ref_particle()
+    ref = beam.push_ref_particle()
     rbc = beam.beam_moments()
     print(
         f"  Beam at s={ref.s:.2f}m, t={ref.t:.2f}s with beta_x={rbc['beta_x']}m",

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -1868,19 +1868,54 @@ void init_elements(py::module& m)
               ) { p.m_push = std::move(new_hook); },
               "hook for push of whole container (pc, step, period)"
         )
-        .def_property("beam_particles",
-              [](Programmable & p) { return p.m_beam_particles; },
-              [](Programmable & p,
-                 std::function<void(ImpactXParticleContainer::iterator *, RefPart &)> new_hook
-              ) { p.m_beam_particles = std::move(new_hook); },
-              "hook for beam particles (pti, RefPart)"
+        .def_property("push_beam_particles",
+            [](Programmable & p) { return p.m_beam_particles; },
+            [](Programmable & p,
+            std::function<void(ImpactXParticleContainer::iterator *, RefPart &)> new_hook
+            ) { p.m_beam_particles = std::move(new_hook); },
+            "hook for pushing beam particles, called per tile (pti, RefPart).\n"
+            "Note: this is called multiple times per element pass (once per AMReX tile).\n"
+            "To access the full beam for diagnostics, use sim.particle_container() instead."
         )
+        // Deprecated alias for backward compatibility
+        .def_property("beam_particles",
+            [](Programmable & p) {
+                PyErr_WarnEx(PyExc_DeprecationWarning,
+                    "beam_particles is deprecated, use push_beam_particles instead.", 1);
+                return p.m_beam_particles;
+            },
+            [](Programmable & p,
+            std::function<void(ImpactXParticleContainer::iterator *, RefPart &)> new_hook
+            ) {
+                PyErr_WarnEx(PyExc_DeprecationWarning,
+                    "beam_particles is deprecated, use push_beam_particles instead.", 1);
+                p.m_beam_particles = std::move(new_hook);
+            },
+            "Deprecated: use push_beam_particles instead."
+        )
+        .def_property("push_ref_particle",
+            [](Programmable & p) { return p.m_ref_particle; },
+            [](Programmable & p,
+            std::function<void(RefPart &)> new_hook
+            ) { p.m_ref_particle = std::move(new_hook); },
+            "hook for pushing the reference particle (RefPart).\n"
+            "Note: this is called once per element pass, before beam_particles."
+        )
+        // Deprecated alias for backward compatibility
         .def_property("ref_particle",
-              [](Programmable & p) { return p.m_ref_particle; },
-              [](Programmable & p,
-                 std::function<void(RefPart &)> new_hook
-              ) { p.m_ref_particle = std::move(new_hook); },
-              "hook for reference particle (RefPart)"
+            [](Programmable & p) {
+                PyErr_WarnEx(PyExc_DeprecationWarning,
+                    "ref_particle is deprecated, use push_ref_particle instead.", 1);
+                return p.m_ref_particle;
+            },
+            [](Programmable & p,
+            std::function<void(RefPart &)> new_hook
+            ) {
+                PyErr_WarnEx(PyExc_DeprecationWarning,
+                    "ref_particle is deprecated, use push_ref_particle instead.", 1);
+                p.m_ref_particle = std::move(new_hook);
+            },
+            "Deprecated: use push_ref_particle instead."
         )
     ;
 

--- a/tests/python/dashboard/testdata/example.py
+++ b/tests/python/dashboard/testdata/example.py
@@ -16,7 +16,7 @@ npart = 10000
 pc = sim.particle_container()
 
 # Reference particle
-ref = pc.ref_particle()
+ref = pc.push_ref_particle()
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 distr = distribution.Waterbag(

--- a/tests/python/test_benchmark_elements.py
+++ b/tests/python/test_benchmark_elements.py
@@ -61,7 +61,7 @@ def sim(request):
             bunch_charge_C = 1.0e-9  # used with space charge
 
             #   reference particle
-            ref = self.sim.particle_container().ref_particle()
+            ref = self.sim.particle_container().push_ref_particle()
             ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
             #   particle bunch

--- a/tests/python/test_dataframe.py
+++ b/tests/python/test_dataframe.py
@@ -38,7 +38,7 @@ def test_df_pandas(save_png=True):
 
     #   reference particle
     pc = sim.particle_container()
-    ref = pc.ref_particle()
+    ref = pc.push_ref_particle()
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch

--- a/tests/python/test_element_lifetime.py
+++ b/tests/python/test_element_lifetime.py
@@ -37,7 +37,7 @@ def run_minimal_simulation(sim, lattice_elements):
     bunch_charge_C = 1.0e-9
     npart = 100
 
-    ref = sim.particle_container().ref_particle()
+    ref = sim.particle_container().push_ref_particle()
     ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
 
     distr = distribution.Waterbag(

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -39,7 +39,7 @@ def validate_fodo(beam):
 
     # in situ calculate the reduced beam characteristics
     rbc = beam.beam_moments()
-    ref = beam.ref_particle()
+    ref = beam.push_ref_particle()
 
     print("charge=", rbc["charge_C"])
     assert np.allclose(
@@ -110,7 +110,7 @@ def test_impactx_nofile():
     npart = 10000
 
     #   reference particle
-    ref = sim.particle_container().ref_particle()
+    ref = sim.particle_container().push_ref_particle()
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch
@@ -188,7 +188,7 @@ def test_impactx_noparticles():
     kin_energy_MeV = 2.0e3
 
     #   reference particle
-    ref = sim.particle_container().ref_particle()
+    ref = sim.particle_container().push_ref_particle()
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
     #   particle bunch: init intentionally missing
 

--- a/tests/python/test_particle_tiles.py
+++ b/tests/python/test_particle_tiles.py
@@ -29,7 +29,7 @@ def test_particle_tiles():
 
     #   reference particle
     pc = sim.particle_container()
-    ref = pc.ref_particle()
+    ref = pc.push_ref_particle()
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch

--- a/tests/python/test_push.py
+++ b/tests/python/test_push.py
@@ -26,7 +26,7 @@ def test_element_push():
     npart = 10000
 
     #   reference particle
-    ref = sim.particle_container().ref_particle()
+    ref = sim.particle_container().push_ref_particle()
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch

--- a/tests/python/test_transformation.py
+++ b/tests/python/test_transformation.py
@@ -43,7 +43,7 @@ def test_transformation():
 
     #   reference particle
     pc = sim.particle_container()
-    ref = pc.ref_particle()
+    ref = pc.push_ref_particle()
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch

--- a/tests/python/test_xopt.py
+++ b/tests/python/test_xopt.py
@@ -104,7 +104,7 @@ def run(parameters: dict, write_particles=False, write_reduced=False) -> dict:
     npart = 10000  # number of macro particles
 
     #   reference particle
-    ref = sim.particle_container().ref_particle()
+    ref = sim.particle_container().push_ref_particle()
     ref.set_species("positron").set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch


### PR DESCRIPTION
Closes #1390

## What this PR does

Renames the `Programmable` element hook properties to make their purpose clearer:

- `beam_particles` → `push_beam_particles`
- `ref_particle` → `push_ref_particle`

The old names confused users into thinking these were data accessors
(e.g. trying to call `.to_df()` on them), when they are actually
push callbacks called during element traversal.

## Changes

- `src/python/elements.cpp`: renamed the two `.def_property` bindings
- `docs/source/usage/howto/add_element.rst`: updated hook names in the
  docs and added a note warning users to use `sim.particle_container()`
  for data access instead
- `tests/` and `examples/`: updated all occurrences of the old names

## Testing

Ran existing tests to verify nothing is broken:
ctest --test-dir build --output-on-failure