### PR TITLE
CI: Reduce CodSpeed Benchmark Noise

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -115,7 +115,10 @@ jobs:
     if: github.event.pull_request.draft == false
     env:
       CMAKE_GENERATOR: Ninja
-      CXXFLAGS: "-Werror -march=x86-64-v3 -mtune=generic"
+      # -falign-functions/-falign-loops pin hot loops to fixed cache-line
+      # boundaries so unrelated edits do not shift their alignment and perturb
+      # the cachegrind cache model (CodSpeed simulation noise).
+      CXXFLAGS: "-Werror -march=x86-64-v3 -mtune=generic -falign-functions=64 -falign-loops=32"
       OMP_NUM_THREADS: 2
     steps:
     - name: system info

--- a/tests/python/test_benchmark_elements.py
+++ b/tests/python/test_benchmark_elements.py
@@ -23,7 +23,7 @@ from impactx import ImpactX, Map6x6, distribution, elements, twiss
 if os.environ.get("IS_CODESPEED_CPU_SIMULATION") == "1":
     # https://codspeed.io/docs/instruments/cpu/index
     rounds = 1
-    npart = 10_000
+    npart = 20_000
 else:
     rounds = 5
     npart = 1_000_000  # increase this to >10M or even 100M to avoid L1/L2/L3 cache effects on some hardware.


### PR DESCRIPTION
The cachegrind cache model is sensitive to code/data layout, so unrelated edits that relink the binary shift hot-loop alignment and perturb simulated cache misses. On the cheapest elements (e.g., drift) this showed up as ~5-6% phantom regressions in cache modeling with identical instruction counts (e.g., from #1488).

Lower this layout-driven floor on the CodSpeed simulation:

- Double the simulated particle count (10k -> 20k) to amplify the steady-state push relative to the roughly fixed cache-model floor.
- Pin hot loops to fixed cache-line boundaries via `-falign-functions` and `-falign-loops` so unrelated edits no longer move their alignment.