### PR TITLE
[WIP] Linear Transport: Centroid Tracking

### DIFF
--- a/src/diagnostics/LinearMap.H
+++ b/src/diagnostics/LinearMap.H
@@ -67,25 +67,33 @@ namespace impactx::diagnostics
 
     /** Compose the linear transport map element-by-element along a lattice.
      *
-     *  Walks the lattice once, advancing a local copy of the reference
-     *  particle through each element's non-linear reference-particle push and
-     *  multiplying the cumulative 6x6 linear transport map by each element's
-     *  per-slice @c transport_map. The caller's reference particle is not
-     *  modified.
+     *  Walks the lattice once, advancing a local copy of the
+     *  reference particle and multiplying the cumulative 6x6 linear
+     *  transport map by each element's per-slice aligned lab-frame linear
+     *  step. Element-local @c transport_map(ref) remains the ideal/local map;
+     *  alignment and roll are mixed in centrally during the traversal. The
+     *  caller's reference particle is not modified.
      *
      *  Slice ordering inside each element matches the envelope tracker in
-     *  @c src/tracking/envelope.cpp : for each of @c nslice sub-steps, first
-     *  advance the reference particle by one slice, then evaluate
-     *  @c transport_map at the post-advance reference state. This keeps both
-     *  code paths consistent for elements whose linear map depends on the
-     *  reference momentum through the element (for example radio-frequency
-     *  cavities).
+     *  @c src/tracking/envelope.cpp : for each of @c nslice sub-steps, the
+     *  reference particle is advanced and the aligned lab-frame
+     *  linear map is evaluated at the post-advance reference state. This
+     *  keeps both code paths consistent for elements whose linear map depends
+     *  on the reference momentum through the element (for example
+     *  radio-frequency cavities).
      *
      *  Effects that are part of the non-linear tracker but not of the linear
      *  map are deliberately skipped here: space charge, Coherent Synchrotron
      *  Radiation (CSR), and Incoherent Synchrotron Radiation (ISR). The
      *  result is a purely element-by-element linear-optics trace appropriate
      *  for Twiss / tune / chromaticity / dispersion diagnostics.
+     *
+     *  Limitation: diagnostics follow each element's @c operator()(RefPart&)
+     *  contract for the reference particle. For @c Multipole, that
+     *  ideal reference push remains a zero-length no-op, so off-axis
+     *  higher-order multipoles contribute local feed-down to the linear map
+     *  but do not propagate constant ideal orbit kicks to downstream
+     *  elements.
      *
      *  Elements whose @c transport_map throws (for example @c NonlinearLens
      *  and @c Programmable explicitly reject a linear-map evaluation) are

--- a/src/diagnostics/LinearMap.cpp
+++ b/src/diagnostics/LinearMap.cpp
@@ -25,9 +25,10 @@ namespace impactx::diagnostics
 {
 namespace
 {
-    /** Evaluate @c element.transport_map(ref), or apply the
-     *  missing-linear-map policy for elements whose @c transport_map is
-     *  known not to be implemented.
+    /** Advance the private reference particle through one element
+     *  slice and return the aligned lab-frame linear transport map, or
+     *  apply the missing-linear-map policy for elements whose
+     *  @c transport_map is known not to be implemented.
      *
      *  The branch is chosen at compile time via
      *  @c T_Element::has_linear_transport (provided by the
@@ -47,7 +48,7 @@ namespace
     Map6x6
     safe_transport_map (
         T_Element const & element,
-        RefPart const & ref,
+        RefPart & ref,
         std::set<std::string> & warned_types,
         OnMissingLinearMap on_missing
     )
@@ -58,12 +59,13 @@ namespace
             // parameter/set/string work in the "missing" branch entirely
             // so the compiler can inline this to a direct call.
             amrex::ignore_unused(warned_types, on_missing);
-            return element.transport_map(ref);
+            return elements::mixin::detail::advance_ref_and_transport_map(element, ref);
         }
         else
         {
             // Cold path: only instantiated for element types whose
             // transport_map is known to throw. No try/catch needed.
+            element(ref);
             std::string const type_name{T_Element::type};
             switch (on_missing)
             {
@@ -128,11 +130,10 @@ namespace
      *  map is returned, starting from the identity; a fresh warning-
      *  deduplication set is maintained per call.
      *
-     *  Uses the same per-element advance / linear-map evaluation
-     *  convention as the envelope tracker in
-     *  @c src/tracking/envelope.cpp , so the resulting linear optics
-     *  is consistent with the tracker for edge-sensitive elements
-     *  such as @c RFCavity, @c SoftQuad, and @c SoftSol.
+     *  Uses the same centralized linear/affine transport convention as the
+     *  envelope tracker in @c src/tracking/envelope.cpp, so the resulting
+     *  linear optics is consistent with the tracker for alignment, roll,
+     *  and edge-/slice-sensitive elements.
      *
      * @tparam F_OnElementExit callable
      *                         @c void(E const&, RefPart const&, Map6x6 const&)
@@ -175,7 +176,6 @@ namespace
                 int const nslice = element.nslice();
                 for (int slice_i = 0; slice_i < nslice; ++slice_i)
                 {
-                    element(ref);
                     Map6x6 const R_slice = safe_transport_map<E>(
                         element, ref, warned_types, on_missing
                     );

--- a/src/elements/Multipole.H
+++ b/src/elements/Multipole.H
@@ -32,7 +32,7 @@ namespace impactx::elements
     struct Multipole
     : public mixin::Named,
       public mixin::BeamOptic<Multipole>,
-      public mixin::LinearTransport<Multipole, false>,
+      public mixin::LinearTransport<Multipole>,
       public mixin::Thin,
       public mixin::Alignment,
       public mixin::NoFinalize
@@ -195,15 +195,67 @@ namespace impactx::elements
 
         /** This function returns the linear transport map.
          *
-         * @param[in] refpart reference particle
+         * The thin multipole kick implemented by @see operator() is
+         *   dpx - i*dpy = -(K_normal + i*K_skew) * (x + i*y)^(m-1) / (m-1)!
+         * which matches the MAD-X MULTIPOLE thin kick (see MAD-X User Guide,
+         * "Generalisation to normal and skew components"):
+         *   dPx - i*dPy = -sum_n (KN_n + i*KS_n) * (x + i*y)^n / n!
+         * under the index mapping n = m_multipole - 1 and the identifications
+         * K_normal <-> KNL[n], K_skew <-> KSL[n] for the integrated strengths
+         * (no factorial rescaling).
+         *
+         * The linear map is the Jacobian of this ideal thin kick around the
+         * incoming reference orbit in the element frame. Alignment and roll
+         * are intentionally not applied here; the @c LinearTransport mixin
+         * wraps this ideal/local map into lab coordinates for envelope and
+         * linear-map workflows. A pure dipole kick (m_multipole == 1)
+         * contributes only to the orbit and yields the identity linear map.
+         * Higher-order multipoles generate linear feed-down when the
+         * reference orbit is off-axis.
+         *
+         * Limitation: @c Multipole keeps the ideal reference-particle push as
+         * a zero-length no-op, matching particle-tracking semantics. As a
+         * consequence, constant ideal orbit kicks from off-axis higher-order
+         * multipoles are not propagated to downstream elements. The returned
+         * map therefore includes only the local feed-down about the current
+         * reference orbit, not downstream optics changes from a moved ideal
+         * reference orbit.
+         *
+         * @param[in] refpart reference particle at the element entrance
          * @returns 6x6 transport matrix
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE
         Map6x6
-        transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
+        transport_map (RefPart const & AMREX_RESTRICT refpart) const
         {
-            throw std::runtime_error(std::string(type) + ": Envelope tracking is not yet implemented!");
-            return Map6x6::Identity();
+            Map6x6 R = Map6x6::Identity();
+
+            int const n = m_multipole - 1;
+            if (n >= 1)
+            {
+                using Complex = amrex::GpuComplex<amrex::ParticleReal>;
+
+                Complex const zeta(refpart.x, refpart.y);
+                Complex const alpha(m_Kn, m_Ks);
+
+                amrex::ParticleReal const inv_factorial_nm1 =
+                    static_cast<amrex::ParticleReal>(n) /
+                    static_cast<amrex::ParticleReal>(m_mfactorial);
+
+                // Linearize the kick around the incoming reference orbit in
+                // the element frame. For n == 1 this reproduces the standard
+                // thin quadrupole matrix, while n >= 2 gives feed-down.
+                Complex const beta = amrex::pow(zeta, n - 1) * alpha * inv_factorial_nm1;
+
+                R(2,1) = -beta.m_real;
+                R(2,3) = +beta.m_imag;
+                R(4,1) = +beta.m_imag;
+                R(4,3) = +beta.m_real;
+            }
+            // n == 0 (dipole kick) is a constant kick and does not affect the
+            // linearized map.
+
+            return R;
         }
 
         int m_multipole; //! multipole index

--- a/src/elements/mixin/alignment.H
+++ b/src/elements/mixin/alignment.H
@@ -10,6 +10,7 @@
 #ifndef IMPACTX_ELEMENTS_MIXIN_ALIGNMENT_H
 #define IMPACTX_ELEMENTS_MIXIN_ALIGNMENT_H
 
+#include "particles/CovarianceMatrix.H"
 #include "particles/ImpactXParticleContainer.H"
 
 #include <ablastr/constant.H>
@@ -126,6 +127,108 @@ namespace impactx::elements::mixin
             T_Real const pyc = py;
             px = pxc * m_cos_rotation - pyc * m_sin_rotation;
             py = pxc * m_sin_rotation + pyc * m_cos_rotation;
+        }
+
+        /** Shift a reference particle into the alignment error frame.
+         *
+         * This overload is stateless and computes the rotation factors
+         * locally so it can be used from transport-map code paths that do
+         * not call @see compute_constants.
+         *
+         * @param[in] refpart reference particle in lab coordinates
+         * @returns reference particle in element-frame coordinates
+         */
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
+        RefPart
+        shift_in (RefPart const & refpart) const
+        {
+            auto const [sin_rotation, cos_rotation] = amrex::Math::sincos(m_rotation);
+
+            RefPart ref_local = refpart;
+
+            // position
+            amrex::ParticleReal const xc = refpart.x - m_dx;
+            amrex::ParticleReal const yc = refpart.y - m_dy;
+            ref_local.x =  xc * cos_rotation + yc * sin_rotation;
+            ref_local.y = -xc * sin_rotation + yc * cos_rotation;
+
+            // momentum
+            amrex::ParticleReal const pxc = refpart.px;
+            amrex::ParticleReal const pyc = refpart.py;
+            ref_local.px =  pxc * cos_rotation + pyc * sin_rotation;
+            ref_local.py = -pxc * sin_rotation + pyc * cos_rotation;
+
+            return ref_local;
+        }
+
+        /** Shift a reference particle out of the alignment error frame.
+         *
+         * This overload is stateless and computes the rotation factors
+         * locally so it can be used from transport-map code paths that do
+         * not call @see compute_constants.
+         *
+         * @param[in] refpart reference particle in element-frame coordinates
+         * @returns reference particle in lab coordinates
+         */
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
+        RefPart
+        shift_out (RefPart const & refpart) const
+        {
+            auto const [sin_rotation, cos_rotation] = amrex::Math::sincos(m_rotation);
+
+            RefPart ref_lab = refpart;
+
+            // position
+            ref_lab.x = refpart.x * cos_rotation - refpart.y * sin_rotation + m_dx;
+            ref_lab.y = refpart.x * sin_rotation + refpart.y * cos_rotation + m_dy;
+
+            // momentum
+            ref_lab.px = refpart.px * cos_rotation - refpart.py * sin_rotation;
+            ref_lab.py = refpart.px * sin_rotation + refpart.py * cos_rotation;
+
+            return ref_lab;
+        }
+
+        /** Rotate an element-frame transport map into lab coordinates.
+         *
+         * The returned map is A^{-1} R A, where A is the linear lab->local
+         * transverse rotation acting on (x, px, y, py). The longitudinal
+         * coordinates (t, pt) are left untouched.
+         *
+         * @param[in] R_local transport map in the element frame
+         * @returns transport map in lab coordinates
+         */
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
+        Map6x6
+        rotate_map (Map6x6 const & R_local) const
+        {
+            if (m_rotation == amrex::ParticleReal(0)) {
+                return R_local;
+            }
+
+            auto const [sin_rotation, cos_rotation] = amrex::Math::sincos(m_rotation);
+
+            Map6x6 A = Map6x6::Identity();
+            A(1,1) = +cos_rotation;
+            A(1,3) = +sin_rotation;
+            A(2,2) = +cos_rotation;
+            A(2,4) = +sin_rotation;
+            A(3,1) = -sin_rotation;
+            A(3,3) = +cos_rotation;
+            A(4,2) = -sin_rotation;
+            A(4,4) = +cos_rotation;
+
+            Map6x6 Ainv = Map6x6::Identity();
+            Ainv(1,1) = +cos_rotation;
+            Ainv(1,3) = -sin_rotation;
+            Ainv(2,2) = +cos_rotation;
+            Ainv(2,4) = -sin_rotation;
+            Ainv(3,1) = +sin_rotation;
+            Ainv(3,3) = +cos_rotation;
+            Ainv(4,2) = +sin_rotation;
+            Ainv(4,4) = +cos_rotation;
+
+            return Ainv * R_local * A;
         }
 
         /** Horizontal translation error

--- a/src/elements/mixin/lineartransport.H
+++ b/src/elements/mixin/lineartransport.H
@@ -20,15 +20,82 @@
 #include <AMReX_REAL.H>
 #include <AMReX_SmallMatrix.H>
 
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <utility>
 
 
 namespace impactx::elements::mixin
 {
     namespace detail
     {
+        template <typename T_Element, typename = void>
+        struct has_compute_constants : std::false_type {};
+
+        template <typename T_Element>
+        struct has_compute_constants<
+            T_Element,
+            std::void_t<decltype(std::declval<T_Element &>().compute_constants(std::declval<RefPart const &>()))>
+        > : std::true_type {};
+
+        template <typename T_Element, typename = void>
+        struct has_particle_push : std::false_type {};
+
+        template <typename T_Element>
+        struct has_particle_push<
+            T_Element,
+            std::void_t<decltype(
+                std::declval<T_Element &>()(
+                    std::declval<amrex::ParticleReal &>(),
+                    std::declval<amrex::ParticleReal &>(),
+                    std::declval<amrex::ParticleReal &>(),
+                    std::declval<amrex::ParticleReal &>(),
+                    std::declval<amrex::ParticleReal &>(),
+                    std::declval<amrex::ParticleReal &>(),
+                    std::declval<std::uint64_t &>(),
+                    std::declval<RefPart const &>()
+                )
+            )>
+        > : std::true_type {};
+
+        /** Push the centroid with the same particle-coordinate contract used in
+         *  particle tracking, after the reference particle has been advanced.
+         *
+         *  This captures constant kicks without changing the shared reference
+         *  particle push semantics across tracking modes.
+         *
+         * @param[in] element the current lattice element
+         * @param[in,out] centroid the beam centroid relative to the reference
+         * @param[in] ref the already-advanced reference particle
+         */
+        template <typename T_Element>
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
+        void
+        push_centroid (
+            T_Element const & element,
+            PhaseSpaceVector & AMREX_RESTRICT centroid,
+            RefPart const & AMREX_RESTRICT ref
+        )
+        {
+            if constexpr (has_compute_constants<T_Element>::value && has_particle_push<T_Element>::value)
+            {
+                T_Element element_copy = element;
+                element_copy.compute_constants(ref);
+
+                auto & x = centroid(1);
+                auto & px = centroid(2);
+                auto & y = centroid(3);
+                auto & py = centroid(4);
+                auto & t = centroid(5);
+                auto & pt = centroid(6);
+                std::uint64_t idcpu = 0;
+
+                element_copy(x, y, t, px, py, pt, idcpu, ref);
+            }
+        }
+
         /** Advance the reference particle and return the corresponding
          *  lab-frame linear transport map for one element slice.
          *
@@ -121,6 +188,36 @@ namespace impactx::elements::mixin
             auto const R = detail::advance_ref_and_transport_map(element, ref);
             cm = R * cm * R.transpose();
         }
+
+        /** Linear push of the covariance matrix and centroid through an
+         *  element.
+         *
+         * Advances the reference particle first, matching particle tracking,
+         * then propagates the centroid with the particle-coordinate contract
+         * and the covariance matrix with the aligned linear transport map.
+         *
+         * @param[in,out] cm covariance matrix
+         * @param[in,out] centroid beam centroid relative to the reference
+         * @param[in,out] ref reference particle seen by downstream elements
+         */
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
+        void
+        operator() (
+            Map6x6 & AMREX_RESTRICT cm,
+            PhaseSpaceVector & AMREX_RESTRICT centroid,
+            RefPart & AMREX_RESTRICT ref
+        ) const
+        {
+            static_assert(
+                std::is_base_of_v<LinearTransport, T_Element>,
+                "LinearTransport can only be used as a mixin class!"
+            );
+
+            T_Element const & element = *static_cast<T_Element const*>(this);
+            auto const R = detail::advance_ref_and_transport_map(element, ref);
+            detail::push_centroid(element, centroid, ref);
+            cm = R * cm * R.transpose();
+        }
     };
 
     /** Partial specialization for elements that have not yet implemented a
@@ -166,6 +263,26 @@ namespace impactx::elements::mixin
         void
         operator() (
             [[maybe_unused]] Map6x6 & AMREX_RESTRICT cm,
+            [[maybe_unused]] RefPart & AMREX_RESTRICT ref
+        ) const
+        {
+            static_assert(
+                std::is_base_of_v<LinearTransport, T_Element>,
+                "LinearTransport can only be used as a mixin class!"
+            );
+            T_Element const & element = *static_cast<T_Element const*>(this);
+
+            (void) element.transport_map(ref);  // expected to throw
+        }
+
+        /** Covariance-matrix and centroid push; identical throwing behavior as
+         *  the primary overload above.
+         */
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
+        void
+        operator() (
+            [[maybe_unused]] Map6x6 & AMREX_RESTRICT cm,
+            [[maybe_unused]] PhaseSpaceVector & AMREX_RESTRICT centroid,
             [[maybe_unused]] RefPart & AMREX_RESTRICT ref
         ) const
         {

--- a/src/elements/mixin/lineartransport.H
+++ b/src/elements/mixin/lineartransport.H
@@ -10,6 +10,7 @@
 #ifndef IMPACTX_ELEMENTS_MIXIN_LINEAR_TRANSPORT_H
 #define IMPACTX_ELEMENTS_MIXIN_LINEAR_TRANSPORT_H
 
+#include "alignment.H"
 #include "particles/CovarianceMatrix.H"
 
 #include <ablastr/constant.H>
@@ -26,6 +27,50 @@
 
 namespace impactx::elements::mixin
 {
+    namespace detail
+    {
+        /** Advance the reference particle and return the corresponding
+         *  lab-frame linear transport map for one element slice.
+         *
+         *  Element-local contracts are without alignment errors (i.e., ideal):
+         *    - @c operator()(RefPart&) advances the ideal reference particle
+         *      without alignment errors.
+         *    - @c transport_map(ref) returns the ideal/local linear map.
+         *
+         *  This helper centralizes @c Alignment handling for linear/envelope
+         *  workflows by shifting the incoming reference particle into
+         *  the element frame, applying the ideal reference push there,
+         *  evaluating the ideal/local map at the updated local reference
+         *  state, and finally transforming both the reference particle and
+         *  linear map back to lab coordinates.
+         *
+         * @param[in] element the current lattice element
+         * @param[in,out] ref the reference particle
+         */
+        template <typename T_Element>
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
+        Map6x6
+        advance_ref_and_transport_map (
+            T_Element const & element,
+            RefPart & AMREX_RESTRICT ref
+        )
+        {
+            if constexpr (std::is_base_of_v<Alignment, T_Element>)
+            {
+                RefPart ref_local = element.shift_in(ref);
+                element(ref_local);
+                auto const R_local = element.transport_map(ref_local);
+                ref = element.shift_out(ref_local);
+                return element.rotate_map(R_local);
+            }
+            else
+            {
+                element(ref);
+                return element.transport_map(ref);
+            }
+        }
+    } // namespace detail
+
     /** Mixin for lattice elements that can be expressed as linear transport maps.
      *
      *  @tparam T_Element   the concrete element type (CRTP).
@@ -52,16 +97,17 @@ namespace impactx::elements::mixin
 
         /** Linear push of the covariance matrix through an element
          *
-         * Expects that the reference particle was advanced first.
+         * Advances the reference particle and pushes the covariance
+         * matrix through the aligned lab-frame linear transport step.
          *
          * @param[in,out] cm covariance matrix
-         * @param[in] ref reference particle
+         * @param[in,out] ref reference particle seen by downstream elements
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE
         void
         operator() (
             Map6x6 & AMREX_RESTRICT cm,
-            RefPart const & AMREX_RESTRICT ref
+            RefPart & AMREX_RESTRICT ref
         ) const
         {
             static_assert(
@@ -72,7 +118,7 @@ namespace impactx::elements::mixin
             // small trick to force every derived class has to implement a method transport_map
             // (w/o using a purely virtual function)
             T_Element const & element = *static_cast<T_Element const*>(this);
-            auto const R = element.transport_map(ref);
+            auto const R = detail::advance_ref_and_transport_map(element, ref);
             cm = R * cm * R.transpose();
         }
     };
@@ -119,17 +165,17 @@ namespace impactx::elements::mixin
         AMREX_GPU_HOST AMREX_FORCE_INLINE
         void
         operator() (
-            Map6x6 & AMREX_RESTRICT cm,
-            RefPart const & AMREX_RESTRICT ref
+            [[maybe_unused]] Map6x6 & AMREX_RESTRICT cm,
+            [[maybe_unused]] RefPart & AMREX_RESTRICT ref
         ) const
         {
             static_assert(
                 std::is_base_of_v<LinearTransport, T_Element>,
                 "LinearTransport can only be used as a mixin class!"
             );
-
             T_Element const & element = *static_cast<T_Element const*>(this);
-            cm = element.transport_map(ref) * cm * element.transport_map(ref).transpose();
+
+            (void) element.transport_map(ref);  // expected to throw
         }
     };
 

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -212,6 +212,7 @@ namespace impactx
 
         // zero out the 6x6 matrix
         CovarianceMatrix cv{};
+        PhaseSpaceVector centroid{0.0_prt, 0.0_prt, 0.0_prt, 0.0_prt, 0.0_prt, 0.0_prt};
 
         // initialize from 2nd order beam moments
         std::visit([&](auto&& distribution) {
@@ -231,21 +232,28 @@ namespace impactx
                 amrex::ParticleReal muxpx = distribution.m_muxpx;
                 amrex::ParticleReal muypy = distribution.m_muypy;
                 amrex::ParticleReal mutpt = distribution.m_mutpt;
+                amrex::ParticleReal meanx = distribution.m_meanx;
+                amrex::ParticleReal meany = distribution.m_meany;
+                amrex::ParticleReal meant = distribution.m_meant;
+                amrex::ParticleReal meanpx = distribution.m_meanpx;
+                amrex::ParticleReal meanpy = distribution.m_meanpy;
+                amrex::ParticleReal meanpt = distribution.m_meanpt;
 
-                // some things we cannot represent in envelope mode
-                if (distribution.m_meanx  != 0.0_prt ||
-                    distribution.m_meany  != 0.0_prt ||
-                    distribution.m_meant  != 0.0_prt ||
-                    distribution.m_meanpx != 0.0_prt ||
-                    distribution.m_meanpy != 0.0_prt ||
-                    distribution.m_meanpt != 0.0_prt ||
-                    distribution.m_dispx  != 0.0_prt ||
+                // some things we cannot represent in envelope mode yet
+                if (distribution.m_dispx  != 0.0_prt ||
                     distribution.m_disppx != 0.0_prt ||
                     distribution.m_dispy  != 0.0_prt ||
                     distribution.m_disppy != 0.0_prt
                 ) {
-                    throw std::runtime_error("Cannot (yet) create envelope for distribution with non-zero means or dispersion! Please see: https://github.com/BLAST-ImpactX/impactx/issues/1114");
+                    throw std::runtime_error("Cannot (yet) create envelope for distribution with non-zero dispersion! Please see: https://github.com/BLAST-ImpactX/impactx/issues/1114");
                 }
+
+                centroid(1) = meanx;
+                centroid(2) = meanpx;
+                centroid(3) = meany;
+                centroid(4) = meanpy;
+                centroid(5) = meant;
+                centroid(6) = meanpt;
 
                 // use distribution inputs to populate a 6x6 covariance matrix
                 amrex::ParticleReal denom_x = 1.0 - muxpx*muxpx;
@@ -271,6 +279,7 @@ namespace impactx
         Envelope env;
         if (intensity) { env.set_beam_intensity(intensity.value()); }
         env.set_covariance_matrix(cv);
+        env.set_centroid(centroid);
 
         return env;
     }

--- a/src/particles/CovarianceMatrix.H
+++ b/src/particles/CovarianceMatrix.H
@@ -22,6 +22,9 @@ namespace impactx
     /** this is the 6x6 covariance matrix */
     using CovarianceMatrix = Map6x6;
 
+    /** this is a phase-space 6-vector in (x, px, y, py, t, pt) ordering */
+    using PhaseSpaceVector = amrex::SmallVector<amrex::ParticleReal, 6, 1>;
+
     /** Return the 6x6 skew-symmetric symplectic form
      *
      * diag([[0,1],[-1,0]], [[0,1],[-1,0]], [[0,1],[-1,0]])
@@ -51,7 +54,14 @@ namespace impactx
      */
     struct Envelope
     {
+        Envelope () = default;
+
+        Envelope (CovarianceMatrix const & env, amrex::ParticleReal beam_intensity)
+            : m_env(env), m_beam_intensity(beam_intensity)
+        {}
+
         CovarianceMatrix m_env; ///< the 6x6 beam covariance matrix
+        PhaseSpaceVector m_centroid{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}; ///< the beam centroid relative to the reference particle
         amrex::ParticleReal m_beam_intensity = 0.0; ///< optional: charge in A (for 3D space charge) or current in A (for 2D space charge)
 
         /** Set envelope beam charge/current for 3D/2D space charge
@@ -94,6 +104,26 @@ namespace impactx
         covariance_matrix () const
         {
             return m_env;
+        }
+
+        /** Set the 6D centroid for envelope tracking
+         *
+         * @param centroid beam centroid relative to the reference particle
+         */
+        Envelope &
+        set_centroid (PhaseSpaceVector const & centroid)
+        {
+            m_centroid = centroid;
+
+            return *this;
+        }
+
+        /** Get the 6D centroid for envelope tracking
+         */
+        PhaseSpaceVector
+        centroid () const
+        {
+            return m_centroid;
         }
 
     };

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -721,6 +721,20 @@ void init_ImpactX (py::module& m)
             },
             "Access the beam particle container."
         )
+        .def_property("envelope",
+            [](ImpactX & ix) -> Envelope & {
+                if (!ix.amr_data->track_envelope.m_env.has_value())
+                {
+                    throw std::runtime_error("Envelope state not set. Did you forget to call sim.init_envelope()?");
+                }
+                return ix.amr_data->track_envelope.m_env.value();
+            },
+            [](ImpactX & ix, Envelope const & env) {
+                ix.amr_data->track_envelope.m_env = env;
+            },
+            py::return_value_policy::reference_internal,
+            "Access the envelope tracking state."
+        )
         .def(
             "rho",
             [](ImpactX & ix, int const lev) { return &ix.amr_data->track_particles.m_rho.at(lev); },

--- a/src/python/distribution.cpp
+++ b/src/python/distribution.cpp
@@ -16,6 +16,28 @@
 namespace py = pybind11;
 using namespace impactx;
 
+namespace
+{
+    std::array<amrex::ParticleReal, 6>
+    to_array (PhaseSpaceVector const & v)
+    {
+        return {v(1), v(2), v(3), v(4), v(5), v(6)};
+    }
+
+    PhaseSpaceVector
+    to_phase_space_vector (std::array<amrex::ParticleReal, 6> const & values)
+    {
+        PhaseSpaceVector v;
+        v(1) = values[0];
+        v(2) = values[1];
+        v(3) = values[2];
+        v(4) = values[3];
+        v(5) = values[4];
+        v(6) = values[5];
+        return v;
+    }
+}
+
 
 void init_distribution(py::module& m)
 {
@@ -208,6 +230,13 @@ void init_distribution(py::module& m)
         .def(py::init<>())
         .def(py::init<CovarianceMatrix, amrex::ParticleReal>())
         .def_property("envelope", &Envelope::covariance_matrix, &Envelope::set_covariance_matrix)
+        .def_property("centroid",
+            [](Envelope const & env) {
+                return to_array(env.centroid());
+            },
+            [](Envelope & env, std::array<amrex::ParticleReal, 6> const & centroid) {
+                env.set_centroid(to_phase_space_vector(centroid));
+            })
         .def_property("beam_intensity", &Envelope::beam_intensity, &Envelope::set_beam_intensity)
     ;
 

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -87,11 +87,11 @@ namespace
         using Element = typename T_PyClass::type;  // py::class<T, options...>
 
         cl.def("push",
-               [](Element & el, Map6x6 & cm, RefPart const & ref) {
+               [](Element & el, Map6x6 & cm, RefPart & ref) {
                    el(cm, ref);
                },
                py::arg("cm"), py::arg("ref"),
-               "Linear push of the covariance matrix through an element. Expects that the reference particle was advanced first."
+               "Linear push of the covariance matrix through an element. Advances the reference particle and mixes in alignment effects internally."
         );
     }
 

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -92,6 +92,7 @@ class CoordSystem:
     def value(self) -> int: ...
 
 class Envelope:
+    centroid: list[float]
     envelope: amrex.space3d.amrex_3d_pybind.SmallMatrix_6x6_F_SI1_double
     @typing.overload
     def __init__(self) -> None: ...
@@ -253,6 +254,13 @@ class ImpactX:
         """
         Access the beam particle container.
         """
+    @property
+    def envelope(self) -> Envelope:
+        """
+        Access the envelope tracking state.
+        """
+    @envelope.setter
+    def envelope(self, arg1: Envelope) -> None: ...
     @property
     def blocking_factor_x(self) -> list[int]:
         """

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -181,13 +181,8 @@ namespace impactx
 
                     std::visit([&ref, &cm](auto&& element)
                     {
-                        // push reference particle in global coordinates
-                        {
-                            BL_PROFILE("impactx::push::RefPart");
-                            element(ref);
-                        }
-
-                        // push Covariance Matrix in external fields
+                        // push Covariance Matrix in external fields and
+                        // advance the reference particle for the next slice
                         element(cm, ref);
 
                     }, element_variant);

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -66,6 +66,7 @@ namespace impactx
         auto & ref = amr_data->track_envelope.m_ref.value();
         auto & env = amr_data->track_envelope.m_env.value();
         auto & cm = env.m_env;
+        auto & centroid = env.m_centroid;
         auto & intensity = env.m_beam_intensity;
 
         // output of init state
@@ -179,11 +180,11 @@ namespace impactx
                         envelope::spacecharge::space_charge3D_push(ref, cm, intensity, slice_ds);
                     }
 
-                    std::visit([&ref, &cm](auto&& element)
+                    std::visit([&ref, &cm, &centroid](auto&& element)
                     {
-                        // push Covariance Matrix in external fields and
-                        // advance the reference particle for the next slice
-                        element(cm, ref);
+                        // push the covariance matrix and centroid in external
+                        // fields and advance the reference particle
+                        element(cm, centroid, ref);
 
                     }, element_variant);
 

--- a/tests/python/test_envelope.py
+++ b/tests/python/test_envelope.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 The ImpactX Community
+#
+# Authors: OpenAI Codex
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import pytest
+
+from impactx import Config, ImpactX, RefPart, create_envelope, distribution, elements
+
+
+def phase_tolerances():
+    if Config.precision == "SINGLE":
+        return 1.0e-7, 5.0e-5
+    return 1.0e-14, 1.0e-8
+
+
+def test_create_envelope_initializes_centroid_from_distribution_means():
+    atol, rtol = phase_tolerances()
+
+    base_kwargs = dict(
+        lambdaX=4.0e-5,
+        lambdaY=5.0e-5,
+        lambdaT=1.0e-3,
+        lambdaPx=1.0e-5,
+        lambdaPy=3.0e-5,
+        lambdaPt=2.0e-3,
+        muxpx=-0.2,
+        muypy=0.3,
+        mutpt=-0.1,
+    )
+    mean_kwargs = dict(
+        meanX=1.5e-3,
+        meanPx=-2.5e-4,
+        meanY=-3.5e-3,
+        meanPy=4.5e-4,
+        meanT=5.5e-3,
+        meanPt=-6.5e-4,
+    )
+
+    env = create_envelope(distribution.Gaussian(**base_kwargs, **mean_kwargs), None)
+    env_zero_mean = create_envelope(distribution.Gaussian(**base_kwargs), None)
+
+    assert np.allclose(
+        np.asarray(env.centroid),
+        np.array(
+            [
+                mean_kwargs["meanX"],
+                mean_kwargs["meanPx"],
+                mean_kwargs["meanY"],
+                mean_kwargs["meanPy"],
+                mean_kwargs["meanT"],
+                mean_kwargs["meanPt"],
+            ]
+        ),
+        atol=atol,
+        rtol=rtol,
+    )
+    assert np.allclose(
+        env.envelope.to_numpy(),
+        env_zero_mean.envelope.to_numpy(),
+        atol=atol,
+        rtol=rtol,
+    )
+
+
+def test_create_envelope_still_rejects_nonzero_dispersion():
+    with pytest.raises(RuntimeError, match="non-zero dispersion"):
+        create_envelope(
+            distribution.Gaussian(
+                lambdaX=4.0e-5,
+                lambdaY=5.0e-5,
+                lambdaT=1.0e-3,
+                lambdaPx=1.0e-5,
+                lambdaPy=3.0e-5,
+                lambdaPt=2.0e-3,
+                dispX=1.0e-3,
+            ),
+            None,
+        )
+
+
+def test_track_envelope_centroid_propagates_constant_kicks():
+    atol, rtol = phase_tolerances()
+
+    sim = ImpactX()
+    sim.init_grids()
+
+    ref = RefPart()
+    ref.set_species("electron").set_kin_energy_MeV(1.0e3)
+
+    sim.init_envelope(
+        ref,
+        distribution.Gaussian(
+            lambdaX=4.0e-5,
+            lambdaY=5.0e-5,
+            lambdaT=1.0e-3,
+            lambdaPx=1.0e-5,
+            lambdaPy=3.0e-5,
+            lambdaPt=2.0e-3,
+        ),
+    )
+
+    k1 = 9.0
+    dx = 2.0e-3
+    drift_ds = 0.4
+    k2 = 7.0
+
+    sim.lattice.extend(
+        [
+            elements.Multipole(multipole=3, K_normal=k1, K_skew=0.0, dx=dx),
+            elements.Drift(ds=drift_ds),
+            elements.Multipole(multipole=3, K_normal=k2, K_skew=0.0),
+        ]
+    )
+
+    sim.track_envelope()
+
+    dpx_1 = -0.5 * k1 * dx * dx
+    x_after_drift = drift_ds * dpx_1
+    dpx_2 = -0.5 * k2 * x_after_drift * x_after_drift
+
+    assert np.allclose(
+        np.asarray(sim.envelope.centroid),
+        np.array([x_after_drift, dpx_1 + dpx_2, 0.0, 0.0, 0.0, 0.0]),
+        atol=atol,
+        rtol=rtol,
+    )
+
+    sim.finalize()

--- a/tests/python/test_lattice_optics.py
+++ b/tests/python/test_lattice_optics.py
@@ -10,19 +10,57 @@
 import numpy as np
 import pytest
 
-from impactx import Config, RefPart, elements
+from impactx import Config, Map6x6, RefPart, elements, push
+
+
+def make_ref(*, x=0.0, y=0.0, px=0.0, py=0.0, species="electron", kin_energy_MeV=1.0e3):
+    """Create a reference particle with configurable transverse coordinates."""
+    ref = RefPart()
+    ref.set_species(species).set_kin_energy_MeV(kin_energy_MeV)
+    ref.x = x
+    ref.y = y
+    ref.px = px
+    ref.py = py
+    return ref
+
+
+def map_equal(lhs, rhs):
+    """Compare Map6x6 or NumPy-array-like values with precision-dependent tolerances."""
+    lhs_np = lhs.to_numpy() if hasattr(lhs, "to_numpy") else lhs
+    rhs_np = rhs.to_numpy() if hasattr(rhs, "to_numpy") else rhs
+
+    if Config.precision == "SINGLE":
+        return np.allclose(lhs_np, rhs_np, atol=1.0e-7, rtol=5.0e-5)
+    else:
+        return np.allclose(lhs_np, rhs_np, atol=1.0e-14, rtol=1.0e-8)
+
+
+def sextupole_feeddown_quadrupole(ref, *, kn, ks, dx=0.0, dy=0.0, rotation=0.0):
+    """Return the thin quadrupole equivalent to a sextupole linearized at ``ref``."""
+    theta = np.deg2rad(rotation)
+    xc = ref.x - dx
+    yc = ref.y - dy
+    zeta_local = complex(
+        xc * np.cos(theta) + yc * np.sin(theta),
+        -xc * np.sin(theta) + yc * np.cos(theta),
+    )
+    feeddown = complex(kn, ks) * zeta_local
+    return elements.Multipole(
+        multipole=2,
+        K_normal=feeddown.real,
+        K_skew=feeddown.imag,
+        rotation=rotation,
+    )
 
 
 def test_lattice_linear_map():
     """Calculate the linear transfer map of a lattice."""
 
     # Create reference particle
-    ref = RefPart()
-    ref.set_species("electron").set_kin_energy_MeV(1.0e3)
+    ref = make_ref()
 
     # Create a valid test lattice (all elements define a linear transfer map)
-    lattice = elements.KnownElementsList()
-    lattice.extend(
+    lattice = elements.KnownElementsList(
         [
             elements.Sbend(name="bend1", ds=1.0, rc=10.0, nslice=2),
             elements.Drift(name="drift1", ds=2.0, nslice=2),
@@ -43,28 +81,145 @@ def test_lattice_linear_map():
         ]
     )
 
-    if Config.precision == "SINGLE":
-        atol = 1.0e-7
-        rtol = 5.0e-5
-    else:
-        atol = 0.0
-        rtol = 1.0e-8
-
     # Calculate Linear Transfer Map
     R = lattice.transfer_map(ref)
-    assert np.allclose(R.to_numpy(), R_expected, rtol=rtol, atol=atol)
+    assert map_equal(R, R_expected)
 
     # Check unexpected/unsupported options
     with pytest.raises(RuntimeError):
         lattice.transfer_map(ref, order="invalid")
 
-    # Create a lattice with an element that does not define a linear transfer map
-    lattice.append(elements.TaperedPL(k=0, taper=0, unit=0))
 
-    # Ensure that the calculation asserts
-    with pytest.raises(RuntimeError):
-        lattice.transfer_map(ref)
+def test_multipole_on_axis_sextupole_has_identity_linear_map():
+    """An on-axis thin sextupole has no linear term."""
+    ref = make_ref()
+    lattice = elements.KnownElementsList(
+        [elements.Multipole(multipole=3, K_normal=2.5, K_skew=-0.7)]
+    )
 
-    # Now the user explicitly assumes that undefined maps are identity maps
-    R = lattice.transfer_map(ref, fallback_identity_map=True)
-    assert np.allclose(R.to_numpy(), R_expected, rtol=rtol, atol=atol)
+    assert map_equal(lattice.transfer_map(ref), Map6x6.identity())
+
+
+def test_multipole_off_axis_sextupole_matches_feeddown_quadrupole():
+    """A sextupole linearized about x!=0 must feed down to a thin quadrupole."""
+    ref_offx = make_ref(x=2.0e-3)
+    ref_center = make_ref()
+    k2 = 11.0
+
+    map_sextupole = elements.KnownElementsList(
+        [elements.Multipole(multipole=3, K_normal=k2, K_skew=0.0)]
+    ).transfer_map(ref_offx)
+
+    map_quadrupole = elements.KnownElementsList(
+        [elements.Multipole(multipole=2, K_normal=k2 * ref_offx.x, K_skew=0.0)]
+    ).transfer_map(ref_center)
+
+    assert map_equal(
+        map_sextupole,
+        map_quadrupole,
+    )
+
+
+def test_multipole_misaligned_sextupole_has_feeddown_at_zero_reference_offset():
+    """A sextupole misalignment must generate feed-down even if ref.x=ref.y=0."""
+    ref = make_ref()
+    kn = 9.0
+    ks = -4.0
+    dx = 1.0e-3
+    dy = -1.5e-3
+    lattice_sextupole = elements.KnownElementsList(
+        [elements.Multipole(multipole=3, K_normal=kn, K_skew=ks, dx=dx, dy=dy)]
+    )
+
+    lattice_quadrupole = elements.KnownElementsList(
+        [sextupole_feeddown_quadrupole(ref, kn=kn, ks=ks, dx=dx, dy=dy)]
+    )
+
+    R = lattice_sextupole.transfer_map(ref)
+    assert not map_equal(R, Map6x6.identity())
+    assert map_equal(R, lattice_quadrupole.transfer_map(make_ref()))
+
+
+def test_multipole_rolled_normal_quadrupole_matches_skew_quadrupole():
+    """A normal quadrupole rolled by 45 degrees becomes a pure skew quadrupole."""
+    ref = make_ref()
+    k1 = 3.0
+
+    map_rolled_normal = elements.KnownElementsList(
+        [elements.Multipole(multipole=2, K_normal=k1, K_skew=0.0, rotation=45.0)]
+    ).transfer_map(ref)
+
+    map_skew = elements.KnownElementsList(
+        [elements.Multipole(multipole=2, K_normal=0.0, K_skew=-k1)]
+    ).transfer_map(ref)
+
+    assert map_equal(map_rolled_normal, map_skew)
+
+
+def test_multipole_reference_particle_ignores_alignment_errors():
+    """Alignment errors act on the beam/map, not on the RefPart push itself."""
+    ref_ideal = make_ref(x=2.0e-3, y=-1.0e-3, px=3.0e-4, py=-2.0e-4)
+    ref_aligned = ref_ideal.copy()
+
+    push(
+        ref_ideal,
+        elements.Multipole(multipole=3, K_normal=9.0, K_skew=-4.0),
+    )
+    push(
+        ref_aligned,
+        elements.Multipole(
+            multipole=3,
+            K_normal=9.0,
+            K_skew=-4.0,
+            dx=1.0e-3,
+            dy=-1.5e-3,
+            rotation=23.0,
+        ),
+    )
+
+    for attr in ("x", "y", "px", "py", "pz", "t", "pt", "s"):
+        assert np.isclose(getattr(ref_aligned, attr), getattr(ref_ideal, attr))
+
+
+def test_multipole_feeddown_composes_across_multiple_misaligned_rotated_maps():
+    """Misalignment/rotation feed-down must compose correctly across a lattice."""
+    ref = make_ref(x=1.6e-3, y=-0.7e-3)
+
+    drift = dict(ds=0.4, nslice=1)
+    sextupole_1 = dict(kn=7.0, ks=-1.5, dx=0.9e-3, dy=-0.5e-3, rotation=17.0)
+    sextupole_2 = dict(kn=-5.0, ks=2.25, dx=-1.1e-3, dy=0.8e-3, rotation=-31.0)
+
+    lattice_sextupoles = elements.KnownElementsList(
+        [
+            elements.Multipole(
+                multipole=3,
+                K_normal=sextupole_1["kn"],
+                K_skew=sextupole_1["ks"],
+                dx=sextupole_1["dx"],
+                dy=sextupole_1["dy"],
+                rotation=sextupole_1["rotation"],
+            ),
+            elements.Drift(**drift),
+            elements.Multipole(
+                multipole=3,
+                K_normal=sextupole_2["kn"],
+                K_skew=sextupole_2["ks"],
+                dx=sextupole_2["dx"],
+                dy=sextupole_2["dy"],
+                rotation=sextupole_2["rotation"],
+            ),
+        ]
+    )
+
+    lattice_feeddown_quads = elements.KnownElementsList(
+        [
+            sextupole_feeddown_quadrupole(ref, **sextupole_1),
+            elements.Drift(**drift),
+            sextupole_feeddown_quadrupole(ref, **sextupole_2),
+        ]
+    )
+
+    assert map_equal(
+        lattice_sextupoles.transfer_map(ref),
+        lattice_feeddown_quads.transfer_map(ref),
+    )


### PR DESCRIPTION
Add a centroid 6D phase vector to our envelope tracking logic.

The goal is to support off-axis envelope propagation and feed-down effects in linear optics from misalignment (translation & rotation) and off-axis reference particle.

This lets transfer maps, and currently developed map traces and Twiss optics see the same feed-down effects that particles experience through the element.

Reusable helper methods are added to the `mixin::Alignment` class that we can use in other elements as well.

## Multipole (Illustrative Example)

Higher-order thin multipoles contribute the correct linear focusing when the reference orbit is off axis or the element is misaligned, including the normal/skew mixing from transverse roll.

Adds regression coverage for sextupole feed-down (e.g. Quads kicks) and periodic lattice optics.