### PR TITLE
Simplify Adding Particles

### DIFF
--- a/cmake/dependencies/pyAMReX.cmake
+++ b/cmake/dependencies/pyAMReX.cmake
@@ -80,7 +80,7 @@ option(ImpactX_pyamrex_internal "Download & build pyAMReX" ON)
 set(ImpactX_pyamrex_repo "https://github.com/AMReX-Codes/pyamrex.git"
     CACHE STRING
     "Repository URI to pull and build pyamrex from if(ImpactX_pyamrex_internal)")
-set(ImpactX_pyamrex_branch "26.05"
+set(ImpactX_pyamrex_branch "11b07edb987d2caa7a3ab18017221fcfe0b3f5b6"
     CACHE STRING
     "Repository branch for ImpactX_pyamrex_repo if(ImpactX_pyamrex_internal)")
 

--- a/examples/edge_effects/run_dipedge.py
+++ b/examples/edge_effects/run_dipedge.py
@@ -10,8 +10,7 @@ import math
 
 import pandas as pd
 
-import amrex.space3d as amr
-from impactx import Config, ImpactX, elements
+from impactx import ImpactX, elements
 
 sim = ImpactX()
 
@@ -42,41 +41,11 @@ dpy = df_initial["py"].to_numpy()
 dt = df_initial["t"].to_numpy()
 dpt = df_initial["pt"].to_numpy()
 # dg = df_initial["gap"].to_numpy()
-if not Config.have_gpu:  # initialize using cpu-based PODVectors
-    dx_podv = amr.PODVector_real_std()
-    dy_podv = amr.PODVector_real_std()
-    dt_podv = amr.PODVector_real_std()
-    dpx_podv = amr.PODVector_real_std()
-    dpy_podv = amr.PODVector_real_std()
-    dpt_podv = amr.PODVector_real_std()
-else:  # initialize on device using arena/gpu-based PODVectors
-    dx_podv = amr.PODVector_real_arena()
-    dy_podv = amr.PODVector_real_arena()
-    dt_podv = amr.PODVector_real_arena()
-    dpx_podv = amr.PODVector_real_arena()
-    dpy_podv = amr.PODVector_real_arena()
-    dpt_podv = amr.PODVector_real_arena()
-
-for p_dx in dx:
-    dx_podv.push_back(p_dx)
-for p_dy in dy:
-    dy_podv.push_back(p_dy)
-for p_dt in dt:
-    dt_podv.push_back(p_dt)
-for p_dpx in dpx:
-    dpx_podv.push_back(p_dpx)
-for p_dpy in dpy:
-    dpy_podv.push_back(p_dpy)
-for p_dpt in dpt:
-    dpt_podv.push_back(p_dpt)
-
 # print(dt)
 print(dpt)
 # print(dg)
 
-beam.add_n_particles(
-    dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, bunch_charge_C
-)
+beam.add_n_particles(dx, dy, dt, dpx, dpy, dpt, qm_eev, bunch_charge_C)
 
 # add beam diagnostics
 monitor = elements.BeamMonitor("monitor", backend="h5")

--- a/examples/initialize_from_array/README.rst
+++ b/examples/initialize_from_array/README.rst
@@ -3,11 +3,6 @@
 Initialize a Beam from Arrays
 =============================
 
-
-.. note::
-
-   This example is an early draft of this workflow and will be simplified in future versions of ImpactX, adding direct support for NumPy and CuPy arrays.
-
 This example demonstrates how a beam can be initialized in ImpactX from array-like structures.
 This allows various applications of interest,
 such as using a beam from a different simulation,

--- a/examples/initialize_from_array/run_from_array.py
+++ b/examples/initialize_from_array/run_from_array.py
@@ -10,7 +10,7 @@ import numpy as np
 import transformation_utilities as pycoord
 
 import amrex.space3d as amr
-from impactx import Config, ImpactX, elements
+from impactx import ImpactX, elements
 
 ################
 
@@ -82,57 +82,14 @@ if amr.ParallelDescriptor.IOProcessor():
     # here we use equal particle weighting, but you can assign any weight to each particle
     w = np.ones_like(dx) * (bunch_charge_C / q_e_C / N_part)
 
-    if not Config.have_gpu:  # initialize using cpu-based PODVectors
-        dx_podv = amr.PODVector_real_std()
-        dy_podv = amr.PODVector_real_std()
-        dt_podv = amr.PODVector_real_std()
-        dpx_podv = amr.PODVector_real_std()
-        dpy_podv = amr.PODVector_real_std()
-        dpt_podv = amr.PODVector_real_std()
-        w_podv = amr.PODVector_real_std()
-    else:  # initialize on device using arena/gpu-based PODVectors
-        dx_podv = amr.PODVector_real_arena()
-        dy_podv = amr.PODVector_real_arena()
-        dt_podv = amr.PODVector_real_arena()
-        dpx_podv = amr.PODVector_real_arena()
-        dpy_podv = amr.PODVector_real_arena()
-        dpt_podv = amr.PODVector_real_arena()
-        w_podv = amr.PODVector_real_arena()
-
-    for p_dx in dx:
-        dx_podv.push_back(p_dx)
-    for p_dy in dy:
-        dy_podv.push_back(p_dy)
-    for p_dt in dt:
-        dt_podv.push_back(p_dt)
-    for p_dpx in dpx:
-        dpx_podv.push_back(p_dpx)
-    for p_dpy in dpy:
-        dpy_podv.push_back(p_dpy)
-    for p_dpt in dpt:
-        dpt_podv.push_back(p_dpt)
-    for p_w in w:
-        w_podv.push_back(p_w)
-
     # This call has two options:
     # A) reassign equal weighting according to bunch_charge_C
     # B) use the particle weighting from the input array w
-    beam.add_n_particles(
-        dx_podv,
-        dy_podv,
-        dt_podv,
-        dpx_podv,
-        dpy_podv,
-        dpt_podv,
-        qm_eev,
-        bunch_charge=bunch_charge_C,
-    )
+    beam.add_n_particles(dx, dy, dt, dpx, dpy, dpt, qm_eev, bunch_charge=bunch_charge_C)
     # ok, let's clear all particles and do option B
     beam.clear_particles()
 
-    beam.add_n_particles(
-        dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, w=w_podv
-    )
+    beam.add_n_particles(dx, dy, dt, dpx, dpy, dpt, qm_eev, w=w)
 
 # build the accelerator lattice
 monitor = elements.BeamMonitor("monitor", backend="h5")

--- a/examples/solenoid_softedge/run_solenoid_softedge_solvable.py
+++ b/examples/solenoid_softedge/run_solenoid_softedge_solvable.py
@@ -9,7 +9,7 @@
 import numpy as np
 
 import amrex.space3d as amr
-from impactx import Config, ImpactX, elements
+from impactx import ImpactX, elements
 
 sim = ImpactX()
 
@@ -42,38 +42,8 @@ dpy = [0, 0, 0, 1, 0, 0]
 dt = [0, 0, 0, 0, 1, 0]
 dpt = [0, 0, 0, 0, 0, 1]
 
-if not Config.have_gpu:  # initialize using cpu-based PODVectors
-    dx_podv = amr.PODVector_real_std()
-    dy_podv = amr.PODVector_real_std()
-    dt_podv = amr.PODVector_real_std()
-    dpx_podv = amr.PODVector_real_std()
-    dpy_podv = amr.PODVector_real_std()
-    dpt_podv = amr.PODVector_real_std()
-else:  # initialize on device using arena/gpu-based PODVectors
-    dx_podv = amr.PODVector_real_arena()
-    dy_podv = amr.PODVector_real_arena()
-    dt_podv = amr.PODVector_real_arena()
-    dpx_podv = amr.PODVector_real_arena()
-    dpy_podv = amr.PODVector_real_arena()
-    dpt_podv = amr.PODVector_real_arena()
-
-for p_dx in dx:
-    dx_podv.push_back(p_dx)
-for p_dy in dy:
-    dy_podv.push_back(p_dy)
-for p_dt in dt:
-    dt_podv.push_back(p_dt)
-for p_dpx in dpx:
-    dpx_podv.push_back(p_dpx)
-for p_dpy in dpy:
-    dpy_podv.push_back(p_dpy)
-for p_dpt in dpt:
-    dpt_podv.push_back(p_dpt)
-
 if amr.ParallelDescriptor.IOProcessor():
-    beam.add_n_particles(
-        dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, bunch_charge_C
-    )
+    beam.add_n_particles(dx, dy, dt, dpx, dpy, dpt, qm_eev, bunch_charge_C)
 
 # specify the on-axis field profile
 zmin = -1.0  # lower value of on-axis longitudinal coordinate (in meters)

--- a/examples/spin_tracking/run_cfbend_spin_scaling.py
+++ b/examples/spin_tracking/run_cfbend_spin_scaling.py
@@ -9,7 +9,7 @@
 import pandas as pd
 
 import amrex.space3d as amr
-from impactx import Config, ImpactX, elements
+from impactx import ImpactX, elements
 
 sim = ImpactX()
 
@@ -46,64 +46,8 @@ if amr.ParallelDescriptor.IOProcessor():
     dsx = df_initial["sx"].to_numpy()
     dsy = df_initial["sy"].to_numpy()
     dsz = df_initial["sz"].to_numpy()
-    if not Config.have_gpu:  # initialize using cpu-based PODVectors
-        dx_podv = amr.PODVector_real_std()
-        dy_podv = amr.PODVector_real_std()
-        dt_podv = amr.PODVector_real_std()
-        dpx_podv = amr.PODVector_real_std()
-        dpy_podv = amr.PODVector_real_std()
-        dpt_podv = amr.PODVector_real_std()
-        dw_podv = amr.PODVector_real_std()
-        dsx_podv = amr.PODVector_real_std()
-        dsy_podv = amr.PODVector_real_std()
-        dsz_podv = amr.PODVector_real_std()
-
-    else:  # initialize on device using arena/gpu-based PODVectors
-        dx_podv = amr.PODVector_real_arena()
-        dy_podv = amr.PODVector_real_arena()
-        dt_podv = amr.PODVector_real_arena()
-        dpx_podv = amr.PODVector_real_arena()
-        dpy_podv = amr.PODVector_real_arena()
-        dpt_podv = amr.PODVector_real_arena()
-        dw_podv = amr.PODVector_real_arena()
-        dsx_podv = amr.PODVector_real_arena()
-        dsy_podv = amr.PODVector_real_arena()
-        dsz_podv = amr.PODVector_real_arena()
-
-    for p_dx in dx:
-        dx_podv.push_back(p_dx)
-    for p_dy in dy:
-        dy_podv.push_back(p_dy)
-    for p_dt in dt:
-        dt_podv.push_back(p_dt)
-    for p_dpx in dpx:
-        dpx_podv.push_back(p_dpx)
-    for p_dpy in dpy:
-        dpy_podv.push_back(p_dpy)
-    for p_dpt in dpt:
-        dpt_podv.push_back(p_dpt)
-    for p_dw in dw:
-        dw_podv.push_back(p_dw)
-    for p_dsx in dsx:
-        dsx_podv.push_back(p_dsx)
-    for p_dsy in dsy:
-        dsy_podv.push_back(p_dsy)
-    for p_dsz in dsz:
-        dsz_podv.push_back(p_dsz)
-
     beam.add_n_particles(
-        dx_podv,
-        dy_podv,
-        dt_podv,
-        dpx_podv,
-        dpy_podv,
-        dpt_podv,
-        qm_eev,
-        bunch_charge_C,
-        None,
-        dsx_podv,
-        dsy_podv,
-        dsz_podv,
+        dx, dy, dt, dpx, dpy, dpt, qm_eev, bunch_charge_C, sx=dsx, sy=dsy, sz=dsz
     )
 
 # add beam diagnostics

--- a/examples/spin_tracking/run_exact_quad_spin_scaling.py
+++ b/examples/spin_tracking/run_exact_quad_spin_scaling.py
@@ -9,7 +9,7 @@
 import pandas as pd
 
 import amrex.space3d as amr
-from impactx import Config, ImpactX, elements
+from impactx import ImpactX, elements
 
 sim = ImpactX()
 
@@ -46,64 +46,8 @@ if amr.ParallelDescriptor.IOProcessor():
     dsx = df_initial["sx"].to_numpy()
     dsy = df_initial["sy"].to_numpy()
     dsz = df_initial["sz"].to_numpy()
-    if not Config.have_gpu:  # initialize using cpu-based PODVectors
-        dx_podv = amr.PODVector_real_std()
-        dy_podv = amr.PODVector_real_std()
-        dt_podv = amr.PODVector_real_std()
-        dpx_podv = amr.PODVector_real_std()
-        dpy_podv = amr.PODVector_real_std()
-        dpt_podv = amr.PODVector_real_std()
-        dw_podv = amr.PODVector_real_std()
-        dsx_podv = amr.PODVector_real_std()
-        dsy_podv = amr.PODVector_real_std()
-        dsz_podv = amr.PODVector_real_std()
-
-    else:  # initialize on device using arena/gpu-based PODVectors
-        dx_podv = amr.PODVector_real_arena()
-        dy_podv = amr.PODVector_real_arena()
-        dt_podv = amr.PODVector_real_arena()
-        dpx_podv = amr.PODVector_real_arena()
-        dpy_podv = amr.PODVector_real_arena()
-        dpt_podv = amr.PODVector_real_arena()
-        dw_podv = amr.PODVector_real_arena()
-        dsx_podv = amr.PODVector_real_arena()
-        dsy_podv = amr.PODVector_real_arena()
-        dsz_podv = amr.PODVector_real_arena()
-
-    for p_dx in dx:
-        dx_podv.push_back(p_dx)
-    for p_dy in dy:
-        dy_podv.push_back(p_dy)
-    for p_dt in dt:
-        dt_podv.push_back(p_dt)
-    for p_dpx in dpx:
-        dpx_podv.push_back(p_dpx)
-    for p_dpy in dpy:
-        dpy_podv.push_back(p_dpy)
-    for p_dpt in dpt:
-        dpt_podv.push_back(p_dpt)
-    for p_dw in dw:
-        dw_podv.push_back(p_dw)
-    for p_dsx in dsx:
-        dsx_podv.push_back(p_dsx)
-    for p_dsy in dsy:
-        dsy_podv.push_back(p_dsy)
-    for p_dsz in dsz:
-        dsz_podv.push_back(p_dsz)
-
     beam.add_n_particles(
-        dx_podv,
-        dy_podv,
-        dt_podv,
-        dpx_podv,
-        dpy_podv,
-        dpt_podv,
-        qm_eev,
-        bunch_charge_C,
-        None,
-        dsx_podv,
-        dsy_podv,
-        dsz_podv,
+        dx, dy, dt, dpx, dpy, dpt, qm_eev, bunch_charge_C, sx=dsx, sy=dsy, sz=dsz
     )
 
 # add beam diagnostics

--- a/examples/spin_tracking/run_exact_sbend_spin_scaling.py
+++ b/examples/spin_tracking/run_exact_sbend_spin_scaling.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 
 import amrex.space3d as amr
-from impactx import Config, ImpactX, elements
+from impactx import ImpactX, elements
 
 sim = ImpactX()
 
@@ -47,64 +47,8 @@ if amr.ParallelDescriptor.IOProcessor():
     dsx = df_initial["sx"].to_numpy()
     dsy = df_initial["sy"].to_numpy()
     dsz = df_initial["sz"].to_numpy()
-    if not Config.have_gpu:  # initialize using cpu-based PODVectors
-        dx_podv = amr.PODVector_real_std()
-        dy_podv = amr.PODVector_real_std()
-        dt_podv = amr.PODVector_real_std()
-        dpx_podv = amr.PODVector_real_std()
-        dpy_podv = amr.PODVector_real_std()
-        dpt_podv = amr.PODVector_real_std()
-        dw_podv = amr.PODVector_real_std()
-        dsx_podv = amr.PODVector_real_std()
-        dsy_podv = amr.PODVector_real_std()
-        dsz_podv = amr.PODVector_real_std()
-
-    else:  # initialize on device using arena/gpu-based PODVectors
-        dx_podv = amr.PODVector_real_arena()
-        dy_podv = amr.PODVector_real_arena()
-        dt_podv = amr.PODVector_real_arena()
-        dpx_podv = amr.PODVector_real_arena()
-        dpy_podv = amr.PODVector_real_arena()
-        dpt_podv = amr.PODVector_real_arena()
-        dw_podv = amr.PODVector_real_arena()
-        dsx_podv = amr.PODVector_real_arena()
-        dsy_podv = amr.PODVector_real_arena()
-        dsz_podv = amr.PODVector_real_arena()
-
-    for p_dx in dx:
-        dx_podv.push_back(p_dx)
-    for p_dy in dy:
-        dy_podv.push_back(p_dy)
-    for p_dt in dt:
-        dt_podv.push_back(p_dt)
-    for p_dpx in dpx:
-        dpx_podv.push_back(p_dpx)
-    for p_dpy in dpy:
-        dpy_podv.push_back(p_dpy)
-    for p_dpt in dpt:
-        dpt_podv.push_back(p_dpt)
-    for p_dw in dw:
-        dw_podv.push_back(p_dw)
-    for p_dsx in dsx:
-        dsx_podv.push_back(p_dsx)
-    for p_dsy in dsy:
-        dsy_podv.push_back(p_dsy)
-    for p_dsz in dsz:
-        dsz_podv.push_back(p_dsz)
-
     beam.add_n_particles(
-        dx_podv,
-        dy_podv,
-        dt_podv,
-        dpx_podv,
-        dpy_podv,
-        dpt_podv,
-        qm_eev,
-        bunch_charge_C,
-        None,
-        dsx_podv,
-        dsy_podv,
-        dsz_podv,
+        dx, dy, dt, dpx, dpy, dpt, qm_eev, bunch_charge_C, sx=dsx, sy=dsy, sz=dsz
     )
 
 # add beam diagnostics

--- a/examples/symplectic_integration/run_exact_quad_on_reference.py
+++ b/examples/symplectic_integration/run_exact_quad_on_reference.py
@@ -7,8 +7,7 @@
 # -*- coding: utf-8 -*-
 
 
-import amrex.space3d as amr
-from impactx import Config, ImpactX, elements
+from impactx import ImpactX, elements
 
 sim = ImpactX()
 
@@ -37,37 +36,7 @@ dy = [0.0]
 dpy = [0.0]
 dt = [0.0]
 dpt = [0.0]
-if not Config.have_gpu:  # initialize using cpu-based PODVectors
-    dx_podv = amr.PODVector_real_std()
-    dy_podv = amr.PODVector_real_std()
-    dt_podv = amr.PODVector_real_std()
-    dpx_podv = amr.PODVector_real_std()
-    dpy_podv = amr.PODVector_real_std()
-    dpt_podv = amr.PODVector_real_std()
-else:  # initialize on device using arena/gpu-based PODVectors
-    dx_podv = amr.PODVector_real_arena()
-    dy_podv = amr.PODVector_real_arena()
-    dt_podv = amr.PODVector_real_arena()
-    dpx_podv = amr.PODVector_real_arena()
-    dpy_podv = amr.PODVector_real_arena()
-    dpt_podv = amr.PODVector_real_arena()
-
-for p_dx in dx:
-    dx_podv.push_back(p_dx)
-for p_dy in dy:
-    dy_podv.push_back(p_dy)
-for p_dt in dt:
-    dt_podv.push_back(p_dt)
-for p_dpx in dpx:
-    dpx_podv.push_back(p_dpx)
-for p_dpy in dpy:
-    dpy_podv.push_back(p_dpy)
-for p_dpt in dpt:
-    dpt_podv.push_back(p_dpt)
-
-beam.add_n_particles(
-    dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, bunch_charge_C
-)
+beam.add_n_particles(dx, dy, dt, dpx, dpy, dpt, qm_eev, bunch_charge_C)
 
 # add beam diagnostics
 monitor = elements.BeamMonitor("monitor", backend="h5")

--- a/examples/symplectic_integration/run_sextupole.py
+++ b/examples/symplectic_integration/run_sextupole.py
@@ -8,8 +8,7 @@
 
 import pandas as pd
 
-import amrex.space3d as amr
-from impactx import Config, ImpactX, elements
+from impactx import ImpactX, elements
 
 sim = ImpactX()
 
@@ -39,37 +38,7 @@ dy = df_initial["y"].to_numpy()
 dpy = df_initial["py"].to_numpy()
 dt = df_initial["t"].to_numpy()
 dpt = df_initial["pt"].to_numpy()
-if not Config.have_gpu:  # initialize using cpu-based PODVectors
-    dx_podv = amr.PODVector_real_std()
-    dy_podv = amr.PODVector_real_std()
-    dt_podv = amr.PODVector_real_std()
-    dpx_podv = amr.PODVector_real_std()
-    dpy_podv = amr.PODVector_real_std()
-    dpt_podv = amr.PODVector_real_std()
-else:  # initialize on device using arena/gpu-based PODVectors
-    dx_podv = amr.PODVector_real_arena()
-    dy_podv = amr.PODVector_real_arena()
-    dt_podv = amr.PODVector_real_arena()
-    dpx_podv = amr.PODVector_real_arena()
-    dpy_podv = amr.PODVector_real_arena()
-    dpt_podv = amr.PODVector_real_arena()
-
-for p_dx in dx:
-    dx_podv.push_back(p_dx)
-for p_dy in dy:
-    dy_podv.push_back(p_dy)
-for p_dt in dt:
-    dt_podv.push_back(p_dt)
-for p_dpx in dpx:
-    dpx_podv.push_back(p_dpx)
-for p_dpy in dpy:
-    dpy_podv.push_back(p_dpy)
-for p_dpt in dpt:
-    dpt_podv.push_back(p_dpt)
-
-beam.add_n_particles(
-    dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, bunch_charge_C
-)
+beam.add_n_particles(dx, dy, dt, dpx, dpy, dpt, qm_eev, bunch_charge_C)
 
 # add beam diagnostics
 monitor = elements.BeamMonitor("monitor", backend="h5")

--- a/src/python/ImpactXParticleContainer.cpp
+++ b/src/python/ImpactXParticleContainer.cpp
@@ -79,7 +79,8 @@ void init_impactxparticlecontainer(py::module& m)
              py::arg("keep_mass")=false, py::arg("keep_charge")=false,
              "Empty the container and reset the reference particle"
         )
-        .def("add_n_particles",
+        // internal: there is a high-level Python wrapper that accepts more types
+        .def("_add_n_particles",
              &ImpactXParticleContainer::AddNParticles,
              py::arg("x"), py::arg("y"), py::arg("t"),
              py::arg("px"), py::arg("py"), py::arg("pt"),

--- a/src/python/impactx/extensions/ImpactXParticleContainer.py
+++ b/src/python/impactx/extensions/ImpactXParticleContainer.py
@@ -296,8 +296,81 @@ def ix_beam_moments_history(self):
     return pd.DataFrame(self.beam_moments_history_list())
 
 
+def _as_real_device_vector(arr):
+    """Convert an input into the AMReX real ``DeviceVector`` that
+    ``AddNParticles`` expects, copying the data as needed.
+
+    Accepts ``None`` (passed through), a NumPy or CuPy array (or array-like),
+    or any pyAMReX ``PODVector``. A ``DeviceVector_real`` is passed through
+    unchanged; any other allocator is copied via ``to_device`` (which picks
+    the AMReX copy direction across memory spaces).
+    """
+    if arr is None:
+        return None
+
+    import amrex.space3d as amr
+
+    # already the exact Gpu::DeviceVector type that AddNParticles expects
+    if isinstance(arr, amr.DeviceVector_real):
+        return arr
+    # any other PODVector allocator: copy into a DeviceVector (CuPy-free)
+    if type(arr).__name__.startswith("PODVector_"):
+        return arr.to_device()
+    # CuPy (and other device) arrays expose the CUDA array interface
+    if hasattr(arr, "__cuda_array_interface__"):
+        return amr.DeviceVector_real.from_cupy(arr)
+    # NumPy arrays and array-likes (lists, tuples, ...)
+    return amr.DeviceVector_real.from_numpy(arr)
+
+
+def ix_pc_add_n_particles(
+    self, x, y, t, px, py, pt, qm, bunch_charge=None, w=None, sx=None, sy=None, sz=None
+):
+    """
+    Add new particles to the container for fixed s.
+
+    The coordinate and weight arguments accept NumPy or CuPy arrays (or
+    array-likes), as well as pyAMReX ``PODVector`` objects. Inputs are copied
+    into device-compatible PODVectors as needed.
+
+    Either the total charge (``bunch_charge``) or the weight of each particle
+    (``w``) must be provided.
+
+    Note: This can only be used *after* the grids have been created, i.e. after
+    ``ImpactX.init_grids`` has been called.
+
+    Parameters
+    ----------
+    x, y, t, px, py, pt : array_like
+        Particle positions (x, y, time-of-flight c*t) and momenta.
+    qm : float
+        Charge over mass in 1/eV.
+    bunch_charge : float, optional
+        Total charge within a bunch in C.
+    w : array_like, optional
+        Weight of each particle: how many real particles to represent.
+    sx, sy, sz : array_like, optional
+        Spin components in x, y, z.
+    """
+    return self._add_n_particles(
+        _as_real_device_vector(x),
+        _as_real_device_vector(y),
+        _as_real_device_vector(t),
+        _as_real_device_vector(px),
+        _as_real_device_vector(py),
+        _as_real_device_vector(pt),
+        qm,
+        bunch_charge,
+        _as_real_device_vector(w),
+        _as_real_device_vector(sx),
+        _as_real_device_vector(sy),
+        _as_real_device_vector(sz),
+    )
+
+
 def register_ImpactXParticleContainer_extension(ixpc):
     """ImpactXParticleContainer helper methods"""
     # register member functions for ImpactXParticleContainer
     ixpc.plot_phasespace = ix_pc_plot_mpl_phasespace
     ixpc.beam_moments_history = ix_beam_moments_history
+    ixpc.add_n_particles = ix_pc_add_n_particles

--- a/tests/python/test_dipedge_ref.py
+++ b/tests/python/test_dipedge_ref.py
@@ -10,8 +10,7 @@ import math
 
 import numpy as np
 
-import amrex.space3d as amr
-from impactx import Config, ImpactX, elements
+from impactx import ImpactX, elements
 
 
 def _track_particle_dipedge(modify_ref_part, edge_angle, g, rc):
@@ -42,37 +41,7 @@ def _track_particle_dipedge(modify_ref_part, edge_angle, g, rc):
     dpy = [0.0]
     dt = [0.0]
     dpt = [0.0]
-    if not Config.have_gpu:  # initialize using cpu-based PODVectors
-        dx_podv = amr.PODVector_real_std()
-        dy_podv = amr.PODVector_real_std()
-        dt_podv = amr.PODVector_real_std()
-        dpx_podv = amr.PODVector_real_std()
-        dpy_podv = amr.PODVector_real_std()
-        dpt_podv = amr.PODVector_real_std()
-    else:  # initialize on device using arena/gpu-based PODVectors
-        dx_podv = amr.PODVector_real_arena()
-        dy_podv = amr.PODVector_real_arena()
-        dt_podv = amr.PODVector_real_arena()
-        dpx_podv = amr.PODVector_real_arena()
-        dpy_podv = amr.PODVector_real_arena()
-        dpt_podv = amr.PODVector_real_arena()
-
-    for p_dx in dx:
-        dx_podv.push_back(p_dx)
-    for p_dy in dy:
-        dy_podv.push_back(p_dy)
-    for p_dt in dt:
-        dt_podv.push_back(p_dt)
-    for p_dpx in dpx:
-        dpx_podv.push_back(p_dpx)
-    for p_dpy in dpy:
-        dpy_podv.push_back(p_dpy)
-    for p_dpt in dpt:
-        dpt_podv.push_back(p_dpt)
-
-    beam.add_n_particles(
-        dx_podv, dy_podv, dt_podv, dpx_podv, dpy_podv, dpt_podv, qm_eev, bunch_charge_C
-    )
+    beam.add_n_particles(dx, dy, dt, dpx, dpy, dpt, qm_eev, bunch_charge_C)
 
     # design the accelerator lattice)
     dipedge1 = elements.DipEdge(


### PR DESCRIPTION
Adding particles from Python arrays was quite verbose and boilerplate-heavy.

This simplifies the existing interfaces to directly accept NumPy or CuPy-style arrays.
All examples and tests have been updated.

Canonical example: https://impactx--1488.org.readthedocs.build/en/1488/usage/examples/initialize_from_array/README.html

Tested locally on GPU: all green and the next function signature is backwards compatible with the old one.