### PR TITLE
Multipole/ChrQuad: Fix `std` Functions in Spin

### DIFF
--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -327,6 +327,7 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
+            using namespace std; // for cmath(float)
 
             // initialize the three components of the axis-angle vector
             T_Real lambdax = 0_prt;

--- a/src/elements/Multipole.H
+++ b/src/elements/Multipole.H
@@ -232,6 +232,7 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
+            using namespace std; // for cmath(float)
 
             // initialize the three components of the axis-angle vector
             T_Real lambdax = 0_prt;


### PR DESCRIPTION
Since we write generic scalar/SIMD, we generically switch between `std::`, AMReX and `vir-simd` functions for math. But if we forget to write  `using namespace std;`, we fall back to C functions, which behave very weird.

For instance, in `ChrQuad` our `abs(m_g)` used integer math, dropping everything after the comma.
* C++: https://en.cppreference.com/cpp/numeric/math/abs
* C: https://en.cppreference.com/c/numeric/math/abs

First seen in #1455