### PR TITLE
MLMG: Default Relative Tolerance (SP)

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1152,7 +1152,7 @@ See there ``nslice`` option on lattice elements for slicing.
 
 Multigrid-specific numerical options:
 
-* ``algo.mlmg_relative_tolerance`` (``float``, optional, default: ``1.e-7``)
+* ``algo.mlmg_relative_tolerance`` (``float``, optional, default: ``1.e-7`` (DP) / ``1.e-4`` (SP))
 
   The relative precision with which the electrostatic space-charge fields should be calculated.
   More specifically, the space-charge fields are computed with an iterative Multi-Level Multi-Grid (MLMG) solver.

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -131,7 +131,7 @@ Collective Effects & Overall Simulation Parameters
 
    .. py:property:: mlmg_relative_tolerance
 
-      Default: ``1.e-7``
+      Default: ``1.e-7`` (DP) / ``1.e-4`` (SP)
 
       The relative precision with which the electrostatic space-charge fields should be calculated.
       More specifically, the space-charge fields are computed with an iterative Multi-Level Multi-Grid (MLMG) solver.

--- a/src/particles/spacecharge/PoissonSolve.cpp
+++ b/src/particles/spacecharge/PoissonSolve.cpp
@@ -75,7 +75,13 @@ namespace impactx::particles::spacecharge
         }
 
         // MLMG options
-        amrex::Real mlmg_relative_tolerance = 1.e-7_rt; // relative TODO: make smaller for SP
+        //   Single precision: achievable relative residual is limited by float32
+        //   round-off (machine epsilon ~1.2e-7).
+#ifdef AMREX_USE_FLOAT
+        amrex::Real mlmg_relative_tolerance = 1.e-4_rt; // relative (single precision)
+#else
+        amrex::Real mlmg_relative_tolerance = 1.e-7_rt; // relative (double precision)
+#endif
         amrex::Real mlmg_absolute_tolerance = 0.0;   // ignored
         pp_algo.queryAddWithParser("mlmg_relative_tolerance", mlmg_relative_tolerance);
         pp_algo.queryAddWithParser("mlmg_absolute_tolerance", mlmg_absolute_tolerance);


### PR DESCRIPTION
Lower the default relative tolerance for the residual of MLMG in single precision. The DP default is stricter than machine epsilon and thus not sensical, leading to unconvered results when run in SP.