### PR TITLE
Linear Transport: Calc `transfer_map` Once

### DIFF
--- a/src/elements/mixin/lineartransport.H
+++ b/src/elements/mixin/lineartransport.H
@@ -72,7 +72,8 @@ namespace impactx::elements::mixin
             // small trick to force every derived class has to implement a method transport_map
             // (w/o using a purely virtual function)
             T_Element const & element = *static_cast<T_Element const*>(this);
-            cm = element.transport_map(ref) * cm * element.transport_map(ref).transpose();
+            auto const R = element.transport_map(ref);
+            cm = R * cm * R.transpose();
         }
     };
 


### PR DESCRIPTION
Just in case a compiler optimization misses this:
We want to calculate `R` exactly once and then transpose it. Before, this was potentially calculated twice.