### PR TITLE
Doc: Update Perlmutter

### DIFF
--- a/docs/source/install/hpc/perlmutter-nersc/install_cpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_cpu_dependencies.sh
@@ -46,6 +46,11 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 # tmpfs build directory: avoids issues often seen with $HOME and is faster
 build_dir=$(mktemp -d)
 
+# CCache (compiler cache)
+curl -Lo ${build_dir}/ccache.tar.xz https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz
+tar -xf ${build_dir}/ccache.tar.xz -C ${build_dir}
+mv ${build_dir}/ccache-4.10.2-linux-x86_64 ${SW_DIR}/ccache-4.10.2
+
 # c-blosc (I/O compression)
 if [ -d $HOME/src/c-blosc ]
 then
@@ -65,44 +70,14 @@ if [ -d $HOME/src/adios2 ]
 then
   cd $HOME/src/adios2
   git fetch --prune
-  git checkout v2.8.3
+  git checkout v2.10.2
   cd -
 else
-  git clone -b v2.8.3 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
+  git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
 fi
-cmake -S $HOME/src/adios2 -B ${build_dir}/adios2-pm-cpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_CUDA=OFF -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.8.3
+cmake -S $HOME/src/adios2 -B ${build_dir}/adios2-pm-cpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_CUDA=OFF -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.10.2
 cmake --build ${build_dir}/adios2-pm-cpu-build --target install -j 16
 rm -rf ${build_dir}/adios2-pm-cpu-build
-
-# BLAS++ (for PSATD+RZ)
-if [ -d $HOME/src/blaspp ]
-then
-  cd $HOME/src/blaspp
-  git fetch --prune
-  git checkout master
-  git pull
-  cd -
-else
-  git clone https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
-fi
-CXX=$(which CC) cmake -S $HOME/src/blaspp -B ${build_dir}/blaspp-pm-cpu-build -Duse_openmp=ON -Dgpu_backend=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-master
-cmake --build ${build_dir}/blaspp-pm-cpu-build --target install --parallel 16
-rm -rf ${build_dir}/blaspp-pm-cpu-build
-
-# LAPACK++ (for PSATD+RZ)
-if [ -d $HOME/src/lapackpp ]
-then
-  cd $HOME/src/lapackpp
-  git fetch --prune
-  git checkout master
-  git pull
-  cd -
-else
-  git clone https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
-fi
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B ${build_dir}/lapackpp-pm-cpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-master
-cmake --build ${build_dir}/lapackpp-pm-cpu-build --target install --parallel 16
-rm -rf ${build_dir}/lapackpp-pm-cpu-build
 
 
 # Python ######################################################################

--- a/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
@@ -46,6 +46,11 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 # tmpfs build directory: avoids issues often seen with $HOME and is faster
 build_dir=$(mktemp -d)
 
+# CCache (compiler cache)
+curl -Lo ${build_dir}/ccache.tar.xz https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz
+tar -xf ${build_dir}/ccache.tar.xz -C ${build_dir}
+mv ${build_dir}/ccache-4.10.2-linux-x86_64 ${SW_DIR}/ccache-4.10.2
+
 # c-blosc (I/O compression)
 if [ -d $HOME/src/c-blosc ]
 then
@@ -65,44 +70,14 @@ if [ -d $HOME/src/adios2 ]
 then
   cd $HOME/src/adios2
   git fetch --prune
-  git checkout v2.8.3
+  git checkout v2.10.2
   cd -
 else
-  git clone -b v2.8.3 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
+  git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
 fi
-cmake -S $HOME/src/adios2 -B ${build_dir}/adios2-pm-gpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.8.3
+cmake -S $HOME/src/adios2 -B ${build_dir}/adios2-pm-gpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.10.2
 cmake --build ${build_dir}/adios2-pm-gpu-build --target install -j 16
 rm -rf ${build_dir}/adios2-pm-gpu-build
-
-# BLAS++ (for PSATD+RZ)
-if [ -d $HOME/src/blaspp ]
-then
-  cd $HOME/src/blaspp
-  git fetch --prune
-  git checkout master
-  git pull
-  cd -
-else
-  git clone https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
-fi
-CXX=$(which CC) cmake -S $HOME/src/blaspp -B ${build_dir}/blaspp-pm-gpu-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-master
-cmake --build ${build_dir}/blaspp-pm-gpu-build --target install --parallel 16
-rm -rf ${build_dir}/blaspp-pm-gpu-build
-
-# LAPACK++ (for PSATD+RZ)
-if [ -d $HOME/src/lapackpp ]
-then
-  cd $HOME/src/lapackpp
-  git fetch --prune
-  git checkout master
-  git pull
-  cd -
-else
-  git clone https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
-fi
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B ${build_dir}/lapackpp-pm-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-master
-cmake --build ${build_dir}/lapackpp-pm-gpu-build --target install --parallel 16
-rm -rf ${build_dir}/lapackpp-pm-gpu-build
 
 
 # Python ######################################################################

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_cpu_impactx.profile.example
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_cpu_impactx.profile.example
@@ -7,28 +7,21 @@ if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in yo
 
 # required dependencies
 module load cpu
-module load cmake/3.24.3
+module load cmake/3.30.2
 module load cray-fftw/3.3.10.6
 
-# optional: for QED support with detailed tables
-export BOOST_ROOT=/global/common/software/spackecp/perlmutter/e4s-23.05/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/boost-1.82.0-ow5r5qrgslcwu33grygouajmuluzuzv3
-
-# optional: for openPMD and PSATD+RZ support
+# optional: for openPMD support
 module load cray-hdf5-parallel/1.12.2.9
 export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.8.3:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/blaspp-master:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/lapackpp-master:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.10.2:$CMAKE_PREFIX_PATH
 
 export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/c-blosc-1.21.1/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.8.3/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/blaspp-master/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/lapackpp-master/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.10.2/lib64:$LD_LIBRARY_PATH
 
-export PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.8.3/bin:${PATH}
+export PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/adios2-2.10.2/bin:${PATH}
 
 # optional: CCache
-export PATH=/global/common/software/spackecp/perlmutter/e4s-23.08/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/ccache-4.8.2-cvooxdw5wgvv2g3vjxjkrpv6dopginv6/bin:$PATH
+export PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/ccache-4.10.2:$PATH
 
 # optional: for Python bindings or libEnsemble
 module load cray-python/3.11.5

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
@@ -9,24 +9,20 @@ if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in yo
 
 # required dependencies
 module load gcc-native/13.2  # default gcc-native/14 breaks pybind11 builds with NVCC 12.9.41
-module load cmake/3.24.3
+module load cmake/3.30.2
 
-# optional: for openPMD and PSATD+RZ support
+# optional: for openPMD support
 module load cray-hdf5-parallel/1.12.2.9
 export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.8.3:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/blaspp-master:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/lapackpp-master:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.10.2:$CMAKE_PREFIX_PATH
 
 export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/c-blosc-1.21.1/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.8.3/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/blaspp-master/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/lapackpp-master/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.10.2/lib64:$LD_LIBRARY_PATH
 
-export PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.8.3/bin:${PATH}
+export PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.10.2/bin:${PATH}
 
 # optional: CCache
-export PATH=/global/common/software/spackecp/perlmutter/e4s-23.08/default/spack/opt/spack/linux-sles15-zen3/gcc-11.2.0/ccache-4.8.2-cvooxdw5wgvv2g3vjxjkrpv6dopginv6/bin:$PATH
+export PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/ccache-4.10.2:$PATH
 
 # optional: for Python bindings or libEnsemble
 module load cray-python/3.11.5


### PR DESCRIPTION
- Newer CMake (for C++20)
- Newer ADIOS2 (2.8 -> 2.10)
- CCache Support (faster compiles)
- No need for BLAS++/LAPACK++ (for WarpX only)

[After this is merged, please update the dependencies and profile accordingly.](https://impactx.readthedocs.io/en/latest/install/hpc/perlmutter.html#update-impactx-dependencies)

first seen by @markabate 