### PR TITLE
Catch Missing Gyromagnetic Anomaly

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1286,6 +1286,8 @@ Currently, the implementation of spin tracking is a work in progress, and this f
 
   Whether to track particle spin.
 
+  Spin tracking uses the gyromagnetic anomaly of the reference particle, which is set together with the particle species (see ``<beam>.particle``).
+
 
 .. _running-cpp-parameters-parser:
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -242,6 +242,9 @@ Collective Effects & Overall Simulation Parameters
       Whether to track particle spin.
       Currently, the implementation of spin tracking is a work in progress, and this feature is not yet supported.
 
+      Spin tracking uses the gyromagnetic anomaly of the reference particle.
+      Set it via ``RefPart.set_species()`` or ``RefPart.set_gyromagnetic_anomaly()``.
+
    .. py:property:: diagnostics
 
       Enable (``True``) or disable (``False``) diagnostics generally (default: ``True``).

--- a/src/tracking/particles.cpp
+++ b/src/tracking/particles.cpp
@@ -26,6 +26,7 @@
 #include <AMReX_Print.H>
 
 #include <memory>
+#include <stdexcept>
 
 
 namespace impactx
@@ -94,6 +95,15 @@ namespace impactx
         pp_algo.query("isr", isr);
         bool spin = false;
         pp_algo.query("spin", spin);
+
+        if (spin && pc->GetRefParticle().gyromagnetic_anomaly == 0.0) {
+            throw std::runtime_error(
+                "algo.spin: Spin tracking is enabled, but the gyromagnetic "
+                "anomaly of the reference particle is zero. Either disable spin "
+                "tracking, set the reference particle species or "
+                "set the value of the gyromagnetic anomaly on it."
+            );
+        }
 
         if (verbose > 0) {
             amrex::Print() << " CSR effects: " << csr << "\n";


### PR DESCRIPTION
With the Python APIs, it is possible to forget to set the gyromagnetic anomaly. The default is zero, which no physical particle has.
This now raises an error and documents clearner. All new examples use the `set_species` API on the reference particle, so this should not cause too many surprises (and if triggered, it advises cleanly).

First seen by Carl Lindstroem.