### PR TITLE
2.5D Gaussian SC: Long Scale Default & Name

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1068,9 +1068,11 @@ See there ``nslice`` option on lattice elements for slicing.
 
       Initial integral region to avoid divergence of integrand at 0.
 
-    * ``algo.space_charge.gauss_pipe_radius`` (``float``, default: ``1.0`` m)
+    * ``algo.space_charge.gauss_long_scale`` (``float``, default: ``1.0`` m)
 
-      Pipe radius parameter for the Gauss2p5D space charge model.
+      Longitudinal space charge scale for the Gauss2p5D space charge model.
+      This is an approximation that only influences the longitudinal momentum (``pt``) kick.
+      A typical value when comparing to a 3D model is :math:`6 \times \gamma \times \sigma_z`.
 
     * ``algo.space_charge.gauss_charge_z_bins`` (``int``, default: ``129``)
 

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1068,11 +1068,13 @@ See there ``nslice`` option on lattice elements for slicing.
 
       Initial integral region to avoid divergence of integrand at 0.
 
-    * ``algo.space_charge.gauss_long_scale`` (``float``, default: ``1.0`` m)
+    * ``algo.space_charge.gauss_long_scale`` (``float``, default: in-situ :math:`6 \cdot \gamma \cdot \sigma_z`)
 
       Longitudinal space charge scale for the Gauss2p5D space charge model.
       This is an approximation that only influences the longitudinal momentum (``pt``) kick.
-      A typical value when comparing to a 3D model is :math:`6 \times \gamma \times \sigma_z`.
+      If not set, it defaults to :math:`6 \cdot \gamma \cdot \sigma_z`, estimated in-situ from the
+      current reduced beam characteristics (with :math:`\sigma_z` the RMS bunch length), which is a
+      typical value when comparing to a 3D model.
 
     * ``algo.space_charge.gauss_charge_z_bins`` (``int``, default: ``129``)
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -103,9 +103,11 @@ Collective Effects & Overall Simulation Parameters
 
    .. py:property:: space_charge_gauss_long_scale
 
-      Longitudinal space charge scale for the Gauss2p5D space charge model (default: ``1.0`` m).
+      Longitudinal space charge scale for the Gauss2p5D space charge model.
       This is an approximation that only influences the longitudinal momentum (``pt``) kick.
-      A typical value when comparing to a 3D model is :math:`6 \times \gamma \times \sigma_z`.
+      If not set, it defaults to :math:`6 \cdot \gamma \cdot \sigma_z`, estimated in-situ from the
+      current reduced beam characteristics (with :math:`\sigma_z` the RMS bunch length), which is a
+      typical value when comparing to a 3D model.
 
    .. py:property:: space_charge_num_longitudinal_bins
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -101,9 +101,11 @@ Collective Effects & Overall Simulation Parameters
 
       Number of bins for longitudinal charge density deposition (default: ``129``).  Used by the Gauss2p5D space charge model.
 
-   .. py:property:: space_charge_gauss_pipe_radius
+   .. py:property:: space_charge_gauss_long_scale
 
-      Pipe radius parameter for the Gauss2p5D space charge model (default: ``1.0`` m).
+      Longitudinal space charge scale for the Gauss2p5D space charge model (default: ``1.0`` m).
+      This is an approximation that only influences the longitudinal momentum (``pt``) kick.
+      A typical value when comparing to a 3D model is :math:`6 \times \gamma \times \sigma_z`.
 
    .. py:property:: space_charge_num_longitudinal_bins
 

--- a/src/particles/spacecharge/Gauss2p5dPush.cpp
+++ b/src/particles/spacecharge/Gauss2p5dPush.cpp
@@ -160,6 +160,7 @@ namespace impactx::particles::spacecharge
         // Standard deviation of the particle positions (speed of light times time delay for t) (unit: meter)
         amrex::ParticleReal const sigx = rbc.at("sig_x");
         amrex::ParticleReal const sigy = rbc.at("sig_y");
+        amrex::ParticleReal const sigt = rbc.at("sig_t");
 
         // physical constants and reference quantities
         amrex::ParticleReal const c0_SI = 2.99792458e8_prt;  // TODO move out
@@ -173,11 +174,13 @@ namespace impactx::particles::spacecharge
 
         int nint = 101;
         amrex::Real delta = 0.01_rt;
-        amrex::Real long_scale = 1.0_rt;
+        amrex::Real long_scale = 6.0_rt * gamma * sigt;
         amrex::ParmParse pp_algo("algo.space_charge");
         pp_algo.queryAddWithParser("gauss_nint", nint);
         pp_algo.queryAddWithParser("gauss_taylor_delta", delta);
-        pp_algo.queryAddWithParser("gauss_long_scale", long_scale);
+        // note: intentionall w/o add because `sigt` is dynamic!
+        //       add would ignore the new beam size in later sim steps
+        pp_algo.queryWithParser("gauss_long_scale", long_scale);
 
         int tp5d_bins = 129;
         pp_algo.queryAddWithParser("gauss_charge_z_bins", tp5d_bins);

--- a/src/particles/spacecharge/Gauss2p5dPush.cpp
+++ b/src/particles/spacecharge/Gauss2p5dPush.cpp
@@ -173,11 +173,11 @@ namespace impactx::particles::spacecharge
 
         int nint = 101;
         amrex::Real delta = 0.01_rt;
-        amrex::Real pipe_radius = 1.0_rt;
+        amrex::Real long_scale = 1.0_rt;
         amrex::ParmParse pp_algo("algo.space_charge");
         pp_algo.queryAddWithParser("gauss_nint", nint);
         pp_algo.queryAddWithParser("gauss_taylor_delta", delta);
-        pp_algo.queryAddWithParser("gauss_pipe_radius", pipe_radius);
+        pp_algo.queryAddWithParser("gauss_long_scale", long_scale);
 
         int tp5d_bins = 129;
         pp_algo.queryAddWithParser("gauss_charge_z_bins", tp5d_bins);
@@ -221,7 +221,7 @@ namespace impactx::particles::spacecharge
         amrex::ParticleReal const pz_push_const =
             log2n
             + 0.577216_prt
-            - 2.0_prt * std::log((sigx + sigy)/pipe_radius/2.0_prt);
+            - 2.0_prt * std::log((sigx + sigy)/long_scale/2.0_prt);
 
         // loop over refinement levels
         int const nLevel = pc.finestLevel();

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -358,18 +358,20 @@ void init_ImpactX (py::module& m)
             },
             "Initial region for computing the integrals (default: ``0.01``)."
         )
-        .def_property("space_charge_gauss_pipe_radius",
+        .def_property("space_charge_gauss_long_scale",
             [](ImpactX & /* ix */) {
-                return detail::get_or_throw<int>("algo.space_charge", "gauss_pipe_radius");
+                return detail::get_or_throw<amrex::Real>("algo.space_charge", "gauss_long_scale");
             },
-            [](ImpactX & /* ix */, amrex::Real const gauss_pipe_radius) {
-                if (gauss_pipe_radius < 0) {
-                    throw std::runtime_error("space_charge_pipe_radius must be strictly positive");
+            [](ImpactX & /* ix */, amrex::Real const gauss_long_scale) {
+                if (gauss_long_scale < 0) {
+                    throw std::runtime_error("space_charge_gauss_long_scale must be strictly positive");
                 }
                 amrex::ParmParse pp_algo("algo.space_charge");
-                pp_algo.add("gauss_pipe_radius", gauss_pipe_radius);
+                pp_algo.add("gauss_long_scale", gauss_long_scale);
             },
-            "Pipe radius parameter for the Gauss2p5D space charge model (default: ``1.0 m``)."
+            "Longitudinal space charge scale for the Gauss2p5D space charge model (default: ``1.0 m``). "
+            "Approximation affecting only the longitudinal momentum (``pt``) kick; a typical value when "
+            "comparing to a 3D model is ``6 * gamma * sigma_z``."
         )
         .def_property("space_charge_num_longitudinal_bins",
             [](ImpactX & /* ix */) {

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -369,9 +369,10 @@ void init_ImpactX (py::module& m)
                 amrex::ParmParse pp_algo("algo.space_charge");
                 pp_algo.add("gauss_long_scale", gauss_long_scale);
             },
-            "Longitudinal space charge scale for the Gauss2p5D space charge model (default: ``1.0 m``). "
-            "Approximation affecting only the longitudinal momentum (``pt``) kick; a typical value when "
-            "comparing to a 3D model is ``6 * gamma * sigma_z``."
+            "Longitudinal space charge scale for the Gauss2p5D space charge model. "
+            "Approximation affecting only the longitudinal momentum (``pt``) kick. "
+            "If not set, it defaults to ``6 * gamma * sigma_z``, estimated in-situ from the current "
+            "reduced beam characteristics, which is a typical value when comparing to a 3D model."
         )
         .def_property("space_charge_num_longitudinal_bins",
             [](ImpactX & /* ix */) {


### PR DESCRIPTION
Rename options in #1473 after discussion in our weekly meeting ([summary](https://github.com/BLAST-ImpactX/impactx/pull/1473#discussion_r3358751371)).
Avoid confusion with transverse SC dynamics (which is open BC).

Default to $$6 \cdot \gamma \cdot \sigma_z$$, which is a good empirical value by @qianglbl for comparisons to 3D.