### PR TITLE
Doc: AI Agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,145 @@
+# AGENTS Guidelines for This Repository
+
+## Project Overview
+
+ImpactX is a high-performance beam dynamics code for particle accelerators with collective effects, the next generation of the IMPACT-Z code. It is built on top of AMReX (adaptive mesh refinement framework) and shares the ABLASTR abstraction layer with WarpX. Particle tracking uses the reference trajectory path length `s` as the independent variable, with symplectic integrators and self-fields (space charge, CSR, wakefields). It runs on CPU/OpenMP, CUDA, HIP, and SYCL backends.
+
+## Development Environment
+
+If you cannot find the `cmake` or `ctest` command, activate the conda environment named `impactx-cpu-mpich-dev` before running shell commands that compile or test ImpactX.
+The `conda` command may be called `conda`, `mamba`, or `micromamba` depending on the system (check aliases and available binaries):
+```bash
+conda activate impactx-cpu-mpich-dev
+```
+If this environment does not yet exist, create it as described in `docs/source/install/dependencies.rst`.
+
+## Build Commands
+
+The cmake build directory is always inside the repository root (or worktree root). Never look for or create a build directory outside of the current working directory.
+
+```bash
+# Configure (common development build with Python bindings)
+cmake --fresh -S . -B build -DImpactX_PYTHON=ON
+
+# Build
+cmake --build build -j 8
+
+# Install Python bindings
+cmake --build build --target pip_install
+
+# Faster rebuild (skip dependency checks)
+cmake --build build -j 8 --target pip_install_nodeps
+
+# Faster link times during development
+cmake -S . -B build -DImpactX_PYTHON=ON -DImpactX_PYTHON_IPO=OFF -DpyAMReX_IPO=OFF
+```
+
+Key CMake options:
+- `-DImpactX_COMPUTE=OMP` — backend: `NOACC`, `OMP`, `CUDA`, `SYCL`, `HIP`
+- `-DImpactX_MPI=ON` — multi-node support
+- `-DImpactX_PYTHON=ON` — Python bindings
+- `-DImpactX_OPENPMD=ON` — HDF5/ADIOS I/O (on by default)
+- `-DImpactX_FFT=ON` — FFT-based solvers (IGF space charge, CSR)
+- `-DImpactX_PRECISION=DOUBLE` — floating point precision: `SINGLE` or `DOUBLE`
+- `-DImpactX_SIMD=ON` — CPU SIMD acceleration
+
+## Testing
+
+Tests use CTest. Each example in `examples/` has an input file (or Python script), an analysis script, and optionally a plot script. Python unit tests live under `tests/python/` and are run via pytest.
+
+```bash
+# List tests
+ctest --test-dir build -N
+
+# Run all tests
+ctest --test-dir build --output-on-failure
+
+# Run specific test by regex
+ctest --test-dir build -R FODO
+
+# Run exact test
+ctest --test-dir build -R "^FODO\..*"
+```
+
+Test output goes to `build/bin/<test_name>/`.
+
+- When debugging/fixing tests: do not modify the tolerance of assert statements in the Python analysis files just to make the tests pass (unless explicitly asked to do so).
+
+### Adding a Test
+
+Use `add_impactx_test()` in `examples/CMakeLists.txt`:
+
+```cmake
+add_impactx_test(<name>
+    examples/<dir>/<input_or_script>   # input file (.in) or Python script (.py)
+    OFF                                 # is_mpi: ON to run with mpirun
+    examples/<dir>/analysis_<...>.py    # validation script
+    examples/<dir>/plot_<...>.py        # optional plot script
+)
+```
+
+Tests must be quick to run on a 2 core CI CPU runner (ideally <30sec) and be written in a CPU/GPU portable way.
+Analysis functions validate the outputs are as expected (e.g., Twiss parameters, emittances, moments).
+
+## Auto-Generated Files
+
+- **`.pyi` stub files** under `src/python/impactx/`: Never modify. They are auto-generated on the `development` branch after a PR is merged (see `.github/workflows/stubs.yml`).
+
+## Linting and Formatting
+
+Pre-commit hooks handle formatting:
+```bash
+python -m pip install -U pre-commit
+pre-commit install
+pre-commit run -a  # run on all files
+```
+
+- **Python**: Ruff (configured in `pyproject.toml`)
+- **C++**: no auto-formatter; follow the style below and existing code
+
+Commits should limit any formatting changes of unchanged code.
+
+## Code Architecture
+
+### Source Layout
+
+- `src/ImpactX.H/.cpp` — main simulation class `impactx::ImpactX`
+- `src/main.cpp` — standalone executable entry point
+- `src/tracking/` — tracking loops (`track_particles`, `track_envelope`, `track_reference`)
+- `src/elements/` — lattice elements (drifts, dipoles, quadrupoles, RF cavities, plasma lenses, apertures, …); `All.H` lists the `KnownElements` variant
+- `src/particles/` — `ImpactXParticleContainer`, distributions, integrators, charge deposition, collect-lost
+- `src/envelope/` — linear envelope tracking via the covariance matrix
+- `src/initialization/` — AMReX setup, input parsing, mesh refinement, distribution & element initialization
+- `src/diagnostics/` — reduced beam characteristics, emittance invariants, openPMD output
+- `src/python/` — pybind11 bindings (`pyImpactX.cpp`, element/distribution bindings)
+- `src/python/impactx/` — Python module (dashboard, MADX import, plotting helpers)
+- `examples/` — physics-driven integration tests (FODO, chicane, cyclotron, IOTA, …)
+- `tests/python/` — pytest-based unit tests
+
+### Key Patterns
+
+- Core simulation state (AMR hierarchy, fields, particle containers) lives in `impactx::initialization::AmrCoreData`, accessed via `ImpactX::amr_data`
+- Lattice stored as `std::list<elements::KnownElements> m_lattice` on `ImpactX`; new elements are added to the `KnownElements` variant in `src/elements/All.H`
+- Space-charge and CSR solvers and many utilities come from `ABLASTR` (shared with WarpX, fetched into `build/_deps/fetchedablastr-src/`)
+- Python bindings are generated via `pybind11` and `pyAMReX`; after C++ changes, rebuild with the `pip_install` target
+- The independent variable of motion is the reference trajectory path length `s` (not time); all integrators are symplectic
+
+## C++ Style
+
+- 4 spaces indentation, no tabs, max 100 chars/line
+- Member variables prefixed with `m_`
+- CamelCase for files and classes (e.g., `ImpactXParticleContainer.H`)
+- Space before `()` in function declarations and definitions
+- Opening brace `{` on new line for functions/classes
+- Always use curly braces for single-statement blocks
+- Use `amrex::` namespace prefix (avoid `using namespace amrex`); ImpactX code lives in `namespace impactx { … }`
+
+### Include Order
+
+In `.cpp` files: (1) corresponding header, (2) ImpactX headers, (3) ImpactX forward declarations, (4) ABLASTR headers, (5) AMReX headers, (6) AMReX forward declarations, (7) third-party headers (pybind11, openPMD, …), (8) standard library. Each group alphabetically sorted with blank lines between groups.
+
+## Version Control
+
+- Main branch: `development` (not `main`)
+- Fork-and-branch workflow; PRs target `development`
+- Pull requests with features and bug fixes need to add a test for coverage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,9 @@ Key CMake options:
 
 Tests use CTest. Each example in `examples/` has an input file (or Python script), an analysis script, and optionally a plot script. Python unit tests live under `tests/python/` and are run via pytest.
 
+You can run the Python unit tests directly with `pytest` from `tests/python/`, but this requires that `cmake --build build --target pip_install` has been run first so the Python package is installed and importable.
+The pytest-based tests are also registered in CTest. Running them via `ctest` is often preferable during development because CTest sets the needed environment variables (especially `PYTHONPATH`) so the build tree is preferred automatically.
+
 ```bash
 # List tests
 ctest --test-dir build -N

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/blast-impactx/impactx",
+  "public_key": "pk_l8yoMPvm1YmDQDFMZagmO"
+}

--- a/docs/source/developers/how_to_develop_with_llms.rst
+++ b/docs/source/developers/how_to_develop_with_llms.rst
@@ -1,0 +1,86 @@
+.. _developers-llm:
+
+LLM-Assisted ImpactX Development
+================================
+
+Large Language Models (LLMs) can assist with ImpactX development tasks such as navigating the codebase, understanding existing implementations, writing new features, debugging, adding tests, and preparing pull requests.
+This guide documents how the ImpactX repository is configured for LLM-based coding assistants and how to get the most out of them.
+
+.. note::
+
+   LLM-generated code should always be reviewed carefully.
+   LLMs can hallucinate APIs, miss physics constraints, or produce code that compiles but is incorrect.
+   The configurations described below help by providing accurate, up-to-date context, but developer judgment remains essential.
+
+   The ImpactX community thus urges you to perform a careful, manual review of all LLM-generated code and documentation before asking for a review of your pull-request.
+   This is important, otherwise you risk to waste the valuable time of our most proficient developers that will need to review your LLM-generated code.
+   (Be considerate that ImpactX developers can prompt an LLM just as efficiently as you can. Your critical thinking skill to make sense of the LLM-generated code and make it sensible for review and maintainable for the long term is what is needed!)
+
+.. note::
+
+   This section is not understood as an endorsement of any of the listed (or unlisted) coding assistants or MCP services.
+   Contributions to this section documenting further services, clients, skills, etc. are encouraged.
+
+.. tip::
+
+   When working with LLM coding assistants, keep in mind that *"most best practices are based on one constraint: [the] context window fills up fast, and performance degrades as it fills"* (`Claude Code Best Practices <https://code.claude.com/docs/en/best-practices>`__).
+   Keep instructions concise, use plan modes, break complex tasks into focused sessions, and provide targeted context rather than overwhelming the assistant with information.
+
+
+AGENTS.md / CLAUDE.md
+---------------------
+
+The repository can include an ``AGENTS.md`` file at its root (as well as a ``CLAUDE.md``, which directly points to ``AGENTS.md``).
+These files are automatically loaded by LLM coding assistants (Claude Code reads ``CLAUDE.md``; other tools such as OpenAI Codex CLI read ``AGENTS.md``) to provide project-specific instructions.
+
+The file contains in a compressed form instructions for an LLM agent:
+With this file present, an LLM assistant working inside the ImpactX repository will automatically know how to build, test, and style code without being told each time.
+
+To update these instructions, edit ``AGENTS.md``.
+Keep this file under 300 lines to preserve LLM context.
+
+
+Skills
+------
+
+LLM assistants such as Claude Code support reusable *skills* — scripted workflows that an assistant can execute on demand, automating multi-step tasks that follow a fixed procedure.
+When defined for ImpactX, skills live in the ``.claude/skills/`` directory and use the prefix ``impactx-`` for easy discovery (start typing ``/impactx`` to see them).
+
+To add a new skill, create a directory under ``.claude/skills/<skill-name>/`` containing a ``SKILL.md`` file that describes the step-by-step procedure.
+
+
+Documentation Context via MCP Servers
+--------------------------------------
+
+LLM assistants work best when they can query up-to-date project documentation.
+The :ref:`AI-Assisted Input File Design <ai_input_design>` workflow page describes how to set up `Model Context Protocol (MCP) <https://modelcontextprotocol.io>`__ servers for this purpose.
+That setup is equally useful for development tasks: the same documentation context that helps write input files also helps an assistant understand ImpactX internals, AMReX, pyAMReX, and ABLASTR APIs, and conventions when writing C++ or Python code.
+
+See :ref:`ai_input_design` for general MCP setup instructions with Context7.
+
+ImpactX and Dependency Documentation on Context7
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`Context7 <https://context7.com>`__ is a service that indexes open-source project documentation and serves it through the MCP protocol.
+Since ImpactX builds on top of `AMReX <https://amrex-codes.github.io/amrex/>`__, `pyAMReX <https://pyamrex.readthedocs.io>`__, `ABLASTR <https://github.com/BLAST-WarpX/warpx>`__ (shared with WarpX), and `openPMD-api <https://openpmd-api.readthedocs.io>`__, providing documentation for these dependencies alongside ImpactX documentation gives the assistant much richer context for development tasks.
+
+The following documentation is available through Context7:
+
+- **ImpactX**: `context7.com/blast-impactx/impactx <https://context7.com/blast-impactx/impactx>`__
+- **WarpX / ABLASTR**: `context7.com/blast-warpx/warpx <https://context7.com/blast-warpx/warpx>`__
+- **AMReX**: `context7.com/amrex-codes/amrex <https://context7.com/amrex-codes/amrex>`__
+- **pyAMReX**: `context7.com/amrex-codes/pyamrex <https://context7.com/amrex-codes/pyamrex>`__
+- **openPMD-api**: `context7.com/openpmd/openpmd-api <https://context7.com/openpmd/openpmd-api>`__
+- **openPMD-viewer**: `context7.com/openpmd/openpmd-viewer <https://context7.com/openpmd/openpmd-viewer>`__
+- **pybind11**: `context7.com/pybind/pybind11 <https://context7.com/pybind/pybind11>`__
+
+When Context7 is connected, the assistant can look up any of those when needed:
+AMReX data structures (e.g., ``MultiFab``, ``ParticleContainer``, ``Geometry``), pyAMReX and pybind11 binding patterns, ABLASTR utilities shared with WarpX, and openPMD I/O APIs directly, which is especially helpful when working, for instance, on:
+
+- Beam-dynamics elements and lattice transport routines
+- Space-charge and collective-effects solvers that use AMReX mesh data structures
+- Particle routines built on ``amrex::ParticleContainer``
+- Python bindings that wrap C++ classes via pybind11 and pyAMReX
+- I/O and diagnostic code that interacts with AMReX plotfiles or openPMD
+
+For instructions on configuring Context7 as an MCP server in your coding assistant (Claude Code, Cursor, VS Code, Windsurf, Codex CLI, and others), see the `Context7 client documentation <https://context7.com/docs/resources/all-clients>`__ and the :ref:`ai_input_design` page.

--- a/docs/source/developers/how_to_develop_with_llms.rst
+++ b/docs/source/developers/how_to_develop_with_llms.rst
@@ -44,7 +44,7 @@ Skills
 ------
 
 LLM assistants such as Claude Code support reusable *skills* — scripted workflows that an assistant can execute on demand, automating multi-step tasks that follow a fixed procedure.
-When defined for ImpactX, skills live in the ``.claude/skills/`` directory and use the prefix ``impactx-`` for easy discovery (start typing ``/impactx`` to see them).
+When (later) defined for ImpactX, skills will live in the ``.claude/skills/`` directory and use the prefix ``impactx-`` for easy discovery (start typing ``/impactx`` to see them).
 
 To add a new skill, create a directory under ``.claude/skills/<skill-name>/`` containing a ``SKILL.md`` file that describes the step-by-step procedure.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -120,6 +120,7 @@ Development
    developers/doxygen
    developers/python
    developers/debugging
+   developers/how_to_develop_with_llms
 
 Maintenance
 -----------

--- a/docs/source/usage/howto.rst
+++ b/docs/source/usage/howto.rst
@@ -9,3 +9,4 @@ This section collects typical user workflows and best practices for ImpactX.
    :maxdepth: 1
 
    howto/add_element
+   howto/ai_input_design

--- a/docs/source/usage/howto/ai_input_design.rst
+++ b/docs/source/usage/howto/ai_input_design.rst
@@ -1,0 +1,74 @@
+.. _ai_input_design:
+
+AI (LLM)-Assisted Input File Design
+===================================
+
+Large Language Models (LLMs) can accelerate the process of creating and modifying ImpactX Python scripts and input files.
+By providing an LLM-based coding assistant with ImpactX documentation as context, users can describe an accelerator lattice and beam configuration in natural language and receive a draft Python script or parameter list file, ask for explanations of existing parameters, or request modifications to an existing configuration.
+
+This workflow is equally applicable to:
+
+- **ImpactX Python scripts** (:ref:`Parameters: Python <usage-python>`)
+- **ImpactX parameter list files** (:ref:`Parameters: Inputs File <running-cpp-parameters>`)
+
+.. note::
+
+   LLM-generated Python scripts and input files should always be reviewed carefully before use.
+   LLMs tend to hallucinate options that do not exist or might miss the mental context of your physics.
+   The guide below tries to improve this situation by providing LLMs all ImpactX examples and documentation automatically, but this remains an active and rapidly evolving field of tooling.
+
+   Validate physics parameters (lattice element lengths and strengths, beam energy and distribution, space-charge and CSR settings, integrator step counts) against your domain knowledge and the `ImpactX documentation <https://impactx.readthedocs.io>`__.
+
+
+.. note::
+
+   This section is not understood as an endorsement of any of the listed (or unlisted) coding assistants or MCP services.
+   Contributions to this section documenting further services, clients, skills, etc are encouraged.
+
+How It Works: MCP Servers
+-------------------------
+
+`Model Context Protocol (MCP) <https://modelcontextprotocol.io>`__ servers are a standardized way to provide external context, such as library documentation, to LLM-based coding assistants.
+When an MCP server is configured, the assistant can query up-to-date ImpactX documentation on demand, rather than relying solely on its training data.
+
+Setting Up Context7 as an MCP Server
+------------------------------------
+
+`Context7 <https://context7.com>`__ is a service that indexes open-source project documentation and serves it through the MCP protocol.
+ImpactX documentation is available at:
+
+    `context7.com/blast-impactx/impactx <https://context7.com/blast-impactx/impactx>`__
+
+When writing Python scripts, users will also encounter `pyAMReX <https://pyamrex.readthedocs.io>`__ APIs (e.g., for accessing mesh and particle data, or for extending simulations with callbacks):
+
+- **pyAMReX**: `context7.com/amrex-codes/pyamrex <https://context7.com/amrex-codes/pyamrex>`__
+
+To configure Context7 for your coding assistant, see the `Context7 documentation <https://context7.com/docs/resources/all-clients>`__.
+Once connected, a coding assistant (Claude Code, Cursor, VS Code Copilot, Windsurf, etc.) can retrieve relevant sections of all the above projects in real time when helping you write or debug Python scripts and input files.
+
+.. tip::
+
+   Some clients support optional API key authentication.
+   See the `Context7 client docs <https://context7.com/docs/resources/all-clients>`__ for details on API keys and OAuth options.
+
+After creating a personal account, Context7 is free within limits for open source projects.
+
+Best Practices
+--------------
+
+When working with LLM coding assistants, keep in mind that *"most best practices are based on one constraint: [the] context window fills up fast, and performance degrades as it fills"* (`Claude Code Best Practices <https://code.claude.com/docs/en/best-practices>`__).
+Starting from examples and iterating incrementally as described below and making a plan with the LLM assistant helps keep sessions focused and productive.
+
+#. **Start from examples.**
+   Run your coding agent inside the ImpactX source directory.
+   Point the assistant to an existing Python script or input file from the ``examples/`` directory (e.g., ``fodo``, ``chicane``, ``iota_lens``) and ask it to adapt the setup to your needs.
+
+#. **Iterate incrementally.**
+   Start with a minimal working lattice, verify it runs, then ask the assistant to add complexity (additional elements, space-charge or CSR, diagnostics, alignment errors, etc.).
+
+#. **Cross-check with documentation.**
+   Use the assistant to look up parameter meanings and valid ranges in the ImpactX docs, especially for numerical parameters like the integrator step counts (``nslice``), space-charge mesh resolution, and Poisson solver settings.
+
+#. **Validate before production runs.**
+   Always run a short test simulation and inspect the output before committing to a large-scale run.
+   The ``examples/`` directory contains analysis scripts (``analysis_*.py``) that can serve as templates for validation.

--- a/docs/source/usage/howto/ai_input_design.rst
+++ b/docs/source/usage/howto/ai_input_design.rst
@@ -23,7 +23,7 @@ This workflow is equally applicable to:
 .. note::
 
    This section is not understood as an endorsement of any of the listed (or unlisted) coding assistants or MCP services.
-   Contributions to this section documenting further services, clients, skills, etc are encouraged.
+   Contributions to this section documenting further services, clients, skills, etc. are encouraged.
 
 How It Works: MCP Servers
 -------------------------

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -7,6 +7,10 @@ This documents how to use ImpactX with an input file (``impactx input_file.in``)
 
 .. tip::
 
+   If you enjoy AI/LLM/agentic workflows, see our :ref:`AI (LLM)-Assisted Input File Design <ai_input_design>` section, too.
+
+.. tip::
+
    Input files use the AMReX `ParmParse <https://amrex-codes.github.io/amrex/docs_html/Basics.html#parmparse>`__ syntax.
    A `parser <https://amrex-codes.github.io/amrex/docs_html/Basics.html#parser>`__) is used for the right-hand-side of all input parameters that consist of one or more integers or floats, so expressions like ``beam.kin_energy = "2.+1."``, ``beam.lambdaY = beam.lambdaX`` and/or using :ref:`user-defined constants <running-cpp-parameters-parser>` are accepted.
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -5,6 +5,10 @@ Parameters: Python
 
 This documents on how to use ImpactX as a Python script (``python3 run_script.py``).
 
+.. tip::
+
+   If you enjoy AI/LLM/agentic workflows, see our :ref:`AI (LLM)-Assisted Input File Design <ai_input_design>` section, too.
+
 Collective Effects & Overall Simulation Parameters
 --------------------------------------------------
 


### PR DESCRIPTION
In the last month, we did a lot of work on documenting AI agentic use in WarpX. This pulls in the docs, best practices for [users](https://impactx--1404.org.readthedocs.build/en/1404/usage/howto/ai_input_design.html) and [developers](https://impactx--1404.org.readthedocs.build/en/1404/developers/how_to_develop_with_llms.html), and claim file for our [Context7 page](https://context7.com/blast-impactx/impactx) equally into ImpactX and adopts them as appropriate.

Original in WarpX co-authored by @RemiLehe 😊