### PR TITLE
Unify mapsteps defaults at `10`

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -740,7 +740,7 @@ This requires these additional parameters:
 * ``<element_name>.rotation`` (``float``, in degrees) rotation error in the transverse plane
 * ``<element_name>.aperture_x`` (``float``, in meters) horizontal half-aperture (elliptical)
 * ``<element_name>.aperture_y`` (``float``, in meters) vertical half-aperture (elliptical)
-* ``<element_name>.mapsteps`` (``integer``) number of integration steps per slice used for map and reference particle push in applied fields (default: ``1``)
+* ``<element_name>.mapsteps`` (``integer``) number of integration steps per slice used for map and reference particle push in applied fields (default: ``10``)
 * ``<element_name>.nslice`` (``integer``) number of slices used for the application of space charge (default: ``1``)
 
 ``quadedge``
@@ -789,7 +789,7 @@ This requires these additional parameters:
 * ``<element_name>.rotation`` (``float``, in degrees) rotation error in the transverse plane
 * ``<element_name>.aperture_x`` (``float``, in meters) horizontal half-aperture (elliptical)
 * ``<element_name>.aperture_y`` (``float``, in meters) vertical half-aperture (elliptical)
-* ``<element_name>.mapsteps`` (``integer``) number of integration steps per slice used for map and reference particle push in applied fields (default: ``1``)
+* ``<element_name>.mapsteps`` (``integer``) number of integration steps per slice used for map and reference particle push in applied fields (default: ``10``)
 * ``<element_name>.nslice`` (``integer``) number of slices used for the application of space charge (default: ``1``)
 
 
@@ -892,7 +892,7 @@ This requires these additional parameters:
 * ``<element_name>.rotation`` (``float``, in degrees) rotation error in the transverse plane
 * ``<element_name>.aperture_x`` (``float``, in meters) horizontal half-aperture (elliptical)
 * ``<element_name>.aperture_y`` (``float``, in meters) vertical half-aperture (elliptical)
-* ``<element_name>.mapsteps`` (``integer``) number of integration steps per slice used for map and reference particle push in applied fields (default: ``1``)
+* ``<element_name>.mapsteps`` (``integer``) number of integration steps per slice used for map and reference particle push in applied fields (default: ``10``)
 * ``<element_name>.nslice`` (``integer``) number of slices used for the application of space charge (default: ``1``)
 
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1705,7 +1705,7 @@ This module provides elements and methods for the accelerator lattice.
 
       magnetic field strength in 1/m
 
-.. py:class:: impactx.elements.RFCavity(ds, escale, freq, phase, *, cos_coefficients=None, sin_coefficients=None, z=None, field_on_axis=None, ncoef=None, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, mapsteps=1, nslice=1, name=None)
+.. py:class:: impactx.elements.RFCavity(ds, escale, freq, phase, *, cos_coefficients=None, sin_coefficients=None, z=None, field_on_axis=None, ncoef=None, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, mapsteps=10, nslice=1, name=None)
 
    A radiofrequency cavity.  See :ref:`Models of Soft-Edge Elements <theory-softedge-elements>`.
 
@@ -1796,7 +1796,7 @@ This module provides elements and methods for the accelerator lattice.
    :param rotation: rotation error in the transverse plane [degrees]
    :param name: an optional name for the element
 
-.. py:class:: impactx.elements.SoftSolenoid(ds, bscale, *, cos_coefficients=None, sin_coefficients=None, z=None, field_on_axis=None, ncoef=None, unit=0, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, mapsteps=1, nslice=1, name=None)
+.. py:class:: impactx.elements.SoftSolenoid(ds, bscale, *, cos_coefficients=None, sin_coefficients=None, z=None, field_on_axis=None, ncoef=None, unit=0, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, mapsteps=10, nslice=1, name=None)
 
    A soft-edge solenoid.  See :ref:`Models of Soft-Edge Elements <theory-softedge-elements>`.
 
@@ -1918,7 +1918,7 @@ This module provides elements and methods for the accelerator lattice.
 
       aperture type (transmit, absorb)
 
-.. py:class:: impactx.elements.SoftQuadrupole(ds, gscale, *, cos_coefficients=None, sin_coefficients=None, z=None, gradient_on_axis=None, ncoef=None, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, mapsteps=1, nslice=1, name=None)
+.. py:class:: impactx.elements.SoftQuadrupole(ds, gscale, *, cos_coefficients=None, sin_coefficients=None, z=None, gradient_on_axis=None, ncoef=None, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, mapsteps=10, nslice=1, name=None)
 
    A soft-edge quadrupole.  See :ref:`Models of Soft-Edge Elements <theory-softedge-elements>`.
 

--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -144,7 +144,7 @@ namespace impactx::elements
             amrex::ParticleReal rotation_degree = 0,
             amrex::ParticleReal aperture_x = 0,
             amrex::ParticleReal aperture_y = 0,
-            int mapsteps = 1,
+            int mapsteps = 10,
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -149,7 +149,7 @@ namespace impactx::elements
             amrex::ParticleReal rotation_degree = 0,
             amrex::ParticleReal aperture_x = 0,
             amrex::ParticleReal aperture_y = 0,
-            int mapsteps = 1,
+            int mapsteps = 10,
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -159,7 +159,7 @@ namespace impactx::elements
             amrex::ParticleReal rotation_degree = 0,
             amrex::ParticleReal aperture_x = 0,
             amrex::ParticleReal aperture_y = 0,
-            int mapsteps = 1,
+            int mapsteps = 10,
             int nslice = 1,
             std::optional<std::string> name = std::nullopt
         )

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -2029,7 +2029,7 @@ void init_elements(py::module& m)
              py::arg("rotation") = 0,
              py::arg("aperture_x") = 0,
              py::arg("aperture_y") = 0,
-             py::arg("mapsteps") = 1,
+             py::arg("mapsteps") = 10,
              py::arg("nslice") = 1,
              py::arg("name") = py::none(),
              "An RF cavity."
@@ -2322,7 +2322,7 @@ void init_elements(py::module& m)
              py::arg("rotation") = 0,
              py::arg("aperture_x") = 0,
              py::arg("aperture_y") = 0,
-             py::arg("mapsteps") = 1,
+             py::arg("mapsteps") = 10,
              py::arg("nslice") = 1,
              py::arg("name") = py::none(),
              "A soft-edge solenoid."
@@ -2596,7 +2596,7 @@ void init_elements(py::module& m)
              py::arg("rotation") = 0,
              py::arg("aperture_x") = 0,
              py::arg("aperture_y") = 0,
-             py::arg("mapsteps") = 1,
+             py::arg("mapsteps") = 10,
              py::arg("nslice") = 1,
              py::arg("name") = py::none(),
              "A soft-edge quadrupole."

--- a/src/python/impactx/extensions/RFCavity.py
+++ b/src/python/impactx/extensions/RFCavity.py
@@ -35,7 +35,7 @@ def register_RFCavity_extension(cls):
         rotation=0,
         aperture_x=0,
         aperture_y=0,
-        mapsteps=1,
+        mapsteps=10,
         nslice=1,
         name=None,
     ):

--- a/src/python/impactx/extensions/SoftQuadrupole.py
+++ b/src/python/impactx/extensions/SoftQuadrupole.py
@@ -34,7 +34,7 @@ def register_SoftQuadrupole_extension(cls):
         rotation=0,
         aperture_x=0,
         aperture_y=0,
-        mapsteps=1,
+        mapsteps=10,
         nslice=1,
         name=None,
     ):

--- a/src/python/impactx/extensions/SoftSolenoid.py
+++ b/src/python/impactx/extensions/SoftSolenoid.py
@@ -34,7 +34,7 @@ def register_SoftSolenoid_extension(cls):
         rotation=0,
         aperture_x=0,
         aperture_y=0,
-        mapsteps=1,
+        mapsteps=10,
         nslice=1,
         name=None,
     ):


### PR DESCRIPTION
Set the default mapsteps value to `10` for `RFCavity`, `SoftSolenoid`, and `SoftQuadrupole` across C++ constructors, Python bindings, extension helpers, and user documentation.

This keeps input-file parsing, Python APIs, and docs in sync.

Before this PR, the defaults where:
- inputs files / C++:
  - `InitElement.cpp` implements 10 (picked as source of truth)
  - `parameters.rst` documents 1 (doc bug)
  - element `.H` header files implement 1, but we always overwrite it explicitly on the call site. thus, mostly notional; currently has no influence on users
- Python:
  - `elements.cpp` implements 5 (inconsistency - actual behavior change for Python users)
  - `python.rst` documents 1 (doc bug)