### PR TITLE
Global `step`: 64bit Integer

### DIFF
--- a/src/diagnostics/DiagnosticOutput.H
+++ b/src/diagnostics/DiagnosticOutput.H
@@ -13,6 +13,7 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/CovarianceMatrix.H"
 
+#include <cstdint>
 #include <string>
 
 
@@ -30,7 +31,7 @@ namespace impactx::diagnostics
     void DiagnosticOutput (
         ImpactXParticleContainer const & pc,
         std::string file_name,
-        int step = 0,
+        int64_t step = 0,
         bool append = false
     );
 
@@ -48,7 +49,7 @@ namespace impactx::diagnostics
         Map6x6 const & cm,
         RefPart const & ref_part,
         std::string file_name,
-        int step = 0,
+        int64_t step = 0,
         bool append = false
     );
 
@@ -64,7 +65,7 @@ namespace impactx::diagnostics
     void DiagnosticOutput (
         RefPart const & ref_part,
         std::string file_name,
-        int step = 0,
+        int64_t step = 0,
         bool append = false
     );
 

--- a/src/diagnostics/DiagnosticOutput.cpp
+++ b/src/diagnostics/DiagnosticOutput.cpp
@@ -17,6 +17,7 @@
 #include <AMReX_REAL.H>       // for ParticleReal
 #include <AMReX_Print.H>      // for PrintToFile
 
+#include <cstdint>
 #include <limits>
 #include <stdexcept>
 #include <utility>
@@ -105,7 +106,7 @@ namespace
     write_ref (
         amrex::AllPrintToFile & file_handler,
         impactx::RefPart const & ref_part,
-        int step
+        int64_t step
     )
     {
         amrex::ParticleReal const s = ref_part.s;
@@ -134,7 +135,7 @@ namespace
         amrex::AllPrintToFile & file_handler,
         std::unordered_map<std::string, amrex::ParticleReal> const & rbc,
         amrex::ParticleReal s,
-        int step
+        int64_t step
     )
     {
         // determine whether to output eigenemittances
@@ -184,7 +185,7 @@ namespace impactx::diagnostics
     void DiagnosticOutput (
         ImpactXParticleContainer const & pc,
         std::string file_name,
-        int step,
+        int64_t step,
         bool append
     )
     {
@@ -209,7 +210,7 @@ namespace impactx::diagnostics
         Map6x6 const & cm,
         RefPart const & ref_part,
         std::string file_name,
-        int step,
+        int64_t step,
         bool append
     )
     {
@@ -229,7 +230,7 @@ namespace impactx::diagnostics
     void DiagnosticOutput (
         RefPart const & ref_part,
         std::string file_name,
-        int step,
+        int64_t step,
         bool append
     )
     {

--- a/src/elements/Programmable.H
+++ b/src/elements/Programmable.H
@@ -22,6 +22,7 @@
 //   SIMD will require better complex math support in vir-simd / C++26
 //   https://github.com/mattkretz/vir-simd/issues/42
 
+#include <cstdint>
 #include <functional>
 #include <stdexcept>
 
@@ -64,7 +65,7 @@ namespace impactx::elements
          */
         void operator() (
             ImpactXParticleContainer & pc,
-            int step,
+            int64_t step,
             int period
         ) const;
 
@@ -138,7 +139,7 @@ namespace impactx::elements
          */
         bool m_threadsafe = false;
 
-        std::function<void(ImpactXParticleContainer *, int, int)> m_push; //! hook for push of whole container (pc, step, period)
+        std::function<void(ImpactXParticleContainer *, int64_t, int)> m_push; //! hook for push of whole container (pc, step, period)
         std::function<void(ImpactXParticleContainer::iterator *, RefPart &)> m_beam_particles; //! hook for beam particles (pti, ref)
         std::function<void(RefPart &)> m_ref_particle; //! hook for reference particle
         std::function<void()> m_finalize; //! hook for finalize cleanup

--- a/src/elements/Programmable.cpp
+++ b/src/elements/Programmable.cpp
@@ -19,7 +19,7 @@ namespace impactx::elements
     void
     Programmable::operator() (
         ImpactXParticleContainer & pc,
-        int step,
+        int64_t step,
         int period
     ) const
     {

--- a/src/elements/Source.H
+++ b/src/elements/Source.H
@@ -16,6 +16,7 @@
 #include "mixin/nofinalize.H"
 #include "mixin/thin.H"
 
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 
@@ -70,7 +71,7 @@ namespace impactx::elements
          */
         void operator() (
             ImpactXParticleContainer & pc,
-            [[maybe_unused]] int step,
+            [[maybe_unused]] int64_t step,
             int period
         );
 

--- a/src/elements/Source.cpp
+++ b/src/elements/Source.cpp
@@ -25,7 +25,7 @@ namespace impactx::elements
     void
     Source::operator() (
         ImpactXParticleContainer & pc,
-        int,
+        int64_t,
         int period
     )
     {

--- a/src/elements/diagnostics/BeamMonitor.H
+++ b/src/elements/diagnostics/BeamMonitor.H
@@ -19,6 +19,7 @@
 #include <AMReX_REAL.H>
 
 #include <any>
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -106,7 +107,7 @@ namespace detail
             std::vector<std::string> const & real_soa_names,
             std::vector<std::string> const & int_soa_names,
             RefPart const & ref_part,
-            int step
+            int64_t step
         );
 
         /** Dump all particles.
@@ -119,7 +120,7 @@ namespace detail
          */
         void operator() (
             ImpactXParticleContainer & pc,
-            int step,
+            int64_t step,
             int period
         );
 
@@ -198,7 +199,7 @@ namespace detail
         std::string m_OpenPMDFileType; //! openPMD backend: usually HDF5 (h5) or ADIOS2 (bp/bp4/bp5) or ADIOS2 SST (sst)
         std::string m_encoding; //! openPMD iteration encoding: "v"ariable based, "f"ile based, "g"roup based (default)
         std::any m_series; //! openPMD::Series that holds potentially multiple outputs
-        int m_step = 0; //! global step for output
+        int64_t m_step = 0; //! global step for output
 
         int m_file_min_digits = 6; //! minimum number of digits to iteration number in file name
 

--- a/src/elements/diagnostics/BeamMonitor.cpp
+++ b/src/elements/diagnostics/BeamMonitor.cpp
@@ -214,7 +214,7 @@ namespace detail {
         std::vector<std::string> const & real_soa_names,
         std::vector<std::string> const & int_soa_names,
         RefPart const & ref_part,
-        int step
+        int64_t step
     ) {
 #ifdef ImpactX_USE_OPENPMD
         m_step = step;
@@ -304,7 +304,7 @@ namespace detail {
     void
     BeamMonitor::operator() (
         ImpactXParticleContainer & pc,
-        int step,
+        int64_t step,
         int period
     )
     {

--- a/src/elements/mixin/beamoptic.H
+++ b/src/elements/mixin/beamoptic.H
@@ -19,6 +19,7 @@
 #include <AMReX_REAL.H>
 #include <AMReX_SIMD.H>
 
+#include <cstdint>
 #include <type_traits>
 
 
@@ -442,7 +443,7 @@ namespace detail
          */
         void operator() (
             ImpactXParticleContainer & pc,
-            int step,
+            int64_t step,
             int period
         )
         {

--- a/src/particles/Push.H
+++ b/src/particles/Push.H
@@ -14,6 +14,8 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/ReferenceParticle.H"
 
+#include <cstdint>
+
 
 namespace impactx
 {
@@ -27,7 +29,7 @@ namespace impactx
     void push (
         ImpactXParticleContainer & pc,
         elements::KnownElements & element_variant,
-        int step,
+        int64_t step,
         int period
     );
 

--- a/src/particles/Push.cpp
+++ b/src/particles/Push.cpp
@@ -19,7 +19,7 @@ namespace impactx
     void push (
         ImpactXParticleContainer & pc,
         elements::KnownElements & element_variant,
-        int step,
+        int64_t step,
         int period
     )
     {

--- a/src/particles/PushAll.H
+++ b/src/particles/PushAll.H
@@ -14,6 +14,8 @@
 
 #include <AMReX_BLProfiler.H>
 
+#include <cstdint>
+
 
 namespace impactx
 {
@@ -33,7 +35,7 @@ namespace impactx
     void push_all (
         ImpactXParticleContainer & pc,
         T_Element & element,
-        [[maybe_unused]] int step,
+        [[maybe_unused]] int64_t step,
         [[maybe_unused]] int period,
         [[maybe_unused]] bool omp_parallel = true
     )
@@ -79,13 +81,13 @@ namespace impactx
     extern template void impactx::push_all<ElementType>( \
         impactx::ImpactXParticleContainer &, \
         ElementType &, \
-        int, int, bool);
+        int64_t, int, bool);
 
 /** Explicit instantiation of push_all<T> — use in element .cpp files. */
 #define IMPACTX_PUSH_INSTANTIATE(ElementType) \
     template void impactx::push_all<ElementType>( \
         impactx::ImpactXParticleContainer &, \
         ElementType &, \
-        int, int, bool);
+        int64_t, int, bool);
 
 #endif // IMPACTX_PUSH_ALL_H

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -12,6 +12,7 @@
 #include <AMReX_Enum.H>
 #include <AMReX_REAL.H>
 
+#include <cstdint>
 #include <map>
 #include <optional>
 #include <string>
@@ -69,7 +70,7 @@ namespace
         using Element = typename T_PyClass::type;  // py::class<T, options...>
 
         cl.def("push",
-            [](Element & el, ImpactXParticleContainer & pc, int step, int period) {
+            [](Element & el, ImpactXParticleContainer & pc, int64_t step, int period) {
                 el(pc, step, period);
             },
             py::arg("pc"), py::arg("step")=0, py::arg("period")=0,
@@ -1908,7 +1909,7 @@ void init_elements(py::module& m)
         .def_property("push",
               [](Programmable & p) { return p.m_push; },
               [](Programmable & p,
-                 std::function<void(ImpactXParticleContainer *, int, int)> new_hook
+                 std::function<void(ImpactXParticleContainer *, int64_t, int)> new_hook
               ) { p.m_push = std::move(new_hook); },
               "hook for push of whole container (pc, step, period)"
         )
@@ -2874,7 +2875,7 @@ void init_elements(py::module& m)
 
 
     // freestanding push function
-    m.def("push", py::overload_cast<ImpactXParticleContainer &, elements::KnownElements &, int, int>(&push),
+    m.def("push", py::overload_cast<ImpactXParticleContainer &, elements::KnownElements &, int64_t, int>(&push),
         py::arg("pc"), py::arg("element"), py::arg("step")=0, py::arg("period")=0,
         "Push a whole particle beam (incl. reference particle) through an element"
     );

--- a/src/tracking/TrackingState.H
+++ b/src/tracking/TrackingState.H
@@ -11,6 +11,7 @@
 
 #include "elements/All.H"
 
+#include <cstdint>
 #include <optional>
 
 
@@ -27,7 +28,7 @@ namespace impactx
          * A state of internal simulation steps, increments also for space charge slice steps in elements.
          * We start in "step 0" (initial state).
          */
-        int m_step = 0;
+        int64_t m_step = 0;
 
         /** For tracking hooks/callbacks, the period in the lattice (e.g., turn or channel period) */
         int m_period = 0;

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -24,6 +24,7 @@
 #include <AMReX_Print.H>
 #include <AMReX_REAL.H>
 
+#include <cstdint>
 #include <memory>
 #include <stdexcept>
 
@@ -44,7 +45,7 @@ namespace impactx
 
         // a global step for diagnostics including space charge slice steps in elements
         //   before we start the tracking loop, we are in "step 0" (initial state)
-        int & step = m_tracking_state.m_step;
+        int64_t & step = m_tracking_state.m_step;
         step = 0;
 
         // period in the lattice (e.g., turns)

--- a/src/tracking/particles.cpp
+++ b/src/tracking/particles.cpp
@@ -25,6 +25,7 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_Print.H>
 
+#include <cstdint>
 #include <memory>
 
 
@@ -43,7 +44,7 @@ namespace impactx
 
         // a global step for diagnostics including space charge slice steps in elements
         //   before we start the tracking loop, we are in "step 0" (initial state)
-        int & step = m_tracking_state.m_step;
+        int64_t & step = m_tracking_state.m_step;
         step = 0;
 
         // period in the lattice (e.g., turns)

--- a/src/tracking/reference.cpp
+++ b/src/tracking/reference.cpp
@@ -20,6 +20,7 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_Print.H>
 
+#include <cstdint>
 #include <memory>
 #include <stdexcept>
 
@@ -38,7 +39,7 @@ namespace impactx
 
         // a global step for diagnostics including space charge slice steps in elements
         //   before we start the tracking loop, we are in "step 0" (initial state)
-        int & step = m_tracking_state.m_step;
+        int64_t & step = m_tracking_state.m_step;
         step = 0;
 
         // period in the lattice (e.g., turns)


### PR DESCRIPTION
Increase the global step counter to 64bit. Basic book-keeping requirement to track through 10^6 turns with say each 500 elements at 20 nslice steps: that example already exceeds the range of int32 (up to ~2e9) by 5x.

There is way more to do, but let's start with the counters because they are simple and essential.

## Counter Point

There is a counter argument to be made besides all the accumulated errors (and why one usually does long-term tracking with effective turn maps):
Let's say we do reference particle only or envelope tracking for 2e9 turns. Let us say we are very fast and push 0.1ms to 1ms, then such a sim would run 2.3 to 23 days. Arguably maybe not very useful (?)