### PR TITLE
Simple Element & Lattice Comparisons

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1249,6 +1249,24 @@ comparison methods. They derive directly from each element's ``to_dict()`` outpu
       # Lattice-wide comparison forwards ignore_attributes to each element.
       lattice_a.isclose(lattice_b, ignore_attributes=["name"])
 
+.. py:function:: impactx.elements.isclose(a, b, *, rtol=1e-12, atol=0.0, ignore_attributes=None)
+
+   Free-function form of :py:meth:`isclose`, equivalent to ``a.isclose(b, ...)``.
+   Accepts either two elements or two iterables of elements
+   (``KnownElementsList``, ``FilteredElementsList``, plain ``list``).
+
+   .. code-block:: python
+
+      from impactx import elements
+
+      # two elements
+      d1 = elements.Drift(ds=1.0, name="d1")
+      d2 = elements.Drift(ds=1.0 + 1e-15, name="d2")
+      elements.isclose(d1, d2, ignore_attributes="name")
+
+      # two lattices (KnownElementsList, FilteredElementsList, or plain list)
+      elements.isclose(lattice_a, lattice_b, ignore_attributes=["name"])
+
 
 Lattice Elements
 ----------------

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -791,8 +791,8 @@ Initial Beam Spin Distribution
    :param muz: z component of the unit vector specifying the mean direction
 
 
-Lattice Elements
-----------------
+Lattice
+-------
 
 This module provides elements and methods for the accelerator lattice.
 
@@ -1056,6 +1056,28 @@ This module provides elements and methods for the accelerator lattice.
          # from my_lattice import get_lattice
          # lattice = get_lattice()
 
+   .. py:method:: __eq__(other)
+
+      Element-wise equality.
+      Number of elements and every pair of elements must compare equal under ``==``.
+
+   .. py:method:: isclose(other, *, rtol=1e-12, atol=0.0, ignore_attributes=None)
+
+      Tolerant element-wise comparison. Number of elements must match.
+      For each pair of elements at the same index, calls the element's own ``isclose``.
+
+      :param other: Any iterable of elements
+         (:py:class:`~impactx.elements.KnownElementsList`,
+         :py:class:`~impactx.elements.FilteredElementsList`, or plain ``list``).
+      :param rtol: Relative tolerance (default ``1e-12``).
+      :param atol: Absolute tolerance (default ``0.0``).
+      :param ignore_attributes: ``to_dict()`` keys to skip when comparing each
+         pair of elements. Accepts a single string or any iterable of strings.
+         Forwarded to each element's ``isclose``; see
+         :ref:`element-comparison-methods` for the full semantics, including
+         the special ``"type"`` key for cross-variant comparisons.
+      :rtype: bool
+
    .. py:method:: plot_survey(ref=None, ax=None, legend=True, legend_ncols=5)
 
       Plot over s of all elements in the KnownElementsList.
@@ -1154,6 +1176,82 @@ This module provides elements and methods for the accelerator lattice.
 
          # Clear alignment errors and apertures
          sim.lattice.select(kind=r".*Quad").replace_with_drifts(keep_alignment=False)
+
+   .. py:method:: __eq__(other)
+
+      Element-wise equality, with the same semantics as
+      :py:meth:`impactx.elements.KnownElementsList.__eq__`. A filtered view
+      compares equal to any iterable of elements (plain Python ``list``,
+      :py:class:`~impactx.elements.KnownElementsList`, or another
+      :py:class:`~impactx.elements.FilteredElementsList`) as long as the
+      lengths and pairwise element comparisons match.
+
+   .. py:method:: isclose(other, *, rtol=1e-12, atol=0.0, ignore_attributes=None)
+
+      Tolerant element-wise comparison, with the same semantics as
+      :py:meth:`impactx.elements.KnownElementsList.isclose`.
+      ``ignore_attributes`` is forwarded to each element's ``isclose``.
+
+.. _element-comparison-methods:
+
+Common comparison methods on lattice elements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Every lattice element class in :py:mod:`impactx.elements` supports the following value-based
+comparison methods. They derive directly from each element's ``to_dict()`` output.
+
+.. py:method:: impactx.elements.Element.__eq__(other)
+
+   Value-based equality. Two elements are equal if they are instances of the
+   same class and their ``to_dict()`` outputs match key-for-key. Float-valued
+   fields are compared via ``==`` (so ``NaN != NaN``); list/matrix values are
+   compared element-wise.
+
+.. py:method:: impactx.elements.Element.isclose(other, *, rtol=1e-12, atol=0.0, ignore_attributes=None)
+
+   Tolerant equality.
+   Float-valued fields are compared via
+   ``math.isclose(rel_tol=rtol, abs_tol=atol)``; lists/matrices of floats are compared
+   element-wise. All other value types (ints, strings, ``None``) fall back to strict ``==``.
+   Mismatched element types and foreign operands return ``False`` (unless ``"type"`` is
+   listed in ``ignore_attributes``).
+
+   :param other: Element to compare against.
+   :param rtol: Relative tolerance forwarded to ``math.isclose`` / ``numpy.allclose``.
+   :param atol: Absolute tolerance. Default ``0.0``.
+   :param ignore_attributes: ``to_dict()`` keys to skip during the comparison.
+      Accepts a single string or any iterable of strings. Useful when comparing
+      loaded files where bookkeeping fields such as ``"name"`` should not
+      affect the verdict. Including the special key ``"type"`` disables the
+      same-class check, so e.g. :py:class:`~impactx.elements.Drift` and
+      :py:class:`~impactx.elements.ExactDrift` can be compared on their common
+      parameters; remaining keys must still match.
+   :rtype: bool
+
+   **Examples:**
+
+   .. code-block:: python
+
+      from impactx import elements
+
+      a = elements.Drift(ds=1.0, name="d1")
+      b = elements.Drift(ds=1.0 + 1e-15, name="d2")
+
+      a == b      # False — name differs and ds differs by float noise
+      a.isclose(b)                              # False — name still differs
+      a.isclose(b, ignore_attributes="name")    # True
+
+      # Compare a Drift to its exact-physics counterpart on common fields.
+      lin = elements.Drift(ds=1.0)
+      ex = elements.ExactDrift(ds=1.0)
+      lin.isclose(ex, ignore_attributes=["type"])  # True
+
+      # Lattice-wide comparison forwards ignore_attributes to each element.
+      lattice_a.isclose(lattice_b, ignore_attributes=["name"])
+
+
+Lattice Elements
+----------------
 
 .. py:class:: impactx.elements.CFbend(ds, rc, k, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, nslice=1, name=None)
 

--- a/src/python/impactx/__init__.py
+++ b/src/python/impactx/__init__.py
@@ -44,6 +44,9 @@ from .extensions.SoftQuadrupole import (
 from .extensions.SoftSolenoid import (
     register_SoftSolenoid_extension,
 )
+from .extensions.Elements import (
+    register_elements_value_semantics,
+)
 
 # at this place we can enhance Python classes with additional methods written
 # in pure Python or add some other Python logic
@@ -65,3 +68,6 @@ register_ImpactXParticleContainer_extension(impactx_pybind.ImpactXParticleContai
 register_RFCavity_extension(impactx_pybind.elements.RFCavity)
 register_SoftQuadrupole_extension(impactx_pybind.elements.SoftQuadrupole)
 register_SoftSolenoid_extension(impactx_pybind.elements.SoftSolenoid)
+
+# Value-based __eq__, __hash__, and isclose() on every element class
+register_elements_value_semantics(impactx_pybind.elements)

--- a/src/python/impactx/extensions/Elements.py
+++ b/src/python/impactx/extensions/Elements.py
@@ -199,9 +199,25 @@ def _element_isclose(
     return _dict_close(d1, d2, rtol, atol)
 
 
+def isclose(a, b, **kwargs):
+    """Free-function form of ``a.isclose(b)``.
+
+    Provided so the call site reads symmetrically in ``a`` and ``b``,
+    like :py:func:`math.isclose` / :py:func:`numpy.isclose`. Equivalent
+    to the method form; forwards ``rtol``, ``atol``, and
+    ``ignore_attributes``. Dispatches to ``b`` if ``a`` lacks
+    ``isclose`` (e.g., a plain Python ``list`` paired with a
+    ``KnownElementsList``).
+    """
+    if hasattr(a, "isclose"):
+        return a.isclose(b, **kwargs)
+    return b.isclose(a, **kwargs)
+
+
 def register_elements_value_semantics(elements_module):
     """Attach ``__eq__``, ``__hash__``, and ``isclose`` to every class
-    in ``elements_module`` that exposes a ``to_dict`` method.
+    in ``elements_module`` that exposes a ``to_dict`` method, and the
+    free-function ``isclose`` on the module itself.
 
     Parameters
     ----------
@@ -222,3 +238,4 @@ def register_elements_value_semantics(elements_module):
         # ``__hash__`` afterwards to keep instances hashable.
         cls.__hash__ = _element_hash
         cls.isclose = _element_isclose
+    elements_module.isclose = isclose

--- a/src/python/impactx/extensions/Elements.py
+++ b/src/python/impactx/extensions/Elements.py
@@ -1,0 +1,224 @@
+"""
+This file is part of ImpactX
+
+Copyright 2026 ImpactX contributors
+Authors: Axel Huebl
+License: BSD-3-Clause-LBNL
+
+Adds value-based ``__eq__``, ``__hash__``, and ``isclose()`` to every
+lattice element class that exposes a ``to_dict()`` method.
+
+The semantics are derived from the dict returned by ``to_dict()``:
+
+- ``__eq__`` compares dict keys and values via ``==`` (with element-wise
+  comparison for lists and ``numpy.array_equal`` for AMReX SmallMatrix
+  values). It returns ``NotImplemented`` for foreign operands so Python's
+  reflected-equality fallback applies.
+- ``__hash__`` is consistent with ``__eq__``. Hashing reflects the
+  element's *current* parameter values; mutating an element after using
+  it as a ``set`` member or ``dict`` key is undefined behavior, the same
+  contract as a hypothetical hashable list.
+- ``isclose(other, *, rtol, atol)`` mirrors ``math.isclose`` /
+  ``numpy.isclose`` naming. Floats use ``math.isclose``; lists of floats
+  are compared element-wise; AMReX SmallMatrix values use
+  ``numpy.allclose``; everything else (ints, strings, ``None``) uses
+  ``==``.
+"""
+
+import inspect
+import math
+
+_DEFAULT_RTOL = 1e-12
+_DEFAULT_ATOL = 0.0
+
+# Names in the elements module that should not receive these methods.
+# KnownElementsList / FilteredElementsList are containers, not elements;
+# they do not currently expose a singular ``to_dict``, but we list them
+# explicitly so the intent is unambiguous.
+_SKIP = frozenset({"KnownElementsList", "FilteredElementsList"})
+
+
+def _canon(v):
+    """Map a ``to_dict()`` value to a hashable, type-tagged form.
+
+    The type tag prevents accidental collisions between different value
+    shapes (e.g., a list and a tuple with the same numeric contents).
+    """
+    if v is None or isinstance(v, (bool, int, str)):
+        return v
+    if isinstance(v, float):
+        # NaN never compares equal under ``__eq__``, so the eq=>hash
+        # invariant is vacuously satisfied. Map all NaNs to a single
+        # sentinel so they at least hash deterministically.
+        return ("__nan__",) if math.isnan(v) else v
+    if isinstance(v, list):
+        return ("list", tuple(_canon(x) for x in v))
+    if hasattr(v, "to_numpy"):  # AMReX SmallMatrix (LinearMap, SpinMap)
+        a = v.to_numpy()
+        return ("ndarray", tuple(a.shape), tuple(a.ravel().tolist()))
+    return ("repr", repr(v))
+
+
+def _values_equal(a, b):
+    if hasattr(a, "to_numpy") and hasattr(b, "to_numpy"):
+        import numpy as np
+
+        return np.array_equal(a.to_numpy(), b.to_numpy())
+    if isinstance(a, list) and isinstance(b, list):
+        return len(a) == len(b) and all(_values_equal(x, y) for x, y in zip(a, b))
+    return a == b
+
+
+def _scalar_close(a, b, rtol, atol):
+    if isinstance(a, float) and isinstance(b, float):
+        if math.isnan(a) or math.isnan(b):
+            return False
+        return math.isclose(a, b, rel_tol=rtol, abs_tol=atol)
+    return a == b
+
+
+def _values_close(a, b, rtol, atol):
+    if isinstance(a, list) and isinstance(b, list):
+        if len(a) != len(b):
+            return False
+        return all(_scalar_close(x, y, rtol, atol) for x, y in zip(a, b))
+    if hasattr(a, "to_numpy") and hasattr(b, "to_numpy"):
+        import numpy as np
+
+        return np.allclose(a.to_numpy(), b.to_numpy(), rtol=rtol, atol=atol)
+    return _scalar_close(a, b, rtol, atol)
+
+
+def _dict_eq(d1, d2):
+    if d1.keys() != d2.keys():
+        return False
+    return all(_values_equal(d1[k], d2[k]) for k in d1)
+
+
+def _dict_close(d1, d2, rtol, atol):
+    if d1.keys() != d2.keys():
+        return False
+    return all(_values_close(d1[k], d2[k], rtol, atol) for k in d1)
+
+
+def _element_eq(self, other):
+    """Value-based equality.
+
+    Two elements are equal iff they are instances of the same class and
+    their ``to_dict()`` outputs match key-for-key. Float values use
+    ``==`` (so ``NaN != NaN``); list values are compared element-wise;
+    AMReX SmallMatrix values use ``numpy.array_equal``.
+
+    Returns ``NotImplemented`` when ``other`` is not the same element
+    type, so Python's reflected-equality fallback applies (e.g., a
+    foreign type's ``__eq__`` gets a chance, ultimately falling back to
+    identity which yields ``False``).
+    """
+    if type(self) is not type(other):
+        return NotImplemented
+    return _dict_eq(self.to_dict(), other.to_dict())
+
+
+def _element_hash(self):
+    """Value-based hash, consistent with ``__eq__``.
+
+    Two elements that compare equal under ``==`` produce the same hash.
+    The hash reflects the element's *current* parameter values; mutating
+    an element after using it as a ``set`` member or ``dict`` key
+    invalidates the container, the same contract a hashable mutable
+    object would have.
+    """
+    d = self.to_dict()
+    return hash(
+        (
+            type(self).__name__,
+            tuple(sorted((k, _canon(v)) for k, v in d.items())),
+        )
+    )
+
+
+def _normalize_ignore(ignore_attributes):
+    """Coerce ``ignore_attributes`` to a frozenset of key names.
+
+    Accepts ``None``, a single string, or any iterable of strings.
+    """
+    if ignore_attributes is None:
+        return frozenset()
+    if isinstance(ignore_attributes, str):
+        return frozenset({ignore_attributes})
+    return frozenset(ignore_attributes)
+
+
+def _element_isclose(
+    self,
+    other,
+    *,
+    rtol=_DEFAULT_RTOL,
+    atol=_DEFAULT_ATOL,
+    ignore_attributes=None,
+):
+    """Tolerant equality for lattice elements.
+
+    Mirrors ``math.isclose`` / ``numpy.isclose`` naming. Float-valued
+    fields are compared via ``math.isclose(rel_tol=rtol, abs_tol=atol)``;
+    lists of floats are compared element-wise; AMReX SmallMatrix values
+    use ``numpy.allclose``. All other value types (ints, strings,
+    ``None``) fall back to strict ``==``. Mismatched element types and
+    foreign operands return ``False`` (unless ``"type"`` is listed in
+    ``ignore_attributes`` — see below).
+
+    Parameters
+    ----------
+    other
+        Element to compare against.
+    rtol : float, optional
+        Relative tolerance forwarded to ``math.isclose`` /
+        ``numpy.allclose``. Default is ``1e-12`` — matches the
+        ``dicts_equal`` helper used in the serialization tests, stricter
+        than the ``math.isclose`` and ``numpy.isclose`` defaults.
+    atol : float, optional
+        Absolute tolerance. Default is ``0.0``.
+    ignore_attributes : str or iterable of str, optional
+        ``to_dict()`` keys to skip when comparing. Useful when comparing
+        loaded files where some bookkeeping fields (``"name"``) or even
+        the element variant (``"type"``) should not affect the verdict.
+
+        Including ``"type"`` disables the strict same-class check, so
+        e.g. ``Drift`` and ``ExactDrift`` can be compared on their
+        common parameters. Any remaining keys must still match between
+        the two ``to_dict()`` outputs.
+    """
+    ignore = _normalize_ignore(ignore_attributes)
+    if "type" in ignore:
+        if not hasattr(other, "to_dict"):
+            return False
+    elif type(self) is not type(other):
+        return False
+    d1 = {k: v for k, v in self.to_dict().items() if k not in ignore}
+    d2 = {k: v for k, v in other.to_dict().items() if k not in ignore}
+    return _dict_close(d1, d2, rtol, atol)
+
+
+def register_elements_value_semantics(elements_module):
+    """Attach ``__eq__``, ``__hash__``, and ``isclose`` to every class
+    in ``elements_module`` that exposes a ``to_dict`` method.
+
+    Parameters
+    ----------
+    elements_module : module
+        Typically ``impactx.impactx_pybind.elements``.
+    """
+    for name in dir(elements_module):
+        if name in _SKIP or name.startswith("_"):
+            continue
+        cls = getattr(elements_module, name)
+        if not inspect.isclass(cls):
+            continue
+        if not hasattr(cls, "to_dict"):
+            continue
+        cls.__eq__ = _element_eq
+        # Assigning ``__eq__`` from Python implicitly sets
+        # ``__hash__ = None`` on the class, so we must reassign
+        # ``__hash__`` afterwards to keep instances hashable.
+        cls.__hash__ = _element_hash
+        cls.isclose = _element_isclose

--- a/src/python/impactx/extensions/KnownElementsList.py
+++ b/src/python/impactx/extensions/KnownElementsList.py
@@ -1043,7 +1043,7 @@ def _lattice_eq(self, other):
     ``list`` convention.
     """
     if not hasattr(other, "__len__") or not hasattr(other, "__iter__"):
-        return NotImplemented
+        raise ValueError(f"{other} does not implement __len__ or __iter__")
     if len(self) != len(other):
         return False
     for a, b in zip(self, other):
@@ -1074,7 +1074,7 @@ def _lattice_isclose(self, other, *, rtol=1e-12, atol=0.0, ignore_attributes=Non
         element's ``isclose``.
     """
     if not hasattr(other, "__len__") or not hasattr(other, "__iter__"):
-        return False
+        raise ValueError(f"{other} does not implement __len__ or __iter__")
     if len(self) != len(other):
         return False
     for a, b in zip(self, other):

--- a/src/python/impactx/extensions/KnownElementsList.py
+++ b/src/python/impactx/extensions/KnownElementsList.py
@@ -1015,6 +1015,92 @@ def from_dicts(self, dicts: list[dict]):
     self.extend([_element_from_dict(d) for d in dicts])
 
 
+# ---------------------------------------------------------------------------
+# Element-wise value comparison (== and isclose) for lattice containers.
+#
+# Duck-typed across container types: a KnownElementsList compares equal to a
+# plain Python list of elements or to a FilteredElementsList as long as the
+# element sequences match. This mirrors the typical select() workflow where
+# users compare a filtered view against a hand-built reference list.
+#
+# No value-based __hash__ is defined: containers are mutable, and elements
+# inside are mutable. The default identity-based hash inherited from ``object``
+# is preserved (KnownElementsList from pybind11; FilteredElementsList from
+# Python) so the existing weak-reference tracking of selections keeps working.
+# ---------------------------------------------------------------------------
+
+
+def _lattice_eq(self, other):
+    """Element-wise equality with any iterable of elements.
+
+    Duck-typed across container types: a ``KnownElementsList`` compares
+    equal to a plain Python ``list`` of elements or to a
+    ``FilteredElementsList`` as long as their lengths match and every
+    pair of elements compares equal under ``==``. Returns
+    ``NotImplemented`` for non-iterable operands so Python's
+    reflected-equality fallback applies. Mutable containers are
+    deliberately unhashable (``__hash__ = None``), matching the Python
+    ``list`` convention.
+    """
+    if not hasattr(other, "__len__") or not hasattr(other, "__iter__"):
+        return NotImplemented
+    if len(self) != len(other):
+        return False
+    for a, b in zip(self, other):
+        if not (a == b):
+            return False
+    return True
+
+
+def _lattice_isclose(self, other, *, rtol=1e-12, atol=0.0, ignore_attributes=None):
+    """Tolerant element-wise comparison with any iterable of elements.
+
+    For each pair of elements at the same index, calls the element's own
+    ``isclose(rtol=..., atol=..., ignore_attributes=...)``. Lengths must
+    match; foreign or non-iterable operands return ``False``. Defaults
+    match the per-element ``isclose`` (``rtol=1e-12``, ``atol=0.0``).
+
+    Parameters
+    ----------
+    other : iterable of elements
+        Any container (``KnownElementsList``, ``FilteredElementsList``,
+        or plain ``list``) whose elements expose ``isclose``.
+    rtol, atol : float
+        Forwarded to each element's ``isclose``.
+    ignore_attributes : str or iterable of str, optional
+        ``to_dict()`` keys to skip when comparing each pair of elements.
+        Includes the special key ``"type"`` to compare across element
+        variants (e.g., ``Drift`` vs ``ExactDrift``). Forwarded to each
+        element's ``isclose``.
+    """
+    if not hasattr(other, "__len__") or not hasattr(other, "__iter__"):
+        return False
+    if len(self) != len(other):
+        return False
+    for a, b in zip(self, other):
+        if hasattr(a, "isclose"):
+            if not a.isclose(
+                b, rtol=rtol, atol=atol, ignore_attributes=ignore_attributes
+            ):
+                return False
+        elif a != b:
+            return False
+    return True
+
+
+# Apply to FilteredElementsList immediately. The pybind11 KnownElementsList is
+# patched inside register_KnownElementsList_extension() below, since that is
+# the sole entry point that receives the bound class.
+#
+# We deliberately do NOT touch __hash__: FilteredElementsList instances are
+# tracked in a WeakSet (see ``_registry_for``) and need to remain hashable.
+# Keeping the inherited identity-based hash means two value-equal containers
+# may hash differently, but containers are not intended as dict/set keys for
+# value-based deduplication.
+FilteredElementsList.__eq__ = _lattice_eq
+FilteredElementsList.isclose = _lattice_isclose
+
+
 def register_KnownElementsList_extension(kel):
     """KnownElementsList helper methods"""
     from ..plot.Survey import plot_survey
@@ -1034,3 +1120,10 @@ def register_KnownElementsList_extension(kel):
     kel.get_kinds = get_kinds
     kel.count_by_kind = count_by_kind
     kel.has_kind = has_kind
+
+    # Element-wise == and isclose() (duck-typed across container types).
+    # No custom __hash__: the inherited identity-based hash is kept so that
+    # KnownElementsList and FilteredElementsList behave the same as Python
+    # lists for the user-visible ``==``/``isclose`` API.
+    kel.__eq__ = _lattice_eq
+    kel.isclose = _lattice_isclose

--- a/tests/python/test_element_value_semantics.py
+++ b/tests/python/test_element_value_semantics.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 The ImpactX Community
+#
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+"""
+Tests for value-based __eq__, __hash__, and isclose() on lattice elements.
+"""
+
+import inspect
+
+import pytest
+
+import amrex.space3d as amr
+from impactx import elements
+
+# ----------------------------------------------------------------------
+# Basic equality and hash
+# ----------------------------------------------------------------------
+
+
+def test_eq_same_params():
+    a = elements.Drift(ds=1.0, name="d1")
+    b = elements.Drift(ds=1.0, name="d1")
+    assert a == b
+    assert hash(a) == hash(b)
+
+
+def test_eq_different_params():
+    a = elements.Drift(ds=1.0, name="d1")
+    b = elements.Drift(ds=2.0, name="d1")
+    assert a != b
+
+
+def test_eq_different_types():
+    # Drift and ExactDrift have the same constructor kwargs but are
+    # distinct element types; they must not compare equal.
+    a = elements.Drift(ds=1.0)
+    b = elements.ExactDrift(ds=1.0)
+    assert a != b
+
+
+def test_eq_foreign_type_returns_notimplemented():
+    # Direct API check: __eq__ returns NotImplemented for foreign operands.
+    a = elements.Drift(ds=1.0)
+    assert a.__eq__("foo") is NotImplemented
+    # Python's reflected fallback should make `==` evaluate to False.
+    assert (a == "foo") is False
+    assert a != "foo"
+
+
+def test_set_membership():
+    s = {elements.Drift(ds=1.0, name="d1")}
+    assert elements.Drift(ds=1.0, name="d1") in s
+    assert elements.Drift(ds=2.0, name="d1") not in s
+
+
+def test_dict_key_usage():
+    a = elements.Drift(ds=1.0, name="d1")
+    b = elements.Drift(ds=1.0, name="d1")
+    d = {a: "first"}
+    assert d[b] == "first"
+
+
+# ----------------------------------------------------------------------
+# isclose: scalars
+# ----------------------------------------------------------------------
+
+
+def test_isclose_accepts_small_perturbation():
+    a = elements.Drift(ds=1.0, name="d1")
+    b = elements.Drift(ds=1.0 + 1e-15, name="d1")
+    assert a.isclose(b)
+    assert not (a == b)
+
+
+def test_isclose_rejects_large_perturbation():
+    a = elements.Drift(ds=1.0)
+    b = elements.Drift(ds=1.001)
+    assert not a.isclose(b)
+
+
+def test_isclose_custom_rtol():
+    a = elements.Drift(ds=1.0)
+    b = elements.Drift(ds=1.0 + 1e-9)
+    # default rtol=1e-12 rejects this
+    assert not a.isclose(b)
+    # loosened rtol accepts it
+    assert a.isclose(b, rtol=1e-6)
+
+
+def test_isclose_with_atol_only():
+    a = elements.Drift(ds=0.0)
+    b = elements.Drift(ds=1e-10)
+    # rtol=0, atol=1e-9 should accept
+    assert a.isclose(b, rtol=0.0, atol=1e-9)
+    # rtol=0, atol=0 should reject (math.isclose default behavior)
+    assert not a.isclose(b, rtol=0.0, atol=0.0)
+
+
+def test_isclose_different_types_returns_false():
+    a = elements.Drift(ds=1.0)
+    b = elements.ExactDrift(ds=1.0)
+    assert not a.isclose(b)
+
+
+def test_isclose_foreign_operand():
+    a = elements.Drift(ds=1.0)
+    assert not a.isclose("foo")
+
+
+# ----------------------------------------------------------------------
+# isclose: list-of-floats (Fourier coefficients, polygon vertices)
+# ----------------------------------------------------------------------
+
+
+def _make_rfcavity(cos_coefs, sin_coefs):
+    return elements.RFCavity(
+        ds=0.5,
+        escale=1e6,
+        freq=1.3e9,
+        phase=-90.0,
+        cos_coefficients=cos_coefs,
+        sin_coefficients=sin_coefs,
+        nslice=2,
+        mapsteps=10,
+        name="rf",
+    )
+
+
+def test_eq_list_of_floats():
+    a = _make_rfcavity([1.0, 2.0, 3.0], [0.0, 0.1, 0.2])
+    b = _make_rfcavity([1.0, 2.0, 3.0], [0.0, 0.1, 0.2])
+    assert a == b
+    assert hash(a) == hash(b)
+
+
+def test_isclose_list_of_floats_perturbed():
+    a = _make_rfcavity([1.0, 2.0, 3.0], [0.0, 0.1, 0.2])
+    b = _make_rfcavity([1.0, 2.0, 3.0 + 1e-15], [0.0, 0.1, 0.2])
+    assert a.isclose(b)
+    assert not (a == b)
+
+
+def test_isclose_list_of_floats_rejected():
+    a = _make_rfcavity([1.0, 2.0, 3.0], [0.0, 0.1, 0.2])
+    b = _make_rfcavity([1.0, 2.0, 3.001], [0.0, 0.1, 0.2])
+    assert not a.isclose(b)
+
+
+def test_isclose_list_length_mismatch():
+    a = _make_rfcavity([1.0, 2.0], [0.0, 0.1])
+    b = _make_rfcavity([1.0, 2.0, 3.0], [0.0, 0.1, 0.2])
+    assert not a.isclose(b)
+    assert a != b
+
+
+# ----------------------------------------------------------------------
+# SmallMatrix-valued entries (LinearMap)
+# ----------------------------------------------------------------------
+
+
+def test_eq_linearmap_same_matrix():
+    R = amr.SmallMatrix_6x6_F_SI1_double.identity()
+    a = elements.LinearMap(R=R, ds=0.5, name="lm")
+    b = elements.LinearMap(R=R, ds=0.5, name="lm")
+    assert a == b
+    assert hash(a) == hash(b)
+
+
+def test_isclose_linearmap_perturbed_matrix():
+    R1 = amr.SmallMatrix_6x6_F_SI1_double.identity()
+    R2 = amr.SmallMatrix_6x6_F_SI1_double.identity()
+    # SmallMatrix_..._SI1_... uses 1-based indexing.
+    R2[1, 1] = 1.0 + 1e-15
+    a = elements.LinearMap(R=R1, ds=0.5, name="lm")
+    b = elements.LinearMap(R=R2, ds=0.5, name="lm")
+    assert a.isclose(b)
+    assert not (a == b)
+
+
+# ----------------------------------------------------------------------
+# NaN handling
+# ----------------------------------------------------------------------
+
+
+def test_nan_not_equal():
+    a = elements.Drift(ds=float("nan"))
+    b = elements.Drift(ds=float("nan"))
+    assert a != b
+    assert not a.isclose(b)
+
+
+def test_nan_hashes_consistently():
+    # Hashing must not raise on NaN values.
+    a = elements.Drift(ds=float("nan"))
+    hash(a)
+
+
+# ----------------------------------------------------------------------
+# Sweep over every patched element class
+# ----------------------------------------------------------------------
+
+
+_SKIP = {"KnownElementsList", "FilteredElementsList"}
+
+
+def _patched_element_classes():
+    for name in dir(elements):
+        if name in _SKIP or name.startswith("_"):
+            continue
+        cls = getattr(elements, name)
+        if not inspect.isclass(cls):
+            continue
+        if not hasattr(cls, "to_dict"):
+            continue
+        yield name, cls
+
+
+def test_every_element_class_is_patched():
+    found_any = False
+    for name, cls in _patched_element_classes():
+        found_any = True
+        # __eq__ replaced
+        assert cls.__eq__ is not object.__eq__, f"{name}: __eq__ not patched"
+        # __hash__ kept (not None) so instances stay hashable
+        assert cls.__hash__ is not None, f"{name}: __hash__ is None"
+        # isclose attached
+        assert callable(getattr(cls, "isclose", None)), f"{name}: isclose missing"
+    assert found_any, "no element classes were discovered"
+
+
+def test_marker_self_equality():
+    # Marker is a thin element with minimal state — sanity check that the
+    # patched methods work for a stripped-down class.
+    a = elements.Marker(name="m")
+    b = elements.Marker(name="m")
+    assert a == b
+    assert hash(a) == hash(b)
+    assert a.isclose(b)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: elements.Drift(ds=1.0, name="d"),
+        lambda: elements.Marker(name="m"),
+        lambda: elements.Quad(ds=0.3, k=2.5, name="q"),
+        lambda: elements.Sbend(ds=0.5, rc=5.0, name="s"),
+    ],
+    ids=["Drift", "Marker", "Quad", "Sbend"],
+)
+def test_self_equality_and_hash(factory):
+    a = factory()
+    b = factory()
+    assert a == b
+    assert hash(a) == hash(b)
+    assert a.isclose(b)
+
+
+# ----------------------------------------------------------------------
+# Container-level value semantics: KnownElementsList & FilteredElementsList
+# ----------------------------------------------------------------------
+
+
+def _build_lattice():
+    lat = elements.KnownElementsList()
+    lat.append(elements.Drift(ds=1.0, name="d1"))
+    lat.append(elements.Quad(ds=0.3, k=2.5, name="q1"))
+    lat.append(elements.Drift(ds=2.0, name="d2"))
+    return lat
+
+
+def test_lattice_eq_same_contents():
+    a = _build_lattice()
+    b = _build_lattice()
+    assert a == b
+
+
+def test_lattice_eq_different_length():
+    a = _build_lattice()
+    b = _build_lattice()
+    b.append(elements.Marker(name="m"))
+    assert a != b
+
+
+def test_lattice_eq_different_element():
+    a = _build_lattice()
+    b = elements.KnownElementsList()
+    b.append(elements.Drift(ds=1.0, name="d1"))
+    b.append(elements.Quad(ds=2.5, k=2.5, name="q1"))  # ds differs
+    b.append(elements.Drift(ds=2.0, name="d2"))
+    assert a != b
+
+
+def test_lattice_eq_with_python_list():
+    # Duck-typed cross-type equality with a plain Python list of elements.
+    a = _build_lattice()
+    py_list = [
+        elements.Drift(ds=1.0, name="d1"),
+        elements.Quad(ds=0.3, k=2.5, name="q1"),
+        elements.Drift(ds=2.0, name="d2"),
+    ]
+    assert a == py_list
+    assert py_list == a  # symmetric
+
+
+def test_lattice_eq_with_filtered_view():
+    # Cross-type duck-typed equality between a KnownElementsList and a
+    # FilteredElementsList covering the same indices.
+    a = _build_lattice()
+    drifts = a.select(kind="Drift")
+    expected = elements.KnownElementsList()
+    expected.append(elements.Drift(ds=1.0, name="d1"))
+    expected.append(elements.Drift(ds=2.0, name="d2"))
+    assert drifts == expected
+    assert expected == drifts  # symmetric across container types
+
+
+def test_lattice_eq_filtered_vs_filtered():
+    a = _build_lattice()
+    b = _build_lattice()
+    assert a.select(kind="Drift") == b.select(kind="Drift")
+    assert a.select(kind="Drift") != b.select(kind="Quad")
+
+
+def test_lattice_eq_foreign_type():
+    a = _build_lattice()
+    assert a != "lattice"
+    assert a != 42
+    assert a != None  # noqa: E711
+
+
+def test_lattice_isclose_with_perturbation():
+    a = _build_lattice()
+    b = elements.KnownElementsList()
+    b.append(elements.Drift(ds=1.0 + 1e-15, name="d1"))
+    b.append(elements.Quad(ds=0.3 + 1e-15, k=2.5, name="q1"))
+    b.append(elements.Drift(ds=2.0, name="d2"))
+    assert a.isclose(b)
+    assert not (a == b)
+
+
+def test_lattice_isclose_rejects_large_perturbation():
+    a = _build_lattice()
+    b = elements.KnownElementsList()
+    b.append(elements.Drift(ds=1.001, name="d1"))
+    b.append(elements.Quad(ds=0.3, k=2.5, name="q1"))
+    b.append(elements.Drift(ds=2.0, name="d2"))
+    assert not a.isclose(b)
+    assert a.isclose(b, rtol=1e-2)
+
+
+def test_lattice_isclose_length_mismatch():
+    a = _build_lattice()
+    b = _build_lattice()
+    b.append(elements.Marker(name="m"))
+    assert not a.isclose(b)
+
+
+def test_lattice_isclose_foreign_type():
+    a = _build_lattice()
+    assert not a.isclose("lattice")
+    assert not a.isclose(None)
+
+
+def test_lattice_isclose_filtered_view():
+    a = _build_lattice()
+    drifts = a.select(kind="Drift")
+    expected = [
+        elements.Drift(ds=1.0 + 1e-15, name="d1"),
+        elements.Drift(ds=2.0, name="d2"),
+    ]
+    assert drifts.isclose(expected)
+
+
+# ----------------------------------------------------------------------
+# isclose ignore_attributes
+# ----------------------------------------------------------------------
+
+
+def test_isclose_ignore_name():
+    a = elements.Drift(ds=1.0, name="alpha")
+    b = elements.Drift(ds=1.0, name="beta")
+    assert not a.isclose(b)
+    assert a.isclose(b, ignore_attributes=["name"])
+
+
+def test_isclose_ignore_single_string():
+    # Convenience: a single string is treated as a one-element set.
+    a = elements.Drift(ds=1.0, name="alpha")
+    b = elements.Drift(ds=1.0, name="beta")
+    assert a.isclose(b, ignore_attributes="name")
+
+
+def test_isclose_ignore_type_across_variants():
+    # Drift and ExactDrift share the same parameter set; ignoring "type"
+    # lets them compare on common fields.
+    a = elements.Drift(
+        ds=1.0,
+        dx=0.001,
+        dy=0.002,
+        rotation=0.05,
+        aperture_x=0.01,
+        aperture_y=0.02,
+        name="d",
+    )
+    b = elements.ExactDrift(
+        ds=1.0,
+        dx=0.001,
+        dy=0.002,
+        rotation=0.05,
+        aperture_x=0.01,
+        aperture_y=0.02,
+        name="d",
+    )
+    assert not a.isclose(b)
+    assert a.isclose(b, ignore_attributes=["type"])
+
+
+def test_isclose_ignore_type_keys_still_must_match():
+    # Drift and Quad have different keys (Quad has "k") even after
+    # dropping "type"; isclose must still return False.
+    a = elements.Drift(ds=1.0, name="x")
+    b = elements.Quad(ds=1.0, k=2.5, name="x")
+    assert not a.isclose(b, ignore_attributes=["type"])
+
+
+def test_isclose_ignore_multiple():
+    a = elements.Drift(ds=1.0, name="alpha", dx=0.001)
+    b = elements.Drift(ds=1.0, name="beta", dx=0.999)
+    assert a.isclose(b, ignore_attributes={"name", "dx"})
+
+
+def test_isclose_ignore_attributes_empty():
+    # Empty iterable behaves like None (no filtering).
+    a = elements.Drift(ds=1.0, name="alpha")
+    b = elements.Drift(ds=1.0, name="beta")
+    assert not a.isclose(b, ignore_attributes=[])
+
+
+def test_lattice_isclose_ignore_attributes_forwarded():
+    # ignore_attributes should be forwarded to each element's isclose.
+    a = elements.KnownElementsList()
+    a.append(elements.Drift(ds=1.0, name="d_a"))
+    a.append(elements.Quad(ds=0.3, k=2.5, name="q_a"))
+
+    b = elements.KnownElementsList()
+    b.append(elements.Drift(ds=1.0, name="d_b"))
+    b.append(elements.Quad(ds=0.3, k=2.5, name="q_b"))
+
+    assert not a.isclose(b)
+    assert a.isclose(b, ignore_attributes=["name"])
+
+
+def test_lattice_isclose_ignore_type_across_variants():
+    # Mixed-variant lattices: ignoring "type" lets a linear lattice
+    # compare equal to its exact-variant counterpart on common fields.
+    a = elements.KnownElementsList()
+    a.append(elements.Drift(ds=1.0, name="d1"))
+    a.append(elements.Drift(ds=2.0, name="d2"))
+
+    b = elements.KnownElementsList()
+    b.append(elements.ExactDrift(ds=1.0, name="d1"))
+    b.append(elements.ExactDrift(ds=2.0, name="d2"))
+
+    assert not a.isclose(b)
+    assert a.isclose(b, ignore_attributes=["type"])
+
+
+def test_lattice_uses_identity_hash():
+    # Containers do not get a value-based __hash__: the inherited identity
+    # hash is preserved (so internal weak-reference tracking of filtered
+    # selections keeps working). Two value-equal containers therefore may
+    # hash differently — they're not meant as dict/set keys for value-based
+    # deduplication.
+    a = _build_lattice()
+    b = _build_lattice()
+    assert a == b
+    assert hash(a) != hash(b)  # identity-based, distinct instances
+    # Filtered views are also hashable (identity-based).
+    drifts_a = a.select(kind="Drift")
+    drifts_b = a.select(kind="Drift")
+    assert drifts_a == drifts_b
+    assert hash(drifts_a) != hash(drifts_b)

--- a/tests/python/test_element_value_semantics.py
+++ b/tests/python/test_element_value_semantics.py
@@ -475,6 +475,33 @@ def test_lattice_isclose_ignore_type_across_variants():
     assert a.isclose(b, ignore_attributes=["type"])
 
 
+def test_free_function_isclose_elements():
+    a = elements.Drift(ds=1.0, name="d1")
+    b = elements.Drift(ds=1.0 + 1e-15, name="d1")
+    assert elements.isclose(a, b)
+    assert elements.isclose(b, a)  # symmetric call form
+    assert elements.isclose(a, b, ignore_attributes="name")
+
+
+def test_free_function_isclose_lattice():
+    a = _build_lattice()
+    b = _build_lattice()
+    assert elements.isclose(a, b)
+
+
+def test_free_function_isclose_list_lhs():
+    # Plain Python list on the left: free function dispatches to the
+    # KnownElementsList on the right, so the call still works.
+    kel = _build_lattice()
+    py = [
+        elements.Drift(ds=1.0 + 1e-15, name="d1"),
+        elements.Quad(ds=0.3, k=2.5, name="q1"),
+        elements.Drift(ds=2.0, name="d2"),
+    ]
+    assert elements.isclose(py, kel)
+    assert elements.isclose(kel, py)
+
+
 def test_lattice_uses_identity_hash():
     # Containers do not get a value-based __hash__: the inherited identity
     # hash is preserved (so internal weak-reference tracking of filtered

--- a/tests/python/test_element_value_semantics.py
+++ b/tests/python/test_element_value_semantics.py
@@ -331,8 +331,10 @@ def test_lattice_eq_filtered_vs_filtered():
 def test_lattice_eq_foreign_type():
     a = _build_lattice()
     assert a != "lattice"
-    assert a != 42
-    assert a != None  # noqa: E711
+    with pytest.raises(ValueError):
+        assert a != 42
+    with pytest.raises(ValueError):
+        assert a != None  # noqa: E711
 
 
 def test_lattice_isclose_with_perturbation():
@@ -365,7 +367,8 @@ def test_lattice_isclose_length_mismatch():
 def test_lattice_isclose_foreign_type():
     a = _build_lattice()
     assert not a.isclose("lattice")
-    assert not a.isclose(None)
+    with pytest.raises(ValueError):
+        assert not a.isclose(None)
 
 
 def test_lattice_isclose_filtered_view():


### PR DESCRIPTION
When loading PALS or MAD-X files, we often need to compare them to a manually validated ground truth.

This adds new comparison and `isclose` operators to our elements and lattice classes, simplifying this process.

[Docs preview here.](https://impactx--1436.org.readthedocs.build/en/1436/usage/python.html#common-comparison-methods-on-lattice-elements)

## Example

```py
from impactx import elements

a = elements.Drift(ds=1.0, name="d1")
b = elements.Drift(ds=1.0 + 1e-15, name="d2")

a == b      # False — name differs and ds differs by float noise
a.isclose(b)                              # False — name still differs
a.isclose(b, ignore_attributes="name")    # True

# Compare a Drift to its exact-physics counterpart on common fields.
lin = elements.Drift(ds=1.0)
ex = elements.ExactDrift(ds=1.0)
lin.isclose(ex, ignore_attributes=["type"])  # True

# Lattice-wide comparison forwards ignore_attributes to each element.
lattice_a.isclose(lattice_b, ignore_attributes=["name"])

# also as free-standing function
elements.isclose(a, b, ignore_attributes="name")    # True
elements.isclose(lattice_a, lattice_b, ignore_attributes=["name"])
```

## Review Guidance

Easiest to check we like the [syntax in the docs](https://impactx--1436.org.readthedocs.build/en/1436/usage/python.html#common-comparison-methods-on-lattice-elements) and the various cases in the tests (`tests/python/test_element_value_semantics.py`).