### PR TITLE
LinearTransport Mixin: Declare Implemented

### DIFF
--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -33,7 +33,7 @@ namespace impactx::elements
     struct Aperture
     : public mixin::Named,
       public mixin::BeamOptic<Aperture>,
-      public mixin::LinearTransport<Aperture>,
+      public mixin::LinearTransport<Aperture, false>,
       public mixin::Thin,
       public mixin::Alignment,
       public mixin::NoFinalize,

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -33,7 +33,7 @@ namespace impactx::elements
     struct ChrAcc
     : public mixin::Named,
       public mixin::BeamOptic<ChrAcc>,
-      public mixin::LinearTransport<ChrAcc>,
+      public mixin::LinearTransport<ChrAcc, false>,
       public mixin::Thick,
       public mixin::Alignment,
       public mixin::PipeAperture,

--- a/src/elements/Multipole.H
+++ b/src/elements/Multipole.H
@@ -32,7 +32,7 @@ namespace impactx::elements
     struct Multipole
     : public mixin::Named,
       public mixin::BeamOptic<Multipole>,
-      public mixin::LinearTransport<Multipole>,
+      public mixin::LinearTransport<Multipole, false>,
       public mixin::Thin,
       public mixin::Alignment,
       public mixin::NoFinalize

--- a/src/elements/NonlinearLens.H
+++ b/src/elements/NonlinearLens.H
@@ -35,7 +35,7 @@ namespace impactx::elements
     struct NonlinearLens
     : public mixin::Named,
       public mixin::BeamOptic<NonlinearLens>,
-      public mixin::LinearTransport<NonlinearLens>,
+      public mixin::LinearTransport<NonlinearLens, false>,
       public mixin::Thin,
       public mixin::Alignment,
       public mixin::NoFinalize

--- a/src/elements/PRot.H
+++ b/src/elements/PRot.H
@@ -33,7 +33,7 @@ namespace impactx::elements
     struct PRot
     : public mixin::Named,
       public mixin::BeamOptic<PRot>,
-      public mixin::LinearTransport<PRot>,
+      public mixin::LinearTransport<PRot, false>,
       public mixin::Thin,
       public mixin::NoFinalize,
       public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>

--- a/src/elements/PolygonAperture.H
+++ b/src/elements/PolygonAperture.H
@@ -52,7 +52,7 @@ namespace impactx::elements
     struct PolygonAperture
     : public mixin::Named,
       public mixin::BeamOptic<PolygonAperture>,
-      public mixin::LinearTransport<PolygonAperture>,
+      public mixin::LinearTransport<PolygonAperture, false>,
       public mixin::Thin,
       public mixin::Alignment,
       public mixin::NoFinalize

--- a/src/elements/Programmable.H
+++ b/src/elements/Programmable.H
@@ -30,7 +30,7 @@ namespace impactx::elements
 {
     struct Programmable
     : public mixin::Named,
-      public mixin::LinearTransport<Programmable>
+      public mixin::LinearTransport<Programmable, false>
       // TODO: public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
     {
         static constexpr auto type = "Programmable";

--- a/src/elements/TaperedPL.H
+++ b/src/elements/TaperedPL.H
@@ -32,7 +32,7 @@ namespace impactx::elements
     struct TaperedPL
     : public mixin::Named,
       public mixin::BeamOptic<TaperedPL>,
-      public mixin::LinearTransport<TaperedPL>,
+      public mixin::LinearTransport<TaperedPL, false>,
       public mixin::Thin,
       public mixin::Alignment,
       public mixin::NoFinalize

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -32,7 +32,7 @@ namespace impactx::elements
     struct ThinDipole
     : public mixin::Named,
       public mixin::BeamOptic<ThinDipole>,
-      public mixin::LinearTransport<ThinDipole>,
+      public mixin::LinearTransport<ThinDipole, false>,
       public mixin::Thin,
       public mixin::Alignment,
       public mixin::NoFinalize,

--- a/src/elements/mixin/lineartransport.H
+++ b/src/elements/mixin/lineartransport.H
@@ -1,4 +1,4 @@
-/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
  *           Berkeley National Laboratory (subject to receipt of any required
  *           approvals from the U.S. Dept. of Energy). All rights reserved.
  *
@@ -19,21 +19,36 @@
 #include <AMReX_REAL.H>
 #include <AMReX_SmallMatrix.H>
 
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
 
 namespace impactx::elements::mixin
 {
-    /** This is a helper class for lattice elements that can be expressed as linear transport maps.
+    /** Mixin for lattice elements that can be expressed as linear transport maps.
+     *
+     *  @tparam T_Element   the concrete element type (CRTP).
+     *  @tparam Implemented whether the element provides a real linear
+     *                      transport map. Defaults to @c true (the element
+     *                      must define its own @c transport_map). Elements
+     *                      that have not yet implemented a linear map
+     *                      inherit @c LinearTransport<E, false>: the
+     *                      partial specialization below provides a default
+     *                      throwing @c transport_map so linear-optics
+     *                      diagnostics and envelope tracking get a uniform,
+     *                      self-documenting error. Such elements are still
+     *                      free to define their own @c transport_map with a
+     *                      more specific message; normal C++ name lookup
+     *                      shadows the mixin's default.
+     *
+     *  Diagnostics use @c std::is_base_of_v<LinearTransport<T, true>, T>
+     *  as the compile-time "has a real linear map" trait.
      */
-    template<typename T_Element>
+    template <typename T_Element, bool Implemented = true>
     struct LinearTransport
     {
-        LinearTransport () = default;
-        LinearTransport (LinearTransport const &) = default;
-        LinearTransport& operator= (LinearTransport const &) = default;
-        LinearTransport (LinearTransport&&) = default;
-        LinearTransport& operator= (LinearTransport&& rhs) = default;
-
-        ~LinearTransport () = default;
+        static constexpr bool has_linear_transport = Implemented;
 
         /** Linear push of the covariance matrix through an element
          *
@@ -56,6 +71,62 @@ namespace impactx::elements::mixin
 
             // small trick to force every derived class has to implement a method transport_map
             // (w/o using a purely virtual function)
+            T_Element const & element = *static_cast<T_Element const*>(this);
+            cm = element.transport_map(ref) * cm * element.transport_map(ref).transpose();
+        }
+    };
+
+    /** Partial specialization for elements that have not yet implemented a
+     *  linear transport map.
+     *
+     *  Provides:
+     *    - a default @c transport_map that throws a uniform, self-documenting
+     *      error (so neither the element nor its callers need custom error
+     *      handling), and
+     *    - the same @c operator() as the primary template, routed through
+     *      the element's (possibly inherited) @c transport_map, which keeps
+     *      downstream code (envelope tracking, @c lattice.transfer_map,
+     *      @c map_trace) uniform across "implemented" and "not implemented"
+     *      elements.
+     *
+     *  Elements that want a more specific error message can still provide
+     *  their own @c transport_map, which shadows the inherited one via
+     *  normal C++ name lookup.
+     */
+    template <typename T_Element>
+    struct LinearTransport<T_Element, false>
+    {
+        static constexpr bool has_linear_transport = false;
+
+        /** Uniform, self-documenting fallback for elements whose linear
+         *  transport map is not yet implemented.
+         */
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
+        Map6x6
+        transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
+        {
+            throw std::runtime_error(
+                std::string(T_Element::type)
+                + ": Linear transport map is not yet implemented for this element."
+            );
+        }
+
+        /** Covariance-matrix push; identical to the primary template. Routed
+         *  through the element's @c transport_map so that any element-side
+         *  override (custom error message) is picked up.
+         */
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
+        void
+        operator() (
+            Map6x6 & AMREX_RESTRICT cm,
+            RefPart const & AMREX_RESTRICT ref
+        ) const
+        {
+            static_assert(
+                std::is_base_of_v<LinearTransport, T_Element>,
+                "LinearTransport can only be used as a mixin class!"
+            );
+
             T_Element const & element = *static_cast<T_Element const*>(this);
             cm = element.transport_map(ref) * cm * element.transport_map(ref).transpose();
         }


### PR DESCRIPTION
We usually only use `mixin` classes once we also declare that something is implemented.

For `LinearTransport` we use some logic that allows to throw and be replaced with identify matrices, if the user choses so. Adding a 2nd template argument to unify the runtime exceptions and to have signature that we can build C++ type traits on.

Purely backend refactoring, no bug fix or feature.