### PR TITLE
Diagnostics File Prefix

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -238,7 +238,7 @@ If the same element name is used multiple times, then an output series is create
 * ``<element_name>.name`` (``string``, default value: ``<element_name>``)
 
   The output series name to use.
-  By default, output is created under ``diags/openPMD/<element_name>.<backend>``.
+  By default, output is created under ``<diag.file_prefix>/openPMD/<element_name>.<backend>``.
 
 * ``<element_name>.backend`` (``string``, default value: ``default``)
 
@@ -1356,13 +1356,25 @@ Diagnostics and output
   By default, diagnostics are computed and written at the beginning and end of the simulation.
   Enabling this flag will write diagnostics at every step and slice step.
 
+* ``diag.file_prefix`` (``string``, optional, default: ``diags``)
+
+  Root directory for diagnostic output.
+  By default, diagnostics are written in the folder ``diags/``.
+
+  Set to an empty string or ``.`` to write diagnostics in the current working directory.
+
+  By default, existing diagnostic directories are moved when a new simulation initializes.
+  Prefixes that resolve to the current working directory, the root directory,
+  or an ancestor of the current working directory are written as requested,
+  but are not moved out of the way during initialization.
+
 * ``diag.file_min_digits`` (``integer``, optional, default: ``6``)
 
   The minimum number of digits used for the step number appended to the diagnostic file names.
 
 * ``diag.backend`` (``string``, default value: ``default``)
 
-  Diagnostics for particles lost in apertures, stored as ``diags/openPMD/particles_lost.*`` at the end of the simulation.
+  Diagnostics for particles lost in apertures, stored as ``<diag.file_prefix>/openPMD/particles_lost.*`` at the end of the simulation.
   See the ``beam_monitor`` element for backend values.
 
 * ``diag.eigenemittances`` (``boolean``, optional, default: ``false``)

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1363,10 +1363,11 @@ Diagnostics and output
 
   Set to an empty string or ``.`` to write diagnostics in the current working directory.
 
-  By default, existing diagnostic directories are moved when a new simulation initializes.
-  Prefixes that resolve to the current working directory, the root directory,
-  or an ancestor of the current working directory are written as requested,
-  but are not moved out of the way during initialization.
+  If a directory at ``diag.file_prefix`` already exists when a simulation starts,
+  ImpactX renames it to ``<diag.file_prefix>.old.<suffix>`` to preserve prior results.
+  This is skipped when ``diag.file_prefix`` resolves to the current working directory,
+  the root directory, or an ancestor of the current working directory; in those cases
+  new output is written alongside existing files.
 
 * ``diag.file_min_digits`` (``integer``, optional, default: ``6``)
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -252,10 +252,11 @@ Collective Effects & Overall Simulation Parameters
 
       Set to ``""`` or ``"."`` to write diagnostics in the current working directory.
 
-      By default, existing diagnostic directories are moved when a new simulation initializes.
-      Prefixes that resolve to the current working directory, the root directory,
-      or an ancestor of the current working directory are written as requested,
-      but are not moved out of the way during initialization.
+      If a directory at ``diag_file_prefix`` already exists when a simulation starts,
+      ImpactX renames it to ``<diag_file_prefix>.old.<suffix>`` to preserve prior results.
+      This is skipped when ``diag_file_prefix`` resolves to the current working directory,
+      the root directory, or an ancestor of the current working directory; in those cases
+      new output is written alongside existing files.
 
    .. py:property:: diag_file_min_digits
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -246,6 +246,17 @@ Collective Effects & Overall Simulation Parameters
       By default, diagnostics is performed at the beginning and end of the simulation.
       Enabling this flag will write diagnostics every step and slice step.
 
+   .. py:property:: diag_file_prefix
+
+      Root directory for diagnostic output (default: folder named ``"diags"``).
+
+      Set to ``""`` or ``"."`` to write diagnostics in the current working directory.
+
+      By default, existing diagnostic directories are moved when a new simulation initializes.
+      Prefixes that resolve to the current working directory, the root directory,
+      or an ancestor of the current working directory are written as requested,
+      but are not moved out of the way during initialization.
+
    .. py:property:: diag_file_min_digits
 
       The minimum number of digits (default: ``6``) used for the step

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -8,11 +8,12 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "ImpactX.H"
+#include "diagnostics/DiagnosticOutput.H"
+#include "diagnostics/FilePrefix.H"
 #include "elements/mixin/dynamicdata.H"
 #include "initialization/InitAmrCore.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/Push.H"
-#include "diagnostics/DiagnosticOutput.H"
 #include "particles/wakefields/HandleWakefield.H"
 
 #include <AMReX.H>
@@ -85,8 +86,8 @@ namespace impactx {
         // move old diagnostics out of the way
         bool diag_enable = true;
         amrex::ParmParse("diag").queryAdd("enable", diag_enable);
-        if (diag_enable) {
-            amrex::UtilCreateCleanDirectory("diags", true);
+        if (diag_enable && diagnostics::FilePrefixCanClean()) {
+            amrex::UtilCreateCleanDirectory(diagnostics::FilePrefix(), true);
         }
 
         // the particle container has been set to track the same Geometry as ImpactX

--- a/src/diagnostics/CMakeLists.txt
+++ b/src/diagnostics/CMakeLists.txt
@@ -3,5 +3,6 @@ target_sources(lib
     ReducedBeamCharacteristics.cpp
     DiagnosticOutput.cpp
     EmittanceInvariants.cpp
+    FilePrefix.cpp
     LinearMap.cpp
 )

--- a/src/diagnostics/DiagnosticOutput.H
+++ b/src/diagnostics/DiagnosticOutput.H
@@ -23,13 +23,13 @@ namespace impactx::diagnostics
      * This prints reduced beam characteristics derived from particles in ASCII.
      *
      * @param pc container of the particles use for diagnostics
-     * @param file_name the file name to write to
+     * @param file_name file base name; the full path is resolved under ``diag.file_prefix``
      * @param step the global step
      * @param append open a new file with a fresh header (false) or append data to an existing file (true)
      */
     void DiagnosticOutput (
         ImpactXParticleContainer const & pc,
-        std::string file_name,
+        std::string const & file_name,
         int step = 0,
         bool append = false
     );
@@ -40,14 +40,14 @@ namespace impactx::diagnostics
      *
      * @param cm covariance matrix
      * @param ref_part reference particle
-     * @param file_name the file name to write to
+     * @param file_name file base name; the full path is resolved under ``diag.file_prefix``
      * @param step the global step
      * @param append open a new file with a fresh header (false) or append data to an existing file (true)
      */
     void DiagnosticOutput (
         Map6x6 const & cm,
         RefPart const & ref_part,
-        std::string file_name,
+        std::string const & file_name,
         int step = 0,
         bool append = false
     );
@@ -57,13 +57,13 @@ namespace impactx::diagnostics
      * This prints reference particle properties in ASCII.
      *
      * @param ref_part reference particle
-     * @param file_name the file name to write to
+     * @param file_name file base name; the full path is resolved under ``diag.file_prefix``
      * @param step the global step
      * @param append open a new file with a fresh header (false) or append data to an existing file (true)
      */
     void DiagnosticOutput (
         RefPart const & ref_part,
-        std::string file_name,
+        std::string const & file_name,
         int step = 0,
         bool append = false
     );

--- a/src/diagnostics/DiagnosticOutput.cpp
+++ b/src/diagnostics/DiagnosticOutput.cpp
@@ -8,6 +8,7 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "DiagnosticOutput.H"
+#include "FilePrefix.H"
 #include "NonlinearLensInvariants.H"
 #include "particles/CovarianceMatrix.H"
 #include "ReducedBeamCharacteristics.H"
@@ -19,7 +20,6 @@
 
 #include <limits>
 #include <stdexcept>
-#include <utility>
 
 
 namespace
@@ -183,7 +183,7 @@ namespace impactx::diagnostics
 {
     void DiagnosticOutput (
         ImpactXParticleContainer const & pc,
-        std::string file_name,
+        std::string const & file_name,
         int step,
         bool append
     )
@@ -195,7 +195,7 @@ namespace impactx::diagnostics
         OutputType const otype = OutputType::PrintReducedBeamCharacteristics;
 
         // keep file open as we add more and more lines
-        amrex::AllPrintToFile file_handler(std::move(file_name));
+        amrex::AllPrintToFile file_handler(FilePrefixPath(file_name));
         prepare_header(file_handler, otype, append);
 
         amrex::ParticleReal const s = pc.GetRefParticle().s;
@@ -208,7 +208,7 @@ namespace impactx::diagnostics
     void DiagnosticOutput (
         Map6x6 const & cm,
         RefPart const & ref_part,
-        std::string file_name,
+        std::string const & file_name,
         int step,
         bool append
     )
@@ -216,7 +216,7 @@ namespace impactx::diagnostics
         BL_PROFILE("impactx::diagnostics::DiagnosticOutput(cm)");
 
         // keep file open as we add more and more lines
-        amrex::AllPrintToFile file_handler(std::move(file_name));
+        amrex::AllPrintToFile file_handler(FilePrefixPath(file_name));
         prepare_header(file_handler, OutputType::PrintReducedBeamCharacteristics, append);
 
         amrex::ParticleReal const s = ref_part.s;
@@ -228,7 +228,7 @@ namespace impactx::diagnostics
 
     void DiagnosticOutput (
         RefPart const & ref_part,
-        std::string file_name,
+        std::string const & file_name,
         int step,
         bool append
     )
@@ -238,7 +238,7 @@ namespace impactx::diagnostics
         OutputType const otype = OutputType::PrintRefParticle;
 
         // keep file open as we add more and more lines
-        amrex::AllPrintToFile file_handler(std::move(file_name));
+        amrex::AllPrintToFile file_handler(FilePrefixPath(file_name));
         prepare_header(file_handler, otype, append);
         write_ref(file_handler, ref_part, step);
     }

--- a/src/diagnostics/FilePrefix.H
+++ b/src/diagnostics/FilePrefix.H
@@ -13,7 +13,7 @@ namespace impactx::diagnostics
 {
     /** Root directory for diagnostic output.
      *
-     * This queries ParmParse every time so runtime changes to diag.file_prefix
+     * This queries ParmParse every time, so runtime changes to diag.file_prefix
      * are honored.
      * Empty string and "." mean the current working directory.
      */
@@ -23,7 +23,7 @@ namespace impactx::diagnostics
      */
     std::string FilePrefixPath (std::string const & name);
 
-    /** Whether diag.file_prefix can be moved out of the way during initialization.
+    /** Whether an existing diag.file_prefix directory may be renamed aside at initialization.
      *
      * Current-directory, root-directory, and ancestor-directory paths are not cleaned.
      */

--- a/src/diagnostics/FilePrefix.H
+++ b/src/diagnostics/FilePrefix.H
@@ -1,0 +1,33 @@
+/* Copyright 2026 The ImpactX Community
+ *
+ * Authors: Axel Huebl, Chad Mitchell
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_DIAGNOSTICS_FILE_PREFIX_H
+#define IMPACTX_DIAGNOSTICS_FILE_PREFIX_H
+
+#include <string>
+
+
+namespace impactx::diagnostics
+{
+    /** Root directory for diagnostic output.
+     *
+     * This queries ParmParse every time so runtime changes to diag.file_prefix
+     * are honored.
+     * Empty string and "." mean the current working directory.
+     */
+    std::string FilePrefix ();
+
+    /** Path to a diagnostic file or directory under diag.file_prefix.
+     */
+    std::string FilePrefixPath (std::string const & name);
+
+    /** Whether diag.file_prefix can be moved out of the way during initialization.
+     *
+     * Current-directory, root-directory, and ancestor-directory paths are not cleaned.
+     */
+    bool FilePrefixCanClean ();
+} // namespace impactx::diagnostics
+
+#endif // IMPACTX_DIAGNOSTICS_FILE_PREFIX_H

--- a/src/diagnostics/FilePrefix.cpp
+++ b/src/diagnostics/FilePrefix.cpp
@@ -1,0 +1,109 @@
+/* Copyright 2026 The ImpactX Community
+ *
+ * Authors: Axel Huebl, Chad Mitchell
+ * License: BSD-3-Clause-LBNL
+ */
+#include "FilePrefix.H"
+
+#include <AMReX_ParmParse.H>
+#include <AMReX_Utility.H>
+
+#include <filesystem>
+#include <string>
+
+
+namespace impactx::diagnostics
+{
+    namespace
+    {
+        std::filesystem::path
+        normalize_file_prefix (std::string const & file_prefix)
+        {
+            std::filesystem::path path = std::filesystem::path(file_prefix).lexically_normal();
+            while (!path.empty() && path.filename().empty() && path.has_parent_path() &&
+                   path != path.root_path())
+            {
+                path = path.parent_path();
+            }
+            return path;
+        }
+
+        bool
+        is_path_prefix (
+            std::filesystem::path const & prefix,
+            std::filesystem::path const & path
+        )
+        {
+            auto path_it = path.begin();
+            for (auto prefix_it = prefix.begin(); prefix_it != prefix.end(); ++prefix_it, ++path_it)
+            {
+                if (path_it == path.end() || *path_it != *prefix_it) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        void
+        create_file_prefix_directory (std::filesystem::path const & file_prefix)
+        {
+            if (file_prefix.empty() || file_prefix == std::filesystem::path(".")) {
+                return;
+            }
+
+            constexpr int permission_flag_rwxrxrx = 0755;
+            std::string const file_prefix_string = file_prefix.string();
+            if (!amrex::UtilCreateDirectory(file_prefix_string, permission_flag_rwxrxrx)) {
+                amrex::CreateDirectoryFailed(file_prefix_string);
+            }
+        }
+    }
+
+    std::string
+    FilePrefix ()
+    {
+        std::string file_prefix = "diags";
+        amrex::ParmParse("diag").queryAdd("file_prefix", file_prefix);
+        return normalize_file_prefix(file_prefix).string();
+    }
+
+    std::string
+    FilePrefixPath (std::string const & name)
+    {
+        std::filesystem::path const file_prefix = normalize_file_prefix(FilePrefix());
+        create_file_prefix_directory(file_prefix);
+
+        if (name.empty()) {
+            return file_prefix.string();
+        }
+
+        bool const use_current_directory = file_prefix.empty() ||
+            file_prefix == std::filesystem::path(".");
+        std::filesystem::path const path = use_current_directory
+            ? std::filesystem::path(name)
+            : file_prefix / std::filesystem::path(name);
+
+        return path.lexically_normal().string();
+    }
+
+    bool
+    FilePrefixCanClean ()
+    {
+        std::filesystem::path const file_prefix = normalize_file_prefix(FilePrefix());
+        if (file_prefix.empty() || file_prefix == std::filesystem::path(".")) {
+            return false;
+        }
+
+        std::filesystem::path const absolute_file_prefix =
+            std::filesystem::absolute(file_prefix).lexically_normal();
+        std::filesystem::path const current_path =
+            std::filesystem::current_path().lexically_normal();
+
+        if (absolute_file_prefix == current_path ||
+            absolute_file_prefix == absolute_file_prefix.root_path())
+        {
+            return false;
+        }
+        return !is_path_prefix(absolute_file_prefix, current_path);
+    }
+} // namespace impactx::diagnostics

--- a/src/diagnostics/FilePrefix.cpp
+++ b/src/diagnostics/FilePrefix.cpp
@@ -52,7 +52,7 @@ namespace impactx::diagnostics
             }
 
             constexpr int permission_flag_rwxrxrx = 0755;
-            std::string const file_prefix_string = file_prefix.string();
+            std::string const file_prefix_string = file_prefix.generic_string();
             if (!amrex::UtilCreateDirectory(file_prefix_string, permission_flag_rwxrxrx)) {
                 amrex::CreateDirectoryFailed(file_prefix_string);
             }
@@ -64,7 +64,7 @@ namespace impactx::diagnostics
     {
         std::string file_prefix = "diags";
         amrex::ParmParse("diag").queryAdd("file_prefix", file_prefix);
-        return normalize_file_prefix(file_prefix).string();
+        return normalize_file_prefix(file_prefix).generic_string();
     }
 
     std::string
@@ -74,7 +74,7 @@ namespace impactx::diagnostics
         create_file_prefix_directory(file_prefix);
 
         if (name.empty()) {
-            return file_prefix.string();
+            return file_prefix.generic_string();
         }
 
         bool const use_current_directory = file_prefix.empty() ||
@@ -83,7 +83,7 @@ namespace impactx::diagnostics
             ? std::filesystem::path(name)
             : file_prefix / std::filesystem::path(name);
 
-        return path.lexically_normal().string();
+        return path.lexically_normal().generic_string();
     }
 
     bool

--- a/src/elements/diagnostics/BeamMonitor.H
+++ b/src/elements/diagnostics/BeamMonitor.H
@@ -4,7 +4,7 @@
  *
  * This file is part of ImpactX.
  *
- * Authors: Axel Huebl
+ * Authors: Axel Huebl, Chad Mitchell
  * License: BSD-3-Clause-LBNL
  */
 #ifndef IMPACTX_ELEMENTS_DIAGS_BEAMMONITOR_H
@@ -179,9 +179,9 @@ namespace detail
         AMREX_FORCE_INLINE
         int period_sample_intervals () const { return m_period_sample_intervals; }
 
-        /** track all m_series_name instances
+        /** track all openPMD series instances
          *
-         * Ensure m_series is the same for the same name.
+         * Ensure m_series is the same for the same output path.
          */
         static inline std::map<std::string, std::any> m_unique_series = {};
 
@@ -198,6 +198,7 @@ namespace detail
         std::string m_OpenPMDFileType; //! openPMD backend: usually HDF5 (h5) or ADIOS2 (bp/bp4/bp5) or ADIOS2 SST (sst)
         std::string m_encoding; //! openPMD iteration encoding: "v"ariable based, "f"ile based, "g"roup based (default)
         std::any m_series; //! openPMD::Series that holds potentially multiple outputs
+        std::string m_series_key; //! full path used as key in m_unique_series
         int m_step = 0; //! global step for output
 
         int m_file_min_digits = 6; //! minimum number of digits to iteration number in file name

--- a/src/elements/diagnostics/BeamMonitor.cpp
+++ b/src/elements/diagnostics/BeamMonitor.cpp
@@ -4,15 +4,16 @@
  *
  * This file is part of ImpactX.
  *
- * Authors: Axel Huebl
+ * Authors: Axel Huebl, Chad Mitchell
  * License: BSD-3-Clause-LBNL
  */
 
 #include "BeamMonitor.H"
 
 #include "ImpactXVersion.H"
-#include "particles/ImpactXParticleContainer.H"
+#include "diagnostics/FilePrefix.H"
 #include "diagnostics/ReducedBeamCharacteristics.H"
+#include "particles/ImpactXParticleContainer.H"
 
 #include <AMReX.H>
 #include <AMReX_BLProfiler.H>
@@ -118,8 +119,10 @@ namespace detail {
         }
 
         // remove from unique series map
-        if (m_unique_series.count(m_series_name) != 0u)
-            m_unique_series.erase(m_series_name);
+        if (!m_series_key.empty() && m_unique_series.count(m_series_key) != 0u) {
+            m_unique_series.erase(m_series_key);
+            m_series_key.clear();
+        }
 #endif // ImpactX_USE_OPENPMD
     }
 
@@ -164,24 +167,28 @@ namespace detail {
         // legacy options from other diagnostics
         pp_diag.queryAddWithParser("file_min_digits", m_file_min_digits);
 
-        // Ensure m_series is the same for the same names.
-        if (m_unique_series.count(m_series_name) == 0u) {
-            std::string filepath = "diags/openPMD/";
-            std::string filename = m_series_name;
+        std::filesystem::path filepath = impactx::diagnostics::FilePrefixPath("openPMD");
+        std::string filename = m_series_name;
 
-            if (series_encoding == openPMD::IterationEncoding::fileBased)
-            {
-                std::string const fileSuffix = std::string("_%0") + std::to_string(m_file_min_digits) + std::string("T");
-                filename.append(fileSuffix);
-            }
-            filename.append(".").append(m_OpenPMDFileType);
+        if (series_encoding == openPMD::IterationEncoding::fileBased)
+        {
+            std::string const fileSuffix =
+                std::string("_%0") + std::to_string(m_file_min_digits) + std::string("T");
+            filename.append(fileSuffix);
+        }
+        filename.append(".").append(m_OpenPMDFileType);
 
-            // transform paths for Windows
+        std::string series_path = (filepath / filename).string();
+
+        // transform paths for Windows
 #   ifdef _WIN32
-            filepath = openPMD::auxiliary::replace_all(filepath, "/", "\\");
+        series_path = openPMD::auxiliary::replace_all(series_path, "/", "\\");
 #   endif
+        m_series_key = series_path;
 
-            auto series = io::Series(filepath + filename, io::Access::CREATE
+        // Ensure m_series is the same for the same full output path.
+        if (m_unique_series.count(m_series_key) == 0u) {
+            auto series = io::Series(m_series_key, io::Access::CREATE
 #   if openPMD_HAVE_MPI==1
                 , amrex::ParallelDescriptor::Communicator()
 #   endif
@@ -189,20 +196,20 @@ namespace detail {
             series.setSoftware("ImpactX", IMPACTX_VERSION);
             series.setIterationEncoding( series_encoding );
             m_series = series;
-            m_unique_series[m_series_name] = series;
+            m_unique_series[m_series_key] = series;
 
             // create a little helper file for ParaView 5.9+
             if (amrex::ParallelDescriptor::IOProcessor())
             {
                 std::filesystem::create_directories(filepath);
-                std::ofstream pv_helper_file(filepath + "paraview.pmd");
+                std::ofstream pv_helper_file((filepath / "paraview.pmd").string());
                 AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pv_helper_file.is_open(), "Could not open paraview.pmd file.");
                 pv_helper_file << filename << "\n";
                 pv_helper_file.close();
             }
         }
         else {
-            m_series = m_unique_series[m_series_name];
+            m_series = m_unique_series[m_series_key];
         }
 #else
         amrex::AllPrint() << "Warning: openPMD output requested but not compiled for series=" << m_series_name << "\n";

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -1,11 +1,12 @@
 /* Copyright 2021-2023 The ImpactX Community
  *
- * Authors: Axel Huebl
+ * Authors: Axel Huebl, Chad Mitchell
  * License: BSD-3-Clause-LBNL
  */
 #include "pyImpactX.H"
 
 #include <ImpactX.H>
+#include <diagnostics/FilePrefix.H>
 #include <initialization/InitDistribution.H>
 #include <particles/transformation/CoordinateTransformation.H>
 #include <particles/ParticleBoundary.H>
@@ -487,6 +488,16 @@ void init_ImpactX (py::module& m)
              "Enable or disable diagnostics every slice step in elements (default: disabled).\n\n"
              "By default, diagnostics is performed at the beginning and end of the simulation.\n"
              "Enabling this flag will write diagnostics every step and slice step."
+        )
+        .def_property("diag_file_prefix",
+             [](ImpactX & /* ix */) {
+                 return diagnostics::FilePrefix();
+             },
+             [](ImpactX & /* ix */, std::string const & file_prefix) {
+                 amrex::ParmParse pp_diag("diag");
+                 pp_diag.add("file_prefix", file_prefix);
+             },
+             "Root directory for diagnostic output (default: ``diags``)."
         )
         .def_property("diag_file_min_digits",
              [](ImpactX & /* ix */) {

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -8,12 +8,13 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "ImpactX.H"
+#include "diagnostics/DiagnosticOutput.H"
+#include "diagnostics/FilePrefix.H"
+#include "envelope/spacecharge/EnvelopeSpaceChargePush.H"
 #include "initialization/Algorithms.H"
 #include "initialization/InitAmrCore.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/Push.H"
-#include "envelope/spacecharge/EnvelopeSpaceChargePush.H"
-#include "diagnostics/DiagnosticOutput.H"
 
 #include <ablastr/warn_manager/WarnManager.H>
 
@@ -82,10 +83,11 @@ namespace impactx
             pp_diag.queryAddWithParser("file_min_digits", file_min_digits);
 
             // print initial reference particle to file
-            diagnostics::DiagnosticOutput(ref, "diags/ref_particle");
+            diagnostics::DiagnosticOutput(ref, diagnostics::FilePrefixPath("ref_particle"));
 
             // print the initial values of reduced beam characteristics
-            diagnostics::DiagnosticOutput(cm, ref, "diags/reduced_beam_characteristics");
+            diagnostics::DiagnosticOutput(
+                cm, ref, diagnostics::FilePrefixPath("reduced_beam_characteristics"));
 
         }
 
@@ -206,10 +208,13 @@ namespace impactx
                     if (diag_enable && slice_step_diagnostics)
                     {
                         // print slice step reference particle to file
-                        diagnostics::DiagnosticOutput(ref, "diags/ref_particle", step, true);
+                        diagnostics::DiagnosticOutput(
+                            ref, diagnostics::FilePrefixPath("ref_particle"), step, true);
 
                         // print slice step reduced beam characteristics to file
-                        diagnostics::DiagnosticOutput(cm, ref, "diags/reduced_beam_characteristics", step, true);
+                        diagnostics::DiagnosticOutput(
+                            cm, ref, diagnostics::FilePrefixPath("reduced_beam_characteristics"),
+                            step, true);
 
                     }
 
@@ -234,10 +239,12 @@ namespace impactx
         if (diag_enable)
         {
             // print final reference particle to file
-            diagnostics::DiagnosticOutput(ref, "diags/ref_particle_final", step);
+            diagnostics::DiagnosticOutput(
+                ref, diagnostics::FilePrefixPath("ref_particle_final"), step);
 
             // print the final values of the reduced beam characteristics
-            diagnostics::DiagnosticOutput(cm, ref, "diags/reduced_beam_characteristics_final", step);
+            diagnostics::DiagnosticOutput(
+                cm, ref, diagnostics::FilePrefixPath("reduced_beam_characteristics_final"), step);
         }
     }
 } // namespace impactx

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -9,7 +9,6 @@
  */
 #include "ImpactX.H"
 #include "diagnostics/DiagnosticOutput.H"
-#include "diagnostics/FilePrefix.H"
 #include "envelope/spacecharge/EnvelopeSpaceChargePush.H"
 #include "initialization/Algorithms.H"
 #include "initialization/InitAmrCore.H"
@@ -83,11 +82,10 @@ namespace impactx
             pp_diag.queryAddWithParser("file_min_digits", file_min_digits);
 
             // print initial reference particle to file
-            diagnostics::DiagnosticOutput(ref, diagnostics::FilePrefixPath("ref_particle"));
+            diagnostics::DiagnosticOutput(ref, "ref_particle");
 
             // print the initial values of reduced beam characteristics
-            diagnostics::DiagnosticOutput(
-                cm, ref, diagnostics::FilePrefixPath("reduced_beam_characteristics"));
+            diagnostics::DiagnosticOutput(cm, ref, "reduced_beam_characteristics");
 
         }
 
@@ -208,13 +206,11 @@ namespace impactx
                     if (diag_enable && slice_step_diagnostics)
                     {
                         // print slice step reference particle to file
-                        diagnostics::DiagnosticOutput(
-                            ref, diagnostics::FilePrefixPath("ref_particle"), step, true);
+                        diagnostics::DiagnosticOutput(ref, "ref_particle", step, true);
 
                         // print slice step reduced beam characteristics to file
                         diagnostics::DiagnosticOutput(
-                            cm, ref, diagnostics::FilePrefixPath("reduced_beam_characteristics"),
-                            step, true);
+                            cm, ref, "reduced_beam_characteristics", step, true);
 
                     }
 
@@ -239,12 +235,11 @@ namespace impactx
         if (diag_enable)
         {
             // print final reference particle to file
-            diagnostics::DiagnosticOutput(
-                ref, diagnostics::FilePrefixPath("ref_particle_final"), step);
+            diagnostics::DiagnosticOutput(ref, "ref_particle_final", step);
 
             // print the final values of the reduced beam characteristics
             diagnostics::DiagnosticOutput(
-                cm, ref, diagnostics::FilePrefixPath("reduced_beam_characteristics_final"), step);
+                cm, ref, "reduced_beam_characteristics_final", step);
         }
     }
 } // namespace impactx

--- a/src/tracking/particles.cpp
+++ b/src/tracking/particles.cpp
@@ -8,16 +8,17 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "ImpactX.H"
+#include "diagnostics/DiagnosticOutput.H"
+#include "diagnostics/FilePrefix.H"
 #include "initialization/Algorithms.H"
 #include "initialization/InitAmrCore.H"
 #include "particles/CollectLost.H"
-#include "particles/ParticleBoundary.H"
 #include "particles/ImpactXParticleContainer.H"
+#include "particles/ParticleBoundary.H"
 #include "particles/Push.H"
-#include "diagnostics/DiagnosticOutput.H"
 #include "particles/spacecharge/HandleSpacecharge.H"
-#include "particles/wakefields/HandleWakefield.H"
 #include "particles/wakefields/HandleISR.H"
+#include "particles/wakefields/HandleWakefield.H"
 
 #include <AMReX.H>
 #include <AMReX_AmrParGDB.H>
@@ -56,7 +57,7 @@ namespace impactx
         // shortcuts
         auto & pc = amr_data->track_particles.m_particle_container;
 
-        // diags
+        // diagnostics
         amrex::ParmParse pp_diag("diag");
         bool diag_enable = true;
         pp_diag.queryAdd("enable", diag_enable);
@@ -73,12 +74,13 @@ namespace impactx
 
             // print initial reference particle to file
             diagnostics::DiagnosticOutput(amr_data->track_particles.m_particle_container->GetRefParticle(),
-                                          "diags/ref_particle",
+                                          diagnostics::FilePrefixPath("ref_particle"),
                                           step);
 
             // print the initial values of reduced beam characteristics
             diagnostics::DiagnosticOutput(*amr_data->track_particles.m_particle_container,
-                                          "diags/reduced_beam_characteristics");
+                                          diagnostics::FilePrefixPath(
+                                              "reduced_beam_characteristics"));
 
         }
 
@@ -173,13 +175,14 @@ namespace impactx
                     if (diag_enable && slice_step_diagnostics) {
                         // print slice step reference particle to file
                         diagnostics::DiagnosticOutput(amr_data->track_particles.m_particle_container->GetRefParticle(),
-                                                      "diags/ref_particle",
+                                                      diagnostics::FilePrefixPath("ref_particle"),
                                                       step,
                                                       true);
 
                         // print slice step reduced beam characteristics to file
                         diagnostics::DiagnosticOutput(*amr_data->track_particles.m_particle_container,
-                                                      "diags/reduced_beam_characteristics",
+                                                      diagnostics::FilePrefixPath(
+                                                          "reduced_beam_characteristics"),
                                                       step,
                                                       true);
 
@@ -206,12 +209,13 @@ namespace impactx
         {
             // print final reference particle to file
             diagnostics::DiagnosticOutput(amr_data->track_particles.m_particle_container->GetRefParticle(),
-                                          "diags/ref_particle_final",
+                                          diagnostics::FilePrefixPath("ref_particle_final"),
                                           step);
 
             // print the final values of the reduced beam characteristics
             diagnostics::DiagnosticOutput(*amr_data->track_particles.m_particle_container,
-                                          "diags/reduced_beam_characteristics_final",
+                                          diagnostics::FilePrefixPath(
+                                              "reduced_beam_characteristics_final"),
                                           step);
 
             // output particles lost in apertures

--- a/src/tracking/particles.cpp
+++ b/src/tracking/particles.cpp
@@ -9,7 +9,6 @@
  */
 #include "ImpactX.H"
 #include "diagnostics/DiagnosticOutput.H"
-#include "diagnostics/FilePrefix.H"
 #include "initialization/Algorithms.H"
 #include "initialization/InitAmrCore.H"
 #include "particles/CollectLost.H"
@@ -74,13 +73,12 @@ namespace impactx
 
             // print initial reference particle to file
             diagnostics::DiagnosticOutput(amr_data->track_particles.m_particle_container->GetRefParticle(),
-                                          diagnostics::FilePrefixPath("ref_particle"),
+                                          "ref_particle",
                                           step);
 
             // print the initial values of reduced beam characteristics
             diagnostics::DiagnosticOutput(*amr_data->track_particles.m_particle_container,
-                                          diagnostics::FilePrefixPath(
-                                              "reduced_beam_characteristics"));
+                                          "reduced_beam_characteristics");
 
         }
 
@@ -175,14 +173,13 @@ namespace impactx
                     if (diag_enable && slice_step_diagnostics) {
                         // print slice step reference particle to file
                         diagnostics::DiagnosticOutput(amr_data->track_particles.m_particle_container->GetRefParticle(),
-                                                      diagnostics::FilePrefixPath("ref_particle"),
+                                                      "ref_particle",
                                                       step,
                                                       true);
 
                         // print slice step reduced beam characteristics to file
                         diagnostics::DiagnosticOutput(*amr_data->track_particles.m_particle_container,
-                                                      diagnostics::FilePrefixPath(
-                                                          "reduced_beam_characteristics"),
+                                                      "reduced_beam_characteristics",
                                                       step,
                                                       true);
 
@@ -209,13 +206,12 @@ namespace impactx
         {
             // print final reference particle to file
             diagnostics::DiagnosticOutput(amr_data->track_particles.m_particle_container->GetRefParticle(),
-                                          diagnostics::FilePrefixPath("ref_particle_final"),
+                                          "ref_particle_final",
                                           step);
 
             // print the final values of the reduced beam characteristics
             diagnostics::DiagnosticOutput(*amr_data->track_particles.m_particle_container,
-                                          diagnostics::FilePrefixPath(
-                                              "reduced_beam_characteristics_final"),
+                                          "reduced_beam_characteristics_final",
                                           step);
 
             // output particles lost in apertures

--- a/src/tracking/reference.cpp
+++ b/src/tracking/reference.cpp
@@ -9,7 +9,6 @@
  */
 #include "ImpactX.H"
 #include "diagnostics/DiagnosticOutput.H"
-#include "diagnostics/FilePrefix.H"
 #include "initialization/Algorithms.H"
 #include "initialization/InitAmrCore.H"
 #include "particles/ImpactXParticleContainer.H"
@@ -64,7 +63,7 @@ namespace impactx
             pp_diag.queryAddWithParser("file_min_digits", file_min_digits);
 
             // print initial reference particle to file
-            diagnostics::DiagnosticOutput(ref, diagnostics::FilePrefixPath("ref_particle"));
+            diagnostics::DiagnosticOutput(ref, "ref_particle");
 
         }
 
@@ -144,8 +143,7 @@ namespace impactx
                     if (diag_enable && slice_step_diagnostics)
                     {
                         // print slice step reference particle to file
-                        diagnostics::DiagnosticOutput(
-                            ref, diagnostics::FilePrefixPath("ref_particle"), step, true);
+                        diagnostics::DiagnosticOutput(ref, "ref_particle", step, true);
                     }
 
                     // inputs: unused parameters (e.g. typos) check after step 1 has finished
@@ -169,8 +167,7 @@ namespace impactx
         if (diag_enable)
         {
             // print final reference particle to file
-            diagnostics::DiagnosticOutput(
-                ref, diagnostics::FilePrefixPath("ref_particle_final"), step);
+            diagnostics::DiagnosticOutput(ref, "ref_particle_final", step);
         }
     }
 } // namespace impactx

--- a/src/tracking/reference.cpp
+++ b/src/tracking/reference.cpp
@@ -8,11 +8,12 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "ImpactX.H"
+#include "diagnostics/DiagnosticOutput.H"
+#include "diagnostics/FilePrefix.H"
 #include "initialization/Algorithms.H"
 #include "initialization/InitAmrCore.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/Push.H"
-#include "diagnostics/DiagnosticOutput.H"
 
 #include <AMReX.H>
 #include <AMReX_AmrParGDB.H>
@@ -63,7 +64,7 @@ namespace impactx
             pp_diag.queryAddWithParser("file_min_digits", file_min_digits);
 
             // print initial reference particle to file
-            diagnostics::DiagnosticOutput(ref, "diags/ref_particle");
+            diagnostics::DiagnosticOutput(ref, diagnostics::FilePrefixPath("ref_particle"));
 
         }
 
@@ -143,7 +144,8 @@ namespace impactx
                     if (diag_enable && slice_step_diagnostics)
                     {
                         // print slice step reference particle to file
-                        diagnostics::DiagnosticOutput(ref, "diags/ref_particle", step, true);
+                        diagnostics::DiagnosticOutput(
+                            ref, diagnostics::FilePrefixPath("ref_particle"), step, true);
                     }
 
                     // inputs: unused parameters (e.g. typos) check after step 1 has finished
@@ -167,7 +169,8 @@ namespace impactx
         if (diag_enable)
         {
             // print final reference particle to file
-            diagnostics::DiagnosticOutput(ref, "diags/ref_particle_final", step);
+            diagnostics::DiagnosticOutput(
+                ref, diagnostics::FilePrefixPath("ref_particle_final"), step);
         }
     }
 } // namespace impactx

--- a/tests/python/test_diags_path.py
+++ b/tests/python/test_diags_path.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+
+import pytest
+
+from impactx import ImpactX, distribution, elements
+
+
+def test_diag_file_prefix():
+    """
+    This tests that diagnostics can be written under a custom file prefix.
+    """
+    sim = ImpactX()
+
+    assert sim.diag_file_prefix == "diags"
+    sim.diag_file_prefix = "initial_diags"
+    assert sim.diag_file_prefix == "initial_diags"
+
+    sim.particle_shape = 2
+    sim.slice_step_diagnostics = True
+    sim.init_grids()
+
+    sim.diag_file_prefix = "custom_diags/"
+    assert sim.diag_file_prefix == "custom_diags"
+
+    # init particle beam
+    kin_energy_MeV = 2.0e3
+    bunch_charge_C = 1.0e-9
+    npart = 1000
+
+    ref = sim.beam.ref
+    ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
+
+    distr = distribution.Waterbag(
+        lambdaX=3.9984884770e-5,
+        lambdaY=3.9984884770e-5,
+        lambdaT=1.0e-3,
+        lambdaPx=2.6623538760e-5,
+        lambdaPy=2.6623538760e-5,
+        lambdaPt=2.0e-3,
+        muxpx=-0.846574929020762,
+        muypy=0.846574929020762,
+        mutpt=0.0,
+    )
+    sim.add_particles(bunch_charge_C, distr, npart)
+
+    sim.lattice.append(elements.Drift(name="d1", ds=0.25))
+    sim.track_particles()
+
+    sim.finalize()
+
+    custom_diags = Path("custom_diags")
+    assert list(custom_diags.glob("ref_particle.*"))
+    assert list(custom_diags.glob("reduced_beam_characteristics.*"))
+    assert list(custom_diags.glob("ref_particle_final.*"))
+    assert list(custom_diags.glob("reduced_beam_characteristics_final.*"))
+    assert not list(Path("initial_diags").glob("ref_particle.*"))
+    assert not list(Path("initial_diags").glob("reduced_beam_characteristics.*"))
+    assert not Path("diags").exists()
+
+
+@pytest.mark.parametrize("file_prefix", ["", "."])
+def test_diag_file_prefix_current_directory(file_prefix):
+    """
+    This tests that an empty or "." diagnostic prefix writes to the current directory.
+    """
+    sim = ImpactX()
+
+    sim.diag_file_prefix = file_prefix
+    assert sim.diag_file_prefix == file_prefix
+
+    Path("keep.txt").write_text("keep")
+
+    sim.particle_shape = 2
+    sim.slice_step_diagnostics = True
+    sim.init_grids()
+
+    ref = sim.beam.ref
+    ref.set_species("electron").set_kin_energy_MeV(2.0e3)
+
+    sim.lattice.append(elements.Drift(name="d1", ds=0.25))
+    sim.track_reference(ref)
+
+    sim.finalize()
+
+    assert Path("keep.txt").read_text() == "keep"
+    assert list(Path(".").glob("ref_particle.*"))
+    assert list(Path(".").glob("ref_particle_final.*"))
+    assert not Path("diags").exists()
+
+
+def test_diag_file_prefix_sibling_directory_cleaned():
+    """
+    This tests that a sibling diagnostic prefix can be moved aside.
+    """
+    sibling_diags = Path("..") / f"{Path.cwd().name}_sibling_diags"
+    sibling_diags.mkdir()
+    (sibling_diags / "stale.txt").write_text("stale")
+
+    sim = ImpactX()
+
+    sim.diag_file_prefix = f"../{sibling_diags.name}/"
+    assert sim.diag_file_prefix == f"../{sibling_diags.name}"
+
+    sim.particle_shape = 2
+    sim.init_grids()
+
+    sim.finalize()
+
+    assert sibling_diags.exists()
+    assert not (sibling_diags / "stale.txt").exists()
+    assert list(Path("..").glob(f"{sibling_diags.name}.old.*"))
+
+
+def test_diag_file_prefix_internal_parent_directory_cleaned():
+    """
+    This tests that an internal ".." component still allows cleaning after normalization.
+    """
+    old_file_prefix = Path("external") / "diags"
+    old_file_prefix.mkdir(parents=True)
+    (old_file_prefix / "stale.txt").write_text("stale")
+
+    sim = ImpactX()
+
+    sim.diag_file_prefix = "external/abc/../diags/"
+    assert sim.diag_file_prefix == "external/diags"
+
+    sim.particle_shape = 2
+    sim.init_grids()
+
+    sim.finalize()
+
+    assert old_file_prefix.exists()
+    assert not (old_file_prefix / "stale.txt").exists()
+    assert list(Path("external").glob("diags.old.*"))
+
+
+def test_diag_file_prefix_parent_path_into_current_directory_cleaned():
+    """
+    This tests that a parent-relative path resolving back into CWD can be cleaned.
+    """
+    old_file_prefix = Path("diags")
+    old_file_prefix.mkdir()
+    (old_file_prefix / "stale.txt").write_text("stale")
+
+    sim = ImpactX()
+
+    sim.diag_file_prefix = f"../{Path.cwd().name}/diags/"
+    assert sim.diag_file_prefix == f"../{Path.cwd().name}/diags"
+
+    sim.particle_shape = 2
+    sim.init_grids()
+
+    sim.finalize()
+
+    assert old_file_prefix.exists()
+    assert not (old_file_prefix / "stale.txt").exists()
+    assert list(Path(".").glob("diags.old.*"))


### PR DESCRIPTION
Currently, we write all diagnostics files, incl. beam monitors into a hard-coded directory `diags/`.

In WarpX, we made this configurable a while ago and this adds a similar, closely-named option here:
* Inputs file: `diag.file_prefix = diags`
* Python: `sim.diag_file_prefix = "diags"`

The option supports sub-folders, no-folders (flat in PWD) and does sensible checks in terms of "back up an existing diags folder", [pls see docs](https://impactx--1460.org.readthedocs.build/en/1460/usage/python.html#impactx.ImpactX.diag_file_prefix).

Recently wondered about by @SchroederSa 

To check:
- [ ] maybe update dashboard too, mostly for file import... (I have a local commit for this ready, but it is noisy and not a central feature we need to expose in the GUI)