### PR TITLE
Python: `sim.beam.ref`

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -269,6 +269,11 @@ Collective Effects & Overall Simulation Parameters
    .. py:method:: particle_container()
 
       Access the beam particle container (:py:class:`impactx.ParticleContainer`).
+      Deprecated: use :py:attr:`beam`.
+
+   .. py:property:: beam
+
+      Access the beam particle container (:py:class:`impactx.ParticleContainer`).
 
    .. py:property:: lattice
 
@@ -356,7 +361,7 @@ Collective Effects & Overall Simulation Parameters
       .. code-block:: python3
 
          def hook_before_period(sim):
-             beam = sim.particle_container()
+             beam = sim.beam
              turn = sim.tracking_period
              # Example: you could now manipulate elements in sim.lattice
              #          for the next turn.
@@ -464,9 +469,14 @@ Particles
    .. py:method:: ref_particle()
 
       Access the reference particle (:py:class:`impactx.RefPart`).
+      Deprecated: use :py:attr:`ref`.
 
       :return: return a data reference to the reference particle
       :rtype: impactx.RefPart
+
+   .. py:property:: ref
+
+      Access the beam reference particle (:py:class:`impactx.RefPart`).
 
    .. py:method:: set_ref_particle(refpart)
 
@@ -605,7 +615,7 @@ Particles
 
       .. code-block:: python
 
-         ref = sim.particle_container().ref_particle()
+         ref = sim.beam.ref
          ref.set_species("electron").set_kin_energy_MeV(2.0e3)
 
    .. py:method:: set_charge_qe(charge_qe)

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -476,7 +476,7 @@ Particles
 
    .. py:property:: ref
 
-      Access the beam reference particle (:py:class:`impactx.RefPart`).
+      Access the reference particle (:py:class:`impactx.RefPart`).
 
    .. py:method:: set_ref_particle(refpart)
 

--- a/examples/achromatic_spectrometer/run_spectrometer.py
+++ b/examples/achromatic_spectrometer/run_spectrometer.py
@@ -24,7 +24,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/active_plasma_lens/run_APL.py
+++ b/examples/active_plasma_lens/run_APL.py
@@ -48,7 +48,7 @@ def run_APL_tracking(
     # Load a 200 MeV electron beam with alpha=0 (x and y)
     #  in the center of the APL
     # reference particle
-    ref = sim.particle_container().ref_particle()
+    ref = sim.beam.ref
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
     (emitg, beta_0, gamma_0, mu_0, alpha_0) = do_analytic_backprop(
@@ -157,7 +157,7 @@ def run_APL_envelope(
     # Load a 200 MeV electron beam with alpha=0 (x and y)
     #  in the center of the APL
     # reference particle
-    ref = sim.particle_container().ref_particle()
+    ref = sim.beam.ref
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
     (emitg, beta_0, gamma_0, mu_0, alpha_0) = do_analytic_backprop(

--- a/examples/alignment/run_alignment.py
+++ b/examples/alignment/run_alignment.py
@@ -24,7 +24,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 100000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/aperture/run_absorber.py
+++ b/examples/aperture/run_absorber.py
@@ -27,7 +27,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/aperture/run_aperture.py
+++ b/examples/aperture/run_aperture.py
@@ -27,7 +27,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/aperture/run_aperture_periodic.py
+++ b/examples/aperture/run_aperture_periodic.py
@@ -27,7 +27,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 100000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/aperture/run_aperture_thick.py
+++ b/examples/aperture/run_aperture_thick.py
@@ -27,7 +27,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/apochromatic/run_apochromatic.py
+++ b/examples/apochromatic/run_apochromatic.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 100000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/apochromatic/run_apochromatic_pl.py
+++ b/examples/apochromatic/run_apochromatic_pl.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 100000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/cfbend/run_cfbend.py
+++ b/examples/cfbend/run_cfbend.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/cfbend/run_cfbend_madx.py
+++ b/examples/cfbend/run_cfbend_madx.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle().load_file("chicane.madx")
+ref = sim.beam.ref.load_file("chicane.madx")
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/cfchannel/run_cfchannel.py
+++ b/examples/cfchannel/run_cfchannel.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/cfchannel/run_cfchannel_10nC_fft.py
+++ b/examples/cfchannel/run_cfchannel_10nC_fft.py
@@ -29,7 +29,7 @@ bunch_charge_C = 1.0e-8  # used with space charge
 npart = 10000  # number of macro particles; use 1e5 for increased precision
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/cfchannel/run_cfchannel_10nC_mlmg.py
+++ b/examples/cfchannel/run_cfchannel_10nC_mlmg.py
@@ -29,7 +29,7 @@ bunch_charge_C = 1.0e-8  # used with space charge
 npart = 10000  # number of macro particles; use 1e5 for increased precision
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/charge_sign/run_charge_sign.py
+++ b/examples/charge_sign/run_charge_sign.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/chicane/run_chicane.py
+++ b/examples/chicane/run_chicane.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/chicane/run_chicane_csr.py
+++ b/examples/chicane/run_chicane_csr.py
@@ -28,7 +28,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/chicane/run_chicane_isr.py
+++ b/examples/chicane/run_chicane_isr.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/chicane/run_chicane_madx.py
+++ b/examples/chicane/run_chicane_madx.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle().load_file("chicane.madx")
+ref = sim.beam.ref.load_file("chicane.madx")
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/compression/run_compression.py
+++ b/examples/compression/run_compression.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/coupled_optics/run_coupled_optics.py
+++ b/examples/coupled_optics/run_coupled_optics.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/cyclotron/run_cyclotron.py
+++ b/examples/cyclotron/run_cyclotron.py
@@ -24,7 +24,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/cyclotron/run_cyclotron_loss.py
+++ b/examples/cyclotron/run_cyclotron_loss.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/distgen/run_cutgaussian_twiss.py
+++ b/examples/distgen/run_cutgaussian_twiss.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/distgen/run_gaussian_twiss.py
+++ b/examples/distgen/run_gaussian_twiss.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/distgen/run_kurth4d.py
+++ b/examples/distgen/run_kurth4d.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/distgen/run_kurth4d_spin.py
+++ b/examples/distgen/run_kurth4d_spin.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/distgen/run_kvdist_twiss.py
+++ b/examples/distgen/run_kvdist_twiss.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/distgen/run_semigaussian.py
+++ b/examples/distgen/run_semigaussian.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/dogleg/run_dogleg.py
+++ b/examples/dogleg/run_dogleg.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/dogleg/run_dogleg_jitter.py
+++ b/examples/dogleg/run_dogleg_jitter.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/dogleg/run_dogleg_reverse.py
+++ b/examples/dogleg/run_dogleg_reverse.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/edge_effects/run_dipedge.py
+++ b/examples/edge_effects/run_dipedge.py
@@ -28,11 +28,11 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 qm_eev = 1.0 / 938.27208816 / 1e6  # electron charge/mass in e / eV
 
-pc = sim.particle_container()
+beam = sim.beam
 
 df_initial = pd.read_csv("./initial_coords.csv", sep=" ")
 dx = df_initial["x"].to_numpy()
@@ -74,7 +74,7 @@ for p_dpt in dpt:
 print(dpt)
 # print(dg)
 
-pc.add_n_particles(
+beam.add_n_particles(
     dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, bunch_charge_C
 )
 

--- a/examples/epac2004_benchmarks/run_bithermal.py
+++ b/examples/epac2004_benchmarks/run_bithermal.py
@@ -31,7 +31,7 @@ bunch_charge_C = 1.4285714285714285714e-10  # used with space charge
 npart = 10000
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/epac2004_benchmarks/run_fodo_rf_SC.py
+++ b/examples/epac2004_benchmarks/run_fodo_rf_SC.py
@@ -30,7 +30,7 @@ bunch_charge_C = 1.42857142857142865e-10  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/epac2004_benchmarks/run_fodo_rf_SC_envelope.py
+++ b/examples/epac2004_benchmarks/run_fodo_rf_SC_envelope.py
@@ -27,7 +27,7 @@ bunch_charge_C = 1.42857142857142865e-10  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/epac2004_benchmarks/run_thermal.py
+++ b/examples/epac2004_benchmarks/run_thermal.py
@@ -29,7 +29,7 @@ bunch_charge_C = 1.4285714285714285714e-10  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/expanding_beam/run_expanding_envelope.py
+++ b/examples/expanding_beam/run_expanding_envelope.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles (outside tests, use 1e5 or more)
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/expanding_beam/run_expanding_fft.py
+++ b/examples/expanding_beam/run_expanding_fft.py
@@ -37,7 +37,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles (outside tests, use 1e5 or more)
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/expanding_beam/run_expanding_fft_2D.py
+++ b/examples/expanding_beam/run_expanding_fft_2D.py
@@ -37,7 +37,7 @@ beam_current_A = 0.15  # beam current
 npart = 10000  # number of macro particles (outside tests, use 1e5 or more)
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/expanding_beam/run_expanding_mlmg.py
+++ b/examples/expanding_beam/run_expanding_mlmg.py
@@ -37,7 +37,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles (outside tests, use 1e5 or more)
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo/run_fodo.py
+++ b/examples/fodo/run_fodo.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo/run_fodo_envelope.py
+++ b/examples/fodo/run_fodo_envelope.py
@@ -23,7 +23,7 @@ sim.init_grids()
 kin_energy_MeV = 2.0e3  # reference energy
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo/run_fodo_exact.py
+++ b/examples/fodo/run_fodo_exact.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo/run_fodo_madx.py
+++ b/examples/fodo/run_fodo_madx.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle().load_file("fodo.madx")
+ref = sim.beam.ref.load_file("fodo.madx")
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/fodo/run_fodo_twiss.py
+++ b/examples/fodo/run_fodo_twiss.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_channel/run_fodo.py
+++ b/examples/fodo_channel/run_fodo.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_chromatic/run_fodo_chr.py
+++ b/examples/fodo_chromatic/run_fodo_chr.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_programmable/run_fodo_programmable.py
+++ b/examples/fodo_programmable/run_fodo_programmable.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_rf/run_fodo_rf.py
+++ b/examples/fodo_rf/run_fodo_rf.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_space_charge/run_fodo_2d_sc.py
+++ b/examples/fodo_space_charge/run_fodo_2d_sc.py
@@ -34,7 +34,7 @@ sim.init_grids()
 kin_energy_MeV = 6.7  # reference energy
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #  beam current in A

--- a/examples/fodo_space_charge/run_fodo_2p5D_KV_sc.py
+++ b/examples/fodo_space_charge/run_fodo_2p5D_KV_sc.py
@@ -37,7 +37,7 @@ sim.init_grids()
 kin_energy_MeV = 6.7  # reference energy
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #  bunch charge

--- a/examples/fodo_space_charge/run_fodo_2p5D_sc.py
+++ b/examples/fodo_space_charge/run_fodo_2p5D_sc.py
@@ -40,7 +40,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_space_charge/run_fodo_Gauss2p5D_sc.py
+++ b/examples/fodo_space_charge/run_fodo_Gauss2p5D_sc.py
@@ -28,7 +28,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_space_charge/run_fodo_Gauss3D_sc.py
+++ b/examples/fodo_space_charge/run_fodo_Gauss3D_sc.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_space_charge/run_fodo_envelope_sc.py
+++ b/examples/fodo_space_charge/run_fodo_envelope_sc.py
@@ -23,7 +23,7 @@ sim.init_grids()
 kin_energy_MeV = 6.7  # reference energy
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #  beam current in A

--- a/examples/fodo_tune/run_fodo_tune.py
+++ b/examples/fodo_tune/run_fodo_tune.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fodo_userdef/run_fodo_userdef.py
+++ b/examples/fodo_userdef/run_fodo_userdef.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/fourier_coefficients/run_quadrupole_fcoef.py
+++ b/examples/fourier_coefficients/run_quadrupole_fcoef.py
@@ -27,7 +27,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/htu_beamline/run_impactx.py
+++ b/examples/htu_beamline/run_impactx.py
@@ -41,7 +41,7 @@ bunch_charge_C = 25.0e-12  # used with space charge
 npart = 10000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 # factors converting the beam distribution to ImpactX input
@@ -75,7 +75,7 @@ sim.track_particles()
 
 # in situ calculate the reduced beam characteristics
 # note: rbc us a dataframe, sim can be finalized once rbc was created
-# beam = sim.particle_container()
+# beam = sim.beam
 # rbc = beam.reduced_beam_characteristics()
 
 # clean shutdown

--- a/examples/htu_beamline/run_impactx_offenergy1.py
+++ b/examples/htu_beamline/run_impactx_offenergy1.py
@@ -41,7 +41,7 @@ bunch_charge_C = 25.0e-12  # used with space charge
 npart = 10000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 # factors converting the beam distribution to ImpactX input
@@ -79,7 +79,7 @@ sim.track_particles()
 
 # in situ calculate the reduced beam characteristics
 # note: rbc us a dataframe, sim can be finalized once rbc was created
-# beam = sim.particle_container()
+# beam = sim.beam
 # rbc = beam.reduced_beam_characteristics()
 
 # clean shutdown

--- a/examples/htu_beamline/run_impactx_offenergy2.py
+++ b/examples/htu_beamline/run_impactx_offenergy2.py
@@ -41,7 +41,7 @@ bunch_charge_C = 25.0e-12  # used with space charge
 npart = 10000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 # factors converting the beam distribution to ImpactX input
@@ -79,7 +79,7 @@ sim.track_particles()
 
 # in situ calculate the reduced beam characteristics
 # note: rbc us a dataframe, sim can be finalized once rbc was created
-# beam = sim.particle_container()
+# beam = sim.beam
 # rbc = beam.reduced_beam_characteristics()
 
 # clean shutdown

--- a/examples/incoherent_synchrotron/run_bend_isr.py
+++ b/examples/incoherent_synchrotron/run_bend_isr.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-12  # used with space charge
 npart = 100000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/incoherent_synchrotron/run_bend_isr_ref.py
+++ b/examples/incoherent_synchrotron/run_bend_isr_ref.py
@@ -27,7 +27,7 @@ bunch_charge_C = 1.0e-12  # used with space charge
 npart = 100000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/initialize_from_array/README.rst
+++ b/examples/initialize_from_array/README.rst
@@ -50,7 +50,7 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
 
 .. attention::
 
-   In MPI-parallel simulations, ``pc.add_n_particles(...)`` is local to the MPI rank, spatial locality does not matter.
+   In MPI-parallel simulations, ``beam.add_n_particles(...)`` is local to the MPI rank, spatial locality does not matter.
    Thus, you can add particles at any MPI rank, e.g., equally chuncked up for perfect load balancing.
 
    You do NOT want to add the same unique particle at multiple MPI ranks.

--- a/examples/initialize_from_array/run_from_array.py
+++ b/examples/initialize_from_array/run_from_array.py
@@ -52,15 +52,15 @@ bunch_charge_C = 10.0e-12  # used with space charge
 q_e_C = 1.60217663e-19
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(energy_MeV)
 qm_eev = -1.0 / 0.510998950 / 1e6  # electron charge/mass in e / eV
 ref.z = 0
 
-pc = sim.particle_container()
+beam = sim.beam
 
 # Note for MPI-parallel simulations:
-#   `pc.add_n_particles(...)` is local to the MPI rank, spatial
+#   `beam.add_n_particles(...)` is local to the MPI rank, spatial
 #   locality does not matter. Thus, you can add particles at any
 #   MPI rank, e.g., equally chuncked up for perfect load balancing.
 #
@@ -117,7 +117,7 @@ if amr.ParallelDescriptor.IOProcessor():
     # This call has two options:
     # A) reassign equal weighting according to bunch_charge_C
     # B) use the particle weighting from the input array w
-    pc.add_n_particles(
+    beam.add_n_particles(
         dx_podv,
         dy_podv,
         dt_podv,
@@ -128,9 +128,9 @@ if amr.ParallelDescriptor.IOProcessor():
         bunch_charge=bunch_charge_C,
     )
     # ok, let's clear all particles and do option B
-    pc.clear_particles()
+    beam.clear_particles()
 
-    pc.add_n_particles(
+    beam.add_n_particles(
         dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, w=w_podv
     )
 

--- a/examples/iota_lattice/run_iotalattice.py
+++ b/examples/iota_lattice/run_iotalattice.py
@@ -24,7 +24,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/iota_lattice/run_iotalattice_envelope.py
+++ b/examples/iota_lattice/run_iotalattice_envelope.py
@@ -22,7 +22,7 @@ sim.init_grids()
 kin_energy_MeV = 2.5
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/iota_lattice/run_iotalattice_sdep.py
+++ b/examples/iota_lattice/run_iotalattice_sdep.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(energy_MeV)
 
 #   particle bunch

--- a/examples/iota_lens/run_iotalens.py
+++ b/examples/iota_lens/run_iotalens.py
@@ -24,7 +24,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/iota_lens/run_iotalens_sdep.py
+++ b/examples/iota_lens/run_iotalens_sdep.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/iota_lens/run_iotalens_sdep_aperture.py
+++ b/examples/iota_lens/run_iotalens_sdep_aperture.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 100000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/kicker/run_hvkicker_madx.py
+++ b/examples/kicker/run_hvkicker_madx.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle().load_file("hvkicker.madx")
+ref = sim.beam.ref.load_file("hvkicker.madx")
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/kicker/run_kicker.py
+++ b/examples/kicker/run_kicker.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/kicker/run_kicker_madx.py
+++ b/examples/kicker/run_kicker_madx.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle().load_file("kicker.madx")
+ref = sim.beam.ref.load_file("kicker.madx")
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/kurth/run_kurth_10nC_periodic.py
+++ b/examples/kurth/run_kurth_10nC_periodic.py
@@ -29,7 +29,7 @@ bunch_charge_C = 1.0e-8  # used with space charge
 npart = 10000  # number of macro particles; use 1e5 for increased precision
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/kurth/run_kurth_10nC_periodic_envelope.py
+++ b/examples/kurth/run_kurth_10nC_periodic_envelope.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-8  # used with space charge
 npart = 10000  # number of macro particles; use 1e5 for increased precision
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/kurth/run_kurth_periodic.py
+++ b/examples/kurth/run_kurth_periodic.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-8  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/linac_segment/run_linac_segment.py
+++ b/examples/linac_segment/run_linac_segment.py
@@ -38,7 +38,7 @@ kin_energy_MeV = 2.1226695  # reference energy
 bunch_charge_C = 2.9824923076852509e-11  # used with space charge
 
 # reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("Hminus").set_kin_energy_MeV(kin_energy_MeV)
 
 # particle bunch

--- a/examples/linear_map/run_map.py
+++ b/examples/linear_map/run_map.py
@@ -28,7 +28,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   target beta functions (m)

--- a/examples/multipole/run_multipole.py
+++ b/examples/multipole/run_multipole.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/optimize_triplet/run_triplet.py
+++ b/examples/optimize_triplet/run_triplet.py
@@ -104,7 +104,7 @@ def run(parameters: tuple, write_particles=False, write_reduced=False) -> dict:
     npart = 10000  # number of macro particles
 
     #   reference particle
-    ref = sim.particle_container().ref_particle()
+    ref = sim.beam.ref
     ref.set_species("positron").set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch
@@ -128,7 +128,7 @@ def run(parameters: tuple, write_particles=False, write_reduced=False) -> dict:
     sim.track_particles()
 
     # in situ calculate the reduced beam characteristics
-    beam = sim.particle_container()
+    beam = sim.beam
     rbc = beam.beam_moments()
 
     # clean shutdown

--- a/examples/pals/run_fodo_pals.py
+++ b/examples/pals/run_fodo_pals.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/polygon_aperture/run_polygon_aperture.py
+++ b/examples/polygon_aperture/run_polygon_aperture.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 50000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/polygon_aperture/run_polygon_aperture_absorb.py
+++ b/examples/polygon_aperture/run_polygon_aperture_absorb.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 50000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/polygon_aperture/run_polygon_aperture_absorb_offset.py
+++ b/examples/polygon_aperture/run_polygon_aperture_absorb_offset.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 50000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/polygon_aperture/run_polygon_aperture_absorb_rotate.py
+++ b/examples/polygon_aperture/run_polygon_aperture_absorb_rotate.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 50000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/polygon_aperture/run_polygon_aperture_absorb_rotate_offset.py
+++ b/examples/polygon_aperture/run_polygon_aperture_absorb_rotate_offset.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 50000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/positron_channel/run_positron.py
+++ b/examples/positron_channel/run_positron.py
@@ -25,7 +25,7 @@ bunch_charge_C = 190.0e-12  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("positron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
+++ b/examples/pytorch_surrogate_model/run_ml_surrogate_15_stage.py
@@ -137,11 +137,9 @@ bunch_charge_C = 10.0e-15  # used with space charge
 
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(energy_MeV)
 ref.z = ebeam_lpa_z0
-
-pc = sim.particle_container()
 
 distr = distribution.Gaussian(
     lambdaX=0.75e-6,
@@ -170,7 +168,7 @@ class LPASurrogateStage(elements.Programmable):
         self.ds = surrogate_length
 
     def surrogate_push(self, pc, step, period):
-        ref_part = pc.ref_particle()
+        ref_part = sim.beam.ref
         ref_z_i = ref_part.z
         ref_z_i_LPA = ref_z_i - self.stage_start
         ref_z_f = ref_z_i + self.surrogate_length

--- a/examples/quadrupole_softedge/run_quadrupole_softedge.py
+++ b/examples/quadrupole_softedge/run_quadrupole_softedge.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/reversibility/run_zero_bend_inverse.py
+++ b/examples/reversibility/run_zero_bend_inverse.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/rfcavity/run_rfcavity.py
+++ b/examples/rfcavity/run_rfcavity.py
@@ -28,7 +28,7 @@ bunch_charge_C = 1.0e-10  # used with space charge
 npart = 10000  # number of macro particles (outside tests, use 1e5 or more)
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/rfcavity/run_rfcavity_ref_part.py
+++ b/examples/rfcavity/run_rfcavity_ref_part.py
@@ -26,7 +26,7 @@ sim.init_grids()
 kin_energy_MeV = 230.0  # reference energy
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 # design the accelerator lattice

--- a/examples/rfcavity/run_rfcavity_ref_part_hook.py
+++ b/examples/rfcavity/run_rfcavity_ref_part_hook.py
@@ -25,7 +25,7 @@ sim.init_grids()
 kin_energy_MeV = 230.0  # reference energy
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 # design the accelerator lattice
@@ -151,8 +151,7 @@ sim.lattice.extend(
 def hook_before_element(sim):
     element = sim.tracking_element
     if element.name == "rf":
-        beam = sim.particle_container()
-        ref = beam.ref_particle()
+        ref = sim.beam.ref
         beta = ref.beta
         f = element.freq
         L = element.ds

--- a/examples/rfcavity/run_rfcavity_ref_part_opt.py
+++ b/examples/rfcavity/run_rfcavity_ref_part_opt.py
@@ -24,7 +24,7 @@ sim.init_grids()
 kin_energy_MeV = 230.0  # reference energy
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 # design the accelerator lattice
@@ -81,8 +81,8 @@ sim.lattice.extend(
 def hook_before_element(sim):
     element = sim.tracking_element
     if type(element) is elements.RFCavity:
-        beam = sim.particle_container()
-        ref = beam.ref_particle()
+        beam = sim.beam
+        ref = beam.ref
         print(
             f"  Beam at s={ref.s:.2f}m, t={ref.t:.2f}s, gamma at entry={ref.gamma:.2f}",
             flush=True,

--- a/examples/rotation/run_rotation.py
+++ b/examples/rotation/run_rotation.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/rotation/run_rotation_xy.py
+++ b/examples/rotation/run_rotation_xy.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used without space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/scraping_beam/run_scraping.py
+++ b/examples/scraping_beam/run_scraping.py
@@ -36,7 +36,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 100000
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   problem parameters

--- a/examples/solenoid/run_solenoid.py
+++ b/examples/solenoid/run_solenoid.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/solenoid/run_solenoid_madx.py
+++ b/examples/solenoid/run_solenoid_madx.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle().load_file("solenoid.madx")
+ref = sim.beam.ref.load_file("solenoid.madx")
 
 #   particle bunch
 distr = distribution.Waterbag(

--- a/examples/solenoid_restart/run_solenoid.py
+++ b/examples/solenoid_restart/run_solenoid.py
@@ -24,12 +24,12 @@ sim.init_grids()
 kin_energy_MeV = 250.0  # reference energy
 
 #   reference particle
-pc = sim.particle_container()
-ref = pc.ref_particle()
+beam = sim.beam
+ref = beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   load particle bunch from file
-push(pc, elements.Source("openPMD", "../solenoid.py/diags/openPMD/monitor.h5"))
+push(beam, elements.Source("openPMD", "../solenoid.py/diags/openPMD/monitor.h5"))
 
 # add beam diagnostics
 monitor = elements.BeamMonitor("monitor", backend="h5")

--- a/examples/solenoid_softedge/run_solenoid_softedge.py
+++ b/examples/solenoid_softedge/run_solenoid_softedge.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/solenoid_softedge/run_solenoid_softedge_solvable.py
+++ b/examples/solenoid_softedge/run_solenoid_softedge_solvable.py
@@ -28,12 +28,12 @@ kin_energy_MeV = 250.0  # reference energy
 bunch_charge_C = 1.0e-9  # used with space charge
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 qm_eev = 1.0 / 938.27208816 / 1e6  # electron charge/mass in e / eV
 
 #   particle bunch
-pc = sim.particle_container()
+beam = sim.beam
 
 dx = [1, 0, 0, 0, 0, 0]
 dpx = [0, 1, 0, 0, 0, 0]
@@ -71,7 +71,7 @@ for p_dpt in dpt:
     dpt_podv.push_back(p_dpt)
 
 if amr.ParallelDescriptor.IOProcessor():
-    pc.add_n_particles(
+    beam.add_n_particles(
         dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, bunch_charge_C
     )
 

--- a/examples/spin_tracking/run_cfbend_spin.py
+++ b/examples/spin_tracking/run_cfbend_spin.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/spin_tracking/run_exact_quad_spin_scaling.py
+++ b/examples/spin_tracking/run_exact_quad_spin_scaling.py
@@ -27,12 +27,12 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 qm_eev = 1.0 / 0.510998950 / 1e6  # electron charge/mass in e / eV
 
-pc = sim.particle_container()
+beam = sim.beam
 
 if amr.ParallelDescriptor.IOProcessor():
     df_initial = pd.read_csv("./initial_coords.csv", sep=" ")
@@ -91,7 +91,7 @@ if amr.ParallelDescriptor.IOProcessor():
     for p_dsz in dsz:
         dsz_podv.push_back(p_dsz)
 
-    pc.add_n_particles(
+    beam.add_n_particles(
         dx_podv,
         dy_podv,
         dt_podv,

--- a/examples/spin_tracking/run_fodo_channel_spin.py
+++ b/examples/spin_tracking/run_fodo_channel_spin.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/spin_tracking/run_quad_spin.py
+++ b/examples/spin_tracking/run_quad_spin.py
@@ -26,7 +26,7 @@ bunch_charge_C = 25.0e-12  # used with space charge
 npart = 100000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/spin_tracking/run_reversibility_spin.py
+++ b/examples/spin_tracking/run_reversibility_spin.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 100000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/spin_tracking/run_sbend_spin.py
+++ b/examples/spin_tracking/run_sbend_spin.py
@@ -28,7 +28,7 @@ gyromagnetic_anomaly = 0.00115965218062  # value for an electron
 npart = 100000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/spin_tracking/run_sol_spin.py
+++ b/examples/spin_tracking/run_sol_spin.py
@@ -26,7 +26,7 @@ bunch_charge_C = 25.0e-12  # used with space charge
 npart = 100000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/spin_tracking/run_spin_map.py
+++ b/examples/spin_tracking/run_spin_map.py
@@ -26,7 +26,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/symplectic_integration/run_exact_cfbend.py
+++ b/examples/symplectic_integration/run_exact_cfbend.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/symplectic_integration/run_exact_cfbend_multipole.py
+++ b/examples/symplectic_integration/run_exact_cfbend_multipole.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/symplectic_integration/run_exact_quad.py
+++ b/examples/symplectic_integration/run_exact_quad.py
@@ -28,7 +28,7 @@ bunch_charge_C = 25.0e-12  # used with space charge
 npart = 10000  # number of macro particles
 
 # set reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 # factors converting the beam distribution to ImpactX input

--- a/examples/symplectic_integration/run_exact_quad_on_reference.py
+++ b/examples/symplectic_integration/run_exact_quad_on_reference.py
@@ -25,11 +25,11 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 qm_eev = 1.0 / 938.27208816 / 1e6  # electron charge/mass in e / eV
 
-pc = sim.particle_container()
+beam = sim.beam
 
 dx = [0.0]
 dpx = [0.0]
@@ -65,7 +65,7 @@ for p_dpy in dpy:
 for p_dpt in dpt:
     dpt_podv.push_back(p_dpt)
 
-pc.add_n_particles(
+beam.add_n_particles(
     dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, bunch_charge_C
 )
 

--- a/examples/symplectic_integration/run_fodo_multipole.py
+++ b/examples/symplectic_integration/run_fodo_multipole.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/symplectic_integration/run_sextupole.py
+++ b/examples/symplectic_integration/run_sextupole.py
@@ -26,11 +26,11 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 qm_eev = 1.0 / 938.27208816 / 1e6  # electron charge/mass in e / eV
 
-pc = sim.particle_container()
+beam = sim.beam
 
 df_initial = pd.read_csv("./initial_coords.csv", sep=" ")
 dx = df_initial["x"].to_numpy()
@@ -67,7 +67,7 @@ for p_dpy in dpy:
 for p_dpt in dpt:
     dpt_podv.push_back(p_dpt)
 
-pc.add_n_particles(
+beam.add_n_particles(
     dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, bunch_charge_C
 )
 

--- a/examples/thin_dipole/run_thin_dipole.py
+++ b/examples/thin_dipole/run_thin_dipole.py
@@ -24,7 +24,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch

--- a/examples/turn_update/run_turn_update.py
+++ b/examples/turn_update/run_turn_update.py
@@ -25,7 +25,7 @@ bunch_charge_C = 1.0e-9  # used with space charge
 npart = 10000  # number of macro particles
 
 #   reference particle
-ref = sim.particle_container().ref_particle()
+ref = sim.beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 #   particle bunch
@@ -65,8 +65,8 @@ def hook_before_period(sim):
     print("- Before turn:")
     print(f"  Updating lattice at turn {turn}, step {step}", flush=True)
 
-    beam = sim.particle_container()
-    ref = beam.ref_particle()
+    beam = sim.beam
+    ref = beam.ref
     rbc = beam.beam_moments()
     print(
         f"  Beam at s={ref.s:.2f}m, t={ref.t:.2f}s with beta_x={rbc['beta_x']}m",

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -700,10 +700,26 @@ void init_ImpactX (py::module& m)
 
         .def("particle_container",
              [](ImpactX & ix) -> ImpactXParticleContainer & {
+                py::warnings::warn(
+                    "particle_container() is deprecated. Use sim.beam instead.",
+                    PyExc_DeprecationWarning,
+                    2
+                );
                 return *ix.amr_data->track_particles.m_particle_container;
              },
              py::return_value_policy::reference_internal,
-             "Access the beam particle container."
+             "Access the beam particle container.\n\n"
+             "Deprecated: use ``sim.beam``."
+        )
+        // Getter-only property is intentional: it returns the live mutable
+        // ImpactXParticleContainer by reference.
+        // A writable property (with assignment) would be ambiguous:
+        // alias (Pythonic) or copy-in (safe) for the simulation-owned particle container.
+        .def_property_readonly("beam",
+            [](ImpactX & ix) -> ImpactXParticleContainer & {
+                return *ix.amr_data->track_particles.m_particle_container;
+            },
+            "Access the beam particle container."
         )
         .def(
             "rho",

--- a/src/python/ImpactXParticleContainer.cpp
+++ b/src/python/ImpactXParticleContainer.cpp
@@ -112,7 +112,7 @@ void init_impactxparticlecontainer(py::module& m)
             [](ImpactXParticleContainer & pc) -> RefPart & {
                 return pc.GetRefParticle();
             },
-            "Access the beam reference particle."
+            "Access the reference particle."
         )
         .def("ref_particle",
             [](ImpactXParticleContainer & pc) -> RefPart & {

--- a/src/python/ImpactXParticleContainer.cpp
+++ b/src/python/ImpactXParticleContainer.cpp
@@ -104,10 +104,28 @@ void init_impactxparticlecontainer(py::module& m)
              ":param sy: spin component in y\n"
              ":param sz: spin component in z\n"
         )
+        // Getter-only property is intentional: it returns the live mutable
+        // RefPart by reference.
+        // A writable property (with assignment) would be ambiguous:
+        // alias (Pythonic) or copy-in (safe) for the simulation-owned RefPart.
+        .def_property_readonly("ref",
+            [](ImpactXParticleContainer & pc) -> RefPart & {
+                return pc.GetRefParticle();
+            },
+            "Access the beam reference particle."
+        )
         .def("ref_particle",
-            py::overload_cast<>(&ImpactXParticleContainer::GetRefParticle),
+            [](ImpactXParticleContainer & pc) -> RefPart & {
+                py::warnings::warn(
+                    "ref_particle() is deprecated. Use beam.ref instead.",
+                    PyExc_DeprecationWarning,
+                    2
+                );
+                return pc.GetRefParticle();
+            },
             py::return_value_policy::reference_internal,
-            "Access the reference particle."
+            "Access the reference particle.\n\n"
+            "Deprecated: use ``beam.ref``."
         )
         .def("set_ref_particle",
              &ImpactXParticleContainer::SetRefParticle,

--- a/tests/python/dashboard/testdata/example.py
+++ b/tests/python/dashboard/testdata/example.py
@@ -13,10 +13,10 @@ kin_energy_MeV = 2000.0
 bunch_charge_C = 1e-09
 npart = 10000
 
-pc = sim.particle_container()
+beam = sim.beam
 
 # Reference particle
-ref = pc.ref_particle()
+ref = beam.ref
 ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
 distr = distribution.Waterbag(

--- a/tests/python/test_benchmark_elements.py
+++ b/tests/python/test_benchmark_elements.py
@@ -52,7 +52,7 @@ def sim(request):
 
             self.sim.init_grids()
 
-            beam = self.sim.particle_container()
+            beam = self.sim.beam
             beam.clear_particles()
 
             # load a 1 GeV electron beam with an initial
@@ -61,7 +61,7 @@ def sim(request):
             bunch_charge_C = 1.0e-9  # used with space charge
 
             #   reference particle
-            ref = self.sim.particle_container().ref_particle()
+            ref = self.sim.beam.ref
             ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
             #   particle bunch
@@ -87,15 +87,13 @@ def sim(request):
                 self.sim.add_particles(bunch_charge_C, distr, npart, spin_vectors)
             else:
                 self.sim.add_particles(bunch_charge_C, distr, npart)
-            assert self.sim.particle_container().total_number_of_particles() == npart
+            assert self.sim.beam.total_number_of_particles() == npart
 
-            self.sim.backup_beam = self.sim.particle_container().make_alike()
-            self.sim.backup_beam.arena = self.sim.particle_container().arena
+            self.sim.backup_beam = self.sim.beam.make_alike()
+            self.sim.backup_beam.arena = self.sim.beam.arena
             assert self.sim.backup_beam.total_number_of_particles() == 0
 
-            self.sim.backup_beam.add_particles(
-                self.sim.particle_container(), local=True
-            )
+            self.sim.backup_beam.add_particles(self.sim.beam, local=True)
             assert self.sim.backup_beam.total_number_of_particles() == npart
 
             return self.sim
@@ -112,20 +110,20 @@ def sim(request):
 
 
 def pc_setup(sim):
-    """Fresh PC for each call of benchmark"""
+    """Fresh beam for each call of benchmark."""
 
     assert sim.backup_beam.total_number_of_particles() == npart
 
     # instead of drawing from the distribution again, create a 2nd
     # particle container and copy the same initial particles again.
-    pc = sim.particle_container()
-    # pc.arena = ... ??
-    pc.clear_particles()
-    pc.add_particles(sim.backup_beam, local=True)
+    beam = sim.beam
+    # beam.arena = ... ??
+    beam.clear_particles()
+    beam.add_particles(sim.backup_beam, local=True)
 
-    assert pc.total_number_of_particles() == npart
+    assert beam.total_number_of_particles() == npart
 
-    return (pc,), {}
+    return (beam,), {}
 
 
 def test_Aperture(benchmark, sim):

--- a/tests/python/test_dataframe.py
+++ b/tests/python/test_dataframe.py
@@ -37,8 +37,8 @@ def test_df_pandas(save_png=True):
     npart = 10000
 
     #   reference particle
-    pc = sim.particle_container()
-    ref = pc.ref_particle()
+    beam = sim.beam
+    ref = beam.ref
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch
@@ -55,10 +55,10 @@ def test_df_pandas(save_png=True):
     )
     sim.add_particles(bunch_charge_C, distr, npart)
 
-    assert pc.total_number_of_particles() == npart
+    assert beam.total_number_of_particles() == npart
 
     # record purely in memory
-    sim.particle_container().store_beam_moments = True
+    sim.beam.store_beam_moments = True
 
     # init accelerator lattice
     fodo = [
@@ -83,7 +83,7 @@ def test_df_pandas(save_png=True):
     sim.track_particles()
 
     # look at beam history (reduced beam diagnostics)
-    beam_moments = sim.particle_container().beam_moments_history()
+    beam_moments = sim.beam.beam_moments_history()
 
     if amr.ParallelDescriptor.IOProcessor():
         print(beam_moments)
@@ -95,7 +95,7 @@ def test_df_pandas(save_png=True):
             plt.show()
 
     # check local particles
-    df = pc.to_df(local=True)
+    df = beam.to_df(local=True)
     print(df)
 
     # ensure the column heads are correctly labeled
@@ -116,13 +116,13 @@ def test_df_pandas(save_png=True):
 
     # compare number of global particles
     # FIXME
-    # df = pc.to_df(local=False)
+    # df = beam.to_df(local=False)
     # if df is not None:
     #    assert npart == len(df)
     #    assert df.columns.tolist() == ['idcpu', 'position_x', 'position_y', 'position_t', 'momentum_x', 'momentum_y', 'momentum_t', 'qm', 'weighting']
 
     # plot
-    fig = pc.plot_phasespace()
+    fig = beam.plot_phasespace()
 
     #   note: figure data available on MPI rank zero
     if fig is not None:

--- a/tests/python/test_element_lifetime.py
+++ b/tests/python/test_element_lifetime.py
@@ -37,7 +37,7 @@ def run_minimal_simulation(sim, lattice_elements):
     bunch_charge_C = 1.0e-9
     npart = 100
 
-    ref = sim.particle_container().ref_particle()
+    ref = sim.beam.ref
     ref.set_charge_qe(1.0).set_mass_MeV(938.27208816).set_kin_energy_MeV(kin_energy_MeV)
 
     distr = distribution.Waterbag(

--- a/tests/python/test_impactx.py
+++ b/tests/python/test_impactx.py
@@ -40,7 +40,6 @@ def validate_fodo(beam):
     # in situ calculate the reduced beam characteristics
     rbc = beam.beam_moments()
     ref = beam.ref_particle()
-
     print("charge=", rbc["charge_C"])
     assert np.allclose(
         [
@@ -83,7 +82,7 @@ def test_impactx_fodo_file():
     sim.track_particles()
 
     # validate the results
-    validate_fodo(sim.particle_container())
+    validate_fodo(sim.beam)
 
     # finalize simulation
     sim.finalize()
@@ -110,7 +109,7 @@ def test_impactx_nofile():
     npart = 10000
 
     #   reference particle
-    ref = sim.particle_container().ref_particle()
+    ref = sim.beam.ref
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch
@@ -127,7 +126,7 @@ def test_impactx_nofile():
     )
     sim.add_particles(bunch_charge_C, distr, npart)
 
-    beam = sim.particle_container()
+    beam = sim.beam
     assert beam.total_number_of_particles() == npart
 
     # init accelerator lattice
@@ -188,7 +187,7 @@ def test_impactx_noparticles():
     kin_energy_MeV = 2.0e3
 
     #   reference particle
-    ref = sim.particle_container().ref_particle()
+    ref = sim.beam.ref
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
     #   particle bunch: init intentionally missing
 
@@ -328,7 +327,27 @@ def test_impactx_fodo_hook():
     assert sim.tracking_element is None
 
     # validate the results
-    validate_fodo(sim.particle_container())
+    validate_fodo(sim.beam)
 
     # finalize simulation
+    sim.finalize()
+
+
+def test_deprecated_beam_ref_accessors_warn():
+    """Legacy accessor methods emit deprecation warnings."""
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.init_grids()
+
+    with pytest.warns(
+        DeprecationWarning, match="particle_container\\(\\) is deprecated"
+    ):
+        beam = sim.particle_container()
+
+    with pytest.warns(DeprecationWarning, match="ref_particle\\(\\) is deprecated"):
+        ref = beam.ref_particle()
+
+    ref.x = 1.5
+    assert beam.ref.x == pytest.approx(1.5)
+
     sim.finalize()

--- a/tests/python/test_particle_tiles.py
+++ b/tests/python/test_particle_tiles.py
@@ -28,8 +28,8 @@ def test_particle_tiles():
     npart = 10000
 
     #   reference particle
-    pc = sim.particle_container()
-    ref = pc.ref_particle()
+    beam = sim.beam
+    ref = beam.ref
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch
@@ -46,7 +46,7 @@ def test_particle_tiles():
     )
     sim.add_particles(bunch_charge_C, distr, npart)
 
-    assert pc.total_number_of_particles() == npart
+    assert beam.total_number_of_particles() == npart
 
     # init accelerator lattice
     fodo = [
@@ -62,8 +62,8 @@ def test_particle_tiles():
     sim.track_particles()
 
     # access local particles
-    for lvl in range(pc.finest_level + 1):
-        for pti in ImpactXParIter(pc, level=lvl):
+    for lvl in range(beam.finest_level + 1):
+        for pti in ImpactXParIter(beam, level=lvl):
             soa = pti.soa()
             real_arrays = soa.get_real_data()
             print(real_arrays)

--- a/tests/python/test_push.py
+++ b/tests/python/test_push.py
@@ -26,7 +26,7 @@ def test_element_push():
     npart = 10000
 
     #   reference particle
-    ref = sim.particle_container().ref_particle()
+    ref = sim.beam.ref
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch
@@ -43,8 +43,8 @@ def test_element_push():
     )
     sim.add_particles(bunch_charge_C, distr, npart)
 
-    pc = sim.particle_container()
-    assert pc.total_number_of_particles() == npart
+    beam = sim.beam
+    assert beam.total_number_of_particles() == npart
 
     # init accelerator lattice
     drift = elements.Drift(name="drift1", ds=0.25)
@@ -61,12 +61,12 @@ def test_element_push():
     sim.track_particles()
 
     # Push manually through a few (unnamed) elements
-    elements.Quad(ds=1.0, k=1.0).push(pc)
-    elements.Drift(ds=0.5).push(pc)
-    elements.Quad(ds=1.0, k=-1.0).push(pc)
+    elements.Quad(ds=1.0, k=1.0).push(beam)
+    elements.Drift(ds=0.5).push(beam)
+    elements.Quad(ds=1.0, k=-1.0).push(beam)
 
     # alternative formulation
-    push(pc, elements.Drift(ds=0.25))
+    push(beam, elements.Drift(ds=0.25))
 
     # push only the reference particle
     assert ref.s == 3.0

--- a/tests/python/test_transformation.py
+++ b/tests/python/test_transformation.py
@@ -42,8 +42,8 @@ def test_transformation():
     npart = 10000  # number of macro particles
 
     #   reference particle
-    pc = sim.particle_container()
-    ref = pc.ref_particle()
+    beam = sim.beam
+    ref = beam.ref
     ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch
@@ -59,23 +59,23 @@ def test_transformation():
         mutpt=0.8,
     )
     sim.add_particles(bunch_charge_C, distr, npart)
-    rbc_s0 = pc.beam_moments()
+    rbc_s0 = beam.beam_moments()
 
     # this must fail: we cannot transform from s to s
     with pytest.raises(Exception):
-        coordinate_transformation(pc, direction=CoordSystem.s)
+        coordinate_transformation(beam, direction=CoordSystem.s)
 
     # transform to t
-    coordinate_transformation(pc, direction=CoordSystem.t)
-    rbc_t = pc.beam_moments()
+    coordinate_transformation(beam, direction=CoordSystem.t)
+    rbc_t = beam.beam_moments()
 
     # this must fail: we cannot transform from t to t
     with pytest.raises(Exception):
-        coordinate_transformation(pc, direction=CoordSystem.t)
+        coordinate_transformation(beam, direction=CoordSystem.t)
 
     # transform back to s
-    coordinate_transformation(pc, direction=CoordSystem.s)
-    rbc_s = pc.beam_moments()
+    coordinate_transformation(beam, direction=CoordSystem.s)
+    rbc_s = beam.beam_moments()
 
     # finalize simulation
     sim.finalize()

--- a/tests/python/test_wake.py
+++ b/tests/python/test_wake.py
@@ -36,8 +36,8 @@ def test_wake(save_png=True):
     sigma_t = 1.9975134930563207e-05
 
     if element_has_csr:
-        pc = sim.particle_container()
-        x_min, y_min, t_min, x_max, y_max, t_max = pc.min_and_max_positions()
+        beam = sim.beam
+        x_min, y_min, t_min, x_max, y_max, t_max = beam.min_and_max_positions()
 
         is_unity_particle_weight = False
         GetNumberDensity = True
@@ -53,7 +53,7 @@ def test_wake(save_png=True):
 
         # Call deposit_charge with the correct type
         wakeconvolution.deposit_charge(
-            pc,
+            beam,
             charge_distribution,
             bin_min,
             bin_size,

--- a/tests/python/test_xopt.py
+++ b/tests/python/test_xopt.py
@@ -104,7 +104,7 @@ def run(parameters: dict, write_particles=False, write_reduced=False) -> dict:
     npart = 10000  # number of macro particles
 
     #   reference particle
-    ref = sim.particle_container().ref_particle()
+    ref = sim.beam.ref
     ref.set_species("positron").set_kin_energy_MeV(kin_energy_MeV)
 
     #   particle bunch
@@ -128,7 +128,7 @@ def run(parameters: dict, write_particles=False, write_reduced=False) -> dict:
     sim.track_particles()
 
     # in situ calculate the reduced beam characteristics
-    beam = sim.particle_container()
+    beam = sim.beam
     rbc = beam.beam_moments()
 
     # clean shutdown


### PR DESCRIPTION
In my quest to make Python input files more user-friendly, this is the next step. Introduce shortcuts for:

- `sim.beam`: alias for `sim.particle_container()`
- `sim.beam.ref`: alias for `sim.particle_container().ref_particle()`

The first commit updates the implementation and adds a deprecation warning for the old long form. The second commit updates all tests & examples.