### PR TITLE
CI: FFTW w/ Newer CMake & VS Studio 2026

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,9 +30,9 @@ jobs:
              ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Download Dependencies
       run: |
-        Invoke-WebRequest http://fftw.org/fftw-3.3.10.tar.gz -OutFile fftw-3.3.10.tar.gz
-        7z.exe x -r fftw-3.3.10.tar.gz
-        7z.exe x -r fftw-3.3.10.tar
+        Invoke-WebRequest http://fftw.org/fftw-3.3.11.tar.gz -OutFile fftw-3.3.11.tar.gz
+        7z.exe x -r fftw-3.3.11.tar.gz
+        7z.exe x -r fftw-3.3.11.tar
 
         Invoke-WebRequest https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_12_2.tar.gz -OutFile hdf5-1_12_2.tar.gz
         7z.exe x -r hdf5-1_12_2.tar.gz
@@ -43,7 +43,7 @@ jobs:
         # https://github.com/actions/runner-images/issues/10004
         CXXFLAGS: "/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"
       run: |
-        cmake -S fftw-3.3.10                     `
+        cmake -S fftw-3.3.11                     `
               -B build_fftw                      `
               -DBUILD_SHARED_LIBS=OFF            `
               -DBUILD_TESTS=OFF                  `
@@ -53,7 +53,7 @@ jobs:
         if(!$?) { Exit $LASTEXITCODE }
         cmake --build build_fftw --config RelWithDebInfo --target install --parallel 4
         if(!$?) { Exit $LASTEXITCODE }
-        cmake -S fftw-3.3.10                     `
+        cmake -S fftw-3.3.11                     `
               -B build_fftwf                     `
               -DBUILD_SHARED_LIBS=OFF            `
               -DBUILD_TESTS=OFF                  `
@@ -151,9 +151,9 @@ jobs:
     - uses: seanmiddleditch/gha-setup-ninja@master
     - name: Download Dependencies
       run: |
-        Invoke-WebRequest http://fftw.org/fftw-3.3.10.tar.gz -OutFile fftw-3.3.10.tar.gz
-        7z.exe x -r fftw-3.3.10.tar.gz
-        7z.exe x -r fftw-3.3.10.tar
+        Invoke-WebRequest http://fftw.org/fftw-3.3.11.tar.gz -OutFile fftw-3.3.11.tar.gz
+        7z.exe x -r fftw-3.3.11.tar.gz
+        7z.exe x -r fftw-3.3.11.tar
 
         Invoke-WebRequest https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_12_2.tar.gz -OutFile hdf5-1_12_2.tar.gz
         7z.exe x -r hdf5-1_12_2.tar.gz
@@ -163,7 +163,7 @@ jobs:
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
 
-        cmake -S fftw-3.3.10                     ^
+        cmake -S fftw-3.3.11                     ^
               -B build_fftw                      ^
               -G "Ninja"                         ^
               -DBUILD_TESTS=OFF                  ^
@@ -175,7 +175,7 @@ jobs:
         if errorlevel 1 exit 1
         cmake --build build_fftw --config Debug --target install --parallel 4
         if errorlevel 1 exit 1
-        cmake -S fftw-3.3.10                     ^
+        cmake -S fftw-3.3.11                     ^
               -B build_fftwf                     ^
               -G "Ninja"                         ^
               -DBUILD_TESTS=OFF                  ^

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -161,7 +161,7 @@ jobs:
     - name: Install Dependencies
       shell: cmd
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+        call "C:\Program Files\Microsoft Visual Studio\2026\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
 
         cmake -S fftw-3.3.11                     ^
               -B build_fftw                      ^
@@ -221,7 +221,7 @@ jobs:
         FFTW3f_DIR: "C:/Program Files (x86)/fftw/"
         HDF5_DIR: "C:/Program Files/HDF_Group/HDF5/1.12.2/cmake/"
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+        call "C:\Program Files\Microsoft Visual Studio\2026\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
 
         cmake -S . -B build                  ^
               -T "ClangCl"                   ^
@@ -249,7 +249,7 @@ jobs:
     - name: Test Simple
       shell: cmd
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+        call "C:\Program Files\Microsoft Visual Studio\2026\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
         set "PATH=C:/Program Files (x86)/ImpactX/bin/;%PATH%"
         python3 examples/fodo/run_fodo.py
         if errorlevel 1 exit 1
@@ -257,14 +257,14 @@ jobs:
     - name: Test
       shell: cmd
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+        call "C:\Program Files\Microsoft Visual Studio\2026\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
         ctest --test-dir build -C Debug --output-on-failure -E AMReX --label-exclude "dashboard"
         if errorlevel 1 exit 1
 
 #    - name: Install
 #      shell: cmd
 #      run: |
-#        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+#        call "C:\Program Files\Microsoft Visual Studio\2026\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
 #        set "HDF5_DIR=C:/Program Files/HDF_Group/HDF5/1.12.2/cmake/"
 #
 #        cmake --build build --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,7 +48,7 @@ jobs:
               -DBUILD_SHARED_LIBS=OFF            `
               -DBUILD_TESTS=OFF                  `
               -DCMAKE_BUILD_TYPE=RelWithDebInfo  `
-              -DCMAKE_POLICY_VERSION_MINIMUM=3.5 `
+              -DCMAKE_POLICY_VERSION_MINIMUM="3.5" `
               -DDISABLE_FORTRAN=ON
         if(!$?) { Exit $LASTEXITCODE }
         cmake --build build_fftw --config RelWithDebInfo --target install --parallel 4
@@ -58,7 +58,7 @@ jobs:
               -DBUILD_SHARED_LIBS=OFF            `
               -DBUILD_TESTS=OFF                  `
               -DCMAKE_BUILD_TYPE=RelWithDebInfo  `
-              -DCMAKE_POLICY_VERSION_MINIMUM=3.5 `
+              -DCMAKE_POLICY_VERSION_MINIMUM="3.5" `
               -DDISABLE_FORTRAN=ON               `
               -DENABLE_FLOAT=ON
         if(!$?) { Exit $LASTEXITCODE }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -161,7 +161,7 @@ jobs:
     - name: Install Dependencies
       shell: cmd
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2026\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+        call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
 
         cmake -S fftw-3.3.11                     ^
               -B build_fftw                      ^
@@ -221,7 +221,7 @@ jobs:
         FFTW3f_DIR: "C:/Program Files (x86)/fftw/"
         HDF5_DIR: "C:/Program Files/HDF_Group/HDF5/1.12.2/cmake/"
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2026\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+        call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
 
         cmake -S . -B build                  ^
               -T "ClangCl"                   ^
@@ -249,7 +249,7 @@ jobs:
     - name: Test Simple
       shell: cmd
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2026\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+        call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
         set "PATH=C:/Program Files (x86)/ImpactX/bin/;%PATH%"
         python3 examples/fodo/run_fodo.py
         if errorlevel 1 exit 1
@@ -257,14 +257,14 @@ jobs:
     - name: Test
       shell: cmd
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2026\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+        call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
         ctest --test-dir build -C Debug --output-on-failure -E AMReX --label-exclude "dashboard"
         if errorlevel 1 exit 1
 
 #    - name: Install
 #      shell: cmd
 #      run: |
-#        call "C:\Program Files\Microsoft Visual Studio\2026\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+#        call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
 #        set "HDF5_DIR=C:/Program Files/HDF_Group/HDF5/1.12.2/cmake/"
 #
 #        cmake --build build --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,6 +48,7 @@ jobs:
               -DBUILD_SHARED_LIBS=OFF            `
               -DBUILD_TESTS=OFF                  `
               -DCMAKE_BUILD_TYPE=RelWithDebInfo  `
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5 `
               -DDISABLE_FORTRAN=ON
         if(!$?) { Exit $LASTEXITCODE }
         cmake --build build_fftw --config RelWithDebInfo --target install --parallel 4
@@ -57,6 +58,7 @@ jobs:
               -DBUILD_SHARED_LIBS=OFF            `
               -DBUILD_TESTS=OFF                  `
               -DCMAKE_BUILD_TYPE=RelWithDebInfo  `
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5 `
               -DDISABLE_FORTRAN=ON               `
               -DENABLE_FLOAT=ON
         if(!$?) { Exit $LASTEXITCODE }
@@ -161,25 +163,27 @@ jobs:
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
 
-        cmake -S fftw-3.3.10                    ^
-              -B build_fftw                     ^
-              -G "Ninja"                        ^
-              -DBUILD_TESTS=OFF                 ^
-              -DBUILD_SHARED_LIBS=OFF           ^
-              -DCMAKE_BUILD_TYPE=Debug          ^
-              -DDISABLE_FORTRAN=ON              ^
+        cmake -S fftw-3.3.10                     ^
+              -B build_fftw                      ^
+              -G "Ninja"                         ^
+              -DBUILD_TESTS=OFF                  ^
+              -DBUILD_SHARED_LIBS=OFF            ^
+              -DCMAKE_BUILD_TYPE=Debug           ^
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
+              -DDISABLE_FORTRAN=ON               ^
               -DENABLE_OPENMP=ON
         if errorlevel 1 exit 1
         cmake --build build_fftw --config Debug --target install --parallel 4
         if errorlevel 1 exit 1
-        cmake -S fftw-3.3.10                    ^
-              -B build_fftwf                    ^
-              -G "Ninja"                        ^
-              -DBUILD_TESTS=OFF                 ^
-              -DBUILD_SHARED_LIBS=OFF           ^
-              -DCMAKE_BUILD_TYPE=Debug          ^
-              -DDISABLE_FORTRAN=ON              ^
-              -DENABLE_FLOAT=ON                 ^
+        cmake -S fftw-3.3.10                     ^
+              -B build_fftwf                     ^
+              -G "Ninja"                         ^
+              -DBUILD_TESTS=OFF                  ^
+              -DBUILD_SHARED_LIBS=OFF            ^
+              -DCMAKE_BUILD_TYPE=Debug           ^
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
+              -DDISABLE_FORTRAN=ON               ^
+              -DENABLE_FLOAT=ON                  ^
               -DENABLE_OPENMP=ON
         if errorlevel 1 exit 1
         cmake --build build_fftwf --config Debug --target install --parallel 4


### PR DESCRIPTION
Migrate to VS 2026: https://github.com/actions/runner-images/issues/14017

Fix FFTW:
```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

-- Building for: Visual Studio 18 2026
-- Configuring incomplete, errors occurred!
```