### PR TITLE
Integrators: With RefPart

### DIFF
--- a/src/elements/ChrDrift.H
+++ b/src/elements/ChrDrift.H
@@ -101,9 +101,9 @@ namespace impactx::elements
 
             // access reference particle values to find beta, gamma
             m_beta = refpart.beta();
-            m_gamma = refpart.gamma();
+            amrex::ParticleReal const gamma = refpart.gamma();
 
-            m_const1 = 1_prt / (2_prt * powi<3>(m_beta) * powi<2>(m_gamma));
+            m_const1 = 1_prt / (2_prt * powi<3>(m_beta) * powi<2>(gamma));
         }
 
         /** This is a chrdrift functor, so that a variable of this type can be used like a chrdrift function.
@@ -115,7 +115,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -127,7 +127,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -156,7 +156,7 @@ namespace impactx::elements
             // the corresponding symplectic update to t
             T_Real term = 2_prt * powi<2>(pt) + powi<2>(px) + powi<2>(py);
             term = 2_prt - 4_prt*m_beta*pt + powi<2>(m_beta)*term;
-            term = -2_prt + powi<2>(m_gamma)*term;
+            term = -2_prt + powi<2>(refpart.gamma())*term;
             term = (-1_prt+m_beta*pt)*term;
             term = term * m_const1;
             t = tout - m_slice_ds * (1_prt / m_beta + term * powi<3>(idelta1));
@@ -280,7 +280,6 @@ namespace impactx::elements
         // see: compute_constants() to refresh
         amrex::ParticleReal m_slice_ds;  //! m_ds / nslice();
         amrex::ParticleReal m_beta;
-        amrex::ParticleReal m_gamma;
         amrex::ParticleReal m_const1;
     };
 

--- a/src/elements/ChrPlasmaLens.H
+++ b/src/elements/ChrPlasmaLens.H
@@ -110,13 +110,13 @@ namespace impactx::elements
 
             // access reference particle values to find beta and gamma
             m_beta = refpart.beta();
-            m_gamma = refpart.gamma();
+            amrex::ParticleReal const gamma = refpart.gamma();
 
             // normalize focusing strength units to MAD-X convention if needed
             m_g = m_unit == 1 ? m_k / refpart.rigidity_Tm() : m_k;
 
             //For m_g=0 time propagation
-            m_const1 = 1_prt / (2_prt * powi<3>(m_beta) * powi<2>(m_gamma));
+            m_const1 = 1_prt / (2_prt * powi<3>(m_beta) * powi<2>(gamma));
         }
 
         /** This is a chrplasmalens functor, so that a variable of this type can be used like a chrplasmalens function.
@@ -128,7 +128,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -140,7 +140,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -236,7 +236,7 @@ namespace impactx::elements
                 // avoiding division by 0
                 T_Real term = 2_prt * powi<2>(pt) + powi<2>(px) + powi<2>(py);
                 term = 2_prt - 4_prt * m_beta * pt + powi<2>(m_beta) * term;
-                term = -2_prt + powi<2>(m_gamma)*term;
+                term = -2_prt + powi<2>(refpart.gamma())*term;
                 term = (-1_prt + m_beta * pt) * term;
                 term = term * m_const1;
                 tout = t - m_slice_ds * (1_prt / m_beta + term / powi<3>(delta1));
@@ -303,7 +303,7 @@ namespace impactx::elements
          * @param sy particle spin y-component
          * @param sz particle spin z-component
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -335,7 +335,7 @@ namespace impactx::elements
             T_Real const inv_delta1 = 1_prt / delta1;
 
             // compute particle relativistic gamma
-            T_Real const gamma = m_gamma * (1_prt - m_beta*pt);
+            T_Real const gamma = refpart.gamma() * (1_prt - m_beta*pt);
             T_Real const gyro_const = 1_prt + refpart.gyromagnetic_anomaly * gamma;
 
             // compute phase advance per unit length in s (in rad/m)
@@ -439,7 +439,6 @@ namespace impactx::elements
         // see: compute_constants() to refresh
         amrex::ParticleReal m_slice_ds;  //! m_ds / nslice();
         amrex::ParticleReal m_beta;
-        amrex::ParticleReal m_gamma;
         amrex::ParticleReal m_g;
         amrex::ParticleReal m_const1;
     };

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -113,12 +113,12 @@ namespace impactx::elements
 
             // access reference particle values to find beta and gamma
             m_beta = refpart.beta();
-            m_gamma = refpart.gamma();
+            amrex::ParticleReal const gamma = refpart.gamma();
 
             // normalize quad units to MAD-X convention if needed
             m_g = m_unit == 1 ? m_k / refpart.rigidity_Tm() : m_k;
 
-            m_const1 = 1_prt / (2_prt * powi<3>(m_beta) * powi<2>(m_gamma));
+            m_const1 = 1_prt / (2_prt * powi<3>(m_beta) * powi<2>(gamma));
         }
 
         /** This is a chrquad functor, so that a variable of this type can be used like a chrquad function.
@@ -130,7 +130,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -142,7 +142,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -216,7 +216,7 @@ namespace impactx::elements
                // the corresponding symplectic update to t (zero strength = drift)
                T_Real term = 2_prt * powi<2>(pt) + powi<2>(px) + powi<2>(py);
                term = 2_prt - 4_prt * m_beta * pt + powi<2>(m_beta) * term;
-               term = -2_prt + powi<2>(m_gamma)*term;
+               term = -2_prt + powi<2>(refpart.gamma())*term;
                term = (-1_prt + m_beta * pt) * term;
                term = term * m_const1;
                t = tout - m_slice_ds * (1_prt / m_beta + term / powi<3>(delta1));
@@ -298,7 +298,7 @@ namespace impactx::elements
          * @param sy particle spin y-component
          * @param sz particle spin z-component
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -313,7 +313,7 @@ namespace impactx::elements
             [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
             [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
             [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -330,7 +330,7 @@ namespace impactx::elements
             T_Real const inv_delta1 = 1_prt / delta1;
 
             // compute particle relativistic gamma
-            T_Real const gamma = m_gamma * (1_prt - m_beta*pt);
+            T_Real const gamma = refpart.gamma() * (1_prt - m_beta*pt);
             T_Real const gyro_const = 1_prt + refpart.gyromagnetic_anomaly * gamma;
 
             // compute phase advance per unit length in s (in rad/m)
@@ -449,7 +449,6 @@ namespace impactx::elements
         // see: compute_constants() to refresh
         amrex::ParticleReal m_slice_ds;  //! m_ds / nslice();
         amrex::ParticleReal m_beta;
-        amrex::ParticleReal m_gamma;
         amrex::ParticleReal m_g;
         amrex::ParticleReal m_const1;
     };

--- a/src/elements/ExactCFbend.H
+++ b/src/elements/ExactCFbend.H
@@ -164,11 +164,6 @@ namespace impactx::elements
 
             // arc length and angle of the current slice
             m_slice_ds = m_ds / nslice();
-
-            // additional constants needed for spin push
-            m_gamma_ref = refpart.gamma();
-            m_gyro_anomaly = refpart.gyromagnetic_anomaly;
-
         }
 
         /** This is an ExactCFbend functor, so that a variable of this type can be used like an ExactCFbend function.
@@ -182,7 +177,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
@@ -193,7 +188,7 @@ namespace impactx::elements
             amrex::ParticleReal & AMREX_RESTRICT py,
             amrex::ParticleReal & AMREX_RESTRICT pt,
             [[maybe_unused]] uint64_t const & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -210,11 +205,11 @@ namespace impactx::elements
 
             // call integrator to advance through slice (int_order = 2 or 4, otherwise default 2)
             if (m_int_order == 2) {
-                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);
+                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,refpart,*this);
             } else if (m_int_order == 4) {
-                integrators::symp4_integrate_particle(particle,zin,zout,nsteps,*this);
+                integrators::symp4_integrate_particle(particle,zin,zout,nsteps,refpart,*this);
             } else if (m_int_order == 6) {
-                integrators::symp6_integrate_particle(particle,zin,zout,nsteps,*this);
+                integrators::symp6_integrate_particle(particle,zin,zout,nsteps,refpart,*this);
             }
 
             // assign updated values
@@ -233,11 +228,13 @@ namespace impactx::elements
          * @param tau Map step size in m
          * @param[in,out] particle particle phase space 6-vector
          * @param[in,out] zeval Longitudinal on-axis location in m
+         * @param[in] refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void map1 (amrex::ParticleReal const tau,
                    amrex::SmallVector<amrex::ParticleReal, 6, 1> & particle,
-                   amrex::ParticleReal & zeval) const
+                   amrex::ParticleReal & zeval,
+                   [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using namespace amrex::Math;  // for powi
@@ -334,11 +331,13 @@ namespace impactx::elements
          * @param tau Map step size in m
          * @param[in,out] particle particle phase space 6-vector
          * @param[in,out] zeval Longitudinal on-axis location in m
+         * @param[in] refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void map2 (amrex::ParticleReal const tau,
                    amrex::SmallVector<amrex::ParticleReal, 6, 1> & particle,
-                   amrex::ParticleReal & zeval) const
+                   amrex::ParticleReal & zeval,
+                   [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using namespace amrex::Math;  // for powi
@@ -441,17 +440,23 @@ namespace impactx::elements
          * @param[in,out] particle particle phase space 6-vector
          * @param[in,out] particle_spin particle spin 3-vector
          * @param[in,out] zeval Longitudinal on-axis location in m
+         * @param[in] refpart reference particle
          */
         template<typename T_Real>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void map3 (amrex::ParticleReal const tau,
                    amrex::SmallVector<T_Real, 6, 1> & particle,
                    amrex::SmallVector<T_Real, 3, 1> & particle_spin,
-                   amrex::ParticleReal & zeval) const
+                   amrex::ParticleReal & zeval,
+                   RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using namespace std; // for cmath(float)
             using amrex::Math::powi;
+
+            // reference particle relativistic factors
+            amrex::ParticleReal const gamma_ref = refpart.gamma();
+            amrex::ParticleReal const gyro_anomaly = refpart.gyromagnetic_anomaly;
 
             // initialize the three components of the axis-angle vector
             T_Real lambdax = 0_prt;
@@ -538,8 +543,8 @@ namespace impactx::elements
 
             // Scaling magnetic field to units used in the T-BMT representation (e.g. q*B/mc).
 
-            Bx = Bx * m_beta * m_gamma_ref / rho;
-            By = By * m_beta * m_gamma_ref / rho;
+            Bx = Bx * m_beta * gamma_ref / rho;
+            By = By * m_beta * gamma_ref / rho;
 
             // Electric field normalized by q/mc^2:
             T_Real const Ex = 0.0_prt;
@@ -550,7 +555,7 @@ namespace impactx::elements
             T_Real const Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
             T_Real const iPnorm = 1_prt/Pnorm;
             T_Real const Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
-            T_Real const gamma = m_gamma_ref * (1_prt - pt*m_beta);
+            T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
             T_Real const ux = px * iPnorm;
             T_Real const uy = py * iPnorm;
             T_Real const uz = Ps * iPnorm;
@@ -559,7 +564,7 @@ namespace impactx::elements
             amrex::ParticleReal const h = 1_prt/m_rc;
 
             // Evaluation of the full Thomas-BMT precession vector.
-            tbmt_precession_vector(x,ux,uy,uz,gamma,h,m_gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
 
             // Generator of the spin rotation for a single step
             lambdax *= tau;
@@ -731,7 +736,7 @@ namespace impactx::elements
          * @param[in,out] sy particle spin y-component
          * @param[in,out] sz particle spin z-component
          * @param[in,out] idcpu particle global index (unused)
-         * @param[in] refpart reference particle (unused)
+         * @param[in] refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -746,7 +751,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
             [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -767,7 +772,7 @@ namespace impactx::elements
             };
 
             // call integrator to advance through slice
-            integrators::symp_integrate_particle_spin(particle,particle_spin,zin,zout,nsteps,m_int_order,*this);
+            integrators::symp_integrate_particle_spin(particle,particle_spin,zin,zout,nsteps,m_int_order,refpart,*this);
 
             // assign updated values
             x = particle(1);
@@ -806,8 +811,6 @@ namespace impactx::elements
         amrex::ParticleReal m_ibeta;          //! 1 / m_beta
         amrex::ParticleReal m_brho;           //! magnetic ridigity in T-m
         amrex::ParticleReal m_rc;             //! magnet radius of curvature
-        amrex::ParticleReal m_gamma_ref;      //! relativistic gamma
-        amrex::ParticleReal m_gyro_anomaly;   //! gyromagnetic anomaly
     };
 
 } // namespace impactx

--- a/src/elements/ExactMultipole.H
+++ b/src/elements/ExactMultipole.H
@@ -163,11 +163,6 @@ namespace impactx::elements
             m_beta = refpart.beta();
             m_ibeta = 1_prt / m_beta;
             m_brho = refpart.rigidity_Tm();
-
-            // additional constants needed for spin push
-            m_gamma_ref = refpart.gamma();
-            m_gyro_anomaly = refpart.gyromagnetic_anomaly;
-
         }
 
         /** This is a Multipole functor, so that a variable of this type can be used like a Multipole function.
@@ -181,7 +176,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -193,7 +188,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -214,13 +209,13 @@ namespace impactx::elements
 
             // call integrator to advance through slice (int_order = 2 or 4, otherwise default 2)
             if (m_int_order == 2) {
-                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);
+                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,refpart,*this);
             } else if (m_int_order == 4) {
-                integrators::symp4_integrate_particle(particle,zin,zout,nsteps,*this);
+                integrators::symp4_integrate_particle(particle,zin,zout,nsteps,refpart,*this);
             } else if (m_int_order == 6) {
-                integrators::symp6_integrate_particle(particle,zin,zout,nsteps,*this);
+                integrators::symp6_integrate_particle(particle,zin,zout,nsteps,refpart,*this);
             } else {
-                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);
+                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,refpart,*this);
             }
 
             // assign updated values
@@ -239,12 +234,14 @@ namespace impactx::elements
          * @param tau Map step size in m
          * @param[in,out] particle particle phase space 6-vector
          * @param[in,out] zeval Longitudinal on-axis location in m
+         * @param[in] refpart reference particle
          */
         template<typename T_Real>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void map1 (amrex::ParticleReal const tau,
                    amrex::SmallVector<T_Real, 6, 1> & particle,
-                   amrex::ParticleReal & zeval) const
+                   amrex::ParticleReal & zeval,
+                   [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
@@ -299,12 +296,14 @@ namespace impactx::elements
          * @param tau Map step size in m
          * @param[in,out] particle particle phase space 6-vector
          * @param[in,out] zeval Longitudinal on-axis location in m
+         * @param[in] refpart reference particle
          */
         template<typename T_Real>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void map2 (amrex::ParticleReal const tau,
                    amrex::SmallVector<T_Real, 6, 1> & particle,
-                   amrex::ParticleReal & zeval) const
+                   amrex::ParticleReal & zeval,
+                   [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using namespace std; // for cmath(float)
@@ -383,17 +382,23 @@ namespace impactx::elements
          * @param[in,out] particle particle phase space 6-vector
          * @param[in,out] particle_spin particle spin 3-vector
          * @param[in,out] zeval Longitudinal on-axis location in m
+         * @param[in] refpart reference particle
          */
         template<typename T_Real>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void map3 (amrex::ParticleReal const tau,
                    amrex::SmallVector<T_Real, 6, 1> & particle,
                    amrex::SmallVector<T_Real, 3, 1> & particle_spin,
-                   amrex::ParticleReal & zeval) const
+                   amrex::ParticleReal & zeval,
+                   RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using namespace std; // for cmath(float)
             using amrex::Math::powi;
+
+            // reference particle relativistic factors
+            amrex::ParticleReal const gamma_ref = refpart.gamma();
+            amrex::ParticleReal const gyro_anomaly = refpart.gyromagnetic_anomaly;
 
             // initialize the three components of the axis-angle vector
             T_Real lambdax = 0_prt;
@@ -441,8 +446,8 @@ namespace impactx::elements
                // multipole contribution to magnetic field normalized by q/mc:
                Complex alpha(knormal_value, kskew_value);
                Complex kick = amrex::pow(zeta, m) * alpha;
-               Bx += kick.m_imag / factorial * m_beta * m_gamma_ref;
-               By += kick.m_real / factorial * m_beta * m_gamma_ref;
+               Bx += kick.m_imag / factorial * m_beta * gamma_ref;
+               By += kick.m_real / factorial * m_beta * gamma_ref;
 
                factorial *= m+1;
 
@@ -457,7 +462,7 @@ namespace impactx::elements
             T_Real const Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
             T_Real const iPnorm = 1_prt/Pnorm;
             T_Real const Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
-            T_Real const gamma = m_gamma_ref * (1_prt - pt*m_beta);
+            T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
             T_Real const ux = px * iPnorm;
             T_Real const uy = py * iPnorm;
             T_Real const uz = Ps * iPnorm;
@@ -466,7 +471,7 @@ namespace impactx::elements
             amrex::ParticleReal const h = 0.0_prt;
 
             // Evaluation of the full Thomas-BMT precession vector.
-            tbmt_precession_vector(x,ux,uy,uz,gamma,h,m_gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
 
             // Generator of the spin rotation for a single step
             lambdax *= tau;
@@ -613,7 +618,7 @@ namespace impactx::elements
          * @param[in,out] sy particle spin y-component
          * @param[in,out] sz particle spin z-component
          * @param[in,out] idcpu particle global index
-         * @param[in] refpart reference particle (unused)
+         * @param[in] refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -628,7 +633,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
             [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -649,7 +654,7 @@ namespace impactx::elements
             };
 
             // call integrator to advance through slice
-            integrators::symp_integrate_particle_spin(particle,particle_spin,zin,zout,nsteps,m_int_order,*this);
+            integrators::symp_integrate_particle_spin(particle,particle_spin,zin,zout,nsteps,m_int_order,refpart,*this);
 
             // assign updated values
             x = particle(1);
@@ -687,8 +692,6 @@ namespace impactx::elements
         amrex::ParticleReal m_beta;           //! beta
         amrex::ParticleReal m_ibeta;          //! 1 / m_beta
         amrex::ParticleReal m_brho;           //! magnetic ridigity in T-m
-        amrex::ParticleReal m_gamma_ref;      //! relativistic gamma
-        amrex::ParticleReal m_gyro_anomaly;   //! gyromagnetic anomaly
     };
 
 } // namespace impactx

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -129,10 +129,6 @@ namespace impactx::elements
 
             // compute phase advance per unit length in s (in rad/m)
             m_omega = std::sqrt(std::abs(m_g));
-
-            // additional constants needed for spin push
-            m_gamma_ref = refpart.gamma();
-            m_gyro_anomaly = refpart.gyromagnetic_anomaly;
         }
 
         /** This is a quad functor, so that a variable of this type can be used like a quad function.
@@ -146,7 +142,7 @@ namespace impactx::elements
          * @param py particle momentum in y
          * @param pt particle momentum in t
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -158,7 +154,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -175,13 +171,13 @@ namespace impactx::elements
 
             // call integrator to advance through slice (int_order = 2 or 4, otherwise default 2)
             if (m_int_order == 2) {
-                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);
+                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,refpart,*this);
             } else if (m_int_order == 4) {
-                integrators::symp4_integrate_particle(particle,zin,zout,nsteps,*this);
+                integrators::symp4_integrate_particle(particle,zin,zout,nsteps,refpart,*this);
             } else if (m_int_order == 6) {
-                integrators::symp6_integrate_particle(particle,zin,zout,nsteps,*this);
+                integrators::symp6_integrate_particle(particle,zin,zout,nsteps,refpart,*this);
             } else {
-                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,*this);
+                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,refpart,*this);
             }
 
             // assign updated values
@@ -201,12 +197,14 @@ namespace impactx::elements
          * @param tau Map step size in m
          * @param[in,out] particle particle phase space 6-vector
          * @param[in,out] zeval Longitudinal on-axis location in m
+         * @param[in] refpart reference particle
          */
         template<typename T_Real>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void map1 (amrex::ParticleReal const tau,
                    amrex::SmallVector<T_Real, 6, 1> & particle,
-                   amrex::ParticleReal & zeval) const
+                   amrex::ParticleReal & zeval,
+                   [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using namespace std; // for cmath(float)
@@ -281,12 +279,14 @@ namespace impactx::elements
          * @param tau Map step size in m
          * @param[in,out] particle particle phase space 6-vector
          * @param[in,out] zeval Longitudinal on-axis location in m
+         * @param[in] refpart reference particle
          */
         template<typename T_Real>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void map2 (amrex::ParticleReal const tau,
                    amrex::SmallVector<T_Real, 6, 1> & particle,
-                   amrex::ParticleReal & zeval) const
+                   amrex::ParticleReal & zeval,
+                   [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using namespace std; // for cmath(float)
@@ -325,17 +325,23 @@ namespace impactx::elements
          * @param[in,out] particle particle phase space 6-vector
          * @param[in,out] particle_spin particle spin 3-vector
          * @param[in,out] zeval Longitudinal on-axis location in m
+         * @param[in] refpart reference particle
          */
         template<typename T_Real>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void map3 (amrex::ParticleReal const tau,
                    amrex::SmallVector<T_Real, 6, 1> & particle,
                    amrex::SmallVector<T_Real, 3, 1> & particle_spin,
-                   amrex::ParticleReal & zeval) const
+                   amrex::ParticleReal & zeval,
+                   RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using namespace std; // for cmath(float)
             using amrex::Math::powi;
+
+            // reference particle relativistic factors
+            amrex::ParticleReal const gamma_ref = refpart.gamma();
+            amrex::ParticleReal const gyro_anomaly = refpart.gyromagnetic_anomaly;
 
             // initialize the three components of the axis-angle vector
             T_Real lambdax = 0_prt;
@@ -353,8 +359,8 @@ namespace impactx::elements
             T_Real sz = particle_spin(3);
 
             // Magnetic field normalized by q/mc:
-            T_Real const Bx = m_g * y * m_beta * m_gamma_ref;
-            T_Real const By = m_g * x * m_beta * m_gamma_ref;
+            T_Real const Bx = m_g * y * m_beta * gamma_ref;
+            T_Real const By = m_g * x * m_beta * gamma_ref;
             T_Real const Bz = 0_prt;
 
             // Electric field normalized by q/mc^2:
@@ -366,7 +372,7 @@ namespace impactx::elements
             T_Real const Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
             T_Real const iPnorm = 1_prt/Pnorm;
             T_Real const Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
-            T_Real const gamma = m_gamma_ref * (1_prt - pt*m_beta);
+            T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
             T_Real const ux = px * iPnorm;
             T_Real const uy = py * iPnorm;
             T_Real const uz = Ps * iPnorm;
@@ -375,7 +381,7 @@ namespace impactx::elements
             amrex::ParticleReal const h = 0.0_prt;
 
             // Evaluation of the full Thomas-BMT precession vector.
-            tbmt_precession_vector(x,ux,uy,uz,gamma,h,m_gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
 
             // Generator of the spin rotation for a single step
             lambdax *= tau;
@@ -499,7 +505,7 @@ namespace impactx::elements
          * @param[in,out] sy particle spin y-component
          * @param[in,out] sz particle spin z-component
          * @param[in,out] idcpu particle global index
-         * @param[in] refpart reference particle (unused)
+         * @param[in] refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -514,7 +520,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
             [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -535,7 +541,7 @@ namespace impactx::elements
             };
 
             // call integrator to advance through slice
-            integrators::symp_integrate_particle_spin(particle,particle_spin,zin,zout,nsteps,m_int_order,*this);
+            integrators::symp_integrate_particle_spin(particle,particle_spin,zin,zout,nsteps,m_int_order,refpart,*this);
 
             // assign updated values
             x = particle(1);
@@ -567,8 +573,6 @@ namespace impactx::elements
         amrex::ParticleReal m_ibeta;          //! 1 / m_beta
         amrex::ParticleReal m_g;              //! quadrupole strength in 1/m^2
         amrex::ParticleReal m_omega;
-        amrex::ParticleReal m_gamma_ref;      //! gamma
-        amrex::ParticleReal m_gyro_anomaly;   //! particle gyromagnetic anomaly
     };
 
 } // namespace impactx

--- a/src/elements/Multipole.H
+++ b/src/elements/Multipole.H
@@ -111,11 +111,8 @@ namespace impactx::elements
             m_inv_factorial = 1.0_prt / static_cast<amrex::ParticleReal>(m_mfactorial);
 
             // additional constants needed for spin push
-            m_gamma_ref = refpart.gamma();
-            m_gyro_anomaly = refpart.gyromagnetic_anomaly;
             m_beta = refpart.beta();
             m_ibeta = 1_prt / m_beta;
-
         }
 
         /** This is a multipole functor, so that a variable of this type can be used like a
@@ -206,7 +203,7 @@ namespace impactx::elements
          * @param sy particle spin y-component
          * @param sz particle spin z-component
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -221,12 +218,16 @@ namespace impactx::elements
             [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
             [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
             [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
             using namespace std; // for cmath(float)
+
+            // reference particle relativistic factors
+            amrex::ParticleReal const gamma_ref = refpart.gamma();
+            amrex::ParticleReal const gyro_anomaly = refpart.gyromagnetic_anomaly;
 
             // initialize the three components of the axis-angle vector
             T_Real lambdax = 0_prt;
@@ -242,8 +243,8 @@ namespace impactx::elements
             // compute multipole magnetic field normalized by q/mc:
             int const m = m_multipole - 1;
             Complex const kick = amrex::pow(zeta, m) * m_alpha;
-            T_Real const Bx = kick.m_imag * m_inv_factorial * m_beta * m_gamma_ref;
-            T_Real const By = kick.m_real * m_inv_factorial * m_beta * m_gamma_ref;
+            T_Real const Bx = kick.m_imag * m_inv_factorial * m_beta * gamma_ref;
+            T_Real const By = kick.m_real * m_inv_factorial * m_beta * gamma_ref;
             T_Real const Bz = 0_prt;
 
             // Electric field normalized by q/mc^2:
@@ -255,7 +256,7 @@ namespace impactx::elements
             T_Real const Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
             T_Real const iPnorm = 1_prt/Pnorm;
             T_Real const Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
-            T_Real const gamma = m_gamma_ref * (1_prt - pt*m_beta);
+            T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
             T_Real const ux = px * iPnorm;
             T_Real const uy = py * iPnorm;
             T_Real const uz = Ps * iPnorm;
@@ -264,7 +265,7 @@ namespace impactx::elements
             amrex::ParticleReal const h = 0.0_prt;
 
             // Evaluation of the full Thomas-BMT precession vector.
-            tbmt_precession_vector(x,ux,uy,uz,gamma,h,m_gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
 
             // push the spin vector using the generator just determined
             rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);
@@ -345,8 +346,6 @@ namespace impactx::elements
         // see: compute_constants() to refresh
         amrex::GpuComplex<amrex::ParticleReal> m_alpha;
         amrex::ParticleReal m_inv_factorial;
-        amrex::ParticleReal m_gamma_ref;      //! relativistic gamma
-        amrex::ParticleReal m_gyro_anomaly;   //! particle gyromagnetic anomaly
         amrex::ParticleReal m_beta;           //! relativistic beta
         amrex::ParticleReal m_ibeta;          //! inverse of beta
     };

--- a/src/elements/QuadEdge.H
+++ b/src/elements/QuadEdge.H
@@ -110,9 +110,8 @@ namespace impactx::elements
 
             Alignment::compute_constants(refpart);
 
-            // access reference particle values to find beta and gamma
+            // access reference particle values to find beta
             m_beta = refpart.beta();
-            m_gamma = refpart.gamma();
 
             // normalize quad units to MAD-X convention if needed
             m_g = m_unit == 1 ? m_k / refpart.rigidity_Tm() : m_k;
@@ -222,7 +221,6 @@ namespace impactx::elements
         amrex::ParticleReal m_g;
         amrex::ParticleReal m_a;
         amrex::ParticleReal m_beta;
-        amrex::ParticleReal m_gamma;
     };
 
 } // namespace impactx

--- a/src/particles/integrators/Integrators.H
+++ b/src/particles/integrators/Integrators.H
@@ -10,8 +10,11 @@
 #ifndef IMPACTX_INTEGRATORS_H_
 #define IMPACTX_INTEGRATORS_H_
 
-#include <AMReX_Extension.H>  // for AMREX_RESTRICT
-#include <AMReX_REAL.H>       // for ParticleReal
+#include "particles/ReferenceParticle.H"
+
+#include <AMReX_Extension.H>     // for AMREX_RESTRICT
+#include <AMReX_REAL.H>          // for ParticleReal
+#include <AMReX_SmallMatrix.H>   // for SmallVector
 
 
 namespace impactx::integrators
@@ -171,6 +174,7 @@ namespace impactx::integrators
     * @param zin  Initial value of independent variable (z-location)
     * @param zout  Final value of independent variable (z-location)
     * @param nsteps  Number of integration steps
+    * @param refpart  Reference particle data
     * @param element  Element defining the two maps associated with H_1 and H_2
     */
     template <typename T_Real, typename T_Element>
@@ -180,6 +184,7 @@ namespace impactx::integrators
         amrex::ParticleReal const zin,
         amrex::ParticleReal const zout,
         int const nsteps,
+        RefPart const & refpart,
         T_Element const & element
     )
     {
@@ -196,9 +201,9 @@ namespace impactx::integrators
         // loop over integration steps
         for(int j=0; j < nsteps; ++j)
         {
-            element.map1(tau1,particle,zeval);
-            element.map2(tau2,particle,zeval);
-            element.map1(tau1,particle,zeval);
+            element.map1(tau1,particle,zeval,refpart);
+            element.map2(tau2,particle,zeval,refpart);
+            element.map1(tau1,particle,zeval,refpart);
         }
     }
 
@@ -218,6 +223,7 @@ namespace impactx::integrators
     * @param zin  Initial value of independent variable (z-location)
     * @param zout  Final value of independent variable (z-location)
     * @param nsteps  Number of integration steps
+    * @param refpart  Reference particle data
     * @param element  Element defining the two maps associated with H_1 and H_2
     */
     template <typename T_Real, typename T_Element>
@@ -227,6 +233,7 @@ namespace impactx::integrators
         amrex::ParticleReal const zin,
         amrex::ParticleReal const zout,
         int const nsteps,
+        RefPart const & refpart,
         T_Element const & element
     )
     {
@@ -246,13 +253,13 @@ namespace impactx::integrators
         // loop over integration steps
         for (int j=0; j < nsteps; ++j)
         {
-            element.map1(tau1,particle,zeval);
-            element.map2(tau2,particle,zeval);
-            element.map1(tau3,particle,zeval);
-            element.map2(tau4,particle,zeval);
-            element.map1(tau3,particle,zeval);
-            element.map2(tau2,particle,zeval);
-            element.map1(tau1,particle,zeval);
+            element.map1(tau1,particle,zeval,refpart);
+            element.map2(tau2,particle,zeval,refpart);
+            element.map1(tau3,particle,zeval,refpart);
+            element.map2(tau4,particle,zeval,refpart);
+            element.map1(tau3,particle,zeval,refpart);
+            element.map2(tau2,particle,zeval,refpart);
+            element.map1(tau1,particle,zeval,refpart);
         }
     }
 
@@ -277,6 +284,7 @@ namespace impactx::integrators
     * @param zin  Initial value of independent variable (z-location)
     * @param zout  Final value of independent variable (z-location)
     * @param nsteps  Number of integration steps
+    * @param refpart  Reference particle data
     * @param element  Element defining the two maps associated with H_1 and H_2
     */
     template <typename T_Real, typename T_Element>
@@ -286,6 +294,7 @@ namespace impactx::integrators
         amrex::ParticleReal const zin,
         amrex::ParticleReal const zout,
         int const nsteps,
+        RefPart const & refpart,
         T_Element const & element
     )
     {
@@ -313,21 +322,21 @@ namespace impactx::integrators
         // loop over integration steps
         for (int j=0; j < nsteps; ++j)
         {
-            element.map1(tau1,particle,zeval);
-            element.map2(tau2,particle,zeval);
-            element.map1(tau3,particle,zeval);
-            element.map2(tau4,particle,zeval);
-            element.map1(tau5,particle,zeval);
-            element.map2(tau6,particle,zeval);
-            element.map1(tau7,particle,zeval);
-            element.map2(tau8,particle,zeval);
-            element.map1(tau7,particle,zeval);
-            element.map2(tau6,particle,zeval);
-            element.map1(tau5,particle,zeval);
-            element.map2(tau4,particle,zeval);
-            element.map1(tau3,particle,zeval);
-            element.map2(tau2,particle,zeval);
-            element.map1(tau1,particle,zeval);
+            element.map1(tau1,particle,zeval,refpart);
+            element.map2(tau2,particle,zeval,refpart);
+            element.map1(tau3,particle,zeval,refpart);
+            element.map2(tau4,particle,zeval,refpart);
+            element.map1(tau5,particle,zeval,refpart);
+            element.map2(tau6,particle,zeval,refpart);
+            element.map1(tau7,particle,zeval,refpart);
+            element.map2(tau8,particle,zeval,refpart);
+            element.map1(tau7,particle,zeval,refpart);
+            element.map2(tau6,particle,zeval,refpart);
+            element.map1(tau5,particle,zeval,refpart);
+            element.map2(tau4,particle,zeval,refpart);
+            element.map1(tau3,particle,zeval,refpart);
+            element.map2(tau2,particle,zeval,refpart);
+            element.map1(tau1,particle,zeval,refpart);
         }
     }
 
@@ -344,6 +353,7 @@ namespace impactx::integrators
     * @param particle_spin  Particle spin data in a 3-vector
     * @param tau  Size of the step in s
     * @param zeval  Evaluation point in s
+    * @param refpart  Reference particle data
     * @param element  Element defining the maps associated with H_1, H_2, and spin.
     */
     template <typename T_Real, typename T_Element>
@@ -353,6 +363,7 @@ namespace impactx::integrators
         amrex::SmallVector<T_Real, 3, 1> & particle_spin,
         amrex::ParticleReal const tau,
         amrex::ParticleReal & zeval,
+        RefPart const & refpart,
         T_Element const & element
     )
     {
@@ -364,11 +375,11 @@ namespace impactx::integrators
         amrex::ParticleReal const tau3 = tau;
 
         // a single second-order step
-        element.map1(tau1,particle,zeval);
-        element.map2(tau2,particle,zeval);
-        element.map3(tau3,particle,particle_spin,zeval);
-        element.map2(tau2,particle,zeval);
-        element.map1(tau1,particle,zeval);
+        element.map1(tau1,particle,zeval,refpart);
+        element.map2(tau2,particle,zeval,refpart);
+        element.map3(tau3,particle,particle_spin,zeval,refpart);
+        element.map2(tau2,particle,zeval,refpart);
+        element.map1(tau1,particle,zeval,refpart);
     }
 
    /** A fourth-order symplectic integration step based on a Hamiltonian
@@ -385,6 +396,7 @@ namespace impactx::integrators
     * @param particle_spin  Particle spin data in a 3-vector
     * @param tau  Size of the step in s
     * @param zeval  Evaluation point in s
+    * @param refpart  Reference particle data
     * @param element  Element defining the maps associated with H_1, H_2, and spin.
     */
     template <typename T_Real, typename T_Element>
@@ -394,6 +406,7 @@ namespace impactx::integrators
         amrex::SmallVector<T_Real, 3, 1> & particle_spin,
         amrex::ParticleReal const tau,
         amrex::ParticleReal & zeval,
+        RefPart const & refpart,
         T_Element const & element
     )
     {
@@ -407,9 +420,9 @@ namespace impactx::integrators
         amrex::ParticleReal const tau2 = tau*z1;
 
         // a single fourth-order step
-        symp2_integrate_particle_spin_step(particle,particle_spin,tau1,zeval,element);
-        symp2_integrate_particle_spin_step(particle,particle_spin,tau2,zeval,element);
-        symp2_integrate_particle_spin_step(particle,particle_spin,tau1,zeval,element);
+        symp2_integrate_particle_spin_step(particle,particle_spin,tau1,zeval,refpart,element);
+        symp2_integrate_particle_spin_step(particle,particle_spin,tau2,zeval,refpart,element);
+        symp2_integrate_particle_spin_step(particle,particle_spin,tau1,zeval,refpart,element);
     }
 
 
@@ -427,6 +440,7 @@ namespace impactx::integrators
     * @param particle_spin  Particle spin data in a 3-vector
     * @param tau  Size of the step in s
     * @param zeval  Evaluation point in s
+    * @param refpart  Reference particle data
     * @param element  Element defining the maps associated with H_1, H_2, and spin.
     */
     template <typename T_Real, typename T_Element>
@@ -436,6 +450,7 @@ namespace impactx::integrators
         amrex::SmallVector<T_Real, 3, 1> & particle_spin,
         amrex::ParticleReal const tau,
         amrex::ParticleReal & zeval,
+        RefPart const & refpart,
         T_Element const & element
     )
     {
@@ -449,9 +464,9 @@ namespace impactx::integrators
         amrex::ParticleReal const tau2 = tau * z1;
 
         // a single sixth-order step
-        symp4_integrate_particle_spin_step(particle,particle_spin,tau1,zeval,element);
-        symp4_integrate_particle_spin_step(particle,particle_spin,tau2,zeval,element);
-        symp4_integrate_particle_spin_step(particle,particle_spin,tau1,zeval,element);
+        symp4_integrate_particle_spin_step(particle,particle_spin,tau1,zeval,refpart,element);
+        symp4_integrate_particle_spin_step(particle,particle_spin,tau2,zeval,refpart,element);
+        symp4_integrate_particle_spin_step(particle,particle_spin,tau1,zeval,refpart,element);
     }
 
 
@@ -470,6 +485,7 @@ namespace impactx::integrators
     * @param zout  Final value of independent variable (z-location)
     * @param nsteps  Number of integration steps
     * @param int_order Order of numerical integration (2, 4, or 6)
+    * @param refpart  Reference particle data
     * @param element  Element defining the maps associated with H_1, H_2, and spin.
     */
     template <typename T_Real, typename T_Element>
@@ -481,6 +497,7 @@ namespace impactx::integrators
         amrex::ParticleReal const zout,
         int const nsteps,
         int int_order,
+        RefPart const & refpart,
         T_Element const & element
     )
     {
@@ -496,13 +513,13 @@ namespace impactx::integrators
         for(int j=0; j < nsteps; ++j)
         {
             if (int_order == 2) {
-                symp2_integrate_particle_spin_step(particle,particle_spin,dz,zeval,element);
+                symp2_integrate_particle_spin_step(particle,particle_spin,dz,zeval,refpart,element);
             } else if (int_order == 4) {
-                symp4_integrate_particle_spin_step(particle,particle_spin,dz,zeval,element);
+                symp4_integrate_particle_spin_step(particle,particle_spin,dz,zeval,refpart,element);
             } else if (int_order == 6) {
-                symp6_integrate_particle_spin_step(particle,particle_spin,dz,zeval,element);
+                symp6_integrate_particle_spin_step(particle,particle_spin,dz,zeval,refpart,element);
             } else {
-                symp2_integrate_particle_spin_step(particle,particle_spin,dz,zeval,element);
+                symp2_integrate_particle_spin_step(particle,particle_spin,dz,zeval,refpart,element);
             }
         }
     }


### PR DESCRIPTION
Pass the reference particle into integrator functions. This allows us to access constants like gamma and gyromagnetic anomaly directly from the already copied reference particle, instead of storing them as an additional (duplicate) member in the element and copying them again to GPU.

This mostly saves registers, performance is the same on testing of `ExactCFbend`, `ExactQuad`, `ExactMultipole` on my laptop. Bigger savings are needed, e.g., via #1423.