### PR TITLE
Shink RefPart by 456 Bytes

### DIFF
--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -220,13 +220,13 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
-            RefPart const & AMREX_RESTRICT refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
 
             // get the linear map
-            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
+            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = m_map;
 
             // symplectic linear map for the RF cavity is computed using the
             // Hamiltonian formalism as described in:
@@ -269,10 +269,10 @@ namespace impactx::elements
             amrex::ParticleReal const sedge = refpart.sedge;
 
             // initialize linear map (deviation) values
-            refpart.map = decltype(refpart.map)::Identity();
+            m_map = decltype(m_map)::Identity();
 
             // initialize the spin-orbit coupling matrix
-            refpart.spin_coupling = {};
+            m_spin_coupling = {};
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
@@ -315,14 +315,14 @@ namespace impactx::elements
                       scale_in = bgi;
                    else
                       scale_in = 1.0_prt;
-                   refpart.map(i, j) = refpart.map(i, j) * scale_in / scale_fin;
+                   m_map(i, j) = m_map(i, j) * scale_in / scale_fin;
                }
             }
 
             // convert spin-orbit coupling map from dynamic to static units
             for (int i=1; i<4; i++) {
                 for (int j=2; j<7; j+=2) {
-                    refpart.spin_coupling(i, j) *= bgi;
+                    m_spin_coupling(i, j) *= bgi;
                 }
             }
 
@@ -372,7 +372,7 @@ namespace impactx::elements
             amrex::SmallVector<T_Real, 6, 1> const v{x, px, y, py, t, pt};
 
             // get the spin-orbit coupling matrix
-            amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> const A = refpart.spin_coupling;
+            amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> const A = m_spin_coupling;
 
             // use phase space variables to obtain the angle-axis generator of spin rotation
             auto const out = A * v;
@@ -403,7 +403,7 @@ namespace impactx::elements
         {
 
             Map6x6 R = Map6x6::Identity();
-            R = refpart.map;
+            R = m_map;
 
             return R;
         }
@@ -500,13 +500,13 @@ namespace impactx::elements
             }
 
             // push the linear map equations
-            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
-            amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> const A = refpart.spin_coupling;
+            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = m_map;
+            amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> const A = m_spin_coupling;
             amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> dA = {};
             amrex::ParticleReal const betgam = refpart.beta_gamma();
 
-            refpart.map(5,5) = R(5,5) + tau*R(6,5)/powi<3>(betgam);
-            refpart.map(5,6) = R(5,6) + tau*R(6,6)/powi<3>(betgam);
+            m_map(5,5) = R(5,5) + tau*R(6,5)/powi<3>(betgam);
+            m_map(5,6) = R(5,6) + tau*R(6,6)/powi<3>(betgam);
 
             // BELOW: if spin is needed only:
             // Define parameters and intermediate constants
@@ -528,7 +528,7 @@ namespace impactx::elements
             dA(2,2) = -dA(1,4);
 
             // update the spin-orbit coupling matrix here
-            refpart.spin_coupling = A + dA*R;
+            m_spin_coupling = A + dA*R;
         }
 
         /** This pushes the reference particle and the linear map matrix
@@ -565,19 +565,19 @@ namespace impactx::elements
             refpart.pt = pt;
 
             // push the linear map equations
-            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
+            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = m_map;
             amrex::ParticleReal const s = tau/refpart.beta_gamma();
             amrex::ParticleReal const L = E0*ezp * std::sin(k*t+phi)/(2_prt*k);
 
-            refpart.map(1,1) = (1_prt-s*L)*R(1,1) + s*R(2,1);
-            refpart.map(1,2) = (1_prt-s*L)*R(1,2) + s*R(2,2);
-            refpart.map(2,1) = -s * powi<2>(L)*R(1,1) + (1_prt+s*L)*R(2,1);
-            refpart.map(2,2) = -s * powi<2>(L)*R(1,2) + (1_prt+s*L)*R(2,2);
+            m_map(1,1) = (1_prt-s*L)*R(1,1) + s*R(2,1);
+            m_map(1,2) = (1_prt-s*L)*R(1,2) + s*R(2,2);
+            m_map(2,1) = -s * powi<2>(L)*R(1,1) + (1_prt+s*L)*R(2,1);
+            m_map(2,2) = -s * powi<2>(L)*R(1,2) + (1_prt+s*L)*R(2,2);
 
-            refpart.map(3,3) = (1_prt-s*L)*R(3,3) + s*R(4,3);
-            refpart.map(3,4) = (1_prt-s*L)*R(3,4) + s*R(4,4);
-            refpart.map(4,3) = -s * powi<2>(L)*R(3,3) + (1_prt+s*L)*R(4,3);
-            refpart.map(4,4) = -s * powi<2>(L)*R(3,4) + (1_prt+s*L)*R(4,4);
+            m_map(3,3) = (1_prt-s*L)*R(3,3) + s*R(4,3);
+            m_map(3,4) = (1_prt-s*L)*R(3,4) + s*R(4,4);
+            m_map(4,3) = -s * powi<2>(L)*R(3,3) + (1_prt+s*L)*R(4,3);
+            m_map(4,4) = -s * powi<2>(L)*R(3,4) + (1_prt+s*L)*R(4,4);
 
         }
 
@@ -618,18 +618,18 @@ namespace impactx::elements
             refpart.pt = pt - E0*(ezintf-ezint) * std::cos(k*t+phi);
 
             // push the linear map equations
-            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
+            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = m_map;
             amrex::ParticleReal const M = E0*(ezintf-ezint)*k * std::sin(k*t+phi);
             amrex::ParticleReal const L = E0*(ezpf-ezp) * std::sin(k*t+phi)/(2_prt*k)+M*0.5_prt;
 
-            refpart.map(2,1) = L*R(1,1) + R(2,1);
-            refpart.map(2,2) = L*R(1,2) + R(2,2);
+            m_map(2,1) = L*R(1,1) + R(2,1);
+            m_map(2,2) = L*R(1,2) + R(2,2);
 
-            refpart.map(4,3) = L*R(3,3) + R(4,3);
-            refpart.map(4,4) = L*R(3,4) + R(4,4);
+            m_map(4,3) = L*R(3,3) + R(4,3);
+            m_map(4,4) = L*R(3,4) + R(4,4);
 
-            refpart.map(6,5) = M*R(5,5) + R(6,5);
-            refpart.map(6,6) = M*R(5,6) + R(6,6);
+            m_map(6,5) = M*R(5,5) + R(6,5);
+            m_map(6,6) = M*R(5,6) + R(6,6);
 
         }
 
@@ -644,6 +644,14 @@ namespace impactx::elements
         amrex::ParticleReal const * m_sin_h_data = nullptr; //! non-owning pointer to host sine coefficients
         amrex::ParticleReal const * m_cos_d_data = nullptr; //! non-owning pointer to device cosine coefficients
         amrex::ParticleReal const * m_sin_d_data = nullptr; //! non-owning pointer to device sine coefficients
+
+        // Reference-trajectory linearization around the reference particle.
+        // Computed during the reference-particle push and consumed during the
+        // particle push.
+        // mutable: written by the const reference push before the element is copied
+        // into the particle-push functor.
+        mutable amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> m_map{}; //! linearized map
+        mutable amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> m_spin_coupling{}; //! linearized spin-orbit coupling matrix
     };
 
 } // namespace impactx

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -226,13 +226,13 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
-            RefPart const & AMREX_RESTRICT refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
 
             // get the linear map
-            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
+            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = m_map;
 
             // symplectic linear map for a quadrupole is computed using the
             // Hamiltonian formalism as described in:
@@ -275,10 +275,10 @@ namespace impactx::elements
             amrex::ParticleReal const sedge = refpart.sedge;
 
             // initialize linear map (deviation) values
-            refpart.map = decltype(refpart.map)::Identity();
+            m_map = decltype(m_map)::Identity();
 
             // initialize the spin-orbit coupling matrix
-            refpart.spin_coupling = {};
+            m_spin_coupling = {};
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
@@ -299,7 +299,7 @@ namespace impactx::elements
                for(int i=1; i<7; ++i){
                  for(int j=1; j<7; ++j){
                     amrex::PrintToFile("QuadMap.txt") << i << " " <<
-                    j << " " << refpart.map(i,j) << "\n";
+                    j << " " << m_map(i,j) << "\n";
                  }
                }
             //
@@ -364,7 +364,7 @@ namespace impactx::elements
             amrex::SmallVector<T_Real, 6, 1> const v{x, px, y, py, t, pt};
 
             // get the spin-orbit coupling matrix
-            amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> const A = refpart.spin_coupling;
+            amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> const A = m_spin_coupling;
 
             // use phase space variables to obtain the angle-axis generator of spin rotation
             auto const out = A * v;
@@ -396,7 +396,7 @@ namespace impactx::elements
         {
 
             Map6x6 R = Map6x6::Identity();
-            R = refpart.map;
+            R = m_map;
 
             return R;
         }
@@ -484,21 +484,21 @@ namespace impactx::elements
             zeval = z + tau;
 
             // push the linear map equations
-            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
+            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = m_map;
             amrex::ParticleReal const betgam = refpart.beta_gamma();
 
-            refpart.map(1,1) = R(1,1) + tau*R(2,1);
-            refpart.map(1,2) = R(1,2) + tau*R(2,2);
-            refpart.map(1,3) = R(1,3) + tau*R(2,3);
-            refpart.map(1,4) = R(1,4) + tau*R(2,4);
+            m_map(1,1) = R(1,1) + tau*R(2,1);
+            m_map(1,2) = R(1,2) + tau*R(2,2);
+            m_map(1,3) = R(1,3) + tau*R(2,3);
+            m_map(1,4) = R(1,4) + tau*R(2,4);
 
-            refpart.map(3,1) = R(3,1) + tau*R(4,1);
-            refpart.map(3,2) = R(3,2) + tau*R(4,2);
-            refpart.map(3,3) = R(3,3) + tau*R(4,3);
-            refpart.map(3,4) = R(3,4) + tau*R(4,4);
+            m_map(3,1) = R(3,1) + tau*R(4,1);
+            m_map(3,2) = R(3,2) + tau*R(4,2);
+            m_map(3,3) = R(3,3) + tau*R(4,3);
+            m_map(3,4) = R(3,4) + tau*R(4,4);
 
-            refpart.map(5,5) = R(5,5) + tau*R(6,5) / powi<2>(betgam);
-            refpart.map(5,6) = R(5,6) + tau*R(6,6) / powi<2>(betgam);
+            m_map(5,5) = R(5,5) + tau*R(6,5) / powi<2>(betgam);
+            m_map(5,6) = R(5,6) + tau*R(6,6) / powi<2>(betgam);
         }
 
         /** This pushes the reference particle and the linear map matrix
@@ -530,21 +530,21 @@ namespace impactx::elements
             refpart.pt = pt;
 
             // push the linear map equations
-            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
+            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = m_map;
             amrex::ParticleReal const alpha = G0*bz;
 
-            refpart.map(2,1) = R(2,1) - tau*alpha*R(1,1);
-            refpart.map(2,2) = R(2,2) - tau*alpha*R(1,2);
-            refpart.map(2,3) = R(2,3) - tau*alpha*R(1,3);
-            refpart.map(2,4) = R(2,4) - tau*alpha*R(1,4);
+            m_map(2,1) = R(2,1) - tau*alpha*R(1,1);
+            m_map(2,2) = R(2,2) - tau*alpha*R(1,2);
+            m_map(2,3) = R(2,3) - tau*alpha*R(1,3);
+            m_map(2,4) = R(2,4) - tau*alpha*R(1,4);
 
-            refpart.map(4,1) = R(4,1) + tau*alpha*R(3,1);
-            refpart.map(4,2) = R(4,2) + tau*alpha*R(3,2);
-            refpart.map(4,3) = R(4,3) + tau*alpha*R(3,3);
-            refpart.map(4,4) = R(4,4) + tau*alpha*R(3,4);
+            m_map(4,1) = R(4,1) + tau*alpha*R(3,1);
+            m_map(4,2) = R(4,2) + tau*alpha*R(3,2);
+            m_map(4,3) = R(4,3) + tau*alpha*R(3,3);
+            m_map(4,4) = R(4,4) + tau*alpha*R(3,4);
 
             // BELOW: if spin is needed only:
-            amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> const A = refpart.spin_coupling;
+            amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> const A = m_spin_coupling;
             amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> dA = {};
             amrex::ParticleReal const gamma = refpart.gamma();
             amrex::ParticleReal G = refpart.gyromagnetic_anomaly;
@@ -554,7 +554,7 @@ namespace impactx::elements
             dA(2,1) = -(1_prt + G*gamma) * tau * alpha;
 
             // update the spin-orbit coupling matrix here
-            refpart.spin_coupling = A + dA*R;
+            m_spin_coupling = A + dA*R;
 
         }
 
@@ -567,6 +567,14 @@ namespace impactx::elements
         amrex::ParticleReal const * m_sin_h_data = nullptr; //! non-owning pointer to host sine coefficients
         amrex::ParticleReal const * m_cos_d_data = nullptr; //! non-owning pointer to device cosine coefficients
         amrex::ParticleReal const * m_sin_d_data = nullptr; //! non-owning pointer to device sine coefficients
+
+        // Reference-trajectory linearization around the reference particle.
+        // Computed during the reference-particle push and consumed during the
+        // particle push.
+        // mutable: written by the const reference push before the element is copied
+        // into the particle-push functor.
+        mutable amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> m_map{}; //! linearized map
+        mutable amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> m_spin_coupling{}; //! linearized spin-orbit coupling matrix
     };
 
 } // namespace impactx

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -236,13 +236,13 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
-            RefPart const & AMREX_RESTRICT refpart
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
 
             // get the linear map
-            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
+            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = m_map;
 
             // symplectic linear map for a solenoid is computed using the
             // Hamiltonian formalism as described in:
@@ -285,11 +285,11 @@ namespace impactx::elements
             amrex::ParticleReal const sedge = refpart.sedge;
 
             // initialize linear map (deviation) values
-            refpart.map = decltype(refpart.map)::Identity();
+            m_map = decltype(m_map)::Identity();
 
             // initialize the spin-orbit coupling matrix and the spin rotation vector
-            refpart.spin_rotation_vector = {};
-            refpart.spin_coupling = {};
+            m_spin_rotation_vector = {};
+            m_spin_coupling = {};
 
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
@@ -309,7 +309,7 @@ namespace impactx::elements
                for(int i=1; i<7; ++i){
                  for(int j=1; j<7; ++j){
                     amrex::PrintToFile("SolMap.txt") << i << " " <<
-                    j << " " << refpart.map(i,j) << "\n";
+                    j << " " << m_map(i,j) << "\n";
                  }
                }
             */
@@ -373,7 +373,7 @@ namespace impactx::elements
             amrex::SmallVector<T_Real, 6, 1> const v{x, px, y, py, t, pt};
 
             // get the spin-orbit coupling matrix
-            amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> const A = refpart.spin_coupling;
+            amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> const A = m_spin_coupling;
 
             // use phase space variables to obtain the angle-axis generator of spin rotation
             auto const out = A * v;
@@ -387,7 +387,7 @@ namespace impactx::elements
             rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);
 
             // axis-angle vector components generating the reference spin map
-            amrex::SmallMatrix<amrex::ParticleReal, 3, 1, amrex::Order::F, 1> const lambda = refpart.spin_rotation_vector;
+            amrex::SmallMatrix<amrex::ParticleReal, 3, 1, amrex::Order::F, 1> const lambda = m_spin_rotation_vector;
             lambdax = lambda(1);
             lambday = lambda(2);
             lambdaz = lambda(3);
@@ -414,7 +414,7 @@ namespace impactx::elements
         {
 
             Map6x6 R = Map6x6::Identity();
-            R = refpart.map;
+            R = m_map;
 
             return R;
         }
@@ -502,21 +502,21 @@ namespace impactx::elements
             zeval = z + tau;
 
             // push the linear map equations
-            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
+            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = m_map;
             amrex::ParticleReal const betgam = refpart.beta_gamma();
 
-            refpart.map(1,1) = R(1,1) + tau*R(2,1);
-            refpart.map(1,2) = R(1,2) + tau*R(2,2);
-            refpart.map(1,3) = R(1,3) + tau*R(2,3);
-            refpart.map(1,4) = R(1,4) + tau*R(2,4);
+            m_map(1,1) = R(1,1) + tau*R(2,1);
+            m_map(1,2) = R(1,2) + tau*R(2,2);
+            m_map(1,3) = R(1,3) + tau*R(2,3);
+            m_map(1,4) = R(1,4) + tau*R(2,4);
 
-            refpart.map(3,1) = R(3,1) + tau*R(4,1);
-            refpart.map(3,2) = R(3,2) + tau*R(4,2);
-            refpart.map(3,3) = R(3,3) + tau*R(4,3);
-            refpart.map(3,4) = R(3,4) + tau*R(4,4);
+            m_map(3,1) = R(3,1) + tau*R(4,1);
+            m_map(3,2) = R(3,2) + tau*R(4,2);
+            m_map(3,3) = R(3,3) + tau*R(4,3);
+            m_map(3,4) = R(3,4) + tau*R(4,4);
 
-            refpart.map(5,5) = R(5,5) + tau*R(6,5)/powi<2>(betgam);
-            refpart.map(5,6) = R(5,6) + tau*R(6,6)/powi<2>(betgam);
+            m_map(5,5) = R(5,5) + tau*R(6,5)/powi<2>(betgam);
+            m_map(5,6) = R(5,6) + tau*R(6,6)/powi<2>(betgam);
 
         }
 
@@ -553,23 +553,23 @@ namespace impactx::elements
             refpart.pt = pt;
 
             // push the linear map equations
-            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
+            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = m_map;
             amrex::ParticleReal const alpha = B0*bz*0.5_prt;
             amrex::ParticleReal const alpha2 = powi<2>(alpha);
 
-            refpart.map(2,1) = R(2,1) - tau*alpha2*R(1,1);
-            refpart.map(2,2) = R(2,2) - tau*alpha2*R(1,2);
-            refpart.map(2,3) = R(2,3) - tau*alpha2*R(1,3);
-            refpart.map(2,4) = R(2,4) - tau*alpha2*R(1,4);
+            m_map(2,1) = R(2,1) - tau*alpha2*R(1,1);
+            m_map(2,2) = R(2,2) - tau*alpha2*R(1,2);
+            m_map(2,3) = R(2,3) - tau*alpha2*R(1,3);
+            m_map(2,4) = R(2,4) - tau*alpha2*R(1,4);
 
-            refpart.map(4,1) = R(4,1) - tau*alpha2*R(3,1);
-            refpart.map(4,2) = R(4,2) - tau*alpha2*R(3,2);
-            refpart.map(4,3) = R(4,3) - tau*alpha2*R(3,3);
-            refpart.map(4,4) = R(4,4) - tau*alpha2*R(3,4);
+            m_map(4,1) = R(4,1) - tau*alpha2*R(3,1);
+            m_map(4,2) = R(4,2) - tau*alpha2*R(3,2);
+            m_map(4,3) = R(4,3) - tau*alpha2*R(3,3);
+            m_map(4,4) = R(4,4) - tau*alpha2*R(3,4);
 
             // BELOW: if spin is needed only:
-            amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> const A = refpart.spin_coupling;
-            amrex::SmallMatrix<amrex::ParticleReal, 3, 1, amrex::Order::F, 1> const v = refpart.spin_rotation_vector;
+            amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> const A = m_spin_coupling;
+            amrex::SmallMatrix<amrex::ParticleReal, 3, 1, amrex::Order::F, 1> const v = m_spin_rotation_vector;
             amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> dA = {};
             amrex::ParticleReal const gamma = refpart.gamma();
             amrex::ParticleReal const beta = refpart.beta();
@@ -590,7 +590,7 @@ namespace impactx::elements
             dA(3,6) = -2_prt *(1_prt + G) * tau * alpha/beta;
 
             // update the spin-orbit coupling matrix here
-            refpart.spin_coupling = A + dA*R;
+            m_spin_coupling = A + dA*R;
 
         }
 
@@ -627,39 +627,39 @@ namespace impactx::elements
             refpart.pt = pt;
 
             // push the linear map equations
-            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = refpart.map;
+            amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> const R = m_map;
             amrex::ParticleReal const theta = tau*B0*bz*0.5_prt;
             amrex::ParticleReal const cs = std::cos(theta);
             amrex::ParticleReal const sn = std::sin(theta);
 
-            refpart.map(1,1) = R(1,1)*cs + R(3,1)*sn;
-            refpart.map(1,2) = R(1,2)*cs + R(3,2)*sn;
-            refpart.map(1,3) = R(1,3)*cs + R(3,3)*sn;
-            refpart.map(1,4) = R(1,4)*cs + R(3,4)*sn;
+            m_map(1,1) = R(1,1)*cs + R(3,1)*sn;
+            m_map(1,2) = R(1,2)*cs + R(3,2)*sn;
+            m_map(1,3) = R(1,3)*cs + R(3,3)*sn;
+            m_map(1,4) = R(1,4)*cs + R(3,4)*sn;
 
-            refpart.map(2,1) = R(2,1)*cs + R(4,1)*sn;
-            refpart.map(2,2) = R(2,2)*cs + R(4,2)*sn;
-            refpart.map(2,3) = R(2,3)*cs + R(4,3)*sn;
-            refpart.map(2,4) = R(2,4)*cs + R(4,4)*sn;
+            m_map(2,1) = R(2,1)*cs + R(4,1)*sn;
+            m_map(2,2) = R(2,2)*cs + R(4,2)*sn;
+            m_map(2,3) = R(2,3)*cs + R(4,3)*sn;
+            m_map(2,4) = R(2,4)*cs + R(4,4)*sn;
 
-            refpart.map(3,1) = R(3,1)*cs - R(1,1)*sn;
-            refpart.map(3,2) = R(3,2)*cs - R(1,2)*sn;
-            refpart.map(3,3) = R(3,3)*cs - R(1,3)*sn;
-            refpart.map(3,4) = R(3,4)*cs - R(1,4)*sn;
+            m_map(3,1) = R(3,1)*cs - R(1,1)*sn;
+            m_map(3,2) = R(3,2)*cs - R(1,2)*sn;
+            m_map(3,3) = R(3,3)*cs - R(1,3)*sn;
+            m_map(3,4) = R(3,4)*cs - R(1,4)*sn;
 
-            refpart.map(4,1) = R(4,1)*cs - R(2,1)*sn;
-            refpart.map(4,2) = R(4,2)*cs - R(2,2)*sn;
-            refpart.map(4,3) = R(4,3)*cs - R(2,3)*sn;
-            refpart.map(4,4) = R(4,4)*cs - R(2,4)*sn;
+            m_map(4,1) = R(4,1)*cs - R(2,1)*sn;
+            m_map(4,2) = R(4,2)*cs - R(2,2)*sn;
+            m_map(4,3) = R(4,3)*cs - R(2,3)*sn;
+            m_map(4,4) = R(4,4)*cs - R(2,4)*sn;
 
             // BELOW: if spin is needed only:
-            amrex::SmallMatrix<amrex::ParticleReal, 3, 1, amrex::Order::F, 1> const v = refpart.spin_rotation_vector;
+            amrex::SmallMatrix<amrex::ParticleReal, 3, 1, amrex::Order::F, 1> const v = m_spin_rotation_vector;
             amrex::ParticleReal dv_z = 0_prt;
             amrex::ParticleReal G = refpart.gyromagnetic_anomaly;
 
             // Update reference spin rotation vector here
             dv_z = -(1_prt + G) * tau * B0 * bz;
-            refpart.spin_rotation_vector(3) = v(3) + dv_z;
+            m_spin_rotation_vector(3) = v(3) + dv_z;
 
         }
 
@@ -673,6 +673,15 @@ namespace impactx::elements
         amrex::ParticleReal const * m_sin_h_data = nullptr; //! non-owning pointer to host sine coefficients
         amrex::ParticleReal const * m_cos_d_data = nullptr; //! non-owning pointer to device cosine coefficients
         amrex::ParticleReal const * m_sin_d_data = nullptr; //! non-owning pointer to device sine coefficients
+
+        // Reference-trajectory linearization around the reference particle.
+        // Computed during the reference-particle push and consumed during the
+        // particle push.
+        // mutable: written by the const reference push before the element is copied
+        // into the particle-push functor.
+        mutable amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> m_map{}; //! linearized map
+        mutable amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> m_spin_coupling{}; //! linearized spin-orbit coupling matrix
+        mutable amrex::SmallMatrix<amrex::ParticleReal, 3, 1, amrex::Order::F, 1> m_spin_rotation_vector{}; //! reference spin rotation vector
     };
 
 } // namespace impactx

--- a/src/particles/ReferenceParticle.H
+++ b/src/particles/ReferenceParticle.H
@@ -45,9 +45,6 @@ namespace impactx
         amrex::ParticleReal gyromagnetic_anomaly = 0.0; ///< anomalous magnetic moment [unitless]
 
         amrex::ParticleReal sedge = 0.0;  ///< value of s at entrance of the current beamline element
-        amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> map{}; ///< linearized map
-        amrex::SmallMatrix<amrex::ParticleReal, 3, 6, amrex::Order::F, 1> spin_coupling{}; ///< linearized spin-orbit coupling matrix
-        amrex::SmallMatrix<amrex::ParticleReal, 3, 1, amrex::Order::F, 1> spin_rotation_vector{}; ///< reference spin rotation vector
 
         /** Copy the reference particle
          *

--- a/src/python/ReferenceParticle.cpp
+++ b/src/python/ReferenceParticle.cpp
@@ -33,9 +33,6 @@ void init_refparticle(py::module& m)
         .def_readwrite("gyromagnetic_anomaly", &RefPart::gyromagnetic_anomaly, "reference particle gyromagnetic anomaly [unitless]")
 
         .def_readwrite("sedge", &RefPart::sedge, "value of s at entrance of the current beamline element")
-        .def_readwrite("map", &RefPart::map, "linearized map")
-        .def_readwrite("spin_coupling", &RefPart::spin_coupling, "linearized spin-orbit coupling matrix")
-        .def_readwrite("spin_rotation_vector", &RefPart::spin_rotation_vector, "reference spin rotation vector")
 
         .def_property_readonly("charge_qe", &RefPart::charge_qe, "Get reference particle charge (positive elementary charge)")
         .def_property_readonly("gamma", &RefPart::gamma, "Get reference particle relativistic gamma")

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -2056,6 +2056,14 @@ void init_elements(py::module& m)
             [](RFCavity & rfc, int mapsteps) { rfc.m_mapsteps = mapsteps; },
             "number of integration steps per slice used for map and reference particle push in applied fields"
         )
+        .def_property_readonly("map",
+            [](RFCavity const & rfc) { return rfc.m_map; },
+            "linearized transport map around the reference particle (valid after a reference-particle push)"
+        )
+        .def_property_readonly("spin_coupling",
+            [](RFCavity const & rfc) { return rfc.m_spin_coupling; },
+            "linearized spin-orbit coupling matrix (valid after a reference-particle push)"
+        )
     ;
     register_push(py_RFCavity);
     register_reverse(py_RFCavity);
@@ -2372,6 +2380,18 @@ void init_elements(py::module& m)
             [](SoftSolenoid & soft_sol, int mapsteps) { soft_sol.m_mapsteps = mapsteps; },
             "number of integration steps per slice used for map and reference particle push in applied fields"
         )
+        .def_property_readonly("map",
+            [](SoftSolenoid const & soft_sol) { return soft_sol.m_map; },
+            "linearized transport map around the reference particle (valid after a reference-particle push)"
+        )
+        .def_property_readonly("spin_coupling",
+            [](SoftSolenoid const & soft_sol) { return soft_sol.m_spin_coupling; },
+            "linearized spin-orbit coupling matrix (valid after a reference-particle push)"
+        )
+        .def_property_readonly("spin_rotation_vector",
+            [](SoftSolenoid const & soft_sol) { return soft_sol.m_spin_rotation_vector; },
+            "reference spin rotation vector (valid after a reference-particle push)"
+        )
     ;
     register_push(py_SoftSolenoid);
     register_reverse(py_SoftSolenoid);
@@ -2612,6 +2632,14 @@ void init_elements(py::module& m)
             [](SoftQuadrupole & soft_quad) { return soft_quad.m_mapsteps; },
             [](SoftQuadrupole & soft_quad, int mapsteps) { soft_quad.m_mapsteps = mapsteps; },
             "number of integration steps per slice used for map and reference particle push in applied fields"
+        )
+        .def_property_readonly("map",
+            [](SoftQuadrupole const & soft_quad) { return soft_quad.m_map; },
+            "linearized transport map around the reference particle (valid after a reference-particle push)"
+        )
+        .def_property_readonly("spin_coupling",
+            [](SoftQuadrupole const & soft_quad) { return soft_quad.m_spin_coupling; },
+            "linearized spin-orbit coupling matrix (valid after a reference-particle push)"
         )
     ;
     register_push(py_SoftQuadrupole);

--- a/tests/python/test_solenoid_softedge_solvable_spin.py
+++ b/tests/python/test_solenoid_softedge_solvable_spin.py
@@ -67,9 +67,10 @@ def test_solenoid_softedge_solvable_spin():
     vpred = Vector3()
     Apred = Map3x6()
 
-    Rmat = ref.map  # not used - included for illustration
-    vmat = ref.spin_rotation_vector
-    Amat = ref.spin_coupling
+    sol_tracked = sim.lattice[0]
+    Rmat = sol_tracked.map  # not used - included for illustration
+    vmat = sol_tracked.spin_rotation_vector
+    Amat = sol_tracked.spin_coupling
 
     print()
     print("Linear map:")


### PR DESCRIPTION
Move out the maps to the 3 elements that use them. Accelerate all other elements.

An alternative implemenetation could move this to the particle container and only copy it in on-demand for phase-space or particle push, which would optimize kernel startup time/kernel parameter bank usage for RFCavity, SoftQuad, SoftSol a bit more.

- [x] fix #1423
- [x] rebase after #1497

## GPU footprint change

GPU kernel parameter bank (`CONSTANT[0]`):

  Measured with `cuobjdump --dump-resource-usage` (RTX A2000, sm_86, double precision):

  | push kernel              | param bank before | after | Δ        |
  |--------------------------|------------------:|------:|---------:|
  | Drift (nospin)           | 1088 B            | 632 B | −456 B   |
  | ExactQuad (nospin)       | 1144 B            | 688 B | −456 B   |
  | ExactCFbend (nospin)     | 1168 B            | 712 B | −456 B   |
  | ExactCFbend (spin)       | 1192 B            | 736 B | −456 B   |
  | ExactMultipole (spin)    | 1192 B            | 736 B | −456 B   |

Every non-matrix element kernel sheds exactly the 456 bytes of matrices.

Bonus: ExactCFbend spin's local-memory spill dropped 1048 → 592 B (−456), since the bloated RefPart is no longer copied into that register-pressured kernel. The 3 matrix elements (RFCavity/SoftSol/SoftQuad) retain ~1.1 KB.

## Performance Impact vs. Headroom Improvement

For compute-bound kernels this makes no difference on GPU.
The payoff is for short, launch/overhead-dominated elements.

The kernel parameter bank (constant memory), which is read once and cached, does (if unread) not affect occupancy (occupancy is driven by registers/shared memory, not param size).
Also, there is a ~4KB limit on this memory bank before spills, no need to over-use it.

Result: register/parameter-bank footprint reduced (and a spill removed in the heaviest spin kernel). Throughput is performance-neutral on GPU for tested elements (incl. Drift).