### PR TITLE
Doc: Python Beam & Field Access

### DIFF
--- a/docs/source/dataanalysis/dataanalysis.rst
+++ b/docs/source/dataanalysis/dataanalysis.rst
@@ -60,6 +60,29 @@ Example to print the integrated orbit path length ``s`` at each beam monitor pos
        print(f"step {k_i:>3}: s_ref={s_ref}")
 
 
+.. _dataanalysis-python-inmemory:
+
+In-Memory Python Access
+-----------------------
+
+In addition to the file-based openPMD output above, ImpactX can be steered from a Python script
+and the beam particles, the reference particle, and the space-charge fields can be inspected or
+modified **live** during a run. This is the right approach for custom in-situ diagnostics,
+turn-by-turn feedback, AI/ML coupling, or any analysis that you don't want to round-trip through (slow) filesystem disks.
+
+* :ref:`usage-howto-python-extend`: the overall pattern, plus the callback surfaces
+  (``sim.hook[...]`` and the :py:class:`~impactx.elements.Programmable` element).
+  For analysis, prefer ``sim.hook[...]`` with ``sim.beam``: the ``Programmable``
+  element hands you particles in per-tile chunks and is intended for custom
+  particle pushes, not observation.
+* :ref:`usage-howto-python-particle-data`: accessing ``sim.beam`` as a pandas DataFrame
+  (via :py:meth:`~impactx.ParticleContainer.to_df`) or iterating over particle tiles for
+  high-performance access.
+* :ref:`usage-howto-python-field-data`: accessing the space-charge fields
+  (:py:meth:`~impactx.ImpactX.rho`, :py:meth:`~impactx.ImpactX.phi`,
+  :py:meth:`~impactx.ImpactX.space_charge_field`) and their lifetime caveats.
+
+
 .. _dataanalysis-beam-characteristics:
 
 Reduced Beam Characteristics

--- a/docs/source/usage/howto.rst
+++ b/docs/source/usage/howto.rst
@@ -10,3 +10,4 @@ This section collects typical user workflows and best practices for ImpactX.
 
    howto/add_element
    howto/ai_input_design
+   howto/python_extend

--- a/docs/source/usage/howto/add_element.rst
+++ b/docs/source/usage/howto/add_element.rst
@@ -44,6 +44,12 @@ The Programmable element can implement a custom element in two ways:
 
 Per ImpactX convention, the reference particle is updated *before* the beam particles are pushed.
 
+.. note::
+
+   The Programmable element is for *replacing* a beamline element's particle push.
+   For in-situ **analysis** of the beam, use :py:attr:`sim.hook <impactx.ImpactX.hook>`
+   callbacks with ``sim.beam`` instead — see :ref:`usage-howto-python-extend`.
+
 Detailed examples that show usage of the programmable element are:
 
 * :ref:`FODO cell <examples-fodo-programmable>`: implements a user-defined drift

--- a/docs/source/usage/howto/python_extend.rst
+++ b/docs/source/usage/howto/python_extend.rst
@@ -1,0 +1,172 @@
+.. _usage-howto-python-extend:
+
+Extend a Simulation with Python
+===============================
+
+Overview
+--------
+
+ImpactX's Python interface lets you weave custom Python code into a running simulation.
+Through this interface, you can **access and modify simulation data**, e.g., particle phase-space coordinates, the reference particle, and space-charge fields, as the simulation is tracking the beam.
+This facilitates a wide range of workflows, including:
+
+   - **In-situ diagnostics** that compute quantities of interest at each turn or element without writing files to disk.
+   - **Dynamic lattice manipulation**, e.g., changing element strengths between turns, ramping voltages, or feedback systems.
+   - **Custom beam optics elements**, e.g., a non-linear kick or a tabulated map, plugged in via the :py:class:`impactx.elements.Programmable` element.
+   - **AI/ML surrogate models** built with PyTorch or TensorFlow to emulate detailed transport in a single element.
+
+Because ImpactX exposes particles and fields *without copies* through `pyAMReX <https://pyamrex.readthedocs.io/>`__,
+per-step Python callbacks have very low overhead and stay GPU-resident when ImpactX runs on GPUs
+(``cupy``, PyTorch, etc. can operate directly on the device data).
+
+.. _usage-howto-python-extend-run:
+
+How to run a simulation with Python extensions
+----------------------------------------------
+
+- **Install ImpactX with the Python interface**: when compiling from source, this means ``-DImpactX_PYTHON=ON``
+  (see :ref:`building <install-developers>`). Pre-built :ref:`ImpactX packages <install-users>` also include this interface.
+
+- **Write a Python script that drives the simulation**, registering callbacks or programmable elements before calling :py:meth:`~impactx.ImpactX.track_particles`.
+  A minimal template looks like:
+
+  .. code-block:: python
+
+     from impactx import ImpactX, distribution, elements
+
+     sim = ImpactX()
+     sim.space_charge = False
+     sim.init_grids()
+
+     # ... set up reference particle, distribution, and lattice ...
+
+     # register tracking hooks or programmable elements here:
+     def after_each_period(sim):
+         turn = sim.tracking_period
+         # e.g. compute a custom diagnostic from sim.beam
+
+     sim.hook["after_period"] = after_each_period
+
+     # advance the simulation
+     sim.track_particles()
+     sim.finalize()
+
+- **Run the script** like any Python script, optionally under MPI:
+
+  .. code-block:: bash
+
+     mpirun -np <n_ranks> python <script>.py
+
+.. _usage-howto-python-extend-callbacks:
+
+Callback Functions
+------------------
+
+ImpactX provides two complementary callback surfaces.
+
+Tracking hooks
+^^^^^^^^^^^^^^
+
+The :py:attr:`~impactx.ImpactX.hook` mapping registers user-defined functions that are invoked at well-defined
+points of the tracking loop. The supported locations are:
+
+* ``"before_period"`` — before each lattice period (e.g. turn or channel period)
+* ``"after_period"`` — after each lattice period
+* ``"before_element"`` — before each lattice element is entered
+* ``"after_element"`` — after each lattice element is exited
+* ``"before_slice"`` — before each element slice (and before that slice's space-charge solve, when enabled; to read freshly-computed space-charge fields, prefer ``"after_element"``)
+
+Each hook receives the :py:class:`~impactx.ImpactX` instance and may inspect or modify simulation state
+through it (e.g., ``sim.beam``, ``sim.lattice``, ``sim.rho``, ``sim.phi``, ...).
+Use :py:attr:`~impactx.ImpactX.tracking_step`, :py:attr:`~impactx.ImpactX.tracking_period`, and
+:py:attr:`~impactx.ImpactX.tracking_element` to identify *where* in the loop the hook was called.
+For instance, you can ``return`` if the current element does not match a type or name.
+
+.. code-block:: python
+
+   def after_each_turn(sim):
+       turn = sim.tracking_period
+       element = sim.tracking_element
+       df = sim.beam.to_df(local=True)
+       if df is not None:
+           print(f"turn {turn} at element={element.name}: "
+                 f"{len(df)} local particles, "
+                 f"<x>={df['position_x'].mean():.3e} m")
+
+   sim.hook["after_period"] = after_each_turn
+
+Full example: :ref:`Acceleration by RF Cavities <examples-rfcavity-ref-part-hook>`.
+
+Programmable lattice element
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For workflows that *replace* a beamline element entirely (rather than observing the beam between elements),
+use the :py:class:`impactx.elements.Programmable` element. It exposes three property hooks:
+
+* :py:attr:`~impactx.elements.Programmable.push`: push the whole particle container.
+* :py:attr:`~impactx.elements.Programmable.ref_particle`: push only the reference particle.
+* :py:attr:`~impactx.elements.Programmable.beam_particles`: called once per particle tile (high-performance);
+  the reference particle is updated *before* this callback fires.
+
+Typical usage (per-tile push) looks like this:
+
+.. code-block:: python
+
+   from impactx import elements
+
+   def my_drift(pge, pti, refpart):
+       """Push the beam particles as a drift over one slice."""
+       soa = pti.soa().to_xp()   # NumPy (CPU) or CuPy (GPU)
+       x = soa.real["position_x"]
+       y = soa.real["position_y"]
+       t = soa.real["position_t"]
+       # ...
+
+       slice_ds = pge.ds / pge.nslice
+       betgam2 = refpart.pt**2 - 1.0
+
+       x[:] += slice_ds * px[:]
+       y[:] += slice_ds * py[:]
+       t[:] += (slice_ds / betgam2) * pt[:]
+
+
+   def my_ref_drift(pge, refpart):
+       """Push the reference particle over one slice."""
+       x = refpart.x
+       px = refpart.px
+       s = refpart.s
+
+       slice_ds = pge.ds / pge.nslice
+
+       # ...
+       refpart.x = x + 1.23
+       refpart.s = s + slice_ds
+
+
+   dr = elements.Programmable(name="my_drift")
+   dr.ds = 0.25
+   dr.nslice = 5
+   dr.beam_particles = lambda pti, refpart: my_drift(dr, pti, refpart)
+   dr.ref_particle = lambda refpart: my_ref_drift(dr, refpart)
+
+   sim.lattice.append(pge)
+
+A complete script is provided in this :ref:`FODO Cell example <examples-fodo-programmable>`.
+For a more complex example, see our :ref:`ML surrogate element example <examples-ml-surrogate>`.
+
+.. _usage-howto-python-extend-data-access:
+
+Accessing simulation data through Python
+----------------------------------------
+
+While the simulation is running, the Python code (i.e., the code inside callback functions) has read and
+write access to the beam particles and the space-charge fields. The two sections below describe the
+specific Python syntax for each.
+
+.. toctree::
+   :maxdepth: 1
+
+   python_particle_data
+   python_field_data
+
+See also :ref:`dataanalysis` for file and streaming-based analysis of the openPMD output written by :py:class:`~impactx.elements.BeamMonitor`.

--- a/docs/source/usage/howto/python_field_data.rst
+++ b/docs/source/usage/howto/python_field_data.rst
@@ -1,0 +1,142 @@
+.. _usage-howto-python-field-data:
+
+Accessing Field Data
+====================
+
+ImpactX exposes the **space-charge fields** computed on the AMR mesh:
+
+  - the charge density :math:`\rho`
+  - the scalar potential :math:`\phi`, and
+  - the resulting force kick vector components,
+
+directly to Python as `pyAMReX <https://pyamrex.readthedocs.io/en/latest/usage/api.html#amrex.space3d.MultiFab>`__ ``MultiFab`` objects.
+
+Selecting a field
+-----------------
+
+Use the following accessors on the :py:class:`~impactx.ImpactX` instance, each of which returns
+a ``MultiFab`` on the requested mesh-refinement level:
+
+.. code-block:: python
+
+   rho = sim.rho(lev=0)                              # charge density
+   phi = sim.phi(lev=0)                              # scalar potential
+   E_x = sim.space_charge_field(lev=0, comp="x")     # x-component of the space-charge force
+   E_y = sim.space_charge_field(lev=0, comp="y")
+   E_z = sim.space_charge_field(lev=0, comp="z")
+
+Available mesh levels range from ``0`` to :py:attr:`sim.finest_level <impactx.ImpactX.finest_level>`.
+
+Lifetime / Validity
+-------------------
+
+.. important::
+
+   The space-charge fields are computed *during* the per-slice space-charge solve.
+   Outside of that window the ``MultiFab`` data may be uninitialized, stale, or empty.
+   You should therefore read them either:
+
+   * From inside a :py:attr:`sim.hook <impactx.ImpactX.hook>` ``"after_element"`` callback,
+     which fires after the element's last per-slice solve and sees the freshly computed
+     fields of that last slice. Note: ``"before_slice"`` fires *before* the slice's solve,
+     so on the very first slice ``phi``/``rho`` are uninitialized.
+   * Or right after :py:meth:`~impactx.ImpactX.track_particles` returns, but before the simulation is finalized.
+
+   See :ref:`usage-howto-python-extend-callbacks` for how to install such a hook.
+   Space-charge must of course be enabled (see :py:attr:`sim.space_charge <impactx.ImpactX.space_charge>`)
+   for the fields to be populated at all.
+
+Mesh metadata
+-------------
+
+To interpret indices and array shapes, query the AMR geometry on the same level:
+
+.. code-block:: python
+
+   geom = sim.Geom(lev=0)
+   prob_lo = geom.ProbLo()        # physical lower corner of the domain
+   prob_hi = geom.ProbHi()        # physical upper corner
+   dx      = geom.CellSize()      # cell sizes (dx, dy, dz)
+
+   ba = sim.boxArray(lev=0)        # box decomposition
+   dm = sim.DistributionMap(lev=0) # which MPI rank owns which box
+
+Accessing field arrays
+----------------------
+
+There are several ways to read or modify a ``MultiFab``, with different trade-offs.
+The underlying API is provided by pyAMReX, see the
+`pyAMReX compute guide <https://pyamrex.readthedocs.io/en/latest/usage/compute.html#fields>`__
+for the full reference.
+
+.. tab-set::
+
+   .. tab-item:: Pre-defined pyAMReX/AMReX methods
+
+      Many reductions and bulk operations are exposed directly as ``MultiFab`` methods:
+
+      .. code-block:: python
+
+         rho_max = rho.max(comp=0)        # maximum value (per component)
+         phi_min = phi.min(comp=0)        # minimum value
+         rho.mult(2.0, 0, 1)              # scale in place
+
+      These have low overhead and run on CPU or GPU as appropriate.
+
+   .. tab-item:: NumPy-like global indexing
+
+      Single elements and slices can be addressed with global ``(i, j, k)`` indices.
+      This is convenient for inspection and debugging.
+
+      .. code-block:: python
+
+         # read a single line of cells (level 0, component 0)
+         line = rho[:, ny // 2, nz // 2]
+
+         # write a single value
+         rho[i, j, k] = 0.0
+
+      Negative-imaginary indices address ghost cells; see the pyAMReX compute guide linked above.
+
+      In MPI-parallel simulations, this indexing interface will trigger MPI communication and can become costly.
+
+   .. tab-item:: Explicit loop over boxes
+
+      For high-performance, GPU-portable access: modifying a field over many cells, or coupling
+      to ``cupy``/``numpy`` arrays in-place.
+      Enables to iterate over the boxes owned by the current MPI rank:
+
+      .. code-block:: python
+
+         for mfi in rho:
+             bx  = mfi.tilebox()
+             arr = rho.array(mfi).to_xp()   # NumPy (CPU) or CuPy (GPU)
+             arr[...] *= 0.5                # in-place modification
+
+      :ref:`to_xp() <https://pyamrex.readthedocs.io/en/latest/usage/zerocopy.html>`__ (or the explicit ``to_numpy()``/``to_cupy()``) returns a zero-copy view
+      into the box's data with the layout matching the local box, including ghost cells.
+
+Full example: plotting the space-charge potential
+-------------------------------------------------
+
+The following script runs a short constant-focusing channel with 3D space charge
+and installs an ``"after_element"`` hook that saves a PNG of the scalar potential
+:math:`\phi` at the transverse mid-plane after the element's last per-slice
+Poisson solve. The same pattern works for ``sim.rho`` and ``sim.space_charge_field``.
+
+This and other examples are available under ``tests/python/``.
+
+.. dropdown:: Full example: ``sim.hook["after_element"]`` reads ``sim.phi``
+
+   .. literalinclude:: ../tests/python/test_space_charge_fields.py
+      :language: python
+      :start-after: # [doc-start] cfchannel-phi-hook
+      :end-before: # [doc-end] cfchannel-phi-hook
+      :dedent: 4
+
+See also
+--------
+
+* :ref:`usage-howto-python-extend` — where and when to install callbacks for live field access.
+* :ref:`usage-howto-python-particle-data` — how to access the beam particles.
+* `pyAMReX compute guide <https://pyamrex.readthedocs.io/en/latest/usage/compute.html>`__ — full reference for ``MultiFab`` access.

--- a/docs/source/usage/howto/python_particle_data.rst
+++ b/docs/source/usage/howto/python_particle_data.rst
@@ -1,0 +1,140 @@
+.. _usage-howto-python-particle-data:
+
+Accessing Beam Particle Data
+============================
+
+Selecting the beam
+------------------
+
+The beam is accessed through :py:attr:`sim.beam <impactx.ImpactX.beam>`, where ``sim`` is the
+:py:class:`~impactx.ImpactX` instance set up as described in :ref:`usage-howto-python-extend-run`.
+This returns an :py:class:`impactx.ParticleContainer`, distributed over MPI ranks.
+
+.. code-block:: python
+
+   pc = sim.beam
+
+The available per-particle attributes are:
+
+* **Positions** relative to the reference particle: ``position_x``, ``position_y``, ``position_t`` (all in meters; ``position_t`` is :math:`c \Delta t`).
+* **Momenta** relative to and normalized by the reference momentum: ``momentum_x``, ``momentum_y``, ``momentum_t``.
+* **Spin** components (only if ``sim.spin = True``): ``spin_x``, ``spin_y``, ``spin_z``.
+* **Charge over mass** ``qm`` (in 1/eV), which is currently inconsistently used in ImpactX.
+* **Macroparticle weight** ``w`` (unitless), how many physical particles a simulation particle represents.
+* **Unique ID** ``idcpu``, a 64bit integer that is unique to a particle over the lifetime of a simulation.
+
+The :py:attr:`~impactx.ParticleContainer.ref` attribute provides the reference particle (a
+:py:class:`impactx.RefPart`). All phase-space coordinates above are relative to the reference particle.
+
+.. note::
+
+   The independent variable in ImpactX is the reference-trajectory path length ``s`` (not time).
+   See :ref:`theory-coordinates-and-units` for the full coordinate and unit conventions.
+
+Accessing/modifying the underlying particle data
+------------------------------------------------
+
+There are two ways to access particle data, with different trade-offs between convenience and performance.
+(For an in-depth discussion of the underlying pyAMReX API, see the
+`pyAMReX particles guide <https://pyamrex.readthedocs.io/en/latest/usage/compute.html#particles>`__.)
+
+.. tab-set::
+
+   .. tab-item:: Global access through a pandas DataFrame (read-only)
+
+      The :py:meth:`~impactx.ParticleContainer.to_df` method returns a
+      `pandas DataFrame <https://pandas.pydata.org/docs/user_guide/dsintro.html#dataframe>`__
+      containing the particle data. The columns of the DataFrame are the particle attributes
+      (e.g. ``position_x``, ``momentum_x``, ``w``, ``id``), and each row corresponds to one
+      macroparticle across all tiles on the current MPI rank.
+
+      .. warning::
+
+         The DataFrame is a *copy* of the particle data. Modifying it does not write back
+         to the simulation.
+
+      .. note::
+
+         ``to_df`` is convenient because it concatenates all particles across tiles
+         into a single table. However, it incurs copies and, on GPU runs, CPU↔GPU data transfers.
+         It is well-suited to debugging and visualization, and not to performance-critical paths.
+
+      .. code-block:: python
+
+         pc = sim.beam
+
+         # local particles only (default): returns particles on the current MPI rank
+         df = pc.to_df(local=True)
+         if df is not None:
+             print("Available attributes:", list(df.columns))
+             print("Number of particles:", len(df))
+             print("position_x:", df["position_x"])
+
+         # positions in the lab frame, by adding the reference particle position
+         ref = pc.ref
+         x_lab = ref.x + df["position_x"]
+
+      To gather particles from *all* MPI ranks onto the root rank, pass ``local=False``:
+
+      .. code-block:: python
+
+         df_global = pc.to_df(local=False)
+         # df_global is non-None only on the root rank
+
+   .. tab-item:: Explicit loop over particle tiles
+
+      The :py:class:`impactx.ImpactXParIter` iterator gives direct, zero-copy access to the
+      Struct-of-Arrays storage of each tile on each mesh-refinement level. This avoids the copies
+      performed by ``to_df`` and is the right choice for performance-critical analysis or in-place
+      modification of the beam.
+
+      .. code-block:: python
+
+         from impactx import ImpactXParIter
+
+         pc = sim.beam
+
+         for lvl in range(pc.finest_level + 1):
+             for pti in ImpactXParIter(pc, level=lvl):
+                 soa = pti.soa().to_xp()   # NumPy (CPU) or CuPy (GPU)
+                 x  = soa.real["position_x"]
+                 px = soa.real["momentum_x"]
+
+                 # in-place modification works:
+                 x[:] += 1.0e-6   # shift every particle by 1 µm
+
+      Inside a :py:class:`impactx.elements.Programmable` ``beam_particles`` callback, the
+      framework hands you a single ``pti`` directly — no need to construct the iterator yourself.
+      See :ref:`usage-howto-python-extend-callbacks` for a full example.
+
+Reference particle
+------------------
+
+The reference particle is accessed via :py:attr:`pc.ref <impactx.ParticleContainer.ref>` and
+returns a :py:class:`impactx.RefPart`. It exposes the integrated path length ``s``, the lab-frame
+position/momentum (``x``, ``y``, ``z``, ``px``, ``py``, ``pz``), the time-of-flight ``t``, the
+energy-related quantities (``pt``, ``beta``, ``gamma``, ``beta_gamma``), and the species mass/charge.
+
+.. code-block:: python
+
+   ref = sim.beam.ref
+   print(f"s = {ref.s:.3f} m, gamma = {ref.gamma:.3f}")
+
+When using :py:class:`~impactx.elements.Programmable` with separate ``ref_particle`` and
+``beam_particles`` callbacks, the reference particle is pushed *before* the beam particles,
+so inside the ``beam_particles`` callback ``refpart`` already reflects the updated reference
+state for the current slice.
+
+Adding new particles
+--------------------
+
+New particles can be appended to the beam at any time after :py:meth:`~impactx.ImpactX.init_grids`
+using :py:meth:`~impactx.ParticleContainer.add_n_particles`. See its API reference for parameters.
+
+See also
+--------
+
+* :ref:`usage-howto-python-extend`: where and when to install callbacks.
+* :ref:`usage-howto-python-field-data`: how to access the space-charge fields.
+* :ref:`dataanalysis`: offline analysis from the openPMD output of the :py:class:`~impactx.elements.BeamMonitor`.
+* `pyAMReX particles guide <https://pyamrex.readthedocs.io/en/latest/usage/compute.html#particles>`__.

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -299,6 +299,55 @@ Collective Effects & Overall Simulation Parameters
 
       Access the beam particle container (:py:class:`impactx.ParticleContainer`).
 
+      For example, ``sim.beam.to_df(local=True)`` returns the local particles as a pandas DataFrame.
+      See :ref:`usage-howto-python-particle-data` for further data-access recipes.
+
+   .. py:method:: rho(lev)
+
+      Return the charge density :math:`\rho` on mesh-refinement level ``lev`` as a pyAMReX ``MultiFab``.
+      Populated when space-charge is enabled (see :py:attr:`space_charge`).
+
+      :param int lev: mesh-refinement level.
+
+      .. note::
+
+         Field data are populated by the space-charge solve at each slice step.
+         They are most reliably read from inside a :py:attr:`hook` ``"after_element"`` callback
+         (the element's last slice has just solved) or right after :py:meth:`track_particles` returns.
+         See :ref:`usage-howto-python-field-data` and the
+         `pyAMReX MultiFab guide <https://pyamrex.readthedocs.io/en/latest/usage/compute.html#fields>`__
+         for indexing details.
+
+   .. py:method:: phi(lev)
+
+      Return the scalar potential :math:`\phi` on mesh-refinement level ``lev`` as a pyAMReX ``MultiFab``.
+      Populated when space-charge is enabled.
+      See lifetime caveats and indexing in :ref:`usage-howto-python-field-data`.
+
+      :param int lev: mesh-refinement level.
+
+   .. py:method:: space_charge_field(lev, comp)
+
+      Return one Cartesian component of the space-charge force as a pyAMReX ``MultiFab``.
+
+      :param int lev: mesh-refinement level.
+      :param str comp: field component to access (``"x"``, ``"y"``, or ``"z"``).
+
+      See lifetime caveats and indexing in :ref:`usage-howto-python-field-data`.
+
+   .. py:method:: Geom(lev)
+
+      Return the AMReX ``Geometry`` object for mesh-refinement level ``lev``.
+      Useful to query the physical domain extent and cell sizes for field data.
+
+   .. py:method:: boxArray(lev)
+
+      Return the AMReX ``BoxArray`` for mesh-refinement level ``lev``.
+
+   .. py:method:: DistributionMap(lev)
+
+      Return the AMReX ``DistributionMapping`` for mesh-refinement level ``lev``.
+
    .. py:property:: lattice
 
       Access the elements in the accelerator lattice.
@@ -398,6 +447,10 @@ Collective Effects & Overall Simulation Parameters
 
          sim.hook["before_period"] = hook_before_period
 
+      Full example: :ref:`Acceleration by RF Cavities <examples-rfcavity-ref-part-hook>`.
+
+      See :ref:`usage-howto-python-extend` for more callback recipes.
+
    .. py:property:: tracking_step
 
       For tracking hooks/callbacks, a global step of the simulation.
@@ -461,6 +514,12 @@ Collective Effects & Overall Simulation Parameters
 
 Particles
 ---------
+
+:py:class:`impactx.ParticleContainer` derives from a pyAMReX particle container.
+Many bulk-access methods used to read or modify the beam in-memory (such as :py:meth:`~impactx.ParticleContainer.to_df` for a pandas DataFrame, or iterating over particle tiles) come from there.
+For a full reference of the inherited compute API, see the `pyAMReX particles guide <https://pyamrex.readthedocs.io/en/latest/usage/compute.html#particles>`__.
+
+For step-by-step recipes on how to access particle data live during a simulation, see :ref:`usage-howto-python-particle-data`.
 
 .. py:class:: impactx.ParticleContainer
 
@@ -562,6 +621,45 @@ Particles
    .. py:method:: redistribute()
 
       Redistribute particles in the current mesh in x, y, z.
+
+   .. py:method:: to_df(local=True)
+
+      Return all beam particles as a `pandas DataFrame <https://pandas.pydata.org/docs/user_guide/dsintro.html#dataframe>`__.
+
+      Columns correspond to the particle attributes
+      (``position_x``, ``position_y``, ``position_t``,
+      ``momentum_x``, ``momentum_y``, ``momentum_t``,
+      optional ``spin_x``, ``spin_y``, ``spin_z``,
+      plus ``qm``, ``w``, and the AMReX-internal ``cpu`` and ``id``).
+      Phase-space coordinates are relative to the reference particle (see :py:attr:`ref`).
+
+      :param bool local: if ``True`` (default), only particles on the current MPI rank are returned.
+                         If ``False``, particles are gathered to the root rank.
+      :return: particle data as a ``pandas.DataFrame``, or ``None`` on ranks without particles.
+
+      .. note::
+
+         The returned DataFrame is a *copy* of the particle data; modifying it does not write back to the simulation.
+         For in-place modification, iterate over particle tiles instead. See :ref:`usage-howto-python-particle-data` and
+         the `pyAMReX particles guide <https://pyamrex.readthedocs.io/en/latest/usage/compute.html#particles>`__.
+
+   .. py:attribute:: iterator
+
+      Alias for :py:class:`impactx.ImpactXParIter`, the per-tile iterator used to access
+      particle data on a mesh-refinement level without copying.
+      The canonical usage is to import the iterator directly:
+
+      .. code-block:: python
+
+         from impactx import ImpactXParIter
+
+         for pti in ImpactXParIter(sim.beam, level=0):
+             soa = pti.soa().to_xp()  # NumPy (CPU) or CuPy (GPU)
+             x = soa.real["position_x"]
+             px = soa.real["momentum_x"]
+
+      See :ref:`usage-howto-python-particle-data` for full usage examples and
+      `pyAMReX particles <https://pyamrex.readthedocs.io/en/latest/usage/compute.html#particles>`__ for the underlying API.
 
 
 .. py:class:: impactx.RefPart
@@ -680,6 +778,24 @@ Particles
          Please report your experience and bugs on `our issue tracker <https://github.com/BLAST-ImpactX/impactx/issues>`__.
 
       :param madx_file: file name to MAD-X file with a ``BEAM`` entry
+
+
+.. py:class:: impactx.ImpactXParIter(particle_container, level)
+
+   Per-tile iterator over the beam particle data on a mesh-refinement level.
+   Yields direct (zero-copy) access to the particle Struct-of-Arrays on CPU or GPU and is the
+   recommended way to access particles in performance-critical paths.
+
+   :param impactx.ParticleContainer particle_container: the beam particle container (e.g. ``sim.beam``).
+   :param int level: mesh-refinement level (typically ``0``).
+
+   See :ref:`usage-howto-python-particle-data` for full usage examples and the
+   `pyAMReX particles guide <https://pyamrex.readthedocs.io/en/latest/usage/compute.html#particles>`__
+   for the underlying API.
+
+.. py:class:: impactx.ImpactXParConstIter(particle_container, level)
+
+   Read-only variant of :py:class:`impactx.ImpactXParIter`.
 
 
 Initial Beam Phase Space Distributions
@@ -1510,10 +1626,24 @@ This module provides elements and methods for the accelerator lattice.
    A programmable beam optics element.
 
    This element can be programmed to receive callback hooks into Python functions.
+   See :ref:`usage-howto-python-extend` for a worked example.
 
    :param ds: Segment length in m.
    :param nslice: number of slices used for the application of space charge
    :param name: an optional name for the element
+
+   .. note::
+
+      The ``Programmable`` element is intended for *replacing* a beamline element's
+      particle push with custom Python code (e.g. a non-linear kick, tabulated map,
+      or ML surrogate). The ``beam_particles`` callback is invoked per particle
+      tile for performance, so the beam is presented in chunks, not as a single
+      global container, which is a poor fit for observation/analysis.
+
+      For **in-situ analysis** of the beam, prefer a :py:attr:`~impactx.ImpactX.hook`
+      callback instead: ``sim.beam`` and methods like
+      :py:meth:`~impactx.ParticleContainer.to_df` give you the full beam in one place.
+      See :ref:`usage-howto-python-particle-data`.
 
    .. py:property:: push
 

--- a/tests/python/test_space_charge_fields.py
+++ b/tests/python/test_space_charge_fields.py
@@ -26,12 +26,13 @@ def test_space_charge_phi_via_hook(save_png=True):
     # [doc-start] cfchannel-phi-hook
     import matplotlib.pyplot as plt
 
-    from impactx import ImpactX, distribution, elements
+    from impactx import ImpactX, amr, distribution, elements
 
     sim = ImpactX()
 
     # numerical parameters
     sim.n_cell = [48, 48, 40]
+    sim.tiny_profiler = False
     sim.particle_shape = 2
     sim.space_charge = "3D"
     sim.poisson_solver = "fft"
@@ -65,9 +66,6 @@ def test_space_charge_phi_via_hook(save_png=True):
         ]
     )
 
-    # capture phi statistics so we can sanity-check below
-    phi_stats = []
-
     def plot_phi(sim):
         """Plot phi at the transverse mid-plane after an element finishes.
 
@@ -77,48 +75,41 @@ def test_space_charge_phi_via_hook(save_png=True):
         (``"before_slice"`` would fire *before* the slice's solve, when phi
         is from a previous slice's solve — or uninitialized on the first slice.)
 
-        GPU/MPI-portable: we iterate over boxes and use ``to_numpy(copy=True)``
-        to bring host-side data we can plot.
+        GPU/MPI-portable: we use global indexing and pyAMReX garthers to rank zero.
         """
         phi = sim.phi(lev=0)
         geom = sim.Geom(lev=0)
-        dr = geom.data().CellSize()
-        ng = phi.n_grow_vect
         half_z = sim.n_cell[2] // 2
+        mm = 1e3
 
-        for mfi in phi:
-            bx = mfi.validbox()
-            arr = phi.array(mfi).to_numpy(copy=True)  # indices x, y, z, comp
+        # this triggers an MPI-collective gather
+        plane = phi[:, :, half_z, 0]
 
-            # shift box to zero-based local mfi index space
-            half_z_local = half_z - bx.lo_vect[2]
-            bx.shift(bx.lo_vect * -1)
-            # skip tiles that don't contain the mid-plane
-            if half_z_local < 0 or half_z_local >= arr.shape[2]:
-                continue
+        # other MPI ranks can return now
+        if not amr.ParallelDescriptor.IOProcessor():
+            return
 
-            # strip ghost cells in the transverse plane
-            plane = arr[ng[0] : -ng[0], ng[1] : -ng[1], half_z_local, 0]
-            phi_stats.append(float(plane.max()))
-
-            if save_png:
-                fig, ax = plt.subplots()
-                im = ax.imshow(
-                    plane.T * 1.0,
-                    origin="lower",
-                    aspect="auto",
-                    extent=[
-                        bx.lo_vect[0] * dr[0],
-                        (bx.lo_vect[0] + plane.shape[0]) * dr[0],
-                        bx.lo_vect[1] * dr[1],
-                        (bx.lo_vect[1] + plane.shape[1]) * dr[1],
-                    ],
-                )
-                fig.colorbar(im, label=r"$\phi$  [V]")
-                ax.set_xlabel(r"$x$  [m]")
-                ax.set_ylabel(r"$y$  [m]")
-                fig.savefig(f"phi_step{sim.tracking_step:04d}.png")
-                plt.close(fig)
+        # now plot on the IOProcessor
+        fig, ax = plt.subplots()
+        im = ax.imshow(
+            plane.T * 1.0,
+            origin="lower",
+            aspect="auto",
+            extent=[
+                geom.ProbLo(0) * mm,
+                geom.ProbHi(0) * mm,
+                geom.ProbLo(1) * mm,
+                geom.ProbHi(0) * mm,
+            ],
+        )
+        fig.colorbar(im, label=r"$\phi$  [V]")
+        ax.set_xlabel(r"$x$  [mm]")
+        ax.set_ylabel(r"$y$  [mm]")
+        if save_png:
+            fig.savefig(f"phi_step{sim.tracking_step:04d}.png")
+        else:
+            plt.show()
+        plt.close(fig)
 
     sim.hook["after_element"] = plot_phi
 
@@ -126,15 +117,6 @@ def test_space_charge_phi_via_hook(save_png=True):
     sim.finalize()
     # [doc-end] cfchannel-phi-hook
 
-    # the hook should have fired at least once and seen a non-trivial potential
-    assert len(phi_stats) > 0
-    assert max(phi_stats) > 0.0
-
 
 if __name__ == "__main__":
-    import amrex.space3d as amr
-
-    amr.initialize([])
     test_space_charge_phi_via_hook(save_png=True)
-    if amr.initialized():
-        amr.finalize()

--- a/tests/python/test_space_charge_fields.py
+++ b/tests/python/test_space_charge_fields.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+"""
+Access space-charge fields from a Python callback hook.
+
+This test runs a short constant-focusing channel with 3D space charge and
+installs a ``sim.hook["before_slice"]`` callback that reads the scalar
+potential ``sim.phi(lev=0)`` after each per-slice Poisson solve and saves a
+PNG of the transverse mid-plane. The same pattern works for ``sim.rho`` and
+``sim.space_charge_field``.
+
+This script is also embedded into the ImpactX documentation via
+``literalinclude``, see
+``docs/source/usage/howto/python_field_data.rst``.
+"""
+
+
+def test_space_charge_phi_via_hook(save_png=True):
+    """Plot the scalar potential phi via a before_slice callback hook."""
+    # [doc-start] cfchannel-phi-hook
+    import matplotlib.pyplot as plt
+
+    from impactx import ImpactX, distribution, elements
+
+    sim = ImpactX()
+
+    # numerical parameters
+    sim.n_cell = [48, 48, 40]
+    sim.particle_shape = 2
+    sim.space_charge = "3D"
+    sim.poisson_solver = "fft"
+    sim.prob_relative = [1.1]
+    sim.slice_step_diagnostics = True
+
+    sim.init_grids()
+
+    # 2 GeV proton beam, ~1 um normalized transverse rms emittance
+    kin_energy_MeV = 2.0e3
+    bunch_charge_C = 1.0e-8
+    npart = 10000
+
+    ref = sim.beam.ref
+    ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
+
+    distr = distribution.Waterbag(
+        lambdaX=1.2154443728379865788e-3,
+        lambdaY=1.2154443728379865788e-3,
+        lambdaT=4.0956844276541331005e-4,
+        lambdaPx=8.2274435782286157175e-4,
+        lambdaPy=8.2274435782286157175e-4,
+        lambdaPt=2.4415943602685364584e-3,
+    )
+    sim.add_particles(bunch_charge_C, distr, npart)
+
+    # short CF cell so the test stays quick
+    sim.lattice.extend(
+        [
+            elements.ConstF(name="cf1", ds=2.0, kx=1.0, ky=1.0, kt=1.0, nslice=5),
+        ]
+    )
+
+    # capture phi statistics so we can sanity-check below
+    phi_stats = []
+
+    def plot_phi(sim):
+        """Plot phi at the transverse mid-plane after an element finishes.
+
+        ``sim.hook["after_element"]`` fires after the element's last per-slice
+        Poisson solve, so ``sim.phi(lev=0)`` holds the freshly computed
+        potential of the last slice when we read it.
+        (``"before_slice"`` would fire *before* the slice's solve, when phi
+        is from a previous slice's solve — or uninitialized on the first slice.)
+
+        GPU/MPI-portable: we iterate over boxes and use ``to_numpy(copy=True)``
+        to bring host-side data we can plot.
+        """
+        phi = sim.phi(lev=0)
+        geom = sim.Geom(lev=0)
+        dr = geom.data().CellSize()
+        ng = phi.n_grow_vect
+        half_z = sim.n_cell[2] // 2
+
+        for mfi in phi:
+            bx = mfi.validbox()
+            arr = phi.array(mfi).to_numpy(copy=True)  # indices x, y, z, comp
+
+            # shift box to zero-based local mfi index space
+            half_z_local = half_z - bx.lo_vect[2]
+            bx.shift(bx.lo_vect * -1)
+            # skip tiles that don't contain the mid-plane
+            if half_z_local < 0 or half_z_local >= arr.shape[2]:
+                continue
+
+            # strip ghost cells in the transverse plane
+            plane = arr[ng[0] : -ng[0], ng[1] : -ng[1], half_z_local, 0]
+            phi_stats.append(float(plane.max()))
+
+            if save_png:
+                fig, ax = plt.subplots()
+                im = ax.imshow(
+                    plane.T * 1.0,
+                    origin="lower",
+                    aspect="auto",
+                    extent=[
+                        bx.lo_vect[0] * dr[0],
+                        (bx.lo_vect[0] + plane.shape[0]) * dr[0],
+                        bx.lo_vect[1] * dr[1],
+                        (bx.lo_vect[1] + plane.shape[1]) * dr[1],
+                    ],
+                )
+                fig.colorbar(im, label=r"$\phi$  [V]")
+                ax.set_xlabel(r"$x$  [m]")
+                ax.set_ylabel(r"$y$  [m]")
+                fig.savefig(f"phi_step{sim.tracking_step:04d}.png")
+                plt.close(fig)
+
+    sim.hook["after_element"] = plot_phi
+
+    sim.track_particles()
+    sim.finalize()
+    # [doc-end] cfchannel-phi-hook
+
+    # the hook should have fired at least once and seen a non-trivial potential
+    assert len(phi_stats) > 0
+    assert max(phi_stats) > 0.0
+
+
+if __name__ == "__main__":
+    import amrex.space3d as amr
+
+    amr.initialize([])
+    test_space_charge_phi_via_hook(save_png=True)
+    if amr.initialized():
+        amr.finalize()


### PR DESCRIPTION
Document in detail how to access beams & fields. [Adopted and inspired by equivalent WarpX docs.](https://warpx.readthedocs.io/en/latest/usage/workflows/python_extend.html)

- [x] [Preview](https://impactx--1462.org.readthedocs.build/en/1462/usage/howto/python_extend.html)
- [x] Also close #1340 
  - [x] double check space charge plots look good and work with/without MPI