### PR TITLE
CI: SIMD in Release, Fix GPUDataRegistry w/ Python LTO

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -156,7 +156,7 @@ jobs:
       run: |
         cmake -S . -B build            \
           -DBUILD_SHARED_LIBS=ON       \
-          -DCMAKE_BUILD_TYPE=Debug     \
+          -DCMAKE_BUILD_TYPE=Release   \
           -DCMAKE_INSTALL_PREFIX=$HOME/.local  \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DImpactX_FFT=ON             \
@@ -176,11 +176,11 @@ jobs:
         export PATH=$HOME/.local/bin:$PATH
         export LD_LIBRARY_PATH=$HOME/.local/lib:$LD_LIBRARY_PATH
 
-        impactx.NOMPI.OMP.DP.OPMD.DEBUG examples/fodo/input_fodo.in algo.particle_shape = 1 || \
+        impactx.NOMPI.OMP.DP.OPMD examples/fodo/input_fodo.in algo.particle_shape = 1 || \
         { cat Backtrace.0.0; exit 1; }
-        impactx.NOMPI.OMP.DP.OPMD.DEBUG examples/fodo/input_fodo.in algo.particle_shape = 2 || \
+        impactx.NOMPI.OMP.DP.OPMD examples/fodo/input_fodo.in algo.particle_shape = 2 || \
         { cat Backtrace.0.0; exit 1; }
-        impactx.NOMPI.OMP.DP.OPMD.DEBUG examples/fodo/input_fodo.in algo.particle_shape = 3 || \
+        impactx.NOMPI.OMP.DP.OPMD examples/fodo/input_fodo.in algo.particle_shape = 3 || \
         { cat Backtrace.0.0; exit 1; }
 
     - name: run installed python module

--- a/src/elements/mixin/dynamicdata.H
+++ b/src/elements/mixin/dynamicdata.H
@@ -37,9 +37,12 @@ namespace impactx::elements::mixin
      * using MyElementData = GPUDataRegistry<MyCoefficients>;
      * @endcode
      *
-     * @warning This template uses function-local static variables. To avoid ODR
-     *          violations (separate registry instances per translation unit), you
-     *          MUST add explicit instantiation control:
+     * @warning This template holds its registry map and ID counter in exported
+     *          inline static data members (`s_next_id`, `s_registry`). To
+     *          guarantee a single shared registry across every translation
+     *          unit and shared library, including downstream DSOs built with
+     *          `-fvisibility=hidden` and/or LTO (e.g. the Python bindings
+     *          module), you MUST add explicit instantiation control:
      *          - In the element header: `IMPACTX_GPUDATA_EXTERN(impactx::elements::MyElement)`
      *          - In the element .cpp:   `IMPACTX_GPUDATA_INSTANTIATE(impactx::elements::MyElement)`
      *
@@ -50,15 +53,23 @@ namespace impactx::elements::mixin
     {
         using DataType = T;  //!< The coefficient/data type stored in this registry
 
-        IMPACTX_EXPORT static int& next_id () {
-            static int id = 0;
-            return id;
-        }
+        // Storage for the registry's state.
+        //
+        // These are inline static data members of the class template (rather
+        // than function-local statics inside inline accessor functions) so
+        // that explicit instantiation of the struct (`template struct
+        // GPUDataRegistry<T>;`) provides one strong, vague-linkage definition
+        // per element type. Combined with `extern template struct` in element
+        // headers, this guarantees a single shared registry across every TU,
+        // including downstream shared libraries built with `-fvisibility=hidden`
+        // and/or LTO (e.g. the Python bindings module), where the previous
+        // function-local-static design produced a hidden duplicate per DSO and
+        // caused emplace/get to disagree across module boundaries.
+        IMPACTX_EXPORT inline static int s_next_id = 0;
+        IMPACTX_EXPORT inline static std::map<int, std::shared_ptr<T>> s_registry{};
 
-        IMPACTX_EXPORT static std::map<int, std::shared_ptr<T>>& registry () {
-            static std::map<int, std::shared_ptr<T>> reg;
-            return reg;
-        }
+        static int& next_id () { return s_next_id; }
+        static std::map<int, std::shared_ptr<T>>& registry () { return s_registry; }
 
         /** Allocate unique ID for a new element instance. */
         static int allocate_id () { return next_id()++; }
@@ -117,10 +128,13 @@ namespace impactx::elements::mixin
 
 /** Suppress implicit instantiation of GPUDataRegistry for an element type.
  *
- * GPUDataRegistry uses function-local static variables for its registry map and
- * ID counter. Without explicit instantiation control, different translation units
- * may each get their own copy of these statics, causing elements to be registered
- * in one registry instance but looked up in another (ODR violation).
+ * GPUDataRegistry holds its registry map and ID counter in exported inline
+ * static data members (`s_next_id`, `s_registry`). Without explicit
+ * instantiation control, different translation units, especially downstream
+ * shared libraries built with `-fvisibility=hidden` and/or LTO (e.g. the
+ * Python bindings module), could materialize a separate copy of these
+ * statics, causing elements to be registered in one registry instance but
+ * looked up in another (ODR violation).
  *
  * Use IMPACTX_GPUDATA_EXTERN in headers and IMPACTX_GPUDATA_INSTANTIATE in the
  * corresponding .cpp file to ensure a single shared registry across the program.
@@ -133,8 +147,8 @@ namespace impactx::elements::mixin
 
 /** Explicit instantiation of GPUDataRegistry for an element type.
  *
- * Provides the single definition of the registry's static variables.
- * Pair with IMPACTX_GPUDATA_EXTERN in the header.
+ * Provides the single definition of the registry's `s_next_id` / `s_registry`
+ * static data members. Pair with IMPACTX_GPUDATA_EXTERN in the header.
  *
  * @param ElementType The element class (must define `using DynamicData = ...`)
  */


### PR DESCRIPTION
The SIMD CI runner often runs out of RAM in the 7GB limited GitHub actions. The reason is that large, complex TUs of elements can take around 700MB+ to compile w/ debug symbols on.

Compiling in release mode does not add `-g` and keeps the RAM peak per TU a bit smaller, around 600MB.

Needed for #1264

This uncovered a bug in Python from #1368 that is fixed, too:

## Fix `GPUDataRegistry<T>`

`GPUDataRegistry<T>` stored its registry map and ID counter as function‑local statics inside inline accessor methods (`next_id()::id`, `registry()::reg`). The `extern template struct GPUDataRegistry<T>` declaration in element headers does not fully suppress instantiation of variadic template members (like `emplace<Args...>`), so `pyImpactX/elements.cpp` ended up implicit‑instantiating emplace locally. With pyImpactX built with `CXX_VISIBILITY_PRESET hidden` + LTO (`ImpactX_PYTHON_IPO=ON`, default), the inlined `registry()`/`next_id()` body inside `emplace` materialized hidden copies of `reg` and `id` inside `pyImpactX.so`, isolated from lib's default‑visibility copies.

The GPU data registry is itself temporary until we implement #1381