### PR TITLE
ChrQuad: Clean `lambdax` Double Update w/ Spin

### DIFF
--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -354,16 +354,27 @@ namespace impactx::elements
             {
 
                 // horizontally focusing quad case
-                lambdax = -gyro_const * ( py/delta1*(cosh_omega_ds - 1_prt) + y*omega*sinh_omega_ds );
-lambdax = -gyro_const * ( py*inv_delta1*(cosh_omega_ds - 1_prt) + y*omega*sinh_omega_ds );
-lambday = -gyro_const * ( px*inv_delta1*(1_prt - cos_omega_ds) + x*omega*sin_omega_ds );
+                lambdax = -gyro_const * (
+                    py * inv_delta1 * (cosh_omega_ds - 1_prt) +
+                    y * omega * sinh_omega_ds
+                );
+                lambday = -gyro_const * (
+                    px * inv_delta1 * (1_prt - cos_omega_ds) +
+                    x * omega * sin_omega_ds
+                );
 
             } else if (m_g < 0.0_prt)
             {
 
                 // horizontally defocusing quad case
-                lambdax = gyro_const * ( py*inv_delta1*(1_prt - cos_omega_ds) + y*omega*sin_omega_ds );
-                lambday = gyro_const * ( px*inv_delta1*(cosh_omega_ds - 1_prt) + x*omega*sinh_omega_ds );
+                lambdax = gyro_const * (
+                    py * inv_delta1 * (1_prt - cos_omega_ds) +
+                    y * omega * sin_omega_ds
+                );
+                lambday = gyro_const * (
+                    px * inv_delta1 * (cosh_omega_ds - 1_prt) +
+                    x * omega * sinh_omega_ds
+                );
 
             } else {
                 // treat as a drift


### PR DESCRIPTION
- `lambdax` was updated twice (unnecessary, result was the same)
- formatting improved