### PR TITLE
Elements: Const Correctness

### DIFF
--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -146,12 +146,12 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-            T_Real & AMREX_RESTRICT x,
-            T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT t,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT px,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT py,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT pt,
             T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -234,15 +234,15 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            T_Real & AMREX_RESTRICT x,
-            T_Real & AMREX_RESTRICT y,
-            T_Real & AMREX_RESTRICT t,
-            T_Real & AMREX_RESTRICT px,
-            T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
+            T_Real const & AMREX_RESTRICT t,
+            T_Real const & AMREX_RESTRICT px,
+            T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sx,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sy,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sz,
             T_IdCpu & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const

--- a/src/elements/Buncher.H
+++ b/src/elements/Buncher.H
@@ -110,9 +110,9 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-            T_Real & AMREX_RESTRICT x,
-            T_Real & AMREX_RESTRICT y,
-            T_Real & AMREX_RESTRICT t,
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
+            T_Real const & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
@@ -128,8 +128,11 @@ namespace impactx::elements
             T_Real ptout = pt;
 
             // advance position and momentum
+            // xout = x;
             pxout = px + m_kV_r2bg2 * x;
+            // yout = y;
             pyout = py + m_kV_r2bg2 * y;
+            // tout = t;
             ptout = pt + m_neg_kV   * t;
 
             // assign updated momenta

--- a/src/elements/CFbend.H
+++ b/src/elements/CFbend.H
@@ -197,7 +197,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -212,14 +212,14 @@ namespace impactx::elements
             // initialize output values of momenta
             T_Real pxout = px;
             T_Real pyout = py;
-            T_Real ptout = pt;
+            // T_Real ptout = pt;
 
             // update horizontal and longitudinal phase space variables
             //   advance position and momentum: (de)focusing
             x =     m_R11 * xout + m_R12 * px + m_R16 * pt;
             pxout = m_R21 * xout + m_R22 * px + m_R26 * pt;
             t =     m_R51 * xout + m_R52 * px + m_R56 * pt + tout;
-            ptout = pt;
+            // ptout = pt;
 
             // update vertical phase space variables
             //   advance position and momentum (de)focusing
@@ -229,7 +229,7 @@ namespace impactx::elements
             // assign updated momenta
             px = pxout;
             py = pyout;
-            pt = ptout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle.
@@ -296,17 +296,17 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt

--- a/src/elements/ChrDrift.H
+++ b/src/elements/ChrDrift.H
@@ -123,9 +123,9 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT x,
             T_Real & AMREX_RESTRICT y,
             T_Real & AMREX_RESTRICT t,
-            T_Real & AMREX_RESTRICT px,
-            T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT px,
+            T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -140,9 +140,9 @@ namespace impactx::elements
             T_Real const tout = t;
 
             // initialize output values of momenta
-            T_Real const pxout = px;
-            T_Real const pyout = py;
-            T_Real const ptout = pt;
+            // T_Real const pxout = px;
+            // T_Real const pyout = py;
+            // T_Real const ptout = pt;
 
             // compute particle momentum deviation delta + 1
             T_Real const idelta1 = 1_prt / sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
@@ -163,9 +163,9 @@ namespace impactx::elements
             // ptout = pt;
 
             // assign updated momenta
-            px = pxout;
-            py = pyout;
-            pt = ptout;
+            // px = pxout;
+            // py = pyout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle.
@@ -214,26 +214,26 @@ namespace impactx::elements
          * @param px particle momentum in x
          * @param py particle momentum in y
          * @param pt particle momentum in t
-         * @param sx particle spin x-component
-         * @param sy particle spin y-component
-         * @param sz particle spin z-component
+         * @param sx particle spin x-component (unused)
+         * @param sy particle spin y-component (unused)
+         * @param sz particle spin z-component (unused)
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real const & AMREX_RESTRICT px,
+            T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sx,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sy,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
              // spin is unaffected

--- a/src/elements/ChrPlasmaLens.H
+++ b/src/elements/ChrPlasmaLens.H
@@ -138,7 +138,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -163,13 +163,13 @@ namespace impactx::elements
             // initialize output values of momenta
             T_Real pxout = px;
             T_Real pyout = py;
-            T_Real const ptout = pt;
+            // T_Real const ptout = pt;
 
             // placeholder variables -- canonical position and momentum
-            T_Real q1 = x;
-            T_Real q2 = y;
-            T_Real p1 = px;
-            T_Real p2 = py;
+            T_Real const q1 = x;
+            T_Real const q2 = y;
+            T_Real const p1 = px;
+            T_Real const p2 = py;
 
             if (m_g > 0_prt)
             {
@@ -250,7 +250,7 @@ namespace impactx::elements
             t = tout;
             px = pxout;
             py = pyout;
-            pt = ptout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle.
@@ -313,11 +313,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT pt,
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -140,7 +140,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -165,7 +165,7 @@ namespace impactx::elements
             // initialize output values of momenta
             T_Real pxout = px;
             T_Real pyout = py;
-            T_Real const ptout = pt;
+            // T_Real const ptout = pt;
 
             // paceholder variables
             T_Real q1 = xout;
@@ -244,7 +244,7 @@ namespace impactx::elements
             // assign updated momenta
             px = pxout;
             py = pyout;
-            pt = ptout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle.
@@ -303,16 +303,16 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ConstF.H
+++ b/src/elements/ConstF.H
@@ -270,9 +270,9 @@ namespace impactx::elements
          * @param px particle momentum in x
          * @param py particle momentum in y
          * @param pt particle momentum in t
-         * @param sx particle spin x-component
-         * @param sy particle spin y-component
-         * @param sz particle spin z-component
+         * @param sx particle spin x-component (unused)
+         * @param sy particle spin y-component (unused)
+         * @param sz particle spin z-component (unused)
          * @param idcpu particle global index
          * @param refpart reference particle (unused)
          */
@@ -285,10 +285,10 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sx,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sy,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/DipEdge.H
+++ b/src/elements/DipEdge.H
@@ -191,7 +191,7 @@ namespace impactx::elements
          *
          * @param x particle position in x
          * @param y particle position in y
-         * @param t particle position in t (unchanged)
+         * @param t particle position in t (unchanged by the linear model)
          * @param px particle momentum in x
          * @param py particle momentum in y
          * @param pt particle momentum in t (unchanged)
@@ -203,10 +203,10 @@ namespace impactx::elements
         void operator() (
             T_Real & AMREX_RESTRICT x,
             T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -227,7 +227,7 @@ namespace impactx::elements
                T_Real yout = y;
                T_Real pyout = py;
                T_Real tout = t;
-               T_Real ptout = pt;
+               // T_Real ptout = pt;
 
                // compute particle momentum deviation delta + 1 (reciprocal)
                T_Real const inv_delta1 = 1_prt / sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
@@ -280,7 +280,7 @@ namespace impactx::elements
                y = yout;
                py = pyout;
                t = tout;
-               pt = ptout;
+               // pt = ptout;
             }
         }
 
@@ -296,12 +296,12 @@ namespace impactx::elements
             using amrex::Math::powi;
 
             // assign input reference particle values
-            [[maybe_unused]] amrex::ParticleReal const x = refpart.x;
-            [[maybe_unused]] amrex::ParticleReal const z = refpart.z;
-            [[maybe_unused]] amrex::ParticleReal const t = refpart.t;
-            [[maybe_unused]] amrex::ParticleReal const px = refpart.px;
-            [[maybe_unused]] amrex::ParticleReal const pz = refpart.pz;
-            [[maybe_unused]] amrex::ParticleReal const pt = refpart.pt;
+            amrex::ParticleReal const x = refpart.x;
+            amrex::ParticleReal const z = refpart.z;
+            amrex::ParticleReal const t = refpart.t;
+            amrex::ParticleReal const px = refpart.px;
+            amrex::ParticleReal const pz = refpart.pz;
+            amrex::ParticleReal const pt = refpart.pt;
 
             if (m_modify_ref_part && m_model == dipedge::Model::nonlinear) {
                 // calculate expensive terms

--- a/src/elements/Drift.H
+++ b/src/elements/Drift.H
@@ -122,9 +122,9 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT x,
             T_Real & AMREX_RESTRICT y,
             T_Real & AMREX_RESTRICT t,
-            T_Real & AMREX_RESTRICT px,
-            T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT px,
+            T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -135,9 +135,9 @@ namespace impactx::elements
             T_Real xout = x;
             T_Real yout = y;
             T_Real tout = t;
-            T_Real pxout = px;
-            T_Real pyout = py;
-            T_Real ptout = pt;
+            // T_Real pxout = px;
+            // T_Real pyout = py;
+            // T_Real ptout = pt;
 
             // advance position and momentum (drift)
             xout = x + m_slice_ds * px;
@@ -151,9 +151,9 @@ namespace impactx::elements
             x = xout;
             y = yout;
             t = tout;
-            px = pxout;
-            py = pyout;
-            pt = ptout;
+            // px = pxout;
+            // py = pyout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle.
@@ -204,24 +204,24 @@ namespace impactx::elements
          * @param pt particle momentum in t
          * @param idcpu particle global index
          * @param refpart reference particle (unused)
-         * @param sx particle spin x-component
-         * @param sy particle spin y-component
-         * @param sz particle spin z-component
+         * @param sx particle spin x-component (unused)
+         * @param sy particle spin y-component (unused)
+         * @param sz particle spin z-component (unused)
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real const & AMREX_RESTRICT px,
+            T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sx,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sy,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
              // spin is unaffected

--- a/src/elements/Empty.H
+++ b/src/elements/Empty.H
@@ -105,12 +105,12 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT x,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT y,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT t,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT px,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT py,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const

--- a/src/elements/ExactCFbend.H
+++ b/src/elements/ExactCFbend.H
@@ -750,7 +750,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ExactDrift.H
+++ b/src/elements/ExactDrift.H
@@ -121,9 +121,9 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT x,
             T_Real & AMREX_RESTRICT y,
             T_Real & AMREX_RESTRICT t,
-            T_Real & AMREX_RESTRICT px,
-            T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT px,
+            T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -138,9 +138,9 @@ namespace impactx::elements
             T_Real const tout = t;
 
             // initialize output values of momenta
-            T_Real const pxout = px;
-            T_Real const pyout = py;
-            T_Real const ptout = pt;
+            // T_Real const pxout = px;
+            // T_Real const pyout = py;
+            // T_Real const ptout = pt;
 
             // compute the radical in the denominator (= pz):
             T_Real const inv_pzden = 1_prt / sqrt(
@@ -159,9 +159,9 @@ namespace impactx::elements
             // ptout = pt;
 
             // assign updated momenta
-            px = pxout;
-            py = pyout;
-            pt = ptout;
+            // px = pxout;
+            // py = pyout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle.
@@ -210,26 +210,26 @@ namespace impactx::elements
          * @param px particle momentum in x
          * @param py particle momentum in y
          * @param pt particle momentum in t
-         * @param sx particle spin x-component
-         * @param sy particle spin y-component
-         * @param sz particle spin z-component
+         * @param sx particle spin x-component (unused)
+         * @param sy particle spin y-component (unused)
+         * @param sz particle spin z-component (unused)
          * @param idcpu particle global index
          * @param refpart reference particle (unused)
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real const & AMREX_RESTRICT px,
+            T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sx,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sy,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
              // spin is unaffected

--- a/src/elements/ExactMultipole.H
+++ b/src/elements/ExactMultipole.H
@@ -617,7 +617,7 @@ namespace impactx::elements
          * @param[in,out] sx particle spin x-component
          * @param[in,out] sy particle spin y-component
          * @param[in,out] sz particle spin z-component
-         * @param[in,out] idcpu particle global index
+         * @param[in,out] idcpu particle global index (unused)
          * @param[in] refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
@@ -632,7 +632,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -504,7 +504,7 @@ namespace impactx::elements
          * @param[in,out] sx particle spin x-component
          * @param[in,out] sy particle spin y-component
          * @param[in,out] sz particle spin z-component
-         * @param[in,out] idcpu particle global index
+         * @param[in,out] idcpu particle global index (unused)
          * @param[in] refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
@@ -519,7 +519,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -160,8 +160,8 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT y,
             T_Real & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
-            T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
             T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -178,8 +178,8 @@ namespace impactx::elements
 
             // initialize output values of momenta
             T_Real pxout = px;
-            T_Real pyout = py;
-            T_Real ptout = pt;
+            // T_Real pyout = py;
+            // T_Real ptout = pt;
 
             // treat the special case of zero field
             if (m_phi==0_prt && m_B==0_prt) {
@@ -200,9 +200,9 @@ namespace impactx::elements
                // ptout = pt;
 
                // assign updated momenta
-               px = pxout;
-               py = pyout;
-               pt = ptout;
+               // px = pxout;
+               // py = pyout;
+               // pt = ptout;
 
             } else {
 
@@ -219,8 +219,8 @@ namespace impactx::elements
 
                    // update momenta
                    pxout = px * m_cos_phi + (pzi - rho / m_rc) * m_sin_phi;
-                   pyout = py;
-                   ptout = pt;
+                   // pyout = py;
+                   // ptout = pt;
 
                    // angle of momentum rotation
                    T_Real const px2f = powi<2>(pxout);
@@ -238,8 +238,8 @@ namespace impactx::elements
 
                        // assign updated momenta
                        px = pxout;
-                       py = pyout;
-                       pt = ptout;
+                       // py = pyout;
+                       // pt = ptout;
                    }
                }
             }
@@ -373,22 +373,22 @@ namespace impactx::elements
          * @param sy particle spin y-component
          * @param sz particle spin z-component
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            T_IdCpu & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -406,12 +406,12 @@ namespace impactx::elements
             T_Real lambdaz = 0_prt;
 
             // store initial variables needed for spin push
-            T_Real ti = t;
-            T_Real Pnorm = sqrt(1_prt + pt*pt - 2_prt*pt*m_ibeta);
-            T_Real gamma = (1_prt - pt*m_beta)*refpart.gamma();
-            T_Real ux = px/Pnorm;
-            T_Real uy = py/Pnorm;
-            T_Real uz = sqrt(1_prt - ux*ux - uy*uy);
+            T_Real const ti = t;
+            T_Real const Pnorm = sqrt(1_prt + pt*pt - 2_prt*pt*m_ibeta);
+            T_Real const gamma = (1_prt - pt*m_beta)*refpart.gamma();
+            T_Real const ux = px/Pnorm;
+            T_Real const uy = py/Pnorm;
+            T_Real const uz = sqrt(1_prt - ux*ux - uy*uy);
 
             // For this element, note that the time-of-flight from entry to
             // exit is needed for evaluation of the spin map, so the phase
@@ -421,10 +421,10 @@ namespace impactx::elements
             (*this)(x, y, t, px, py, pt, idcpu, refpart);
 
             // particle transit time through the slice
-            T_Real dt = t - ti + m_slice_phi * m_rc * m_ibeta;
+            T_Real const dt = t - ti + m_slice_phi * m_rc * m_ibeta;
 
             // advance in cyclotron phase
-            T_Real theta = dt / m_rc * m_beta_gamma / gamma;
+            T_Real const theta = dt / m_rc * m_beta_gamma / gamma;
 
             lambdax = m_gyro * theta * (gamma - 1_prt) * uy * ux;
             lambday = m_gyro * theta * ( -gamma + (gamma - 1_prt) * uy * uy );

--- a/src/elements/Kicker.H
+++ b/src/elements/Kicker.H
@@ -102,24 +102,24 @@ namespace impactx::elements
          *
          * The @see compute_constants method must be called before pushing particles through this operator.
          *
-         * @param x particle position in x
-         * @param y particle position in y
-         * @param t particle position in t
+         * @param x particle position in x (unused)
+         * @param y particle position in y (unused)
+         * @param t particle position in t (unused)
          * @param px particle momentum in x
          * @param py particle momentum in y
-         * @param pt particle momentum in t
+         * @param pt particle momentum in t (unused)
          * @param idcpu particle global index (unused)
          * @param refpart reference particle (unused)
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-            T_Real & AMREX_RESTRICT x,
-            T_Real & AMREX_RESTRICT y,
-            T_Real & AMREX_RESTRICT t,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT x,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT y,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -127,9 +127,9 @@ namespace impactx::elements
             using namespace amrex::literals; // for _rt and _prt
 
             // access position data
-            T_Real const xout = x;
-            T_Real const yout = y;
-            T_Real const tout = t;
+            // T_Real const xout = x;
+            // T_Real const yout = y;
+            // T_Real const tout = t;
 
             // normalize quad units to MAD-X convention if needed
             amrex::ParticleReal const dpx = m_xkick * m_p_scale;
@@ -138,22 +138,22 @@ namespace impactx::elements
             // initialize output values of momenta
             T_Real pxout = px;
             T_Real pyout = py;
-            T_Real ptout = pt;
+            // T_Real ptout = pt;
 
             // advance position and momentum
-            x = xout;
+            // x = xout;
             pxout = px + dpx;
 
-            y = yout;
+            // y = yout;
             pyout = py + dpy;
 
-            t = tout;
-            ptout = pt;
+            // t = tout;
+            // ptout = pt;
 
             // assign updated momenta
             px = pxout;
             py = pyout;
-            pt = ptout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle. */

--- a/src/elements/LinearMap.H
+++ b/src/elements/LinearMap.H
@@ -130,11 +130,11 @@ namespace impactx::elements
          *
          * @param x particle position in x
          * @param y particle position in y
-         * @param t particle position in t (unused)
+         * @param t particle position in t
          * @param px particle momentum in x
          * @param py particle momentum in y
-         * @param pt particle momentum in t (unused)
-         * @param idcpu particle global index
+         * @param pt particle momentum in t
+         * @param idcpu particle global index (unused)
          * @param refpart reference particle (unused)
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
@@ -153,7 +153,7 @@ namespace impactx::elements
             using namespace amrex::literals; // for _rt and _prt
 
             // input and output phase space vectors
-            amrex::SmallVector<T_Real, 6, 1> vectorin{
+            amrex::SmallVector<T_Real, 6, 1> const vectorin{
                 x, px, y, py, t, pt
             };
 
@@ -241,24 +241,24 @@ namespace impactx::elements
          * @param pt particle momentum in t
          * @param idcpu particle global index
          * @param refpart reference particle (unused)
-         * @param sx particle spin x-component
-         * @param sy particle spin y-component
-         * @param sz particle spin z-component
+         * @param sx particle spin x-component (unused)
+         * @param sy particle spin y-component (unused)
+         * @param sz particle spin z-component (unused)
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sx,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sy,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
              // spin is unaffected

--- a/src/elements/Marker.H
+++ b/src/elements/Marker.H
@@ -82,12 +82,12 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT x,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT y,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT t,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT px,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT py,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const

--- a/src/elements/Multipole.H
+++ b/src/elements/Multipole.H
@@ -122,22 +122,22 @@ namespace impactx::elements
          *
          * @param x particle position in x
          * @param y particle position in y
-         * @param t particle position in t
+         * @param t particle position in t (unused)
          * @param px particle momentum in x
          * @param py particle momentum in y
-         * @param pt particle momentum in t
+         * @param pt particle momentum in t (unused)
          * @param idcpu particle global index (unused)
          * @param refpart reference particle (unused)
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-            T_Real & AMREX_RESTRICT x,
-            T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -152,12 +152,12 @@ namespace impactx::elements
             //amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
 
             // initialize output values
-            T_Real xout = x;
-            T_Real yout = y;
-            T_Real tout = t;
+            // T_Real xout = x;
+            // T_Real yout = y;
+            // T_Real tout = t;
             T_Real pxout = px;
             T_Real pyout = py;
-            T_Real ptout = pt;
+            // T_Real ptout = pt;
 
             // assign complex position and complex multipole strength
             Complex const zeta(x, y);
@@ -176,15 +176,15 @@ namespace impactx::elements
             pyout = py + dpy;
 
             // tout = t;
-            ptout = pt;
+            // ptout = pt;
 
             // assign updated values
-            x = xout;
-            y = yout;
-            t = tout;
+            // x = xout;
+            // y = yout;
+            // t = tout;
             px = pxout;
             py = pyout;
-            pt = ptout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle. */
@@ -208,16 +208,16 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
+            T_Real const & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/NonlinearLens.H
+++ b/src/elements/NonlinearLens.H
@@ -102,22 +102,22 @@ namespace impactx::elements
          *
          * @param x particle position in x
          * @param y particle position in y
-         * @param t particle position in t
+         * @param t particle position in t (unused)
          * @param px particle momentum in x
          * @param py particle momentum in y
-         * @param pt particle momentum in t
+         * @param pt particle momentum in t (unused)
          * @param idcpu particle global index (unused)
          * @param refpart reference particle (unused)
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-            T_Real & AMREX_RESTRICT x,
-            T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -133,12 +133,12 @@ namespace impactx::elements
             //amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
 
             // initialize output values
-            T_Real xout = x;
-            T_Real yout = y;
-            T_Real tout = t;
+            // T_Real xout = x;
+            // T_Real yout = y;
+            // T_Real tout = t;
             T_Real pxout = px;
             T_Real pyout = py;
-            T_Real ptout = pt;
+            // T_Real ptout = pt;
 
             // assign complex position zeta = (x + iy)/cnll
             Complex zeta(x, y);
@@ -171,15 +171,15 @@ namespace impactx::elements
             pyout = py + dpy;
 
             // tout = t;
-            ptout = pt;
+            // ptout = pt;
 
             // assign updated values
-            x = xout;
-            y = yout;
-            t = tout;
+            // x = xout;
+            // y = yout;
+            // t = tout;
             px = pxout;
             py = pyout;
-            pt = ptout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle. */

--- a/src/elements/PRot.H
+++ b/src/elements/PRot.H
@@ -113,8 +113,8 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT y,
             T_Real & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
-            T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -128,8 +128,8 @@ namespace impactx::elements
             T_Real yout = y;
             T_Real tout = t;
             T_Real pxout = px;
-            T_Real pyout = py;
-            T_Real ptout = pt;
+            // T_Real pyout = py;
+            // T_Real ptout = pt;
 
             T_Real const pz = sqrt(
                 1.0_prt -
@@ -145,18 +145,18 @@ namespace impactx::elements
             pxout = px * m_cos_theta + (pz - m_cos_phi_in) * m_sin_theta;
 
             yout = y + py * x * m_sin_theta / pzf;
-            pyout = py;
+            // pyout = py;
 
             tout = t - (pt - m_inv_beta) * x * m_sin_theta / pzf;
-            ptout = pt;
+            // ptout = pt;
 
             // assign updated values
             x = xout;
             y = yout;
             t = tout;
             px = pxout;
-            py = pyout;
-            pt = ptout;
+            // py = pyout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle. */

--- a/src/elements/PlaneXYRot.H
+++ b/src/elements/PlaneXYRot.H
@@ -98,10 +98,10 @@ namespace impactx::elements
          *
          * @param x particle position in x
          * @param y particle position in y
-         * @param t particle position in t
+         * @param t particle position in t (unused)
          * @param px particle momentum in x
          * @param py particle momentum in y
-         * @param pt particle momentum in t
+         * @param pt particle momentum in t (unused)
          * @param idcpu particle global index (unused)
          * @param refpart reference particle
          */
@@ -110,10 +110,10 @@ namespace impactx::elements
         void operator() (
             T_Real & AMREX_RESTRICT x,
             T_Real & AMREX_RESTRICT y,
-            T_Real & AMREX_RESTRICT t,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -121,10 +121,10 @@ namespace impactx::elements
             // initialize output values
             T_Real xout = x;
             T_Real yout = y;
-            T_Real tout = t;
+            // T_Real tout = t;
             T_Real pxout = px;
             T_Real pyout = py;
-            T_Real ptout = pt;
+            // T_Real ptout = pt;
 
             // advance position and momentum
             xout = x * m_cos_phi - y * m_sin_phi;
@@ -139,10 +139,10 @@ namespace impactx::elements
             // assign updated values
             x = xout;
             y = yout;
-            t = tout;
+            // t = tout;
             px = pxout;
             py = pyout;
-            pt = ptout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle. */

--- a/src/elements/PolygonAperture.H
+++ b/src/elements/PolygonAperture.H
@@ -172,12 +172,12 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-            T_Real & AMREX_RESTRICT x,
-            T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT t,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT px,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT py,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT pt,
             T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -208,14 +208,14 @@ namespace impactx::elements
 #endif
 
             // if the aperture is periodic, shift sx,sy coordinates to the fundamental domain
-            T_Real u = (m_repeat_x == 0_prt) ? sx : (fmod(abs(sx)+dx, m_repeat_x)-dx);
-            T_Real v = (m_repeat_y == 0_prt) ? sy : (fmod(abs(sy)+dy, m_repeat_y)-dy);
+            T_Real const u = (m_repeat_x == 0_prt) ? sx : (fmod(abs(sx)+dx, m_repeat_x)-dx);
+            T_Real const v = (m_repeat_y == 0_prt) ? sy : (fmod(abs(sy)+dy, m_repeat_y)-dy);
 
             // compare against the aperture boundary
             VBool inside_aperture;
 
             // calculate whether point is inside polygon or not
-            T_Real r2 = powi<2>(u) + powi<2>(v);
+            T_Real const r2 = powi<2>(u) + powi<2>(v);
             // are we inside the minimum radius?
             if (r2 < m_min_radius2) {
                 inside_aperture = VBool(true); // yes!
@@ -286,15 +286,15 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            T_Real & AMREX_RESTRICT x,
-            T_Real & AMREX_RESTRICT y,
-            T_Real & AMREX_RESTRICT t,
-            T_Real & AMREX_RESTRICT px,
-            T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
+            T_Real const & AMREX_RESTRICT t,
+            T_Real const & AMREX_RESTRICT px,
+            T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sx,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sy,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sz,
             T_IdCpu & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const

--- a/src/elements/Quad.H
+++ b/src/elements/Quad.H
@@ -143,7 +143,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -156,7 +156,7 @@ namespace impactx::elements
             T_Real tout = t;
             T_Real pxout = px;
             T_Real pyout = py;
-            T_Real const ptout = pt;
+            // T_Real const ptout = pt;
 
             if (m_k > 0.0_prt)
             {
@@ -196,7 +196,7 @@ namespace impactx::elements
             t = tout;
             px = pxout;
             py = pyout;
-            pt = ptout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle.
@@ -306,17 +306,17 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt

--- a/src/elements/QuadEdge.H
+++ b/src/elements/QuadEdge.H
@@ -139,10 +139,10 @@ namespace impactx::elements
         void operator() (
             T_Real & AMREX_RESTRICT x,
             T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -154,7 +154,7 @@ namespace impactx::elements
 
             // compute particle momentum deviation delta + 1
             T_Real const delta1 = sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
-            T_Real a = m_a / delta1;
+            T_Real const a = m_a / delta1;
 
             // initialize output values
             T_Real xout = x;
@@ -164,9 +164,9 @@ namespace impactx::elements
             T_Real pyout = py;
 
             // intermediate quantities to be used below
-            T_Real x2my2 = x*x - y*y;
-            T_Real x2py2 = x*x + y*y;
-            T_Real denominator = 1_prt - 9_prt*powi<2>(a)*powi<2>(x2my2);
+            T_Real const x2my2 = x*x - y*y;
+            T_Real const x2py2 = x*x + y*y;
+            T_Real const denominator = 1_prt - 9_prt*powi<2>(a)*powi<2>(x2my2);
 
             // apply edge focusing (transverse phase space)
             xout = x - a * (powi<3>(x) + 3_prt * x * powi<2>(y));
@@ -176,7 +176,7 @@ namespace impactx::elements
             pyout = (py - 3_prt*a*py*x2py2 + 6_prt*a*px*x*y) / denominator;
 
             // apply edge focusing (longitudinal phase space)
-            T_Real f4 = a * ( pxout * (powi<3>(x) + 3_prt*x*powi<2>(y))
+            T_Real const f4 = a * ( pxout * (powi<3>(x) + 3_prt*x*powi<2>(y))
                                          - pyout * (powi<3>(y) + 3_prt*y*powi<2>(x)) );
             tout = t + f4 * (pt - 1_prt/m_beta) / powi<2>(delta1);
 

--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -343,7 +343,7 @@ namespace impactx::elements
          * @param sy particle spin y-component
          * @param sz particle spin z-component
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -357,7 +357,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/Sbend.H
+++ b/src/elements/Sbend.H
@@ -174,8 +174,8 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT y,
             T_Real & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
-            T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -189,8 +189,8 @@ namespace impactx::elements
 
             // initialize output values of momenta
             T_Real pxout = px;
-            T_Real const pyout = py;
-            T_Real const ptout = pt;
+            // T_Real const pyout = py;
+            // T_Real const ptout = pt;
 
             // advance position and momentum (sector bend)
             T_Real const R22 =  m_R11;
@@ -222,8 +222,8 @@ namespace impactx::elements
             y = yout;
             t = tout;
             px = pxout;
-            py = pyout;
-            pt = ptout;
+            // py = pyout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle.
@@ -357,17 +357,17 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt

--- a/src/elements/ShortRF.H
+++ b/src/elements/ShortRF.H
@@ -107,8 +107,8 @@ namespace impactx::elements
          *
          * The @see compute_constants method must be called before pushing particles through this operator.
          *
-         * @param x particle position in x
-         * @param y particle position in y
+         * @param x particle position in x (unused)
+         * @param y particle position in y (unused)
          * @param t particle position in t
          * @param px particle momentum in x
          * @param py particle momentum in y
@@ -119,9 +119,9 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-            T_Real & AMREX_RESTRICT x,
-            T_Real & AMREX_RESTRICT y,
-            T_Real & AMREX_RESTRICT t,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT x,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT y,
+            T_Real const & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
@@ -139,29 +139,29 @@ namespace impactx::elements
             pt = pt * m_bgi;
 
             // initialize output values
-            T_Real xout = x;
-            T_Real yout = y;
-            T_Real tout = t;
-            T_Real pxout = px;
-            T_Real pyout = py;
+            // T_Real xout = x;
+            // T_Real yout = y;
+            // T_Real tout = t;
+            // T_Real pxout = px;
+            // T_Real pyout = py;
             T_Real ptout = pt;
 
             // advance position and momentum in dynamic units
             // xout = x;
-            pxout = px;
+            // pxout = px;
 
             // yout = y;
-            pyout = py;
+            // pyout = py;
 
             // tout = t;
             ptout = pt - m_V * cos(m_k * t + m_phi) + m_V_cos_phi;
 
             // assign updated values
-            x = xout;
-            y = yout;
-            t = tout;
-            px = pxout;
-            py = pyout;
+            // x = xout;
+            // y = yout;
+            // t = tout;
+            // px = pxout;
+            // py = pyout;
             pt = ptout;
 
             // final conversion from dynamic to static units:

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -335,7 +335,7 @@ namespace impactx::elements
          * @param sy particle spin y-component
          * @param sz particle spin z-component
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -349,7 +349,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -344,7 +344,7 @@ namespace impactx::elements
          * @param sy particle spin y-component
          * @param sz particle spin z-component
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -358,7 +358,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            T_IdCpu & AMREX_RESTRICT idcpu,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/Sol.H
+++ b/src/elements/Sol.H
@@ -150,7 +150,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -163,7 +163,7 @@ namespace impactx::elements
             T_Real tout = t;
             T_Real pxout = px;
             T_Real pyout = py;
-            T_Real ptout = pt;
+            // T_Real ptout = pt;
 
             // advance positions and momenta using map for focusing
             xout = m_cos_theta        * x
@@ -177,12 +177,12 @@ namespace impactx::elements
                   + m_cos_theta           * py;
 
             tout = t + m_ds_bg2 * pt;
-            ptout = pt;
+            // ptout = pt;
 
             // assign intermediate momenta
             px = pxout;
             py = pyout;
-            pt = ptout;
+            // pt = ptout;
 
             // advance positions and momenta using map for rotation
             x = m_cos_theta * xout
@@ -196,12 +196,12 @@ namespace impactx::elements
                    + m_cos_theta * py;
 
             t = tout;
-            ptout = pt;
+            // ptout = pt;
 
             // assign updated values
             px = pxout;
             py = pyout;
-            pt = ptout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle.
@@ -259,17 +259,17 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt

--- a/src/elements/SpinMap.H
+++ b/src/elements/SpinMap.H
@@ -99,24 +99,24 @@ namespace impactx::elements
         /** This is a SpinMap functor, so that a variable of this type can be used like a
          *  SpinMap function.
          *
-         * @param x particle position in x
-         * @param y particle position in y
+         * @param x particle position in x (unused)
+         * @param y particle position in y (unused)
          * @param t particle position in t (unused)
-         * @param px particle momentum in x
-         * @param py particle momentum in y
+         * @param px particle momentum in x (unused)
+         * @param py particle momentum in y (unused)
          * @param pt particle momentum in t (unused)
-         * @param idcpu particle global index
+         * @param idcpu particle global index (unused)
          * @param refpart reference particle (unused)
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT x,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT y,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT t,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT px,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT py,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -172,17 +172,17 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT t,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT px,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sx,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sy,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
+            T_Real const & AMREX_RESTRICT t,
+            T_Real const & AMREX_RESTRICT px,
+            T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -193,7 +193,7 @@ namespace impactx::elements
             T_Real lambdaz = 0_prt;
 
             // input phase space 6-vector
-            amrex::SmallVector<T_Real, 6, 1> vectorin{
+            amrex::SmallVector<T_Real, 6, 1> const vectorin{
                 x, px, y, py, t, pt
             };
 

--- a/src/elements/TaperedPL.H
+++ b/src/elements/TaperedPL.H
@@ -110,22 +110,22 @@ namespace impactx::elements
          *
          * @param x particle position in x
          * @param y particle position in y
-         * @param t particle position in t
+         * @param t particle position in t (unused)
          * @param px particle momentum in x
          * @param py particle momentum in y
-         * @param pt particle momentum in t
+         * @param pt particle momentum in t (unused)
          * @param idcpu particle global index (unused)
          * @param refpart reference particle (unused)
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-            T_Real & AMREX_RESTRICT x,
-            T_Real & AMREX_RESTRICT y,
-            T_Real & AMREX_RESTRICT t,
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -135,30 +135,30 @@ namespace impactx::elements
             using namespace std; // for cmath(float)
 
             // initialize output values
-            T_Real xout = x;
-            T_Real yout = y;
-            T_Real tout = t;
+            // T_Real xout = x;
+            // T_Real yout = y;
+            // T_Real tout = t;
             T_Real pxout = px;
             T_Real pyout = py;
-            T_Real ptout = pt;
+            // T_Real ptout = pt;
 
             // advance position and momentum
-            xout = x;
+            // xout = x;
             pxout = px - m_g * ( x + m_taper*0.5_prt * (powi<2>(x) + powi<2>(y)) );
 
-            yout = y;
+            // yout = y;
             pyout = py - m_g * ( y + m_taper * x * y );
 
-            tout = t;
-            ptout = pt;
+            // tout = t;
+            // ptout = pt;
 
             // assign updated values
-            x = xout;
-            y = yout;
-            t = tout;
+            // x = xout;
+            // y = yout;
+            // t = tout;
             px = pxout;
             py = pyout;
-            pt = ptout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle. */
@@ -182,16 +182,16 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            T_Real & AMREX_RESTRICT x,
-            T_Real & AMREX_RESTRICT y,
-            T_Real & AMREX_RESTRICT t,
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
+            T_Real const & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT pt,
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu & AMREX_RESTRICT idcpu,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {
@@ -218,7 +218,7 @@ namespace impactx::elements
             T_Real lambdaz = 0_prt;
 
             // compute multipole magnetic field normalized by q/mc:
-            amrex::ParticleReal gamma_ref = refpart.gamma();
+            amrex::ParticleReal const gamma_ref = refpart.gamma();
             T_Real const Bx = -m_g * ( y + m_taper * x * y ) * gamma_ref * m_beta;
             T_Real const By = m_g * ( x + m_taper*0.5_prt * (powi<2>(x) + powi<2>(y)) ) * gamma_ref * m_beta;
             T_Real const Bz = 0_prt;
@@ -242,7 +242,7 @@ namespace impactx::elements
             amrex::ParticleReal const h = 0.0_prt;
 
             // Evaluation of the full Thomas-BMT precession vector.
-            amrex::ParticleReal gyro_anomaly = refpart.gyromagnetic_anomaly;
+            amrex::ParticleReal const gyro_anomaly = refpart.gyromagnetic_anomaly;
             tbmt_precession_vector(x, ux, uy, uz, gamma, h, gyro_anomaly, Bx, By, Bz, Ex, Ey, Ez, lambdax, lambday, lambdaz);
 
             // push the spin vector using the generator just determined

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -103,10 +103,10 @@ namespace impactx::elements
          * The @see compute_constants method must be called before pushing particles through this operator.
          *
          * @param x particle position in x
-         * @param y particle position in y
+         * @param y particle position in y (unused)
          * @param t particle position in t
          * @param px particle momentum in x
-         * @param py particle momentum in y
+         * @param py particle momentum in y (unused)
          * @param pt particle momentum in t
          * @param idcpu particle global index (unused)
          * @param refpart reference particle (unused)
@@ -114,12 +114,12 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (
-            T_Real & AMREX_RESTRICT x,
-            T_Real & AMREX_RESTRICT y,
+            T_Real const & AMREX_RESTRICT x,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT y,
             T_Real & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
-            T_Real & AMREX_RESTRICT py,
-            T_Real & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
@@ -130,32 +130,32 @@ namespace impactx::elements
 
             // access position data
             T_Real const xout = x;
-            T_Real const yout = y;
+            // T_Real const yout = y;
             T_Real const tout = t;
 
             // initialize output values of momenta
             T_Real pxout = px;
-            T_Real pyout = py;
-            T_Real ptout = pt;
+            // T_Real pyout = py;
+            // T_Real ptout = pt;
 
             // compute the function expressing dp/p in terms of pt (labeled f in Ripken etc.)
             T_Real const f = -1.0_prt + sqrt(1.0_prt - 2.0_prt * pt / m_beta + powi<2>(pt));
             T_Real const fprime = (1.0_prt - m_beta*pt) / (m_beta * (1.0_prt + f));
 
             // advance position and momentum
-            x = xout;
+            // x = xout;
             pxout = px - powi<2>(m_kx) * m_ds * xout + m_kx * m_ds * f; //eq (3.2b)
 
-            y = yout;
-            pyout = py;
+            // y = yout;
+            // pyout = py;
 
             t = tout + m_kx * xout * m_ds * fprime; //eq (3.2e)
-            ptout = pt;
+            // ptout = pt;
 
             // assign updated momenta
             px = pxout;
-            py = pyout;
-            pt = ptout;
+            // py = pyout;
+            // pt = ptout;
         }
 
         /** This pushes the reference particle. */


### PR DESCRIPTION
We rely on proper marking of `const` to avoid unnecessary write-back/store in SIMD code. Ensure all phase space and spin pushes are properly declared. Simplify code that never truly modifies a passed argument.