### PR TITLE
Handle Alignment in Spin Push

### DIFF
--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -147,8 +147,8 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT x,
             T_Real & AMREX_RESTRICT y,
             [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            T_Real & AMREX_RESTRICT px,
-            T_Real & AMREX_RESTRICT py,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
             [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
             T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
@@ -160,9 +160,6 @@ namespace impactx::elements
             using std::fmod;
             using std::abs;
             using VBool = decltype(x>0_prt);
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // define intermediate variables
             amrex::ParticleReal const dx = m_repeat_x * 0.5_prt;
@@ -211,9 +208,6 @@ namespace impactx::elements
             // For absorb: invalidate if inside aperture
             auto const invalid_mask = m_action == Action::transmit ? !inside_aperture : inside_aperture;
             amrex::ParticleIDWrapper<T_IdCpu>{idcpu}.make_invalid(invalid_mask);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle. */

--- a/src/elements/Buncher.H
+++ b/src/elements/Buncher.H
@@ -116,7 +116,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/Buncher.H
+++ b/src/elements/Buncher.H
@@ -122,9 +122,6 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
 
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
-
             // initialize output values of momenta
             T_Real pxout = px;
             T_Real pyout = py;
@@ -139,9 +136,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle. */

--- a/src/elements/CFbend.H
+++ b/src/elements/CFbend.H
@@ -198,14 +198,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // initialize output values
             T_Real xout = x;
@@ -233,12 +230,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/CFbend.H
+++ b/src/elements/CFbend.H
@@ -198,7 +198,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ChrDrift.H
+++ b/src/elements/ChrDrift.H
@@ -126,7 +126,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ChrDrift.H
+++ b/src/elements/ChrDrift.H
@@ -126,16 +126,13 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
             using namespace std; // for cmath(float)
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // access position data
             T_Real const xout = x;
@@ -169,12 +166,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/ChrPlasmaLens.H
+++ b/src/elements/ChrPlasmaLens.H
@@ -139,7 +139,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ChrPlasmaLens.H
+++ b/src/elements/ChrPlasmaLens.H
@@ -139,16 +139,13 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
             using namespace std; // for cmath(float)
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // compute particle momentum deviation delta + 1
             T_Real const delta1 = sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
@@ -254,12 +251,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -141,7 +141,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -141,16 +141,13 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
             using namespace std; // for cmath(float)
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // access position data
             T_Real const xout = x;
@@ -248,12 +245,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -146,9 +146,6 @@ namespace impactx::elements
             using namespace std; // for cmath(float)
             namespace stdx = amrex::simd::stdx;
 
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
-
             // initial conversion from static to dynamic units:
             px = px * m_bgi;
             py = py * m_bgi;
@@ -225,12 +222,6 @@ namespace impactx::elements
             px = px / m_bgf;
             py = py / m_bgf;
             pt = pt / m_bgf;
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/ConstF.H
+++ b/src/elements/ConstF.H
@@ -189,14 +189,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // initialize output values
             T_Real xout = x;
@@ -223,12 +220,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/ConstF.H
+++ b/src/elements/ConstF.H
@@ -189,7 +189,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/DipEdge.H
+++ b/src/elements/DipEdge.H
@@ -207,7 +207,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/DipEdge.H
+++ b/src/elements/DipEdge.H
@@ -216,9 +216,6 @@ namespace impactx::elements
             using namespace std; // for cmath(float)
             using amrex::Math::powi;
 
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
-
             if (m_model == dipedge::Model::linear) {
                // apply linear model
                px = px + m_R21 * x;
@@ -285,9 +282,6 @@ namespace impactx::elements
                t = tout;
                pt = ptout;
             }
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
 

--- a/src/elements/Drift.H
+++ b/src/elements/Drift.H
@@ -125,7 +125,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/Drift.H
+++ b/src/elements/Drift.H
@@ -125,14 +125,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // initialize output values
             T_Real xout = x;
@@ -157,12 +154,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/Empty.H
+++ b/src/elements/Empty.H
@@ -111,7 +111,7 @@ namespace impactx::elements
             [[maybe_unused]] T_Real & AMREX_RESTRICT px,
             [[maybe_unused]] T_Real & AMREX_RESTRICT py,
             [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ExactCFbend.H
+++ b/src/elements/ExactCFbend.H
@@ -192,7 +192,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT px,
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
-            [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] uint64_t const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ExactCFbend.H
+++ b/src/elements/ExactCFbend.H
@@ -192,14 +192,11 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT px,
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
-            uint64_t & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] uint64_t & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // numerical integration parameters
             amrex::ParticleReal const zin = 0_prt;
@@ -227,12 +224,6 @@ namespace impactx::elements
             py = particle(4);
             t = particle(5);
             pt = particle(6);
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes a particle in an ExactMultipole element through
@@ -739,7 +730,7 @@ namespace impactx::elements
          * @param[in,out] sx particle spin x-component
          * @param[in,out] sy particle spin y-component
          * @param[in,out] sz particle spin z-component
-         * @param[in,out] idcpu particle global index
+         * @param[in,out] idcpu particle global index (unused)
          * @param[in] refpart reference particle (unused)
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
@@ -754,14 +745,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // numerical integration parameters
             amrex::ParticleReal const zin = 0_prt;
@@ -791,12 +779,6 @@ namespace impactx::elements
             sx = particle_spin(1);
             sy = particle_spin(2);
             sz = particle_spin(3);
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
 

--- a/src/elements/ExactDrift.H
+++ b/src/elements/ExactDrift.H
@@ -124,16 +124,13 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using namespace std; // for cmath(float)
             using amrex::Math::powi;
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // initialize output values
             T_Real const xout = x;
@@ -165,12 +162,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/ExactDrift.H
+++ b/src/elements/ExactDrift.H
@@ -124,7 +124,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ExactMultipole.H
+++ b/src/elements/ExactMultipole.H
@@ -192,14 +192,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // coordinates within the multipole (not needed)
             //amrex::ParticleReal const s = refpart.s;
@@ -233,12 +230,6 @@ namespace impactx::elements
             py = particle(4);
             t = particle(5);
             pt = particle(6);
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes a particle in an ExactMultipole element through
@@ -636,14 +627,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // numerical integration parameters
             amrex::ParticleReal const zin = 0_prt;
@@ -673,12 +661,6 @@ namespace impactx::elements
             sx = particle_spin(1);
             sy = particle_spin(2);
             sz = particle_spin(3);
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
 

--- a/src/elements/ExactMultipole.H
+++ b/src/elements/ExactMultipole.H
@@ -192,7 +192,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -157,7 +157,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -157,14 +157,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // numerical integration parameters
             amrex::ParticleReal const zin = 0_prt;
@@ -194,12 +191,6 @@ namespace impactx::elements
             py = particle(4);
             t = particle(5);
             pt = particle(6);
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes a particle in an ExactQuad element through
@@ -522,14 +513,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // numerical integration parameters
             amrex::ParticleReal const zin = 0_prt;
@@ -559,12 +547,6 @@ namespace impactx::elements
             sx = particle_spin(1);
             sy = particle_spin(2);
             sz = particle_spin(3);
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the covariance matrix. */

--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -171,9 +171,6 @@ namespace impactx::elements
             using namespace std; // for cmath(float)
             namespace stdx = amrex::simd::stdx;
 
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
-
             // access position data
             T_Real const xout = x;
             T_Real const yout = y;
@@ -246,12 +243,6 @@ namespace impactx::elements
                    }
                }
             }
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/Kicker.H
+++ b/src/elements/Kicker.H
@@ -120,7 +120,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/Kicker.H
+++ b/src/elements/Kicker.H
@@ -126,9 +126,6 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
 
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
-
             // access position data
             T_Real const xout = x;
             T_Real const yout = y;
@@ -157,9 +154,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle. */

--- a/src/elements/LinearMap.H
+++ b/src/elements/LinearMap.H
@@ -146,7 +146,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/LinearMap.H
+++ b/src/elements/LinearMap.H
@@ -152,9 +152,6 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
 
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
-
             // input and output phase space vectors
             amrex::SmallVector<T_Real, 6, 1> vectorin{
                 x, px, y, py, t, pt
@@ -170,9 +167,6 @@ namespace impactx::elements
             py = vectorout(4);
             t = vectorout(5);
             pt = vectorout(6);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/Marker.H
+++ b/src/elements/Marker.H
@@ -88,7 +88,7 @@ namespace impactx::elements
             [[maybe_unused]] T_Real & AMREX_RESTRICT px,
             [[maybe_unused]] T_Real & AMREX_RESTRICT py,
             [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/Multipole.H
+++ b/src/elements/Multipole.H
@@ -147,9 +147,6 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
 
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
-
             // a complex type with two T_Real
             using Complex = amrex::GpuComplex<T_Real>;
 
@@ -191,9 +188,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle. */

--- a/src/elements/Multipole.H
+++ b/src/elements/Multipole.H
@@ -141,7 +141,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/NonlinearLens.H
+++ b/src/elements/NonlinearLens.H
@@ -118,7 +118,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/NonlinearLens.H
+++ b/src/elements/NonlinearLens.H
@@ -128,9 +128,6 @@ namespace impactx::elements
             // a complex type with two T_Real
             using Complex = amrex::GpuComplex<T_Real>;
 
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
-
             // access reference particle values to find (beta*gamma)^2
             //amrex::ParticleReal const pt_ref = refpart.pt;
             //amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
@@ -183,9 +180,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle. */

--- a/src/elements/PRot.H
+++ b/src/elements/PRot.H
@@ -115,7 +115,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/PlaneXYRot.H
+++ b/src/elements/PlaneXYRot.H
@@ -114,7 +114,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/PlaneXYRot.H
+++ b/src/elements/PlaneXYRot.H
@@ -118,9 +118,6 @@ namespace impactx::elements
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
-
             // initialize output values
             T_Real xout = x;
             T_Real yout = y;
@@ -146,9 +143,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle. */

--- a/src/elements/PolygonAperture.H
+++ b/src/elements/PolygonAperture.H
@@ -173,8 +173,8 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT x,
             T_Real & AMREX_RESTRICT y,
             [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            T_Real & AMREX_RESTRICT px,
-            T_Real & AMREX_RESTRICT py,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
             [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
             T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
@@ -190,9 +190,6 @@ namespace impactx::elements
             using std::abs;
             using amrex::arg;
             using VBool = decltype(x>0_prt);
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // define intermediate variables
             amrex::ParticleReal const dx = m_repeat_x * 0.5_prt;
@@ -263,9 +260,6 @@ namespace impactx::elements
             // For absorb: invalidate if inside aperture
             auto const invalid_mask = m_action == Action::transmit ? !inside_aperture : inside_aperture;
             amrex::ParticleIDWrapper<T_IdCpu>{idcpu}.make_invalid(invalid_mask);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle. */

--- a/src/elements/Quad.H
+++ b/src/elements/Quad.H
@@ -144,14 +144,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // initialize output values
             T_Real xout = x;
@@ -200,12 +197,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/Quad.H
+++ b/src/elements/Quad.H
@@ -144,7 +144,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/QuadEdge.H
+++ b/src/elements/QuadEdge.H
@@ -153,9 +153,6 @@ namespace impactx::elements
             using amrex::Math::powi;
             using namespace std; // for cmath(float)
 
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
-
             // compute particle momentum deviation delta + 1
             T_Real const delta1 = sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
             T_Real a = m_a / delta1;
@@ -190,9 +187,6 @@ namespace impactx::elements
             t = tout;
             px = pxout;
             py = pyout;
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle. */

--- a/src/elements/QuadEdge.H
+++ b/src/elements/QuadEdge.H
@@ -144,7 +144,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -219,14 +219,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // get the linear map
             amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
@@ -248,12 +245,6 @@ namespace impactx::elements
             py = out[4];
             t  = out[5];
             pt = out[6];
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -219,7 +219,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/Sbend.H
+++ b/src/elements/Sbend.H
@@ -176,14 +176,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // initialize output values
             T_Real xout = x;
@@ -227,12 +224,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/Sbend.H
+++ b/src/elements/Sbend.H
@@ -176,7 +176,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ShortRF.H
+++ b/src/elements/ShortRF.H
@@ -125,7 +125,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ShortRF.H
+++ b/src/elements/ShortRF.H
@@ -133,9 +133,6 @@ namespace impactx::elements
             using namespace amrex::literals; // for _rt and _prt
             using namespace std; // for cmath(float)
 
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
-
             // initial conversion from static to dynamic units:
             px = px * m_bgi;
             py = py * m_bgi;
@@ -171,9 +168,6 @@ namespace impactx::elements
             px = px / m_bgf;
             py = py / m_bgf;
             pt = pt / m_bgf;
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle. */

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -225,14 +225,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // get the linear map
             amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
@@ -254,12 +251,6 @@ namespace impactx::elements
             py = out[4];
             t  = out[5];
             pt = out[6];
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -225,7 +225,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -235,7 +235,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -235,14 +235,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // get the linear map
             amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
@@ -264,12 +261,6 @@ namespace impactx::elements
             py = out[4];
             t  = out[5];
             pt = out[6];
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/Sol.H
+++ b/src/elements/Sol.H
@@ -151,14 +151,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
 
             // initialize output values
             T_Real xout = x;
@@ -205,12 +202,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // apply transverse aperture
-            apply_aperture(x, y, idcpu);
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle.

--- a/src/elements/Sol.H
+++ b/src/elements/Sol.H
@@ -151,7 +151,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/SpinMap.H
+++ b/src/elements/SpinMap.H
@@ -117,7 +117,7 @@ namespace impactx::elements
             [[maybe_unused]] T_Real & AMREX_RESTRICT px,
             [[maybe_unused]] T_Real & AMREX_RESTRICT py,
             [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/TaperedPL.H
+++ b/src/elements/TaperedPL.H
@@ -132,9 +132,6 @@ namespace impactx::elements
             using amrex::Math::powi;
             using namespace std; // for cmath(float)
 
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
-
             // initialize output values
             T_Real xout = x;
             T_Real yout = y;
@@ -160,9 +157,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle. */

--- a/src/elements/TaperedPL.H
+++ b/src/elements/TaperedPL.H
@@ -113,7 +113,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index (unused)
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -124,7 +124,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -128,9 +128,6 @@ namespace impactx::elements
             using amrex::Math::powi;
             using namespace std; // for cmath(float)
 
-            // shift due to alignment errors of the element
-            shift_in(x, y, px, py);
-
             // access position data
             T_Real const xout = x;
             T_Real const yout = y;
@@ -159,9 +156,6 @@ namespace impactx::elements
             px = pxout;
             py = pyout;
             pt = ptout;
-
-            // undo shift due to alignment errors of the element
-            shift_out(x, y, px, py);
         }
 
         /** This pushes the reference particle. */

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -120,7 +120,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/mixin/alignment.H
+++ b/src/elements/mixin/alignment.H
@@ -96,6 +96,26 @@ namespace impactx::elements::mixin
             py = -pxc * m_sin_rotation + pyc * m_cos_rotation;
         }
 
+        /** Rotate a transverse vector into the alignment error frame
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
+         *
+         * @param[inout] sx horizontal spin/vector component
+         * @param[inout] sy vertical spin/vector component
+         */
+        template<typename T_Real>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void rotate_in (
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy
+        ) const
+        {
+            T_Real const sxc = sx;
+            T_Real const syc = sy;
+            sx =  sxc * m_cos_rotation + syc * m_sin_rotation;
+            sy = -sxc * m_sin_rotation + syc * m_cos_rotation;
+        }
+
         /** Shift the particle out of the alignment error frame
          *
          * The @see compute_constants method must be called before pushing particles through this operator.
@@ -127,6 +147,26 @@ namespace impactx::elements::mixin
             T_Real const pyc = py;
             px = pxc * m_cos_rotation - pyc * m_sin_rotation;
             py = pxc * m_sin_rotation + pyc * m_cos_rotation;
+        }
+
+        /** Rotate a transverse vector out of the alignment error frame
+         *
+         * The @see compute_constants method must be called before pushing particles through this operator.
+         *
+         * @param[inout] sx horizontal spin/vector component
+         * @param[inout] sy vertical spin/vector component
+         */
+        template<typename T_Real>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void rotate_out (
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy
+        ) const
+        {
+            T_Real const sxc = sx;
+            T_Real const syc = sy;
+            sx = sxc * m_cos_rotation - syc * m_sin_rotation;
+            sy = sxc * m_sin_rotation + syc * m_cos_rotation;
         }
 
         /** Horizontal translation error

--- a/src/elements/mixin/beamoptic.H
+++ b/src/elements/mixin/beamoptic.H
@@ -10,6 +10,8 @@
 #ifndef IMPACTX_ELEMENTS_MIXIN_BEAMOPTIC_H
 #define IMPACTX_ELEMENTS_MIXIN_BEAMOPTIC_H
 
+#include "alignment.H"
+#include "pipeaperture.H"
 #include "spintransport.H"
 
 #include "particles/ImpactXParticleContainer.H"
@@ -109,8 +111,15 @@ namespace detail
      * themselves, but we better help a little for robustness. Background:
      * https://github.com/AMReX-Codes/amrex/pull/4520#issuecomment-3064064215
      *
+     * The `ForceWriteback` flag forces the writeback regardless of the push
+     * method's argument constness. Use it for slots that may be modified by
+     * something other than the named push method itself (e.g., a pre/post
+     * step in the caller), where the push method's signature is not the
+     * authoritative source of truth for whether the value changed.
+     *
      * @tparam P_Method pointer to the push method (for is_nth_arg_non_const)
      * @tparam N the argument index (for is_nth_arg_non_const)
+     * @tparam ForceWriteback if true, write back regardless of P_Method's argument constness
      * @tparam T data type
      * @tparam IndexType int or SIMD index
      * @tparam ValType the type of the value to store
@@ -118,7 +127,8 @@ namespace detail
      * @param ptr pointer to the SoA data
      * @param i index or SIMD index
      */
-    template <auto P_Method, int N, typename T, typename IndexType, typename ValType>
+    template <auto P_Method, int N, bool ForceWriteback = false,
+              typename T, typename IndexType, typename ValType>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void store_pdata (
         ValType const & AMREX_RESTRICT val,
@@ -128,7 +138,7 @@ namespace detail
     {
 #ifdef AMREX_USE_SIMD
         if constexpr (!std::is_integral_v<IndexType>) {
-            if constexpr (amrex::simd::is_nth_arg_non_const(P_Method, N)) {
+            if constexpr (ForceWriteback || amrex::simd::is_nth_arg_non_const(P_Method, N)) {
                 // write back to memory
                 // TODO stdx::vector_aligned needs alignment guarantees
                 //      https://github.com/AMReX-Codes/amrex/issues/4592
@@ -227,8 +237,27 @@ namespace detail
             decltype(auto) sz = load_pdata(m_part_sz, i);
             decltype(auto) idcpu = load_pdata(m_part_idcpu, i);
 
+            // pre/post-push functionality declared by mixin classes
+            constexpr bool has_alignment = std::is_base_of_v<mixin::Alignment, T_Element>;
+            constexpr bool has_aperture = std::is_base_of_v<mixin::PipeAperture, T_Element>;
+
+            // shift into the alignment-error frame (compile-time gated)
+            if constexpr (has_alignment) {
+                m_element.shift_in(x, y, px, py);
+            }
+
             // push spin & phase space through element
             m_element.spin_and_phasespace_push(x, y, t, px, py, pt, sx, sy, sz, idcpu, m_ref_part);
+
+            // apply transverse aperture in the element-local frame (compile-time gated)
+            if constexpr (has_aperture) {
+                m_element.apply_aperture(x, y, idcpu);
+            }
+
+            // shift back to the lab frame (compile-time gated)
+            if constexpr (has_alignment) {
+                m_element.shift_out(x, y, px, py);
+            }
 
             // SIMD: write back to memory
 #ifdef AMREX_USE_SIMD
@@ -238,16 +267,22 @@ namespace detail
                 using IdCpuType = std::decay_t<decltype(idcpu)>;
                 constexpr auto P_Method = &T_Element::template spin_and_phasespace_push<RealType, IdCpuType>;
 
-                store_pdata<P_Method, 0>(x, m_part_x, i);
-                store_pdata<P_Method, 1>(y, m_part_y, i);
-                store_pdata<P_Method, 2>(t, m_part_t, i);
-                store_pdata<P_Method, 3>(px, m_part_px, i);
-                store_pdata<P_Method, 4>(py, m_part_py, i);
-                store_pdata<P_Method, 5>(pt, m_part_pt, i);
-                store_pdata<P_Method, 6>(sx, m_part_sx, i);
-                store_pdata<P_Method, 7>(sy, m_part_sy, i);
-                store_pdata<P_Method, 8>(sz, m_part_sz, i);
-                store_pdata<P_Method, 9>(idcpu, m_part_idcpu, i);
+                // shift_in/shift_out write x, y, px, py; apply_aperture writes idcpu.
+                // These wrapper-modified slots must be stored regardless of the push
+                // method's argument constness.
+                constexpr bool wb_align    = has_alignment;
+                constexpr bool wb_aperture = has_aperture;
+
+                store_pdata<P_Method, 0, wb_align>   (x,     m_part_x,     i);
+                store_pdata<P_Method, 1, wb_align>   (y,     m_part_y,     i);
+                store_pdata<P_Method, 2>             (t,     m_part_t,     i);
+                store_pdata<P_Method, 3, wb_align>   (px,    m_part_px,    i);
+                store_pdata<P_Method, 4, wb_align>   (py,    m_part_py,    i);
+                store_pdata<P_Method, 5>             (pt,    m_part_pt,    i);
+                store_pdata<P_Method, 6>             (sx,    m_part_sx,    i);
+                store_pdata<P_Method, 7>             (sy,    m_part_sy,    i);
+                store_pdata<P_Method, 8>             (sz,    m_part_sz,    i);
+                store_pdata<P_Method, 9, wb_aperture>(idcpu, m_part_idcpu, i);
             }
 #endif
         }
@@ -344,8 +379,27 @@ namespace detail
             decltype(auto) pt = load_pdata(m_part_pt, i);
             decltype(auto) idcpu = load_pdata(m_part_idcpu, i);
 
+            // pre/post-push functionality declared by mixin classes
+            constexpr bool has_alignment = std::is_base_of_v<mixin::Alignment, T_Element>;
+            constexpr bool has_aperture = std::is_base_of_v<mixin::PipeAperture, T_Element>;
+
+            // shift into the alignment-error frame (compile-time gated)
+            if constexpr (has_alignment) {
+                m_element.shift_in(x, y, px, py);
+            }
+
             // push through element
             m_element(x, y, t, px, py, pt, idcpu, m_ref_part);
+
+            // apply transverse aperture in the element-local frame (compile-time gated)
+            if constexpr (has_aperture) {
+                m_element.apply_aperture(x, y, idcpu);
+            }
+
+            // shift back to the lab frame (compile-time gated)
+            if constexpr (has_alignment) {
+                m_element.shift_out(x, y, px, py);
+            }
 
             // write back to memory
 #ifdef AMREX_USE_SIMD
@@ -355,13 +409,19 @@ namespace detail
                 using IdCpuType = std::decay_t<decltype(idcpu)>;
                 constexpr auto P_Method = &T_Element::template operator()<RealType, IdCpuType>;
 
-                store_pdata<P_Method, 0>(x, m_part_x, i);
-                store_pdata<P_Method, 1>(y, m_part_y, i);
-                store_pdata<P_Method, 2>(t, m_part_t, i);
-                store_pdata<P_Method, 3>(px, m_part_px, i);
-                store_pdata<P_Method, 4>(py, m_part_py, i);
-                store_pdata<P_Method, 5>(pt, m_part_pt, i);
-                store_pdata<P_Method, 6>(idcpu, m_part_idcpu, i);
+                // shift_in/shift_out write x, y, px, py; apply_aperture writes idcpu.
+                // These wrapper-modified slots must be stored regardless of the push
+                // method's argument constness.
+                constexpr bool wb_align    = has_alignment;
+                constexpr bool wb_aperture = has_aperture;
+
+                store_pdata<P_Method, 0, wb_align>   (x,     m_part_x,     i);
+                store_pdata<P_Method, 1, wb_align>   (y,     m_part_y,     i);
+                store_pdata<P_Method, 2>             (t,     m_part_t,     i);
+                store_pdata<P_Method, 3, wb_align>   (px,    m_part_px,    i);
+                store_pdata<P_Method, 4, wb_align>   (py,    m_part_py,    i);
+                store_pdata<P_Method, 5>             (pt,    m_part_pt,    i);
+                store_pdata<P_Method, 6, wb_aperture>(idcpu, m_part_idcpu, i);
             }
 #endif
         }

--- a/src/elements/mixin/beamoptic.H
+++ b/src/elements/mixin/beamoptic.H
@@ -244,6 +244,7 @@ namespace detail
             // shift into the alignment-error frame (compile-time gated)
             if constexpr (has_alignment) {
                 m_element.shift_in(x, y, px, py);
+                m_element.rotate_in(sx, sy);
             }
 
             // push spin & phase space through element
@@ -257,6 +258,7 @@ namespace detail
             // shift back to the lab frame (compile-time gated)
             if constexpr (has_alignment) {
                 m_element.shift_out(x, y, px, py);
+                m_element.rotate_out(sx, sy);
             }
 
             // SIMD: write back to memory
@@ -267,7 +269,8 @@ namespace detail
                 using IdCpuType = std::decay_t<decltype(idcpu)>;
                 constexpr auto P_Method = &T_Element::template spin_and_phasespace_push<RealType, IdCpuType>;
 
-                // shift_in/shift_out write x, y, px, py; apply_aperture writes idcpu.
+                // shift_in/shift_out write x, y, px, py; rotate_in/rotate_out
+                // write sx, sy; apply_aperture writes idcpu.
                 // These wrapper-modified slots must be stored regardless of the push
                 // method's argument constness.
                 constexpr bool wb_align    = has_alignment;
@@ -279,8 +282,8 @@ namespace detail
                 store_pdata<P_Method, 3, wb_align>   (px,    m_part_px,    i);
                 store_pdata<P_Method, 4, wb_align>   (py,    m_part_py,    i);
                 store_pdata<P_Method, 5>             (pt,    m_part_pt,    i);
-                store_pdata<P_Method, 6>             (sx,    m_part_sx,    i);
-                store_pdata<P_Method, 7>             (sy,    m_part_sy,    i);
+                store_pdata<P_Method, 6, wb_align>   (sx,    m_part_sx,    i);
+                store_pdata<P_Method, 7, wb_align>   (sy,    m_part_sy,    i);
                 store_pdata<P_Method, 8>             (sz,    m_part_sz,    i);
                 store_pdata<P_Method, 9, wb_aperture>(idcpu, m_part_idcpu, i);
             }

--- a/tests/python/test_reversibility_elements.py
+++ b/tests/python/test_reversibility_elements.py
@@ -270,25 +270,17 @@ def test_ChrPlasmaLens(sim, unit, k):
 
 @pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_ChrQuad(sim):
-    kwargs = {} if sim.spin else PIPE_KWARGS
     roundtrip(
-        elements.ChrQuad(ds=1.0, k=1.0, unit=0, nslice=nslice, **kwargs),
+        elements.ChrQuad(ds=1.0, k=1.0, unit=0, nslice=nslice, **PIPE_KWARGS),
         sim,
         spin=sim.spin,
     )
 
 
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_ChrQuad_marylie_unit(sim):
     roundtrip(
         elements.ChrQuad(ds=1.0, k=3.5, unit=1, nslice=nslice, **PIPE_KWARGS),
-        sim,
-    )
-
-
-@pytest.mark.parametrize("sim", [True], indirect=True, ids=["spin"])
-def test_ChrQuad_marylie_unit_spin(sim):
-    roundtrip(
-        elements.ChrQuad(ds=1.0, k=1.0, unit=1, nslice=nslice),
         sim,
         spin=sim.spin,
     )
@@ -415,9 +407,8 @@ def test_ExactSbend(sim):
 
 @pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_Quad(sim):
-    kwargs = {} if sim.spin else PIPE_KWARGS
     roundtrip(
-        elements.Quad(ds=1.0, k=1.0, nslice=nslice, **kwargs),
+        elements.Quad(ds=1.0, k=1.0, nslice=nslice, **PIPE_KWARGS),
         sim,
         spin=sim.spin,
     )
@@ -425,9 +416,8 @@ def test_Quad(sim):
 
 @pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_Sbend(sim):
-    kwargs = {} if sim.spin else PIPE_KWARGS
     roundtrip(
-        elements.Sbend(ds=0.5, rc=-10.346, nslice=nslice, **kwargs),
+        elements.Sbend(ds=0.5, rc=-10.346, nslice=nslice, **PIPE_KWARGS),
         sim,
         spin=sim.spin,
     )
@@ -509,9 +499,8 @@ def test_SoftSolenoid(sim, unit, bscale):
 
 @pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_Sol(sim):
-    kwargs = {} if sim.spin else PIPE_KWARGS
     roundtrip(
-        elements.Sol(ds=3.820395, ks=0.8223219329893234, **kwargs),
+        elements.Sol(ds=3.820395, ks=0.8223219329893234, **PIPE_KWARGS),
         sim,
         spin=sim.spin,
     )

--- a/tests/python/test_reversibility_elements.py
+++ b/tests/python/test_reversibility_elements.py
@@ -223,14 +223,13 @@ def roundtrip(
 
 @pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_CFbend(sim):
-    kwargs = {} if sim.spin else PIPE_KWARGS
     roundtrip(
         elements.CFbend(
             ds=0.5,
             rc=7.613657587094493,
             k=-7.057403,
             nslice=nslice,
-            **kwargs,
+            **PIPE_KWARGS,
         ),
         sim,
         spin=sim.spin,
@@ -253,14 +252,13 @@ def test_ChrDrift(sim):
     ids=["madx", "si"],
 )
 def test_ChrPlasmaLens(sim, unit, k):
-    kwargs = {} if sim.spin else PIPE_KWARGS
     roundtrip(
         elements.ChrPlasmaLens(
             ds=0.331817852986604588,
             k=k,
             unit=unit,
             nslice=nslice,
-            **kwargs,
+            **PIPE_KWARGS,
         ),
         sim,
         phase_atol=2e-6 if unit == 1 else phase_atol,
@@ -362,7 +360,6 @@ def test_ExactMultipole(sim, unit, k_normal, k_skew):
     ids=["madx", "si"],
 )
 def test_ExactCFbend(sim, unit, k_normal, k_skew):
-    kwargs = {} if sim.spin else PIPE_KWARGS
     roundtrip(
         elements.ExactCFbend(
             ds=1.0,
@@ -372,7 +369,7 @@ def test_ExactCFbend(sim, unit, k_normal, k_skew):
             int_order=4,
             mapsteps=mapsteps,
             nslice=nslice,
-            **kwargs,
+            **PIPE_KWARGS,
         ),
         sim,
         phase_atol=1e-4 if Config.precision == "SINGLE" else 1e-8,
@@ -544,13 +541,12 @@ def test_NonlinearLens(sim):
 @pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 @pytest.mark.parametrize(("unit", "k"), [(0, 1.0 / 0.5), (1, 6.0)], ids=["madx", "si"])
 def test_TaperedPL(sim, unit, k):
-    kwargs = {} if sim.spin else ALIGNMENT_KWARGS
     roundtrip(
         elements.TaperedPL(
             k=k,
             taper=11.488289081903567,
             unit=unit,
-            **kwargs,
+            **ALIGNMENT_KWARGS,
         ),
         sim,
         spin=sim.spin,


### PR DESCRIPTION
Fix #1328 #1453

Move out alignment shift and pipe aperture from individual elements into beam optics logic.

Rotate spin transverse vector in/out.

Enable all tests that we had to skip so far.

- [x] rebase after #1457