### PR TITLE
TaperedPL: symmetric split for spin

### DIFF
--- a/src/elements/TaperedPL.H
+++ b/src/elements/TaperedPL.H
@@ -125,7 +125,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            RefPart const & AMREX_RESTRICT refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -134,12 +134,6 @@ namespace impactx::elements
 
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
-
-            // normalize focusing strength units to MAD-X convention if needed
-            amrex::ParticleReal g = m_k;
-            if (m_unit == 1) {
-                g = m_k / refpart.rigidity_Tm();
-            }
 
             // initialize output values
             T_Real xout = x;
@@ -151,10 +145,10 @@ namespace impactx::elements
 
             // advance position and momentum
             xout = x;
-            pxout = px - g * ( x + m_taper*0.5_prt * (powi<2>(x) + powi<2>(y)) );
+            pxout = px - m_g * ( x + m_taper*0.5_prt * (powi<2>(x) + powi<2>(y)) );
 
             yout = y;
-            pyout = py - g * ( y + m_taper * x * y );
+            pyout = py - m_g * ( y + m_taper * x * y );
 
             tout = t;
             ptout = pt;
@@ -209,12 +203,6 @@ namespace impactx::elements
             using namespace std; // for cmath(float)
             using amrex::Math::powi;
 
-            // normalize focusing strength units to MAD-X convention if needed
-            amrex::ParticleReal g = m_k;
-            if (m_unit == 1) {
-                g = m_k / refpart.rigidity_Tm();
-            }
-
             // Symmetric (Strang) split: half momentum kick, then the spin
             // rotation evaluated at the half-kicked momentum, then the second
             // half momentum kick. The transverse kicks depend only on (x, y),
@@ -226,8 +214,8 @@ namespace impactx::elements
             // O(Omega * dp) spin residual that breaks reversibility.
 
             // transverse momentum kick amounts (x, y unchanged by a thin lens)
-            T_Real const dpx = g * ( x + m_taper*0.5_prt * (powi<2>(x) + powi<2>(y)) );
-            T_Real const dpy = g * ( y + m_taper * x * y );
+            T_Real const dpx = m_g * ( x + m_taper*0.5_prt * (powi<2>(x) + powi<2>(y)) );
+            T_Real const dpy = m_g * ( y + m_taper * x * y );
 
             // first half kick
             px = px - 0.5_prt * dpx;

--- a/src/elements/TaperedPL.H
+++ b/src/elements/TaperedPL.H
@@ -209,6 +209,30 @@ namespace impactx::elements
             using namespace std; // for cmath(float)
             using amrex::Math::powi;
 
+            // normalize focusing strength units to MAD-X convention if needed
+            amrex::ParticleReal g = m_k;
+            if (m_unit == 1) {
+                g = m_k / refpart.rigidity_Tm();
+            }
+
+            // Symmetric (Strang) split: half momentum kick, then the spin
+            // rotation evaluated at the half-kicked momentum, then the second
+            // half momentum kick. The transverse kicks depend only on (x, y),
+            // which are invariant for this thin lens, so the kick is time-reversal
+            // symmetric and the BMT generator is evaluated at the same physical
+            // momentum in both directions. Reversing the element (negating the
+            // strength) therefore yields the exact inverse of this map; an
+            // asymmetric "rotate then full kick" ordering would leave an
+            // O(Omega * dp) spin residual that breaks reversibility.
+
+            // transverse momentum kick amounts (x, y unchanged by a thin lens)
+            T_Real const dpx = g * ( x + m_taper*0.5_prt * (powi<2>(x) + powi<2>(y)) );
+            T_Real const dpy = g * ( y + m_taper * x * y );
+
+            // first half kick
+            px = px - 0.5_prt * dpx;
+            py = py - 0.5_prt * dpy;
+
             // initialize the three components of the axis-angle vector
             T_Real lambdax = 0_prt;
             T_Real lambday = 0_prt;
@@ -225,7 +249,8 @@ namespace impactx::elements
             T_Real const Ey = 0.0_prt;
             T_Real const Ez = 0.0_prt;
 
-            // Quantities required to evaluate the full Thomas-BMT precession vector.
+            // Quantities required to evaluate the full Thomas-BMT precession
+            // vector, at the half-kicked transverse momentum.
             T_Real const Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
             T_Real const iPnorm = 1_prt/Pnorm;
             T_Real const Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
@@ -244,8 +269,9 @@ namespace impactx::elements
             // push the spin vector using the generator just determined
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
 
-            // phase space push
-            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+            // second half kick
+            px = px - 0.5_prt * dpx;
+            py = py - 0.5_prt * dpy;
 
         }
 

--- a/src/elements/TaperedPL.H
+++ b/src/elements/TaperedPL.H
@@ -203,23 +203,18 @@ namespace impactx::elements
             using namespace std; // for cmath(float)
             using amrex::Math::powi;
 
-            // Symmetric (Strang) split: half momentum kick, then the spin
-            // rotation evaluated at the half-kicked momentum, then the second
-            // half momentum kick. The transverse kicks depend only on (x, y),
-            // which are invariant for this thin lens, so the kick is time-reversal
-            // symmetric and the BMT generator is evaluated at the same physical
-            // momentum in both directions. Reversing the element (negating the
-            // strength) therefore yields the exact inverse of this map; an
-            // asymmetric "rotate then full kick" ordering would leave an
-            // O(Omega * dp) spin residual that breaks reversibility.
+            // The Thomas-BMT generator is evaluated at the transverse momentum
+            // halfway through the kick, so that reversing the element (negating
+            // the strength) produces the exact inverse rotation.
+            T_Real const px_in = px;
+            T_Real const py_in = py;
 
-            // transverse momentum kick amounts (x, y unchanged by a thin lens)
-            T_Real const dpx = m_g * ( x + m_taper*0.5_prt * (powi<2>(x) + powi<2>(y)) );
-            T_Real const dpy = m_g * ( y + m_taper * x * y );
+            // pure phase-space push (shared with the non-spin operator())
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
 
-            // first half kick
-            px = px - 0.5_prt * dpx;
-            py = py - 0.5_prt * dpy;
+            // transverse momenta at the kick midpoint
+            T_Real const px_mid = 0.5_prt * (px_in + px);
+            T_Real const py_mid = 0.5_prt * (py_in + py);
 
             // initialize the three components of the axis-angle vector
             T_Real lambdax = 0_prt;
@@ -238,13 +233,13 @@ namespace impactx::elements
             T_Real const Ez = 0.0_prt;
 
             // Quantities required to evaluate the full Thomas-BMT precession
-            // vector, at the half-kicked transverse momentum.
+            // vector, at the midpoint transverse momentum.
             T_Real const Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
             T_Real const iPnorm = 1_prt/Pnorm;
-            T_Real const Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
+            T_Real const Ps = sqrt(Pnorm*Pnorm - px_mid*px_mid - py_mid*py_mid);
             T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
-            T_Real const ux = px * iPnorm;
-            T_Real const uy = py * iPnorm;
+            T_Real const ux = px_mid * iPnorm;
+            T_Real const uy = py_mid * iPnorm;
             T_Real const uz = Ps * iPnorm;
 
             // Zero curvature in a quadrupole
@@ -256,10 +251,6 @@ namespace impactx::elements
 
             // push the spin vector using the generator just determined
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
-
-            // second half kick
-            px = px - 0.5_prt * dpx;
-            py = py - 0.5_prt * dpy;
 
         }
 


### PR DESCRIPTION
The spin push rotated the spin vector with a Thomas-BMT generator built from the entry momentum, then applied the full transverse kick. `reverse()` only negates the strength and reuses the same "rotate-then-kick" order, so the in/out rotations were evaluated at different momenta (`p0` vs `p1 = p0 - dp`) and did not cancel, leaving an `O(Omega * dp) ~ 7e-8` spin residual that broke reversibility. The orbit, depending only on `(x, y)`, stayed exact.

Evaluate the BMT generator at the transverse momentum halfway through the kick (average of entry and exit), reusing the shared phase-space `operator()` for the kick itself. Because `(x, y, pt)` are invariant under this thin lens and the kick is linear in the reversible strength, the midpoint momentum is identical forward and reversed while the generator is odd in strength, so negating the strength is the exact inverse rotation.

Spin roundtrip residual drops from ~7e-8 to ~3e-16 (machine precision for DP).

Found and fixed w/ Claude while adding tests in #1455