### PR TITLE
Fix `transfer_map` for edge- and slice-dependent linear optics

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -847,7 +847,19 @@ This module provides elements and methods for the accelerator lattice.
 
    .. py:method:: transfer_map(ref, order="linear", fallback_identity_map=False)
 
-      Calculate the transfer map of the elements in the list.
+      Calculate the end-to-end transfer map of the elements in the list.
+
+      Currently only the linear transfer map is implemented (``order="linear"``);
+      the ``order`` parameter is reserved for future higher-order extensions.
+      In linear mode the 6x6 map is composed element by element, using each
+      element's analytic per-slice linear transport map.
+
+      Collective effects like space charge, Coherent/Incoherent Synchrotron
+      Radiation (CSR/ISR), and wakefield effects are not applied here; the
+      returned map describes the purely linear single-particle dynamics of the
+      design lattice.
+
+      Phase-space ordering in the returned matrix is ``(x, px, y, py, t, pt)``.
 
       .. dropdown:: Example
          :color: light
@@ -857,11 +869,46 @@ This module provides elements and methods for the accelerator lattice.
          .. literalinclude:: tests/python/test_lattice_optics.py
             :language: bash
 
-      :param ref: A reference particle.
+      :param ref: reference particle at the starting s
       :param order: So far, only the calculation of linear transfer maps is supported.
       :param fallback_identity_map: For elements with an undefined transfer map in the lattice, assume the identity matrix.
-      :return: The transfer map of all elements in the list.
+      :return: The end-to-end transfer map of the lattice.
       :rtype: Map6x6
+
+   .. py:method:: map_trace(ref)
+
+      Trace the cumulative 6x6 linear transport map element by element.
+
+      The reference particle is passed by value (intentional copy); the
+      caller's reference particle is not modified in place. This matches the
+      convention used by :py:meth:`~transfer_map`.
+
+      This per-element trace is what :py:meth:`~impactx.impactx_pybind.ImpactX.twiss`
+      consumes to transport Twiss functions through the lattice.
+
+      If you only need the final cumulative map at the lattice exit, prefer
+      :py:meth:`~transfer_map` instead of indexing the last entry of
+      :py:meth:`~map_trace`.
+
+      :param ref: A reference particle.
+      :return: A list of dictionaries, one per lattice element plus a leading
+               entry for the starting position. Each entry contains:
+
+               * ``s``    -- integrated path length along the reference
+                 orbit, in meters;
+               * ``name`` -- user-supplied element name (empty string if not
+                 named);
+               * ``type`` -- element type string (e.g. ``"Drift"``,
+                 ``"Quad"``, ``"Sbend"``);
+               * ``M``    -- cumulative 6x6 linear transport map from the
+                 start of the lattice to the exit of this element (a
+                 ``Map6x6`` instance; call ``.to_numpy()`` for a standard
+                 C-ordered NumPy array).
+
+               The first entry always has the identity map at the starting
+               ``s``; the last entry contains the same map as
+               :py:meth:`~transfer_map`.
+      :rtype: list[dict]
 
    .. py:method:: to_dicts()
 

--- a/src/diagnostics/CMakeLists.txt
+++ b/src/diagnostics/CMakeLists.txt
@@ -3,4 +3,5 @@ target_sources(lib
     ReducedBeamCharacteristics.cpp
     DiagnosticOutput.cpp
     EmittanceInvariants.cpp
+    LinearMap.cpp
 )

--- a/src/diagnostics/LinearMap.H
+++ b/src/diagnostics/LinearMap.H
@@ -1,0 +1,140 @@
+/* Copyright 2026 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_DIAGNOSTICS_LINEAR_MAP_H
+#define IMPACTX_DIAGNOSTICS_LINEAR_MAP_H
+
+#include "elements/All.H"
+#include "particles/CovarianceMatrix.H"
+#include "particles/ReferenceParticle.H"
+
+#include <list>
+#include <string>
+#include <vector>
+
+
+namespace impactx::diagnostics
+{
+    /** Policy for how @ref map_trace and @ref linear_map handle elements
+     *  whose @c transport_map evaluation throws, i.e. elements that do not
+     *  provide an analytic linear transport map (for example
+     *  @c NonlinearLens or @c Programmable).
+     *
+     *  The distinction between the two identity-substituting policies is
+     *  deliberate: @c IdentityWithWarning is appropriate when the user has
+     *  not asked for a fallback (e.g. from the Twiss diagnostic) and should
+     *  be made aware that part of the lattice was ignored;
+     *  @c IdentitySilent is appropriate when the user has explicitly opted
+     *  in to the fallback (e.g. through @c transfer_map's
+     *  @c fallback_identity_map=True kwarg) and does not want repeated
+     *  warnings.
+     */
+    enum class OnMissingLinearMap
+    {
+        IdentityWithWarning,  //!< substitute the identity map, record one warning per element type
+        IdentitySilent,       //!< substitute the identity map without emitting a warning
+        Throw                 //!< re-raise as @c std::runtime_error naming the offending element
+    };
+
+    /** One entry in a per-element trace of the cumulative linear transport map.
+     *
+     *  Each entry records the cumulative 6x6 linear transport map from the
+     *  start of the traversal (where the map is the identity) up to the exit
+     *  of one lattice element, along with a small amount of metadata
+     *  describing that element. The entries in @c map_trace form a sequence
+     *  parallel to the element list, with one extra leading entry for the
+     *  starting position.
+     *
+     *  Phase-space ordering in @c M_cumulative is (x, px, y, py, t, pt), with
+     *  x, y transverse positions (meters), px, py transverse canonical momenta
+     *  normalized by the reference momentum, t arrival-time deviation relative
+     *  to the reference (in meters of c*dt), and pt the momentum deviation
+     *  relative to the reference (dimensionless).
+     */
+    struct MapTraceEntry
+    {
+        amrex::ParticleReal s;          //!< integrated path length along the reference orbit, in meters
+        std::string element_name;       //!< user-supplied element name; empty if the element was not named
+        std::string element_type;       //!< element type string (e.g. "Drift", "Quad", "Sbend")
+        Map6x6 M_cumulative;            //!< cumulative 6x6 linear transport map from the start up to the exit of this element
+    };
+
+    /** Compose the linear transport map element-by-element along a lattice.
+     *
+     *  Walks the lattice once, advancing a local copy of the reference
+     *  particle through each element's non-linear reference-particle push and
+     *  multiplying the cumulative 6x6 linear transport map by each element's
+     *  per-slice @c transport_map. The caller's reference particle is not
+     *  modified.
+     *
+     *  Slice ordering inside each element matches the envelope tracker in
+     *  @c src/tracking/envelope.cpp : for each of @c nslice sub-steps, first
+     *  advance the reference particle by one slice, then evaluate
+     *  @c transport_map at the post-advance reference state. This keeps both
+     *  code paths consistent for elements whose linear map depends on the
+     *  reference momentum through the element (for example radio-frequency
+     *  cavities).
+     *
+     *  Effects that are part of the non-linear tracker but not of the linear
+     *  map are deliberately skipped here: space charge, Coherent Synchrotron
+     *  Radiation (CSR), and Incoherent Synchrotron Radiation (ISR). The
+     *  result is a purely element-by-element linear-optics trace appropriate
+     *  for Twiss / tune / chromaticity / dispersion diagnostics.
+     *
+     *  Elements whose @c transport_map throws (for example @c NonlinearLens
+     *  and @c Programmable explicitly reject a linear-map evaluation) are
+     *  handled according to @p on_missing: either replaced by the identity
+     *  (with a single warning per offending element type recorded via the
+     *  ABLASTR warn manager) or re-raised as a @c std::runtime_error naming
+     *  the offending element.
+     *
+     * @param[in] lattice         list of lattice elements to traverse
+     * @param[in] ref_part_init   reference particle at the starting s
+     * @param[in] on_missing      policy for elements without a linear map;
+     *                            default is identity + warning
+     * @return                    vector of entries, size @c lattice.size() + 1 ;
+     *                            the first entry is the identity map at the
+     *                            starting s, each subsequent entry is the
+     *                            cumulative map at the exit of one element.
+     */
+    std::vector<MapTraceEntry>
+    map_trace (
+        std::list<elements::KnownElements> const & lattice,
+        RefPart const & ref_part_init,
+        OnMissingLinearMap on_missing = OnMissingLinearMap::IdentityWithWarning
+    );
+
+    /** Return the end-to-end linear transport map of a lattice.
+     *
+     *  Convenience wrapper around @ref map_trace that returns only the final
+     *  cumulative map. For a ring, this is the one-turn map used as input to
+     *  the Wolski eigendecomposition [Wolski, Phys. Rev. ST Accel. Beams 9,
+     *  024001 (2006); doi:10.1103/PhysRevSTAB.9.024001] of the periodic
+     *  Twiss, tune, and dispersion diagnostics in
+     *  @c impactx.twiss_lattice.compute_twiss (see the Python module for
+     *  the full bibliography, including the Courant-Snyder [Ann. Phys. 3, 1
+     *  (1958)] and Mais-Ripken [DESY M-82-05, DESY 88-114] references that
+     *  underlie the coupled parameterization).
+     *
+     * @param[in] lattice         list of lattice elements
+     * @param[in] ref_part_init   reference particle at the starting s
+     * @param[in] on_missing      policy for elements without a linear map;
+     *                            default is identity + warning
+     * @return                    end-to-end 6x6 linear transport map
+     */
+    Map6x6
+    linear_map (
+        std::list<elements::KnownElements> const & lattice,
+        RefPart const & ref_part_init,
+        OnMissingLinearMap on_missing = OnMissingLinearMap::IdentityWithWarning
+    );
+
+} // namespace impactx::diagnostics
+
+#endif // IMPACTX_DIAGNOSTICS_LINEAR_MAP_H

--- a/src/diagnostics/LinearMap.cpp
+++ b/src/diagnostics/LinearMap.cpp
@@ -1,0 +1,248 @@
+/* Copyright 2026 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "LinearMap.H"
+
+#include <ablastr/warn_manager/WarnManager.H>
+
+#include <AMReX_BLProfiler.H>
+#include <AMReX_REAL.H>
+
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <variant>
+
+
+namespace impactx::diagnostics
+{
+namespace
+{
+    /** Evaluate @c element.transport_map(ref), or apply the
+     *  missing-linear-map policy for elements whose @c transport_map is
+     *  known not to be implemented.
+     *
+     *  The branch is chosen at compile time via
+     *  @c T_Element::has_linear_transport (provided by the
+     *  @c mixin::LinearTransport base):
+     *
+     *    - Elements with an implemented linear map (the vast majority):
+     *      the call is forwarded directly without any @c try/@c catch.
+     *      This is the hot path and compiles to a single virtual-free
+     *      call with no exception machinery.
+     *    - Elements without an implemented linear map: the @p on_missing
+     *      policy is applied -- either re-raise as a
+     *      @c std::runtime_error naming the element, substitute the
+     *      identity with a one-per-type warning, or substitute the
+     *      identity silently.
+     */
+    template <typename T_Element>
+    Map6x6
+    safe_transport_map (
+        T_Element const & element,
+        RefPart const & ref,
+        std::set<std::string> & warned_types,
+        OnMissingLinearMap on_missing
+    )
+    {
+        if constexpr (T_Element::has_linear_transport)
+        {
+            // Hot path: element has an implemented linear map. Avoid the
+            // parameter/set/string work in the "missing" branch entirely
+            // so the compiler can inline this to a direct call.
+            amrex::ignore_unused(warned_types, on_missing);
+            return element.transport_map(ref);
+        }
+        else
+        {
+            // Cold path: only instantiated for element types whose
+            // transport_map is known to throw. No try/catch needed.
+            std::string const type_name{T_Element::type};
+            switch (on_missing)
+            {
+                case OnMissingLinearMap::Throw:
+                {
+                    std::string msg = "Undefined linear transport map in lattice for element ";
+                    if (element.has_name()) { msg += element.name() + " "; }
+                    msg += "of type " + type_name;
+                    throw std::runtime_error(msg);
+                }
+                case OnMissingLinearMap::IdentityWithWarning:
+                {
+                    if (warned_types.insert(type_name).second)
+                    {
+                        ablastr::warn_manager::WMRecordWarning(
+                            "ImpactX::diagnostics::map_trace",
+                            "Element type '" + type_name + "' does not provide a "
+                            "linear transport map. It is being treated as the "
+                            "identity for this diagnostic. Any linear-optics "
+                            "output (Twiss, tune, chromaticity, dispersion) will "
+                            "therefore not include this element's contribution.",
+                            ablastr::warn_manager::WarnPriority::medium
+                        );
+                    }
+                    return Map6x6::Identity();
+                }
+                case OnMissingLinearMap::IdentitySilent:
+                {
+                    // User explicitly opted in to identity fallback;
+                    // suppress the warning as they already know.
+                    return Map6x6::Identity();
+                }
+            }
+            // All enum values handled above; unreachable.
+            return Map6x6::Identity();
+        }
+    }
+
+    /** Functor type used as the default @c walk_lattice exit hook.
+     *
+     *  Its call operator does nothing. When used as the default template
+     *  argument of @ref walk_lattice, it allows callers that only care
+     *  about the cumulative linear map to omit the hook altogether.
+     */
+    struct NoopElementExit
+    {
+        template <typename T_Element>
+        void operator() (
+            T_Element const & /*element*/,
+            RefPart const & /*ref*/,
+            Map6x6 const & /*M_cum*/
+        ) const noexcept
+        {}
+    };
+
+    /** Traverse the lattice, advancing the reference particle and
+     *  composing the cumulative linear transport map, with a
+     *  per-element exit hook.
+     *
+     *  The reference particle passed in is copied internally; the
+     *  caller's reference particle is never modified. The cumulative
+     *  map is returned, starting from the identity; a fresh warning-
+     *  deduplication set is maintained per call.
+     *
+     *  Uses the same per-element advance / linear-map evaluation
+     *  convention as the envelope tracker in
+     *  @c src/tracking/envelope.cpp , so the resulting linear optics
+     *  is consistent with the tracker for edge-sensitive elements
+     *  such as @c RFCavity, @c SoftQuad, and @c SoftSol.
+     *
+     * @tparam F_OnElementExit callable
+     *                         @c void(E const&, RefPart const&, Map6x6 const&)
+     *                         invoked once per element after all
+     *                         slices have been processed; defaults to
+     *                         @c NoopElementExit (no-op)
+     * @param[in] lattice         lattice to traverse
+     * @param[in] ref_part_init   reference particle at the starting s
+     *                            (copied internally)
+     * @param[in] on_missing      policy for elements without a
+     *                            linear transport map
+     * @param[in] on_element_exit per-element hook (optional)
+     * @return end-to-end 6x6 linear transport map
+     */
+    template <typename F_OnElementExit = NoopElementExit>
+    Map6x6
+    walk_lattice (
+        std::list<elements::KnownElements> const & lattice,
+        RefPart const & ref_part_init,
+        OnMissingLinearMap on_missing,
+        F_OnElementExit && on_element_exit = NoopElementExit{}
+    )
+    {
+        // private copy of the reference particle
+        RefPart ref = ref_part_init;
+        Map6x6 M_cum = Map6x6::Identity();
+
+        // warn only once per element type
+        std::set<std::string> warned_types;
+
+        // The element loop mirrors src/tracking/envelope.cpp
+        for (auto const & element_variant : lattice)
+        {
+            ref.sedge = ref.s;
+
+            std::visit([&](auto && element)
+            {
+                using E = std::decay_t<decltype(element)>;
+
+                int const nslice = element.nslice();
+                for (int slice_i = 0; slice_i < nslice; ++slice_i)
+                {
+                    element(ref);
+                    Map6x6 const R_slice = safe_transport_map<E>(
+                        element, ref, warned_types, on_missing
+                    );
+                    M_cum = R_slice * M_cum;
+                }
+
+                on_element_exit(element, ref, M_cum);
+            }, element_variant);
+        }
+
+        return M_cum;
+    }
+} // namespace
+
+    std::vector<MapTraceEntry>
+    map_trace (
+        std::list<elements::KnownElements> const & lattice,
+        RefPart const & ref_part_init,
+        OnMissingLinearMap on_missing
+    )
+    {
+        BL_PROFILE("impactx::diagnostics::map_trace");
+
+        std::vector<MapTraceEntry> trace;
+        trace.reserve(lattice.size() + 1u);
+
+        // Leading entry: identity map at the starting s. This makes the
+        // returned vector always start at the beginning of the lattice so
+        // downstream code (e.g., Twiss propagation) can treat every entry uniformly.
+        trace.push_back(MapTraceEntry{
+            ref_part_init.s,
+            std::string{},
+            std::string{"<start>"},
+            Map6x6::Identity()
+        });
+
+        walk_lattice(
+            lattice, ref_part_init, on_missing,
+            [&trace](auto const & element, RefPart const & ref_now, Map6x6 const & M_now)
+            {
+                using E = std::decay_t<decltype(element)>;
+                trace.push_back(MapTraceEntry{
+                    ref_now.s,
+                    element.has_name() ? element.name() : std::string{},
+                    std::string{E::type},
+                    M_now
+                });
+            }
+        );
+
+        return trace;
+    }
+
+    Map6x6
+    linear_map (
+        std::list<elements::KnownElements> const & lattice,
+        RefPart const & ref_part_init,
+        OnMissingLinearMap on_missing
+    )
+    {
+        BL_PROFILE("impactx::diagnostics::linear_map");
+
+        // End-to-end map only: rely on walk_lattice's default no-op
+        // element-exit hook (NoopElementExit), so no per-element
+        // MapTraceEntry (two std::string copies plus a 6x6 matrix per
+        // element) is constructed.
+        return walk_lattice(lattice, ref_part_init, on_missing);
+    }
+
+} // namespace impactx::diagnostics

--- a/src/python/lattice.cpp
+++ b/src/python/lattice.cpp
@@ -5,6 +5,7 @@
  */
 #include "pyImpactX.H"
 
+#include <diagnostics/LinearMap.H>
 #include <elements/All.H>
 #include <elements/mixin/lineartransport.H>
 #include <elements/transformation/Insert.H>
@@ -23,6 +24,7 @@ using namespace impactx;
 void init_lattice(py::module& me)
 {
     using elements::KnownElements;
+    namespace ix_diag = ::impactx::diagnostics;
 
     // all-element type list
     using KnownElementsList = std::list<KnownElements>;
@@ -80,61 +82,90 @@ void init_lattice(py::module& me)
 
         .def(
             "transfer_map",
+            // The reference particle is taken by value. pybind11 copies it
+            // from the caller on entry, so the caller's ``sim.beam.ref`` is
+            // not modified when the internal traversal advances the
+            // reference.
             [](
-                KnownElementsList &v,
-                RefPart ref, // note: intentional copy
+                KnownElementsList const & v,
+                RefPart ref,
                 std::string order,
                 bool fallback_identity_map
             )
             {
                 if (order != "linear") {
-                    throw std::runtime_error("So far, only the calculation of linear transfer maps are supported in this function.");
+                    throw std::runtime_error(
+                        "Only the calculation of linear transfer maps is "
+                        "currently supported."
+                    );
                 }
-                Map6x6 linear_transfer_map = Map6x6::Identity();
-                for (auto & el_v : v)
-                {
-                    // advance reference particle
-                    std::visit([&ref](auto && el) {
-                        el(ref);
-                    }, el_v);
-
-                    // extract element transport map, handle fallback
-                    Map6x6 element_transport_map = Map6x6::Identity();
-                    int element_nslice;
-                    std::visit([&ref, &fallback_identity_map, &element_transport_map, &element_nslice](auto const & el) {
-                        using Element = std::decay_t<decltype(el)>;
-                        std::string not_impl_msg = "Undefined transfer map in lattice for element ";
-                        if (el.has_name()) not_impl_msg += el.name() + " ";
-                        not_impl_msg += std::string("of type ") + Element::type;
-
-                        if constexpr (std::is_base_of_v<elements::mixin::LinearTransport<Element>, Element>) {
-                            try {
-                                element_transport_map = el.transport_map(ref);
-                                element_nslice = el.nslice();
-                            } catch (std::exception const &) {
-                                if (!fallback_identity_map) {
-                                    throw std::runtime_error(not_impl_msg);
-                                }
-                            }
-                        } else {
-                            if (!fallback_identity_map) {
-                                throw std::runtime_error(not_impl_msg);
-                            }
-                        }
-                    }, el_v);
-
-                    // advance linear transfer map
-                    for (int n = 0; n < element_nslice; n++) {
-                        linear_transfer_map = element_transport_map * linear_transfer_map;
-                    }
-                }
-                return linear_transfer_map;
+                auto const on_missing = fallback_identity_map
+                    ? ix_diag::OnMissingLinearMap::IdentitySilent
+                    : ix_diag::OnMissingLinearMap::Throw;
+                return ix_diag::linear_map(v, ref, on_missing);
             },
             py::arg("ref"),
             py::arg("order") = "linear",
             py::arg("fallback_identity_map") = false,
-            "Calculate the transfer map of the elements in the list."
-            )
+            "Calculate the end-to-end transfer map of the elements in the list.\n\n"
+            "Currently only the linear transfer map is implemented (``order=\"linear\"``);\n"
+            "the ``order`` parameter is reserved for future higher-order extensions.\n"
+            "In linear mode the 6x6 map is composed element by element, using each\n"
+            "element's analytic per-slice linear transport map.\n\n"
+            "Collective effects like space charge, Coherent/Incoherent Synchrotron\n"
+            "Radiation (CSR/ISR), and wakefield effects are not applied here; the\n"
+            "returned map describes the purely linear single-particle dynamics of the\n"
+            "design lattice.\n\n"
+            "Phase-space ordering in the returned matrix is (x, px, y, py, t, pt).\n\n"
+            ":param ref: reference particle at the starting s\n"
+            ":param order: So far, only the calculation of linear transfer maps is supported.\n"
+            ":param fallback_identity_map: For elements with an undefined transfer map in the lattice, assume the identity matrix.\n"
+        )
+
+        .def(
+            "map_trace",
+            [](KnownElementsList const & v, RefPart ref)  // intentional copy of ref
+            {
+                auto const trace = ix_diag::map_trace(v, ref);
+
+                py::list out;
+                for (auto const & e : trace)
+                {
+                    py::dict d;
+                    d["s"] = e.s;
+                    d["name"] = e.element_name;
+                    d["type"] = e.element_type;
+                    d["M"] = e.M_cumulative;
+                    out.append(std::move(d));
+                }
+                return out;
+            },
+            py::arg("ref"),
+            "Trace the cumulative 6x6 linear transport map element by element.\n\n"
+            "The reference particle is passed by value (intentional copy); the\n"
+            "caller's reference particle is not modified in place. This matches\n"
+            "the convention used by ``transfer_map``.\n\n"
+            "This per-element trace is what ``sim.twiss()`` consumes to transport\n"
+            "Twiss functions through the lattice.\n\n"
+            "If you only need the final cumulative map at the lattice exit,\n"
+            "prefer ``transfer_map(ref)`` instead of indexing the last entry\n"
+            "of ``map_trace(ref)``.\n\n"
+            ":param ref: A reference particle.\n"
+            ":return: A list of dictionaries, one per lattice element plus a\n"
+            "    leading entry for the starting position. Each entry contains:\n\n"
+            "    * ``s``    -- integrated path length along the reference orbit,\n"
+            "      in meters;\n"
+            "    * ``name`` -- user-supplied element name (empty string if not\n"
+            "      named);\n"
+            "    * ``type`` -- element type string (e.g. ``\"Drift\"``,\n"
+            "      ``\"Quad\"``, ``\"Sbend\"``);\n"
+            "    * ``M``    -- cumulative 6x6 linear transport map from the\n"
+            "      start of the lattice to the exit of this element (a\n"
+            "      ``Map6x6`` instance; call ``.to_numpy()`` for a standard\n"
+            "      C-ordered NumPy array).\n\n"
+            "    The first entry always has the identity map at the starting\n"
+            "    ``s``; the last entry contains the same map as ``transfer_map``."
+        )
     ;
 
 


### PR DESCRIPTION
`transfer_map` now follows the reference orbit with the correct element entrance `s` and per-slice reference update, so the accumulated linear map matches the actual single-particle optics through the lattice.

This fixes wrong end-to-end maps for elements whose linear response depends on the evolving reference state, especially RF cavities and soft field elements such as SoftQuadrupole and SoftSolenoid.

Also add an element-by-element map trace, so the build-up of focusing and coupling can be inspected along `s` instead of only at the lattice exit. Both implementations share the same logic / do not repeat themselves. We will use the map trace in follow-up PRs that implement twiss optics/diagnostics.