### PR TITLE
Fix SP: `to_py()` Matrix Type

### DIFF
--- a/src/python/impactx/extensions/KnownElementsList.py
+++ b/src/python/impactx/extensions/KnownElementsList.py
@@ -10,7 +10,7 @@ import os
 import re
 import weakref
 
-from impactx import elements
+from impactx import Config, elements
 
 # All live FilteredElementsList views for a lattice (WeakKeyDictionary: key is KnownElementsList).
 _filtered_views_by_lattice: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
@@ -960,6 +960,9 @@ def to_py(self) -> str:
         ]
     )
 
+    # match the SmallMatrix element type to the build's precision
+    real_t = "float" if Config.precision == "SINGLE" else "double"
+
     for d in self.to_dicts():
         element_type = d["type"]
         kwargs = _filter_kwargs(d)
@@ -969,7 +972,7 @@ def to_py(self) -> str:
             formatted_v, matrix_dims = _format_value(v)
             if matrix_dims:
                 rows, cols = matrix_dims
-                matrix_cls = f"amr.SmallMatrix_{rows}x{cols}_F_SI1_double"
+                matrix_cls = f"amr.SmallMatrix_{rows}x{cols}_F_SI1_{real_t}"
                 formatted_parts.append(f"{k}={matrix_cls}({repr(formatted_v)})")
             else:
                 formatted_parts.append(f"{k}={repr(formatted_v)}")

--- a/tests/python/test_element_serialization.py
+++ b/tests/python/test_element_serialization.py
@@ -17,7 +17,10 @@ import numpy as np
 import pytest
 
 import amrex.space3d as amr
-from impactx import elements
+from impactx import Config, elements
+
+# amrex Real SmallMatrix precision suffix matching the build
+_REAL = "float" if Config.precision == "SINGLE" else "double"
 
 
 def get_constructor_params(element_class):
@@ -359,7 +362,7 @@ def all_elements():
         )
     )
 
-    R = amr.SmallMatrix_6x6_F_SI1_double.identity()
+    R = getattr(amr, f"SmallMatrix_6x6_F_SI1_{_REAL}").identity()
     lattice.append(
         elements.LinearMap(
             R=R, ds=0.5, dx=0.001, dy=0.002, rotation=0.05, name="test_linearmap"
@@ -538,9 +541,9 @@ def all_elements():
         )
     )
 
-    v = amr.SmallMatrix_3x1_F_SI1_double()
+    v = getattr(amr, f"SmallMatrix_3x1_F_SI1_{_REAL}")()
     v.set_val(0.1)
-    A = amr.SmallMatrix_3x6_F_SI1_double()
+    A = getattr(amr, f"SmallMatrix_3x6_F_SI1_{_REAL}")()
     A.set_val(0.01)
     lattice.append(
         elements.SpinMap(

--- a/tests/python/test_element_value_semantics.py
+++ b/tests/python/test_element_value_semantics.py
@@ -16,7 +16,18 @@ import inspect
 import pytest
 
 import amrex.space3d as amr
-from impactx import elements
+from impactx import Config, elements
+
+# amrex Real SmallMatrix precision suffix matching the build
+_REAL = "float" if Config.precision == "SINGLE" else "double"
+
+# Perturbation sized to the build precision: large enough that == distinguishes the
+# values, yet within _CLOSE_RTOL so isclose() is True (sub-epsilon at double, ~1e-5 at
+# single). _PERT_CUSTOM stays below the explicit rtol=1e-6 used in test_isclose_custom_rtol.
+if Config.precision == "SINGLE":
+    _PERT, _CLOSE_RTOL, _PERT_CUSTOM = 1e-5, 1e-3, 5e-7
+else:
+    _PERT, _CLOSE_RTOL, _PERT_CUSTOM = 1e-15, 1e-12, 1e-9
 
 # ----------------------------------------------------------------------
 # Basic equality and hash
@@ -73,8 +84,8 @@ def test_dict_key_usage():
 
 def test_isclose_accepts_small_perturbation():
     a = elements.Drift(ds=1.0, name="d1")
-    b = elements.Drift(ds=1.0 + 1e-15, name="d1")
-    assert a.isclose(b)
+    b = elements.Drift(ds=1.0 + _PERT, name="d1")
+    assert a.isclose(b, rtol=_CLOSE_RTOL)
     assert not (a == b)
 
 
@@ -86,7 +97,7 @@ def test_isclose_rejects_large_perturbation():
 
 def test_isclose_custom_rtol():
     a = elements.Drift(ds=1.0)
-    b = elements.Drift(ds=1.0 + 1e-9)
+    b = elements.Drift(ds=1.0 + _PERT_CUSTOM)
     # default rtol=1e-12 rejects this
     assert not a.isclose(b)
     # loosened rtol accepts it
@@ -141,8 +152,8 @@ def test_eq_list_of_floats():
 
 def test_isclose_list_of_floats_perturbed():
     a = _make_rfcavity([1.0, 2.0, 3.0], [0.0, 0.1, 0.2])
-    b = _make_rfcavity([1.0, 2.0, 3.0 + 1e-15], [0.0, 0.1, 0.2])
-    assert a.isclose(b)
+    b = _make_rfcavity([1.0, 2.0, 3.0 + _PERT], [0.0, 0.1, 0.2])
+    assert a.isclose(b, rtol=_CLOSE_RTOL)
     assert not (a == b)
 
 
@@ -165,7 +176,7 @@ def test_isclose_list_length_mismatch():
 
 
 def test_eq_linearmap_same_matrix():
-    R = amr.SmallMatrix_6x6_F_SI1_double.identity()
+    R = getattr(amr, f"SmallMatrix_6x6_F_SI1_{_REAL}").identity()
     a = elements.LinearMap(R=R, ds=0.5, name="lm")
     b = elements.LinearMap(R=R, ds=0.5, name="lm")
     assert a == b
@@ -173,13 +184,13 @@ def test_eq_linearmap_same_matrix():
 
 
 def test_isclose_linearmap_perturbed_matrix():
-    R1 = amr.SmallMatrix_6x6_F_SI1_double.identity()
-    R2 = amr.SmallMatrix_6x6_F_SI1_double.identity()
+    R1 = getattr(amr, f"SmallMatrix_6x6_F_SI1_{_REAL}").identity()
+    R2 = getattr(amr, f"SmallMatrix_6x6_F_SI1_{_REAL}").identity()
     # SmallMatrix_..._SI1_... uses 1-based indexing.
-    R2[1, 1] = 1.0 + 1e-15
+    R2[1, 1] = 1.0 + _PERT
     a = elements.LinearMap(R=R1, ds=0.5, name="lm")
     b = elements.LinearMap(R=R2, ds=0.5, name="lm")
-    assert a.isclose(b)
+    assert a.isclose(b, rtol=_CLOSE_RTOL)
     assert not (a == b)
 
 
@@ -340,10 +351,10 @@ def test_lattice_eq_foreign_type():
 def test_lattice_isclose_with_perturbation():
     a = _build_lattice()
     b = elements.KnownElementsList()
-    b.append(elements.Drift(ds=1.0 + 1e-15, name="d1"))
-    b.append(elements.Quad(ds=0.3 + 1e-15, k=2.5, name="q1"))
+    b.append(elements.Drift(ds=1.0 + _PERT, name="d1"))
+    b.append(elements.Quad(ds=0.3 + _PERT, k=2.5, name="q1"))
     b.append(elements.Drift(ds=2.0, name="d2"))
-    assert a.isclose(b)
+    assert a.isclose(b, rtol=_CLOSE_RTOL)
     assert not (a == b)
 
 

--- a/tests/python/test_lattice_select.py
+++ b/tests/python/test_lattice_select.py
@@ -896,10 +896,10 @@ def test_replace_each_default_keep_name_not_ds():
     new_sel = sel.replace_each(template)
     assert type(lattice[1]) is elements.Quad
     assert lattice[1].name == "qf1"
-    assert lattice[1].ds == 0.01
+    assert lattice[1].ds == pytest.approx(0.01)
     assert lattice[1].k == 99.0
     assert lattice[2].name == "qd1"
-    assert lattice[2].ds == 0.01
+    assert lattice[2].ds == pytest.approx(0.01)
     assert len(new_sel) == 2
     assert new_sel[0].name == "qf1"
     with pytest.raises(RuntimeError, match="no longer valid"):
@@ -931,7 +931,7 @@ def test_replace_each_keep_name_and_ds_false():
     template = elements.Quad(name="tpl", ds=0.01, k=7.0)
     lattice.select(kind="Quad").replace_each(template, keep_name=False)
     assert lattice[0].name == "tpl"
-    assert lattice[0].ds == 0.01
+    assert lattice[0].ds == pytest.approx(0.01)
     assert lattice[0].k == 7.0
 
 
@@ -996,8 +996,8 @@ def test_replace_with_drifts_keep_alignment():
 
     # Default: keep_alignment=True
     lattice.select(kind="Quad").replace_with_drifts()
-    assert lattice[0].dx == 0.01
-    assert lattice[0].dy == 0.02
+    assert lattice[0].dx == pytest.approx(0.01)
+    assert lattice[0].dy == pytest.approx(0.02)
     assert lattice[0].rotation == 0.5
 
     # Reset and test keep_alignment=False
@@ -1029,8 +1029,8 @@ def test_replace_with_drifts_keep_aperture():
         [elements.Quad(name="q1", ds=0.5, k=1.0, aperture_x=0.05, aperture_y=0.03)]
     )
     lattice.select(kind="Quad").replace_with_drifts(keep_aperture=True)
-    assert lattice[0].aperture_x == 0.05
-    assert lattice[0].aperture_y == 0.03
+    assert lattice[0].aperture_x == pytest.approx(0.05)
+    assert lattice[0].aperture_y == pytest.approx(0.03)
 
 
 def test_chained_replace_each():


### PR DESCRIPTION
In the lattice Python code serialization, we should not promote `SmallMatrix` blindly to `double` but keep the build-time precision type.

Update is_close tests to use FP-type sensible mini deltas for tests.

Follow-up to #1366 #1436