### PR TITLE
Linear Transport: Programmable

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1500,6 +1500,19 @@ This module provides elements and methods for the accelerator lattice.
          This function is called for the reference particle as it passes through the element.
          The reference particle is updated *before* the beam particles are pushed.
 
+   .. py:property:: linear_map
+
+      This is a function hook for pushing the linear transport map as a function of the reference particle.
+      When set, it is used by envelope tracking and diagnostics like :py:meth:`impactx.elements.KnownElementsList.transfer_map`,
+      :py:meth:`impactx.elements.KnownElementsList.map_trace` and Twiss diagnostics.
+
+      This accepts a function or lambda with the following argument:
+
+      .. py:method:: user_defined_map_function(refpart: impactx.RefPart)
+
+         This function is called when querying the linear transport map of the element.
+         The reference particle must be updated *before* this call.
+
 .. py:class:: impactx.elements.Quad(ds, k, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, nslice=1, name=None)
 
    A Quadrupole magnet.

--- a/src/diagnostics/LinearMap.cpp
+++ b/src/diagnostics/LinearMap.cpp
@@ -62,8 +62,17 @@ namespace
         }
         else
         {
-            // Cold path: only instantiated for element types whose
-            // transport_map is known to throw. No try/catch needed.
+            // Cold path: element has no compile-time-guaranteed linear
+            // map. Some elements (e.g. @c Programmable with an
+            // optional user-supplied hook) can still provide one at
+            // runtime -- try them first and fall through to the
+            // @p on_missing policy only if they throw.
+            try {
+                return element.transport_map(ref);
+            } catch (std::exception const &) {
+                // Fall through to the policy branch below.
+            }
+
             std::string const type_name{T_Element::type};
             switch (on_missing)
             {

--- a/src/elements/Programmable.H
+++ b/src/elements/Programmable.H
@@ -88,17 +88,34 @@ namespace impactx::elements
 
         /** This function returns the linear transport map.
          *
+         * By default, @c Programmable provides no linear map because its
+         * particle push is an arbitrary user callback. Users who know the
+         * Jacobian of their push around the reference trajectory can opt
+         * in by setting the @c m_transport_map hook: a callable that
+         * returns a 6x6 transport matrix as a function of the current
+         * reference particle. When set, this hook is used by envelope
+         * tracking, @c lattice.transfer_map, @c map_trace, and Twiss.
+         *
+         * If the hook is not set, this function throws a runtime error
+         * pointing the user to the hook (or, for purely linear pushes,
+         * to the @c LinearMap element).
+         *
          * @param[in] refpart reference particle
-         * @returns 6x6 transport matrix
+         * @returns 6x6 transport matrix from the user-supplied hook
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE
         Map6x6
-        transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
+        transport_map (RefPart const & AMREX_RESTRICT refpart) const
         {
-            // TODO: can/should we fuse the two elements?
-            throw std::runtime_error("The Programmable element cannot be used for linear transport maps. Use the LinearMap element instead.");
-
-            return Map6x6::Identity();
+            if (m_transport_map == nullptr) {
+                throw std::runtime_error(
+                    "Programmable: no linear transport map hook was set. "
+                    "Set Programmable.transport_map_hook = <callable(refpart)->6x6> "
+                    "for envelope/linear-optics tracking, or use the LinearMap "
+                    "element for a purely linear map."
+                );
+            }
+            return m_transport_map(refpart);
         }
 
         /** Number of slices used for the application of space charge
@@ -141,6 +158,7 @@ namespace impactx::elements
         std::function<void(ImpactXParticleContainer *, int, int)> m_push; //! hook for push of whole container (pc, step, period)
         std::function<void(ImpactXParticleContainer::iterator *, RefPart &)> m_beam_particles; //! hook for beam particles (pti, ref)
         std::function<void(RefPart &)> m_ref_particle; //! hook for reference particle
+        std::function<Map6x6(RefPart const &)> m_transport_map; //! optional hook for linear transport map (refpart -> 6x6)
         std::function<void()> m_finalize; //! hook for finalize cleanup
     };
 

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -1917,6 +1917,17 @@ void init_elements(py::module& m)
               ) { p.m_ref_particle = std::move(new_hook); },
               "hook for reference particle (RefPart)"
         )
+        .def_property("linear_map",
+              [](Programmable & p) { return p.m_transport_map; },
+              [](Programmable & p,
+                 std::function<Map6x6(RefPart const &)> new_hook
+              ) { p.m_transport_map = std::move(new_hook); },
+              "hook returning the 6x6 linear transport map for this "
+              "element as a function of the reference particle; when set, it is "
+              "used by envelope tracking, lattice.transfer_map, map_trace, and "
+              "the Twiss diagnostics; when unset, those diagnostics raise a "
+              "runtime error."
+        )
     ;
 
     py::class_<Quad, elements::mixin::Named, elements::mixin::Thick, elements::mixin::Alignment, elements::mixin::PipeAperture> py_Quad(me, "Quad");

--- a/tests/python/test_lattice_optics.py
+++ b/tests/python/test_lattice_optics.py
@@ -68,3 +68,53 @@ def test_lattice_linear_map():
     # Now the user explicitly assumes that undefined maps are identity maps
     R = lattice.transfer_map(ref, fallback_identity_map=True)
     assert np.allclose(R.to_numpy(), R_expected, rtol=rtol, atol=atol)
+
+
+def test_programmable_linear_hook():
+    """When Programmable.linear_map hook is set, it must be used by
+    transfer_map. When it is unset, transfer_map must raise."""
+    from impactx import Map6x6
+
+    ref = RefPart()
+    ref.set_species("electron").set_kin_energy_MeV(100.0)
+
+    # A user-supplied linear map: a thin quad kick with strength k_user.
+    k_user = 0.7
+    R_user = np.eye(6)
+    R_user[1, 0] = -k_user
+    R_user[3, 2] = -k_user
+
+    def my_map(_refpart):
+        out = Map6x6()
+        for i in range(6):
+            for j in range(6):
+                out[i + 1, j + 1] = float(R_user[i, j])
+        return out
+
+    # Without hook: must raise. (extend() copies the element into the
+    # lattice's variant, so any subsequent modification of the local
+    # Python handle does not propagate into the lattice.)
+    lattice_no_hook = elements.KnownElementsList()
+    lattice_no_hook.extend(
+        [elements.Drift(ds=0.1), elements.Programmable(), elements.Drift(ds=0.1)]
+    )
+    with pytest.raises(RuntimeError):
+        lattice_no_hook.transfer_map(ref)
+
+    # With hook set before insertion: drift(0.1) * R_user * drift(0.1).
+    prog = elements.Programmable()
+    prog.linear_map = my_map
+    lattice = elements.KnownElementsList()
+    lattice.extend([elements.Drift(ds=0.1), prog, elements.Drift(ds=0.1)])
+    R = lattice.transfer_map(ref).to_numpy()
+
+    pt = ref.pt
+    bg2 = pt * pt - 1.0
+    D = np.eye(6)
+    D[0, 1] = 0.1
+    D[2, 3] = 0.1
+    D[4, 5] = 0.1 / bg2
+    R_expected = D @ R_user @ D
+
+    tol = 1.0e-4 if Config.precision == "SINGLE" else 1.0e-10
+    assert np.max(np.abs(R - R_expected)) < tol


### PR DESCRIPTION
Enable to set the linear transfer map of the programmable element, if desired. Simply accepts a ref-particle dependent function generator for a 6x6 matrix. This is a bit more general than `SpinMap` element, which has a static map that does not depend on `ref`.