### PR TITLE
CI: CodSpeed Microarch Ubuntu

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -115,9 +115,14 @@ jobs:
     if: github.event.pull_request.draft == false
     env:
       CMAKE_GENERATOR: Ninja
-      CXXFLAGS: "-Werror"
+      CXXFLAGS: "-Werror -march=x86-64-v3 -mtune=generic"
       OMP_NUM_THREADS: 2
     steps:
+    - name: system info
+      run: |
+        cat /proc/cpuinfo
+        lscpu
+
     - name: Free More Disk Space
       uses: ax3l/free-disk-space@main
       with:

--- a/docs/source/install/cmake.rst
+++ b/docs/source/install/cmake.rst
@@ -398,9 +398,23 @@ We also support adding `additional compiler flags via environment variables <htt
    # example: treat all compiler warnings as errors
    export CXXFLAGS="-Werror"
 
+.. tip::
+
+   To get the most performance out of your CPU, compile for the
+   instruction set of the machine you run on:
+
+   .. code-block:: bash
+
+      export CXXFLAGS="-march=native -mtune=native"
+
+   Use ``-march=native`` only for builds that run on the same CPU generation they were
+   compiled on. For portable binaries, pick a specific baseline architecture instead
+   (e.g. ``-march=x86-64-v3 -mtune=generic`` for AMD/Intel CPUs build since the year 2021, our :ref:`HPC configurations <install-hpc>` set the right match in their profile files for you).
+   Also enable our vectorization option in the table below: ``-DImpactX_SIMD=ON``
+
 .. note::
 
-   Please clean your build directory with ``rm -rf build/`` after changing the compiler.
+   Please clean your build directory with ``rm -rf build/`` after changing the compiler or environment variables like ``CXXFLAGS``.
    Now call ``cmake -S . -B build`` (+ further options) again to re-initialize the build configuration.
 
 


### PR DESCRIPTION
Pin the microarch for our SIMD [CodSpeed](https://codspeed.io/BLAST-ImpactX/impactx) benchmark to the observed 2021+ CPUs that are currently available on x86-64 Ubuntu 24.04 runners (`march`).
Make more reproducible when newer AMD/Intel CPUs are assigned by pinning to the lower (Zen 3) generation CPUs in the pool.