### PR TITLE
SoftElements: `zlen` always Positive

### DIFF
--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -363,7 +363,7 @@ namespace impactx::elements
 
             // specify constants
             using ablastr::constant::math::pi;
-            amrex::ParticleReal const zlen = m_ds;
+            amrex::ParticleReal const zlen = std::abs(m_ds);
             amrex::ParticleReal const zmid = zlen * 0.5_prt;
 
             // compute on-axis electric field (z is relative to cavity midpoint)

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -362,7 +362,7 @@ namespace impactx::elements
 
             // specify constants
             using ablastr::constant::math::pi;
-            amrex::ParticleReal const zlen = m_ds;
+            amrex::ParticleReal const zlen = std::abs(m_ds);
             amrex::ParticleReal const zmid = zlen * 0.5_prt;
 
             // compute on-axis magnetic field (z is relative to quadrupole midpoint)

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -371,7 +371,7 @@ namespace impactx::elements
 
             // specify constants
             using ablastr::constant::math::pi;
-            amrex::ParticleReal const zlen = m_ds;
+            amrex::ParticleReal const zlen = std::abs(m_ds);
             amrex::ParticleReal const zmid = zlen * 0.5_prt;
 
             // compute on-axis magnetic field (z is relative to solenoid midpoint)


### PR DESCRIPTION
`zlen` of an element must always be positive, even if `ds` is negative.