### PR TITLE
Spin-Tracking for Apertures

### DIFF
--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -16,6 +16,7 @@
 #include "mixin/beamoptic.H"
 #include "mixin/thin.H"
 #include "mixin/lineartransport.H"
+#include "mixin/spintransport.H"
 #include "mixin/named.H"
 #include "mixin/nofinalize.H"
 
@@ -36,6 +37,7 @@ namespace impactx::elements
       public mixin::LinearTransport<Aperture>,
       public mixin::Thin,
       public mixin::Alignment,
+      public mixin::SpinTransport,
       public mixin::NoFinalize,
       public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
     {
@@ -218,6 +220,44 @@ namespace impactx::elements
 
         /** This pushes the reference particle. */
         using Thin::operator();
+
+        /** This operator pushes the particle spin.
+         *
+         * An aperture is field-free, so the spin is unaffected.
+         *
+         * @param x particle position in x
+         * @param y particle position in y
+         * @param t particle position in t
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param sx particle spin x-component (unused)
+         * @param sy particle spin y-component (unused)
+         * @param sz particle spin z-component (unused)
+         * @param idcpu particle global index
+         * @param refpart reference particle (unused)
+         */
+        template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void spin_and_phasespace_push (
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
+            T_IdCpu & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
+            // spin is unaffected
+
+            // phase space push
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+        }
 
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();

--- a/src/elements/PolygonAperture.H
+++ b/src/elements/PolygonAperture.H
@@ -18,6 +18,7 @@
 #include "mixin/lineartransport.H"
 #include "mixin/named.H"
 #include "mixin/nofinalize.H"
+#include "mixin/spintransport.H"
 #include "mixin/thin.H"
 #include "mixin/TrackedVector.H"
 
@@ -55,6 +56,7 @@ namespace impactx::elements
       public mixin::LinearTransport<PolygonAperture>,
       public mixin::Thin,
       public mixin::Alignment,
+      public mixin::SpinTransport,
       public mixin::NoFinalize
       // public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
     {
@@ -270,6 +272,44 @@ namespace impactx::elements
 
         /** This pushes the reference particle. */
         using Thin::operator();
+
+        /** This operator pushes the particle spin.
+         *
+         * An aperture is field-free, so the spin is unaffected.
+         *
+         * @param x particle position in x
+         * @param y particle position in y
+         * @param t particle position in t
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param sx particle spin x-component (unused)
+         * @param sy particle spin y-component (unused)
+         * @param sz particle spin z-component (unused)
+         * @param idcpu particle global index
+         * @param refpart reference particle (unused)
+         */
+        template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void spin_and_phasespace_push (
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
+            T_IdCpu & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
+            // spin is unaffected
+
+            // phase space push
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+        }
 
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();

--- a/tests/python/test_benchmark_elements.py
+++ b/tests/python/test_benchmark_elements.py
@@ -126,6 +126,7 @@ def pc_setup(sim):
     return (beam,), {}
 
 
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_Aperture(benchmark, sim):
     el = elements.Aperture(
         name="collimator", aperture_x=4.0e-5, aperture_y=4.0e-5, shape="rectangular"
@@ -281,6 +282,29 @@ def test_NonlinearLens(benchmark, sim):
 
 def test_PlaneXYRot(benchmark, sim):
     el = elements.PlaneXYRot(name="rotation1", angle=90.0)
+    benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)
+
+
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
+def test_PolygonAperture(benchmark, sim):
+    # cross-shaped polygon, scaled from examples/polygon_aperture to the
+    # ~3.2e-5 m rms beam size of the sim fixture; min_radius2=0 so that
+    # every particle exercises the full polygon winding computation
+    vertices_x = [
+        float(u)
+        for u in "2e-5 2e-5 -2e-5 -2e-5 -6e-5 -6e-5 -2e-5 -2e-5 2e-5 2e-5 6e-5 6e-5 2e-5".split()
+    ]
+    vertices_y = [
+        float(u)
+        for u in "2e-5 6e-5 6e-5 2e-5 2e-5 -2e-5 -2e-5 -6e-5 -6e-5 -2e-5 -2e-5 2e-5 2e-5".split()
+    ]
+    el = elements.PolygonAperture(
+        name="collimator2",
+        vertices_x=vertices_x,
+        vertices_y=vertices_y,
+        min_radius2=0.0,
+        action="transmit",
+    )
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)
 
 


### PR DESCRIPTION
Our thin apertures do not affect spin tracking. Expose them to our spin tracking loops by forwarding directly to the phase space push.