### PR TITLE
Add spin to ConstF.

### DIFF
--- a/src/elements/ConstF.H
+++ b/src/elements/ConstF.H
@@ -299,11 +299,10 @@ namespace impactx::elements
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
-             // spin is unaffected
+            // spin is unaffected
 
             // phase space push
             (*this)(x, y, t, px, py, pt, idcpu, refpart);
-
         }
 
 

--- a/src/elements/ConstF.H
+++ b/src/elements/ConstF.H
@@ -16,6 +16,7 @@
 #include "mixin/beamoptic.H"
 #include "mixin/thick.H"
 #include "mixin/lineartransport.H"
+#include "mixin/spintransport.H"
 #include "mixin/named.H"
 #include "mixin/nofinalize.H"
 
@@ -37,6 +38,7 @@ namespace impactx::elements
       public mixin::Thick,
       public mixin::Alignment,
       public mixin::PipeAperture,
+      public mixin::SpinTransport,
       public mixin::NoFinalize,
       public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
     {
@@ -266,6 +268,44 @@ namespace impactx::elements
             refpart.s = s + slice_ds;
 
         }
+
+        /** This operator pushes the particle spin.
+         *
+         * @param x particle position in x
+         * @param y particle position in y
+         * @param t particle position in t
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param sx particle spin x-component
+         * @param sy particle spin y-component
+         * @param sz particle spin z-component
+         * @param idcpu particle global index
+         * @param refpart reference particle (unused)
+         */
+        template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void spin_and_phasespace_push (
+            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
+             // spin is unaffected
+
+            // phase space push
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+
+        }
+
 
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();

--- a/src/elements/ConstF.H
+++ b/src/elements/ConstF.H
@@ -269,7 +269,9 @@ namespace impactx::elements
 
         }
 
-        /** This operator pushes the particle spin.
+        /** This operator pushes the particle spin and phase space.
+         *
+         * Note: the spin is unaffected by this element.
          *
          * @param x particle position in x
          * @param y particle position in y

--- a/src/elements/ConstF.H
+++ b/src/elements/ConstF.H
@@ -288,17 +288,17 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real & AMREX_RESTRICT pt,
             [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
             [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
             [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            T_IdCpu & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             // spin is unaffected

--- a/tests/python/test_benchmark_elements.py
+++ b/tests/python/test_benchmark_elements.py
@@ -170,6 +170,7 @@ def test_ChrAcc(benchmark, sim):
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)
 
 
+# Spin is not affected by this element, no need to test variant
 def test_ConstF(benchmark, sim):
     el = elements.ConstF(name="constf1", ds=2.0, kx=1.0, ky=1.0, kt=1.0, nslice=nslice)
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)

--- a/tests/python/test_reversibility_elements.py
+++ b/tests/python/test_reversibility_elements.py
@@ -301,6 +301,7 @@ def test_ChrAcc(sim):
     )
 
 
+# Spin is not affected by this element, no need to test variant
 def test_ConstF(sim):
     roundtrip(
         elements.ConstF(ds=2.0, kx=1.0, ky=1.0, kt=1.0, nslice=nslice, **PIPE_KWARGS),


### PR DESCRIPTION
The ConstF element is an "artificial" element that provides (optional) linear focusing in each of the three phase planes.  Since it is not directly associated with a physical field configuration, no action is provided on the particle spin.