### PR TITLE
Linear Transport: Thin Dipole

### DIFF
--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -32,7 +32,7 @@ namespace impactx::elements
     struct ThinDipole
     : public mixin::Named,
       public mixin::BeamOptic<ThinDipole>,
-      public mixin::LinearTransport<ThinDipole, false>,
+      public mixin::LinearTransport<ThinDipole>,
       public mixin::Thin,
       public mixin::Alignment,
       public mixin::NoFinalize,
@@ -193,15 +193,59 @@ namespace impactx::elements
 
         /** This function returns the linear transport map.
          *
+         * Linearization of the Ripken-Schmidt thin-dipole kick
+         * (eqs. 3.2 of CERN/SL/95-12 (AP), 1995, already cited in the
+         * class docstring) about the reference trajectory. With the
+         * effective arc length ds = theta * rc and curvature kx = 1/rc,
+         * the thin kick is
+         *   dpx = - kx^2 * ds * x + kx * ds * f(pt)
+         *   dt  = + kx * ds * x * f'(pt)
+         * where f(pt) = -1 + sqrt(1 - 2*pt/beta + pt^2) satisfies
+         * f(0) = 0, f'(0) = 1/beta. The Jacobian at the origin yields:
+         *   R(2,1) = - kx^2 * ds     = - theta / rc
+         *   R(2,6) = - kx * ds / beta = - theta / beta
+         *   R(5,1) = + kx * ds / beta = + theta / beta
+         * All other entries are identity.
+         *
+         * Cross-check: in the short-arc limit (theta << 1) this agrees
+         * with Sbend::transport_map, specifically
+         *   R(2,1) = -sin(theta)/rc  ~ -theta/rc,
+         *   R(2,6) = -sin(theta)/bet ~ -theta/bet,
+         *   R(5,1) = +sin(theta)/bet ~ +theta/bet,
+         * after dropping the thick-lens drift contributions
+         * (R(1,2) = rc*sin(theta), R(5,6) = ... etc.) that a thin
+         * element does not carry.
+         *
+         * Sign convention: ImpactX uses pt = -Delta(gamma)/(beta0*gamma0)
+         * (opposite sign to MAD-X's PT = +Delta(E)/(p0*c)); the signs of
+         * the (2,6) and (5,1) entries above therefore match the sibling
+         * Sbend element in ImpactX but differ by an overall sign from
+         * the MAD-X thin-dipole formulas.
+         *
+         * Ideal behavior only: alignment and rotation errors and
+         * feed-down from a nonzero reference orbit are ignored; the
+         * linearization is taken at (x, y, t) = (0, 0, 0) and pt = 0.
+         *
          * @param[in] refpart reference particle
          * @returns 6x6 transport matrix
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE
         Map6x6
-        transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
+        transport_map (RefPart const & AMREX_RESTRICT refpart) const
         {
-            throw std::runtime_error(std::string(type) + ": Envelope tracking is not yet implemented!");
-            return Map6x6::Identity();
+            using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
+
+            amrex::ParticleReal const beta = refpart.beta();
+            amrex::ParticleReal const ds = m_theta * m_rc;     // effective arc length
+            amrex::ParticleReal const kx = 1.0_prt / m_rc;     // curvature
+
+            Map6x6 R = Map6x6::Identity();
+            R(2,1) = -powi<2>(kx) * ds;      // geometric focusing
+            R(2,6) = -kx * ds / beta;        // chromatic dispersion kick
+            R(5,1) = +kx * ds / beta;        // path-length coupling to x
+
+            return R;
         }
 
         amrex::ParticleReal m_theta;  //! dipole bending angle (rad)

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -194,8 +194,7 @@ namespace impactx::elements
         /** This function returns the linear transport map.
          *
          * Linearization of the Ripken-Schmidt thin-dipole kick
-         * (eqs. 3.2 of CERN/SL/95-12 (AP), 1995, already cited in the
-         * class docstring) about the reference trajectory. With the
+         * about the reference trajectory. With the
          * effective arc length ds = theta * rc and curvature kx = 1/rc,
          * the thin kick is
          *   dpx = - kx^2 * ds * x + kx * ds * f(pt)
@@ -206,21 +205,6 @@ namespace impactx::elements
          *   R(2,6) = - kx * ds / beta = - theta / beta
          *   R(5,1) = + kx * ds / beta = + theta / beta
          * All other entries are identity.
-         *
-         * Cross-check: in the short-arc limit (theta << 1) this agrees
-         * with Sbend::transport_map, specifically
-         *   R(2,1) = -sin(theta)/rc  ~ -theta/rc,
-         *   R(2,6) = -sin(theta)/bet ~ -theta/bet,
-         *   R(5,1) = +sin(theta)/bet ~ +theta/bet,
-         * after dropping the thick-lens drift contributions
-         * (R(1,2) = rc*sin(theta), R(5,6) = ... etc.) that a thin
-         * element does not carry.
-         *
-         * Sign convention: ImpactX uses pt = -Delta(gamma)/(beta0*gamma0)
-         * (opposite sign to MAD-X's PT = +Delta(E)/(p0*c)); the signs of
-         * the (2,6) and (5,1) entries above therefore match the sibling
-         * Sbend element in ImpactX but differ by an overall sign from
-         * the MAD-X thin-dipole formulas.
          *
          * Ideal behavior only: alignment and rotation errors and
          * feed-down from a nonzero reference orbit are ignored; the


### PR DESCRIPTION
Implement an ideal `transport_map` for the thin dipole element.