### PR TITLE
Add support for nonzero dispersion in envelope mode

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1613,18 +1613,18 @@ add_impactx_test(dogleg-reverse.py
 )
 
 # Dogleg in Reverse with Envelope Tracking #############################################
-# 
+#
 add_impactx_test(dogleg-reverse-envelope
     examples/dogleg/input_dogleg_reverse_envelope.in
     ON   # ImpactX MPI-parallel
     examples/dogleg/analysis_dogleg_reverse_envelope.py
-    OFF  # no plot script yet   
+    OFF  # no plot script yet
 )
 add_impactx_test(dogleg-reverse-envelope.py
     examples/dogleg/run_dogleg_reverse_envelope.py
     ON   # ImpactX MPI-parallel
     examples/dogleg/analysis_dogleg_reverse_envelope.py
-    OFF  # no plot script yet  
+    OFF  # no plot script yet
 )
 
 # Dogleg with Energy Jitter ###################################################

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1612,6 +1612,21 @@ add_impactx_test(dogleg-reverse.py
     OFF  # no plot script yet
 )
 
+# Dogleg in Reverse with Envelope Tracking #############################################
+# 
+add_impactx_test(dogleg-reverse-envelope
+    examples/dogleg/input_dogleg_reverse_envelope.in
+    ON   # ImpactX MPI-parallel
+    examples/dogleg/analysis_dogleg_reverse_envelope.py
+    OFF  # no plot script yet   
+)
+add_impactx_test(dogleg-reverse-envelope.py
+    examples/dogleg/run_dogleg_reverse_envelope.py
+    ON   # ImpactX MPI-parallel
+    examples/dogleg/analysis_dogleg_reverse_envelope.py
+    OFF  # no plot script yet  
+)
+
 # Dogleg with Energy Jitter ###################################################
 #
 add_impactx_test(dogleg-jitter

--- a/examples/dogleg/README.rst
+++ b/examples/dogleg/README.rst
@@ -113,6 +113,65 @@ We run the following script to analyze correctness:
       :caption: You can copy this file from ``examples/dogleg/analysis_dogleg_reverse.py``.
 
 
+
+.. _examples-dogleg-reverse-env:
+
+Dogleg in Reverse Using Envelope Solver
+========================================
+
+This is identical to :ref:`reverse dogleg example <examples-dogleg-reverse>`, except that envelope tracking is used instead of particle tracking.
+
+The primary purpose is to demonstrate the initialization of a beam with a nonzero x-pt correlation in a lattice region with nonzero dispersion.
+
+In this example, the x-pt correlation of the beam is removed at the dogleg exit, and the dispersion goes to zero.
+
+The initial dispersion is taken to be -267 mm.
+
+In this test, the initial and final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must
+agree with nominal values.
+
+In addition, the initial and final values of :math:`\alpha_x`, :math:`\alpha_y`, :math:`\beta_x`, :math:`\beta_y`, :math:`D_x`, and :math:`D_{px}` must
+agree with nominal values.
+
+Run
+---
+
+This example can be run **either** as:
+
+* **Python** script: ``python3 run_dogleg_reverse_envelope.py`` or
+* ImpactX **executable** using an input file: ``impactx input_dogleg_reverse_envelope.in``
+
+For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+
+.. tab-set::
+
+   .. tab-item:: Python: Script
+
+       .. literalinclude:: run_dogleg_reverse_envelope.py
+          :language: python3
+          :caption: You can copy this file from ``examples/dogleg/run_dogleg_reverse_envelope.py``.
+
+   .. tab-item:: Executable: Input File
+
+       .. literalinclude:: input_dogleg_reverse_envelope.in
+          :language: ini
+          :caption: You can copy this file from ``examples/dogleg/input_dogleg_reverse_envelope.in``.
+
+
+Analyze
+-------
+
+We run the following script to analyze correctness:
+
+.. dropdown:: Script ``analysis_dogleg_reverse_envelope.py``
+
+   .. literalinclude:: analysis_dogleg_reverse_envelope.py
+      :language: python3
+      :caption: You can copy this file from ``examples/dogleg/analysis_dogleg_reverse_envelope.py``.
+
+
+
+
 .. _examples-dogleg-jitter:
 
 Dogleg with Energy Jitter

--- a/examples/dogleg/README.rst
+++ b/examples/dogleg/README.rst
@@ -117,7 +117,7 @@ We run the following script to analyze correctness:
 .. _examples-dogleg-reverse-env:
 
 Dogleg in Reverse Using Envelope Solver
-========================================
+=======================================
 
 This is identical to :ref:`reverse dogleg example <examples-dogleg-reverse>`, except that envelope tracking is used instead of particle tracking.
 

--- a/examples/dogleg/analysis_dogleg_reverse_envelope.py
+++ b/examples/dogleg/analysis_dogleg_reverse_envelope.py
@@ -136,7 +136,9 @@ assert np.allclose(
 
 print("")
 print("Initial Twiss functions:")
-print(f"  alpha_x={alpha_xi:e} beta_x={beta_xi:e} alpha_y={alpha_yi:e} beta_y={beta_yi:e}")
+print(
+    f"  alpha_x={alpha_xi:e} beta_x={beta_xi:e} alpha_y={alpha_yi:e} beta_y={beta_yi:e}"
+)
 print(f"  dispersion_x={dispersion_xi:e} dispersion_px={dispersion_pxi:e}")
 
 atol = 0.0  # ignored
@@ -158,7 +160,9 @@ assert np.allclose(
 
 print("")
 print("Final Twiss functions:")
-print(f"  alpha_x={alpha_xf:e} beta_x={beta_xf:e} alpha_y={alpha_yf:e} beta_y={beta_yf:e}")
+print(
+    f"  alpha_x={alpha_xf:e} beta_x={beta_xf:e} alpha_y={alpha_yf:e} beta_y={beta_yf:e}"
+)
 print(f"  dispersion_x={dispersion_xf:e} dispersion_px={dispersion_pxf:e}")
 
 atol = 0.0  # ignored
@@ -192,4 +196,3 @@ assert np.allclose(
     ],
     atol=4.0e-5,
 )
-

--- a/examples/dogleg/analysis_dogleg_reverse_envelope.py
+++ b/examples/dogleg/analysis_dogleg_reverse_envelope.py
@@ -52,6 +52,8 @@ alpha_y = rbc["alpha_y"]
 beta_y = rbc["beta_y"]
 dispersion_x = rbc["dispersion_x"]
 dispersion_px = rbc["dispersion_px"]
+dispersion_y = rbc["dispersion_y"] 
+dispersion_py = rbc["dispersion_py"]
 
 sigma_xi = sigma_x.iloc[0]
 sigma_yi = sigma_y.iloc[0]
@@ -65,6 +67,8 @@ alpha_yi = alpha_y.iloc[0]
 beta_yi = beta_y.iloc[0]
 dispersion_xi = dispersion_x.iloc[0]
 dispersion_pxi = dispersion_px.iloc[0]
+dispersion_yi = dispersion_y.iloc[0]
+dispersion_pyi = dispersion_py.iloc[0]
 
 length = len(s) - 1
 
@@ -81,6 +85,8 @@ alpha_yf = alpha_y.iloc[length]
 beta_yf = beta_y.iloc[length]
 dispersion_xf = dispersion_x.iloc[length]
 dispersion_pxf = dispersion_px.iloc[length]
+dispersion_yf = dispersion_y.iloc[length]
+dispersion_pyf = dispersion_py.iloc[length]
 
 
 print("Initial Beam:")
@@ -140,6 +146,7 @@ print(
     f"  alpha_x={alpha_xi:e} beta_x={beta_xi:e} alpha_y={alpha_yi:e} beta_y={beta_yi:e}"
 )
 print(f"  dispersion_x={dispersion_xi:e} dispersion_px={dispersion_pxi:e}")
+print(f"  dispersion_y={dispersion_yi:e} dispersion_py={dispersion_pyi:e}")
 
 atol = 0.0  # ignored
 rtol = 2.5e-2
@@ -157,6 +164,15 @@ assert np.allclose(
     rtol=rtol,
     atol=atol,
 )
+assert np.allclose(
+    [dispersion_pxi, dispersion_yi, dispersion_pyi],
+    [
+        0.0,
+        0.0,
+        0.0,
+    ],
+    atol=4.0e-5,
+)
 
 print("")
 print("Final Twiss functions:")
@@ -164,6 +180,7 @@ print(
     f"  alpha_x={alpha_xf:e} beta_x={beta_xf:e} alpha_y={alpha_yf:e} beta_y={beta_yf:e}"
 )
 print(f"  dispersion_x={dispersion_xf:e} dispersion_px={dispersion_pxf:e}")
+print(f"  dispersion_y={dispersion_yf:e} dispersion_py={dispersion_pyf:e}")
 
 atol = 0.0  # ignored
 rtol = 2.0e-2

--- a/examples/dogleg/analysis_dogleg_reverse_envelope.py
+++ b/examples/dogleg/analysis_dogleg_reverse_envelope.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+import glob
+import re
+
+import numpy as np
+import pandas as pd
+
+
+def read_file(file_pattern):
+    for filename in glob.glob(file_pattern):
+        df = pd.read_csv(filename, delimiter=r"\s+")
+        if "step" not in df.columns:
+            step = int(re.findall(r"[0-9]+", filename)[0])
+            df["step"] = step
+        yield df
+
+
+def read_time_series(file_pattern):
+    """Read in all CSV files from each MPI rank (and potentially OpenMP
+    thread). Concatenate into one Pandas dataframe.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    return pd.concat(
+        read_file(file_pattern),
+        axis=0,
+        ignore_index=True,
+    )  # .set_index('id')
+
+
+# read reduced diagnostics
+rbc = read_time_series("diags/reduced_beam_characteristics.*")
+
+s = rbc["s"]
+sigma_x = rbc["sigma_x"]
+sigma_y = rbc["sigma_y"]
+sigma_t = rbc["sigma_t"]
+emittance_x = rbc["emittance_x"]
+emittance_y = rbc["emittance_y"]
+emittance_t = rbc["emittance_t"]
+alpha_x = rbc["alpha_x"]
+beta_x = rbc["beta_x"]
+alpha_y = rbc["alpha_y"]
+beta_y = rbc["beta_y"]
+dispersion_x = rbc["dispersion_x"]
+dispersion_px = rbc["dispersion_px"]
+
+sigma_xi = sigma_x.iloc[0]
+sigma_yi = sigma_y.iloc[0]
+sigma_ti = sigma_t.iloc[0]
+emittance_xi = emittance_x.iloc[0]
+emittance_yi = emittance_y.iloc[0]
+emittance_ti = emittance_t.iloc[0]
+alpha_xi = alpha_x.iloc[0]
+beta_xi = beta_x.iloc[0]
+alpha_yi = alpha_y.iloc[0]
+beta_yi = beta_y.iloc[0]
+dispersion_xi = dispersion_x.iloc[0]
+dispersion_pxi = dispersion_px.iloc[0]
+
+length = len(s) - 1
+
+sf = s.iloc[length]
+sigma_xf = sigma_x.iloc[length]
+sigma_yf = sigma_y.iloc[length]
+sigma_tf = sigma_t.iloc[length]
+emittance_xf = emittance_x.iloc[length]
+emittance_yf = emittance_y.iloc[length]
+emittance_tf = emittance_t.iloc[length]
+alpha_xf = alpha_x.iloc[length]
+beta_xf = beta_x.iloc[length]
+alpha_yf = alpha_y.iloc[length]
+beta_yf = beta_y.iloc[length]
+dispersion_xf = dispersion_x.iloc[length]
+dispersion_pxf = dispersion_px.iloc[length]
+
+
+print("Initial Beam:")
+print(f"  sigx={sigma_xi:e} sigy={sigma_yi:e} sigt={sigma_ti:e}")
+print(
+    f"  emittance_x={emittance_xi:e} emittance_y={emittance_yi:e} emittance_t={emittance_ti:e}"
+)
+
+atol = 0.0  # ignored
+rtol = 2.0e-2  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigma_xi, sigma_yi, sigma_ti, emittance_xi, emittance_yi, emittance_ti],
+    [
+        1.924711e-03,
+        2.165646e-05,
+        1.102534e-04,
+        7.668809e-09,
+        1.018986e-10,
+        8.588054e-09,
+    ],
+    rtol=rtol,
+    atol=atol,
+)
+
+
+print("")
+print("Final Beam:")
+print(f"  sigx={sigma_xf:e} sigy={sigma_yf:e} sigt={sigma_tf:e}")
+print(
+    f"  emittance_x={emittance_xf:e} emittance_y={emittance_yf:e} emittance_t={emittance_tf:e}"
+)
+
+atol = 0.0  # ignored
+rtol = 2.5e-2  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigma_xf, sigma_yf, sigma_tf, emittance_xf, emittance_yf, emittance_tf],
+    [
+        2.057123e-05,
+        6.911405e-05,
+        2.012573e-05,
+        8.174618e-11,
+        1.018986e-10,
+        1.151058e-08,
+    ],
+    rtol=rtol,
+    atol=atol,
+)
+
+
+print("")
+print("Initial Twiss functions:")
+print(f"  alpha_x={alpha_xi:e} beta_x={beta_xi:e} alpha_y={alpha_yi:e} beta_y={beta_yi:e}")
+print(f"  dispersion_x={dispersion_xi:e} dispersion_px={dispersion_pxi:e}")
+
+atol = 0.0  # ignored
+rtol = 2.5e-2
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [alpha_xi, beta_xi, alpha_yi, beta_yi, dispersion_xi],
+    [
+        1.340770e00,
+        1.440253e01,
+        -1.347747e00,
+        4.602637e00,
+        -2.667038e-01,
+    ],
+    rtol=rtol,
+    atol=atol,
+)
+
+print("")
+print("Final Twiss functions:")
+print(f"  alpha_x={alpha_xf:e} beta_x={beta_xf:e} alpha_y={alpha_yf:e} beta_y={beta_yf:e}")
+print(f"  dispersion_x={dispersion_xf:e} dispersion_px={dispersion_pxf:e}")
+
+atol = 0.0  # ignored
+rtol = 2.0e-2
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [beta_xf, alpha_yf, beta_yf],
+    [
+        5.176642e00,
+        -4.973010e00,
+        4.687750e01,
+    ],
+    rtol=rtol,
+    atol=atol,
+)
+
+# We use absolute tolerance for the following quantities, because these
+
+assert np.allclose(
+    [alpha_xf],
+    [
+        0.0,
+    ],
+    atol=0.1,
+)
+assert np.allclose(
+    [dispersion_xf],
+    [
+        0.0,
+    ],
+    atol=4.0e-5,
+)
+

--- a/examples/dogleg/analysis_dogleg_reverse_envelope.py
+++ b/examples/dogleg/analysis_dogleg_reverse_envelope.py
@@ -52,7 +52,7 @@ alpha_y = rbc["alpha_y"]
 beta_y = rbc["beta_y"]
 dispersion_x = rbc["dispersion_x"]
 dispersion_px = rbc["dispersion_px"]
-dispersion_y = rbc["dispersion_y"] 
+dispersion_y = rbc["dispersion_y"]
 dispersion_py = rbc["dispersion_py"]
 
 sigma_xi = sigma_x.iloc[0]

--- a/examples/dogleg/input_dogleg_reverse_envelope.in
+++ b/examples/dogleg/input_dogleg_reverse_envelope.in
@@ -1,10 +1,7 @@
 ###############################################################################
 # Particle Beam(s)
 ###############################################################################
-beam.npart = 10000
-beam.units = static
 beam.kin_energy = 5.0e3
-beam.charge = 1.0e-9
 beam.particle = electron
 beam.distribution = waterbag_from_twiss
 beam.alphaX = 1.33858302795180

--- a/examples/dogleg/input_dogleg_reverse_envelope.in
+++ b/examples/dogleg/input_dogleg_reverse_envelope.in
@@ -1,0 +1,69 @@
+###############################################################################
+# Particle Beam(s)
+###############################################################################
+beam.npart = 10000
+beam.units = static
+beam.kin_energy = 5.0e3
+beam.charge = 1.0e-9
+beam.particle = electron
+beam.distribution = waterbag_from_twiss
+beam.alphaX = 1.33858302795180
+beam.alphaY = -1.347910457923642
+beam.alphaT = 92.624347459105241
+beam.betaX = 14.37407309218588
+beam.betaY = 4.600362059144475
+beam.betaT = 1.4153999755967554
+beam.emittX = 8.180911194584674375e-11
+beam.emittY = 1.020438927769593e-10
+beam.emittT = 8.5698645128164239e-09
+beam.dispX = -0.2667
+
+###############################################################################
+# Beamline: lattice elements and segments
+###############################################################################
+lattice.elements = monitor sbend1 dipedge1 drift1 dipedge2 sbend2 drift2 monitor
+lattice.reverse = true
+lattice.nslice = 25
+
+sbend1.type = sbend
+sbend1.ds = 0.500194828041958       # projected length 0.5 m, angle 2.77 deg
+sbend1.rc = -10.3462283686195526
+
+drift1.type = drift
+drift1.ds = 5.0058489435            # projected length 5 m
+
+sbend2.type = sbend
+sbend2.ds = sbend1.ds               # projected length 0.5 m, angle 2.77 deg
+sbend2.rc = -sbend1.rc
+
+drift2.type = drift
+drift2.ds = 0.5
+
+dipedge1.type = dipedge   # dipole edge focusing
+dipedge1.psi = -0.048345620280243
+dipedge1.rc = -10.3462283686195526
+dipedge1.g = 0.0
+dipedge1.K2 = 0.0
+
+dipedge2.type = dipedge
+dipedge2.psi = -dipedge1.psi
+dipedge2.rc = -dipedge1.rc
+dipedge2.g = 0.0
+dipedge2.K2 = 0.0
+
+monitor.type = beam_monitor
+monitor.backend = h5
+
+
+###############################################################################
+# Algorithms
+###############################################################################
+algo.track = "envelope"
+algo.space_charge = false
+
+
+###############################################################################
+# Diagnostics
+###############################################################################
+diag.slice_step_diagnostics = true
+diag.eigenemittances = true

--- a/examples/dogleg/run_dogleg_reverse_envelope.py
+++ b/examples/dogleg/run_dogleg_reverse_envelope.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Marco Garten, Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+from impactx import ImpactX, distribution, elements, twiss
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# load a 5 GeV electron beam with an initial
+# normalized transverse rms emittance of 1 um
+kin_energy_MeV = 5.0e3  # reference energy
+bunch_charge_C = 1.0e-9  # used with space charge
+npart = 10000  # number of macro particles
+
+#   reference particle
+ref = sim.beam.ref
+ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
+
+#   particle bunch
+distr = distribution.Waterbag(
+    **twiss(
+        beta_x=14.374073092185883,
+        beta_y=4.6003616743069093,
+        beta_t=1.4153999755977573,
+        emitt_x=8.180911194584674375e-11,
+        emitt_y=1.020438927769593e-10,
+        emitt_t=8.5698645128105327e-09,
+        alpha_x=1.3385830279518021,
+        alpha_y=-1.3479109197361046,
+        alpha_t=92.624347459169869,
+        dispersion_x=-0.26669723385388505,
+    ),
+)
+sim.init_envelope(ref, distr, bunch_charge_C)
+
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+
+# design the accelerator lattice
+ns = 25  # number of slices per ds in the element
+rc = 10.3462283686195526  # bend radius (meters)
+psi = 0.048345620280243  # pole face rotation angle (radians)
+lb = 0.500194828041958  # bend arc length (meters)
+
+# Drift elements
+dr1 = elements.Drift(name="dr1", ds=5.0058489435, nslice=ns)
+dr2 = elements.Drift(name="dr2", ds=0.5, nslice=ns)
+
+# Bend elements
+sbend1 = elements.Sbend(name="sbend1", ds=lb, rc=-rc, nslice=ns)
+sbend2 = elements.Sbend(name="sbend2", ds=lb, rc=rc, nslice=ns)
+
+# Dipole Edge Focusing elements
+dipedge1 = elements.DipEdge(name="dipedge1", psi=-psi, rc=-rc, g=0.0, K2=0.0)
+dipedge2 = elements.DipEdge(name="dipedge2", psi=psi, rc=rc, g=0.0, K2=0.0)
+
+lattice_dogleg = [sbend1, dipedge1, dr1, dipedge2, sbend2, dr2]
+
+sim.lattice.append(monitor)
+lattice_dogleg.reverse()
+sim.lattice.extend(lattice_dogleg)
+sim.lattice.append(monitor)
+
+# run simulation
+sim.track_envelope()
+
+# clean shutdown
+sim.finalize()

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -278,6 +278,7 @@ namespace impactx
                 dmat(2,6) = -disppx;
                 dmat(3,3) = 1_prt;
                 dmat(3,6) = -dispy;
+                dmat(4,4) = 1_prt;
                 dmat(4,6) = -disppy;
                 dmat(5,5) = 1_prt;
                 dmat(6,6) = 1_prt;

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -242,13 +242,9 @@ namespace impactx
                     distribution.m_meant  != 0.0_prt ||
                     distribution.m_meanpx != 0.0_prt ||
                     distribution.m_meanpy != 0.0_prt ||
-                    distribution.m_meanpt != 0.0_prt ||
-                    distribution.m_dispx  != 0.0_prt ||
-                    distribution.m_disppx != 0.0_prt ||
-                    distribution.m_dispy  != 0.0_prt ||
-                    distribution.m_disppy != 0.0_prt
+                    distribution.m_meanpt != 0.0_prt
                 ) {
-                    throw std::runtime_error("Cannot (yet) create envelope for distribution with non-zero means or dispersion! Please see: https://github.com/BLAST-ImpactX/impactx/issues/1114");
+                    throw std::runtime_error("Cannot (yet) create envelope for distribution with non-zero means! Please see: https://github.com/BLAST-ImpactX/impactx/issues/1114");
                 }
 
                 // use distribution inputs to populate a 6x6 covariance matrix

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -231,6 +231,10 @@ namespace impactx
                 amrex::ParticleReal muxpx = distribution.m_muxpx;
                 amrex::ParticleReal muypy = distribution.m_muypy;
                 amrex::ParticleReal mutpt = distribution.m_mutpt;
+                amrex::ParticleReal dispx = distribution.m_dispx;
+                amrex::ParticleReal disppx = distribution.m_disppx;
+                amrex::ParticleReal dispy = distribution.m_dispy;
+                amrex::ParticleReal disppy = distribution.m_disppy;
 
                 // some things we cannot represent in envelope mode
                 if (distribution.m_meanx  != 0.0_prt ||
@@ -265,6 +269,19 @@ namespace impactx
                 cv(5,6) = -lambdaT*lambdaPt*mutpt / denom_t;
                 cv(6,5) = cv(5,6);
                 cv(6,6) = lambdaPt*lambdaPt / denom_t;
+
+                // normalizing matrix to handle nonzero dispersion
+                CovarianceMatrix dmat{};
+                dmat(1,1) = 1_prt;
+                dmat(1,6) = -dispx;
+                dmat(2,2) = 1_prt;
+                dmat(2,6) = -disppx;
+                dmat(3,3) = 1_prt;
+                dmat(3,6) = -dispy;
+                dmat(4,6) = -disppy;
+                dmat(5,5) = 1_prt;
+                dmat(6,6) = 1_prt;
+                cv = dmat * cv * dmat.transpose();
             }
         }, distr);
 


### PR DESCRIPTION
This PR adds support for initializing a beam with nonzero dispersion when the code is run in envelope mode.  Although coupled envelope transport is already supported, the code currently assumes that the _initial_ beam covariance matrix does not include coupling among the 3 phase planes.

This PR add the capability to initialize the bunch covariance matrix at a lattice location with nonzero dispersion.  It addresses one part of Issue #1114 

- [x] add covariance matrix initialization
- [x] add benchmark example
- [x] update documentation