### PR TITLE
Fix dashboard lattice state sync

### DIFF
--- a/src/python/impactx/dashboard/Input/defaults_helper.py
+++ b/src/python/impactx/dashboard/Input/defaults_helper.py
@@ -165,15 +165,19 @@ class InputDefaultsHelper:
                 else:
                     parameter_type = type_and_default
 
-            match parameter_type:
-                case optional_type if "Optional" in optional_type:
-                    parameter_type = parameter_type[len("Optional[") : -1]
-                case "typing.SupportsFloat":
-                    parameter_type = "float"
-                case "typing.SupportsInt":
-                    parameter_type = "int"
-                case "str | None":
-                    parameter_type = "str"
+            for optional_prefix in ("typing.Optional[", "Optional["):
+                if parameter_type.startswith(
+                    optional_prefix
+                ) and parameter_type.endswith("]"):
+                    parameter_type = parameter_type[len(optional_prefix) : -1]
+                    break
+
+            if parameter_type.startswith(("typing.SupportsFloat", "SupportsFloat")):
+                parameter_type = "float"
+            elif parameter_type.startswith(("typing.SupportsInt", "SupportsInt")):
+                parameter_type = "int"
+            elif parameter_type == "str | None":
+                parameter_type = "str"
 
             parameters.append((name, default, parameter_type))
 

--- a/src/python/impactx/dashboard/Input/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/lattice/ui.py
@@ -19,6 +19,7 @@ from .. import DashboardDefaults
 from ..defaults import BEAM_MONITOR_DEFAULT_NAME
 from ..defaults_helper import InputDefaultsHelper
 from ..validation import DashboardValidation, errors_tracker
+from ..visualization.lattice import update_lattice_statistics
 from .utils import LatticeConfigurationHelper
 from .variable_handler import LatticeVariableHandler
 
@@ -71,6 +72,7 @@ def add_lattice_element() -> dict:
 
     state.selected_lattice_list.append(lattice_element)
     errors_tracker.update_simulation_validation_status()
+    update_lattice_statistics()
     return lattice_element
 
 
@@ -166,12 +168,14 @@ def on_lattice_element_parameter_change(
 
     errors_tracker.update_simulation_validation_status()
     state.dirty("selected_lattice_list")
+    update_lattice_statistics()
 
 
 @ctrl.add("deleteLatticeElement")
 def on_delete_LatticeElement_click(index):
     state.selected_lattice_list.pop(index)
     state.dirty("selected_lattice_list")
+    update_lattice_statistics()
 
 
 @ctrl.add("move_latticeElementIndex_up")
@@ -182,6 +186,7 @@ def on_move_latticeElementIndex_up_click(index):
             state.selected_lattice_list[index],
         )
         state.dirty("selected_lattice_list")
+        update_lattice_statistics()
 
 
 @ctrl.add("move_latticeElementIndex_down")
@@ -192,6 +197,7 @@ def on_move_latticeElementIndex_down_click(index):
             state.selected_lattice_list[index],
         )
         state.dirty("selected_lattice_list")
+        update_lattice_statistics()
 
 
 @ctrl.add("nsliceDefaultChange")

--- a/src/python/impactx/dashboard/Input/lattice/variable_handler.py
+++ b/src/python/impactx/dashboard/Input/lattice/variable_handler.py
@@ -4,6 +4,7 @@ from ... import ctrl, html, state, vuetify
 from ...Input.components import CardComponents
 from ..utils import GeneralFunctions
 from ..validation import DashboardValidation, errors_tracker
+from ..visualization.lattice import update_lattice_statistics
 
 init_value = ""
 state.variables = [
@@ -34,19 +35,7 @@ class LatticeVariableHandler:
             - Even though the variable "ns" still exists in the variable configuration,
             the deleted element's index is now invalid.
         """
-        for lattice in state.lattice_elements_using_variables.values():
-            try:
-                lattice_id = lattice["element_reference"]
-                lattice_index = state.selected_lattice_list.index(lattice_id)
-            except ValueError:
-                continue  # skip the deleted elements
-
-            ctrl.updateLatticeElementParameters(
-                lattice_index,
-                lattice["parameter_name"],
-                lattice["ui_input"],
-                lattice["parameter_type"],
-            )
+        LatticeVariableHandler.update_lattice_parameter_bindings()
         LatticeVariableHandler.update_delete_availability()
 
     # -----------------------------------------------------------------------------
@@ -65,6 +54,7 @@ class LatticeVariableHandler:
         new_variable = {key: "" for key in state.variables[0]}
         state.variables.append(new_variable)
         state.dirty("variables")
+        LatticeVariableHandler.update_delete_availability()
 
     @staticmethod
     @ctrl.add("delete_variable")
@@ -78,6 +68,8 @@ class LatticeVariableHandler:
 
         state.variables.pop(index)
         state.dirty("variables")
+        LatticeVariableHandler.update_lattice_parameter_bindings()
+        LatticeVariableHandler.update_delete_availability()
 
     @staticmethod
     @ctrl.add("update_variable")
@@ -101,6 +93,7 @@ class LatticeVariableHandler:
         else:
             variable["value"] = GeneralFunctions.convert_to_numeric(event)
         state.dirty("variables")
+        LatticeVariableHandler.update_lattice_parameter_bindings()
 
     @staticmethod
     @ctrl.add("reset_variables")
@@ -113,6 +106,8 @@ class LatticeVariableHandler:
             {"name": init_value, "value": init_value, "error_message": init_value}
         ]
         state.dirty("variables")
+        LatticeVariableHandler.update_lattice_parameter_bindings()
+        LatticeVariableHandler.update_delete_availability()
 
     # -----------------------------------------------------------------------------
     # Methods
@@ -128,6 +123,28 @@ class LatticeVariableHandler:
 
         state.is_only_variable = True if len(state.variables) == 1 else False
         state.dirty("is_only_variable")
+
+    @staticmethod
+    def update_lattice_parameter_bindings() -> None:
+        """
+        Refresh lattice parameters whose UI input references dashboard variables.
+        """
+
+        for lattice in list(state.lattice_elements_using_variables.values()):
+            try:
+                lattice_id = lattice["element_reference"]
+                lattice_index = state.selected_lattice_list.index(lattice_id)
+            except ValueError:
+                continue  # skip deleted elements
+
+            ctrl.updateLatticeElementParameters(
+                lattice_index,
+                lattice["parameter_name"],
+                lattice["ui_input"],
+                lattice["parameter_type"],
+            )
+
+        update_lattice_statistics()
 
     @staticmethod
     def get_duplicate_indexes(new_name: str, current_index: int) -> list:

--- a/src/python/impactx/dashboard/Input/utils.py
+++ b/src/python/impactx/dashboard/Input/utils.py
@@ -15,6 +15,39 @@ from .defaults import DashboardDefaults
 
 class GeneralFunctions:
     @staticmethod
+    def reset_lattice_runtime_state() -> None:
+        """
+        Reset derived lattice state that is not covered by default inputs.
+        """
+
+        state.selected_lattice_list = []
+        state.lattice_elements_using_variables = {}
+        state.total_elements = 0
+        state.total_steps = 0
+        state.element_counts = {}
+        state.lattice_is_empty = True
+        state.total_length = None
+        state.min_length = None
+        state.max_length = None
+        state.avg_length = None
+        state.length_stats_content = []
+
+        for state_name in (
+            "selected_lattice_list",
+            "lattice_elements_using_variables",
+            "total_elements",
+            "total_steps",
+            "element_counts",
+            "lattice_is_empty",
+            "total_length",
+            "min_length",
+            "max_length",
+            "avg_length",
+            "length_stats_content",
+        ):
+            state.dirty(state_name)
+
+    @staticmethod
     def normalize_for_v_model(name: str) -> str:
         """
         Normalizes a name for use as a v-model variable name.
@@ -112,9 +145,11 @@ class GeneralFunctions:
             if input_section == "distribution_parameters":
                 state.dirty("distribution_type")
             elif input_section == "lattice_configuration":
-                state.selected_lattice_list = []
+                GeneralFunctions.reset_lattice_runtime_state()
                 state.variables = [{"name": "", "value": "", "error_message": ""}]
+                state.is_only_variable = True
                 state.dirty("variables")
+                state.dirty("is_only_variable")
             elif input_section == "space_charge":
                 state.dirty("max_level")
 
@@ -122,11 +157,16 @@ class GeneralFunctions:
             DashboardParser.reset_importing_states()
             state.update(DashboardDefaults.DEFAULT_VALUES)
             state.dirty("distribution_type")
-            state.selected_lattice_list = []
+            GeneralFunctions.reset_lattice_runtime_state()
             state.dirty("max_level")
             state.variables = [{"name": "", "value": "", "error_message": ""}]
+            state.is_only_variable = True
+            state.has_loaded_impactx_example = False
             state.dirty("variables")
-            state.selected_impactx_example = None
+            state.dirty("is_only_variable")
+            state.dirty("has_loaded_impactx_example")
+            state.impactx_example = None
+            state.dirty("impactx_example")
 
     @staticmethod
     def set_state_to_numeric(state_name: str) -> None:

--- a/src/python/impactx/dashboard/Input/visualization/lattice/__init__.py
+++ b/src/python/impactx/dashboard/Input/visualization/lattice/__init__.py
@@ -1,7 +1,9 @@
 from .statistics import LatticeVisualizerStatisticComponents as StatComponents
 from .statistics import LatticeVisualizerStatisticUtils as StatUtils
+from .statistics import update_lattice_statistics
 
 __all__ = [
     "StatComponents",
     "StatUtils",
+    "update_lattice_statistics",
 ]

--- a/src/python/impactx/dashboard/Input/visualization/lattice/statistics.py
+++ b/src/python/impactx/dashboard/Input/visualization/lattice/statistics.py
@@ -17,7 +17,7 @@ state.avg_length = 0
 state.total_steps = 0
 state.element_counts = {}
 state.length_stats_content = ""
-state.lattice_is_empty = len(state.selected_lattice_list) == 0
+state.lattice_is_empty = len(getattr(state, "selected_lattice_list", []) or []) == 0
 
 
 class LatticeVisualizerStatisticUtils:
@@ -32,7 +32,9 @@ class LatticeVisualizerStatisticUtils:
         """
         values = []
 
-        for element in state.selected_lattice_list:
+        selected_lattice_list = getattr(state, "selected_lattice_list", []) or []
+
+        for element in selected_lattice_list:
             for param in element.get("parameters", []):
                 if param.get("parameter_name", "").lower() == parameter_name.lower():
                     try:
@@ -75,7 +77,9 @@ class LatticeVisualizerStatisticUtils:
         :return: Dictionary of element counts indexed by element name.
         """
         counts = {}
-        for element in state.selected_lattice_list:
+        selected_lattice_list = getattr(state, "selected_lattice_list", []) or []
+
+        for element in selected_lattice_list:
             key = str(element["name"]).lower()
             # can't do += 1 because key is not already initialized
             counts[key] = counts.get(key, 0) + 1
@@ -99,6 +103,31 @@ class LatticeVisualizerStatisticUtils:
         """
         steps = LatticeVisualizerStatisticUtils._extract_parameter_values("nslice", int)
         return sum(steps)
+
+
+def update_lattice_statistics() -> None:
+    """
+    Recompute all lattice statistics from the current lattice state.
+    """
+    selected_lattice_list = getattr(state, "selected_lattice_list", []) or []
+
+    state.total_elements = len(selected_lattice_list)
+    state.total_steps = LatticeVisualizerStatisticUtils.update_total_steps()
+    state.element_counts = LatticeVisualizerStatisticUtils.update_element_counts()
+    LatticeVisualizerStatisticUtils.update_length_statistics()
+
+    for state_name in (
+        "total_elements",
+        "total_steps",
+        "element_counts",
+        "lattice_is_empty",
+        "total_length",
+        "min_length",
+        "max_length",
+        "avg_length",
+        "length_stats_content",
+    ):
+        state.dirty(state_name)
 
 
 class LatticeVisualizerStatisticComponents:

--- a/src/python/impactx/dashboard/Input/visualization/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/visualization/lattice/ui.py
@@ -8,17 +8,14 @@ License: BSD-3-Clause-LBNL
 
 from .... import html, state, vuetify
 from ....Input.components import CardBase
-from . import StatComponents, StatUtils
+from . import StatComponents, update_lattice_statistics
 
 
 def _update_statistics() -> None:
     """
     Update statistics based on the current selected lattice elements.
     """
-    state.total_elements = len(state.selected_lattice_list)
-    state.total_steps = StatUtils.update_total_steps()
-    state.element_counts = StatUtils.update_element_counts()
-    StatUtils.update_length_statistics()
+    update_lattice_statistics()
 
 
 @state.change("selected_lattice_list")

--- a/src/python/impactx/dashboard/Toolbar/examples_loader/loader.py
+++ b/src/python/impactx/dashboard/Toolbar/examples_loader/loader.py
@@ -12,6 +12,8 @@ from ...Input.utils import GeneralFunctions
 from ..file_imports.ui_populator import populate_impactx_simulation_file_to_ui
 
 state.impactx_example_list = []
+state.is_loading_impactx_example = False
+state.has_loaded_impactx_example = False
 
 IMPACTX_PYTHON_ROOT = Path(__file__).resolve().parents[3]
 
@@ -32,14 +34,28 @@ DASHBOARD_EXAMPLES = {
 class DashboardExamplesLoader:
     @state.change("impactx_example")
     def on_selected_impactx_example_change(**kwargs):
-        if state.impactx_example is None:
-            GeneralFunctions.reset_inputs("all")
-        if state.impactx_example in state.impactx_example_list:
+        if state.is_loading_impactx_example:
+            return
+
+        selected_example = state.impactx_example
+
+        if selected_example is None:
+            if state.has_loaded_impactx_example:
+                state.has_loaded_impactx_example = False
+                GeneralFunctions.reset_inputs("all")
+            return
+
+        if selected_example in state.impactx_example_list:
             example_script = DashboardExamplesLoader._get_example_content(
-                state.impactx_example
+                selected_example
             )
             if example_script:
-                populate_impactx_simulation_file_to_ui(example_script)
+                state.is_loading_impactx_example = True
+                try:
+                    populate_impactx_simulation_file_to_ui(example_script)
+                    state.has_loaded_impactx_example = True
+                finally:
+                    state.is_loading_impactx_example = False
 
     @staticmethod
     def get_examples_directory() -> Path:

--- a/src/python/impactx/dashboard/Toolbar/file_imports/ui_populator.py
+++ b/src/python/impactx/dashboard/Toolbar/file_imports/ui_populator.py
@@ -9,6 +9,7 @@ License: BSD-3-Clause-LBNL
 from ... import ctrl, state
 from ...Input.lattice.ui import add_lattice_element
 from ...Input.lattice.variable_handler import LatticeVariableHandler
+from ...Input.visualization.lattice import update_lattice_statistics
 from .python.parser import DashboardParser
 
 
@@ -125,6 +126,8 @@ def _populate_lattice_config_to_ui(parsed_data):
                     parameter_type,
                 )
 
+    update_lattice_statistics()
+
 
 @staticmethod
 def _populate_lattice_config_variables_to_ui(parsed_data):
@@ -136,4 +139,6 @@ def _populate_lattice_config_variables_to_ui(parsed_data):
         if not any(var["name"] == name for var in state.variables):
             state.variables.append({"name": name, "value": value, "error_message": ""})
     state.dirty("variables")
+    LatticeVariableHandler.update_lattice_parameter_bindings()
     LatticeVariableHandler.update_delete_availability()
+    update_lattice_statistics()

--- a/tests/python/dashboard/test_impactx_examples_lattice.py
+++ b/tests/python/dashboard/test_impactx_examples_lattice.py
@@ -124,3 +124,23 @@ def test_examples(dashboard) -> None:
     # test lattice builds w/example importing
     test_examples.dogleg_lattice()  # uses lattice.append() and lattice.extend()
     test_examples.chicane_lattice()  # uses .reverse()
+
+
+def test_example_selector(dashboard) -> None:
+    """
+    Exercise loading an example through the dashboard example selector state.
+    """
+
+    example_path = "fodo/run_fodo.py"
+
+    for _ in range(TIMEOUT):
+        examples = dashboard.get_state("impactx_example_list") or []
+        if example_path in examples:
+            break
+        time.sleep(1)
+    else:
+        raise AssertionError(f"{example_path} was not loaded into the examples list")
+
+    dashboard.set_state("impactx_example", example_path)
+    dashboard.assert_state("total_elements", 11)
+    dashboard.assert_state("total_length", "3.0m")

--- a/tests/python/dashboard/utils.py
+++ b/tests/python/dashboard/utils.py
@@ -106,9 +106,12 @@ class DashboardTester:
         :param element_name: Name of the lattice element to add.
         """
         try:
+            current_lattice = self.get_state("selected_lattice_list") or []
+            expected_count = len(current_lattice) + 1
             self.set_state("selected_lattice", element_name)
             self.assert_state("is_selected_element_invalid", False)
             self.sb.click("#add_lattice_element")
+            self.assert_state_list_length("selected_lattice_list", expected_count)
         except Exception as error:
             raise Exception(
                 f"Unable to set input for lattice element '{element_name}': {str(error)}"
@@ -247,6 +250,34 @@ class DashboardTester:
             f"state['{state_name}'] never became '{expected_input}' after {timeout} seconds "
             f"(last value: '{value}').\n"
             f"curr_view_details_log: {self.get_state('curr_view_details_log')}"
+        )
+
+    def assert_state_list_length(
+        self, state_name: str, expected_length: int, timeout=TIMEOUT
+    ):
+        """
+        Checks if trame.state[state_name] is a list with the expected length.
+        """
+        value = None
+        for i in range(timeout):
+            try:
+                value = self.get_state(state_name)
+            except TimeoutException:
+                value = None
+
+            if isinstance(value, list) and len(value) == expected_length:
+                return
+
+            current_length = len(value) if isinstance(value, list) else None
+            print(
+                f"Waiting for len(state['{state_name}']) to become '{expected_length}' "
+                f"- (current length: '{current_length}') - ({i + 1}s elapsed)"
+            )
+            time.sleep(1)
+
+        raise TimeoutError(
+            f"len(state['{state_name}']) never became '{expected_length}' "
+            f"after {timeout} seconds (last value: '{value}')."
         )
 
     def get_state(self, state_name):


### PR DESCRIPTION
- Normalize pybind types like `typing.SupportsFloat[...]` and `typing.SupportsInt[...]` before validation.
- Recompute lattice statistics explicitly after lattice add, delete, reorder, import, and parameter updates.
- Refresh lattice parameters when dashboard variables change, so `sim_input` resolves correctly.
- Reset derived lattice/stat state on dashboard reset.
- Make the dashboard test helper wait for lattice list growth after clicking `ADD`.

First seen in #1402