### PR TITLE
Envelope Tracking with Rotation

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -30,9 +30,10 @@ Tracking Modes
 
   .. note::
 
-     Our current ``envelope`` tracking implements ideal transfer maps, assuming always zero misalignments (translation or rotations).
-     Support for misalignments and feed-down effects in envelope tracking is in development.
-     Until then, misalignment options set on elements are silently ignored.
+     Our current ``envelope`` tracking implements ideal transfer maps, assuming always zero misalignments (translations).
+     Element rotations are handled.
+     Support for translations errors, non-zero envelope means, and feed-down effects in envelope tracking is in development.
+     Until then, translations errors set on elements are silently ignored.
 
 .. _running-cpp-parameters-particle:
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -437,9 +437,10 @@ Collective Effects & Overall Simulation Parameters
 
       .. note::
 
-         Our current envelope tracking implements ideal transfer maps, assuming always zero misalignments (translation or rotations).
-         Support for misalignments and feed-down effects in envelope tracking is in development.
-         Until then, misalignment options set on elements are silently ignored.
+         Our current envelope tracking implements ideal transfer maps, assuming always zero misalignments for translations.
+         Element rotations are handled.
+         Support for translations errors, non-zero envelope means, and feed-down effects in envelope tracking is in development.
+         Until then, translations errors set on elements are silently ignored.
 
    .. py:method:: track_reference(ref)
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -325,6 +325,12 @@ Collective Effects & Overall Simulation Parameters
       For example, ``sim.beam.to_df(local=True)`` returns the local particles as a pandas DataFrame.
       See :ref:`usage-howto-python-particle-data` for further data-access recipes.
 
+   .. py:property:: envelope
+
+      Access the beam envelope (:py:class:`impactx.Envelope`: a 6x6 covariance matrix
+      and beam intensity) used for envelope tracking.
+      Only available after :py:meth:`init_envelope`.
+
    .. py:method:: rho(lev)
 
       Return the charge density :math:`\rho` on mesh-refinement level ``lev`` as a pyAMReX ``MultiFab``.
@@ -493,6 +499,34 @@ Collective Effects & Overall Simulation Parameters
    .. py:method:: resize_mesh()
 
       Resize the mesh :py:attr:`~domain` based on the :py:attr:`~dynamic_size` and related parameters.
+
+
+.. py:class:: impactx.Envelope
+
+   The beam envelope used for envelope (covariance) tracking: a 6x6 covariance
+   matrix relative to a reference particle, plus an optional beam intensity.
+   Created from a distribution by :py:meth:`impactx.ImpactX.init_envelope` and
+   accessed (during or after :py:meth:`impactx.ImpactX.track_envelope`) via
+   :py:attr:`impactx.ImpactX.envelope`.
+
+   .. py:property:: envelope
+
+      The 6x6 beam covariance matrix (a ``Map6x6``).
+
+   .. py:property:: beam_intensity
+
+      The beam intensity: bunch charge (C) for 3D or beam current (A) for 2D space charge.
+
+   .. py:method:: beam_moments(ref)
+
+      Calculate beam moments (position and momentum moments, emittances, Twiss
+      functions, dispersion, ...) from this envelope's covariance matrix and a
+      reference particle. The envelope counterpart of
+      :py:meth:`impactx.ParticleContainer.beam_moments`.
+
+      :param ref: the reference particle (object from :py:class:`impactx.RefPart`)
+      :return: a dictionary of beam moments
+      :rtype: dict[str, float]
 
 
 .. py:class:: impactx.Config

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1627,6 +1627,15 @@ add_impactx_test(dogleg-reverse-envelope.py
     OFF  # no plot script yet
 )
 
+# Dogleg, Vertical (bends rolled 90 deg) ######################################
+#
+add_impactx_test(dogleg-vertical.py
+    examples/dogleg/run_dogleg_vertical.py
+    OFF  # ImpactX MPI-parallel (script runs two sims: envelope then particles)
+    OFF  # no analysis script (the run script self-validates in-situ)
+    OFF  # no plot script
+)
+
 # Dogleg with Energy Jitter ###################################################
 #
 add_impactx_test(dogleg-jitter

--- a/examples/dogleg/README.rst
+++ b/examples/dogleg/README.rst
@@ -171,6 +171,29 @@ We run the following script to analyze correctness:
 
 
 
+.. _examples-dogleg-vertical:
+
+Vertical Dogleg
+===============
+
+This is identical to the :ref:`dogleg example <examples-dogleg>`, except that every bend (and its dip-edge focusing) is rotated by 90 degrees, so the lattice bends in the vertical (:math:`y`) plane. The dogleg therefore generates dispersion in :math:`y` instead of :math:`x`.
+
+To obtain the exact :math:`x \leftrightarrow y` mirror image of the horizontal dogleg, the initial Twiss functions are exchanged :math:`x \leftrightarrow y` as well.
+
+The same lattice is tracked first with the **envelope** (covariance) solver and then with **particle** tracking, in the same script.
+
+The script asserts in-situ that the final values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, :math:`\epsilon_t`, :math:`\alpha_x`, :math:`\alpha_y`, :math:`\beta_x`, :math:`\beta_y`, and :math:`D_y` agree with nominal values -- for both the envelope and the particle beam (the dispersion now appears in :math:`y`).
+
+Run
+---
+
+This example runs both envelope and particle tracking and is provided as a Python script: ``python3 run_dogleg_vertical.py``.
+
+.. literalinclude:: run_dogleg_vertical.py
+   :language: python3
+   :caption: You can copy this file from ``examples/dogleg/run_dogleg_vertical.py``.
+
+
 
 .. _examples-dogleg-jitter:
 

--- a/examples/dogleg/run_dogleg_vertical.py
+++ b/examples/dogleg/run_dogleg_vertical.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 ImpactX contributors
+# Authors: Marco Garten, Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+from impactx import ImpactX, distribution, elements
+
+# This is the vertical-bending variant of the 2-bend dogleg lattice: every bend
+# (and its dip-edge focusing) is rolled by 90 degrees, so the dispersion that
+# the dogleg generates appears in the vertical (y) plane instead of horizontal
+# (x). To obtain the x <-> y mirror image of the horizontal dogleg, the initial
+# Twiss functions are exchanged x <-> y as well.
+#
+# The same lattice is run first with the envelope (covariance) solver and then
+# with particle tracking, exercising both the linear-map and the particle path
+# through rolled (tilted) elements.
+
+kin_energy_MeV = 5.0e3  # reference energy
+bunch_charge_C = 1.0e-9  # used with space charge
+npart = 10000  # number of macro particles
+
+
+def dogleg_vertical_distribution():
+    """A 5 GeV electron Waterbag with x <-> y exchanged relative to the
+    horizontal dogleg (see ``run_dogleg.py``)."""
+    return distribution.Waterbag(
+        lambdaX=1.3084093142e-5,  # exchanged with lambdaY
+        lambdaY=2.2951017632e-5,  # exchanged with lambdaX
+        lambdaT=5.5555553e-8,
+        lambdaPx=2.803697378e-6,  # exchanged with lambdaPy
+        lambdaPy=1.598353425e-6,  # exchanged with lambdaPx
+        lambdaPt=2.000000000e-6,
+        muxpx=0.933345606203060,  # == muypy, so the exchange leaves it unchanged
+        muypy=0.933345606203060,
+        mutpt=0.999999961419755,
+    )
+
+
+def dogleg_vertical_lattice():
+    """The horizontal dogleg lattice with all bends and dip edges rolled by
+    90 degrees, so it bends in the vertical (y) plane."""
+    ns = 25  # number of slices per ds in the element
+    rc = 10.3462283686195526  # bend radius (meters)
+    psi = 0.048345620280243  # pole face rotation angle (radians)
+    lb = 0.500194828041958  # bend arc length (meters)
+    roll = 90.0  # roll the bending plane from horizontal (x) to vertical (y)
+
+    # Drift elements
+    dr1 = elements.Drift(name="dr1", ds=5.0058489435, nslice=ns)
+    dr2 = elements.Drift(name="dr2", ds=0.5, nslice=ns)
+
+    # Bend elements (rolled by 90 degrees)
+    sbend1 = elements.Sbend(name="sbend1", ds=lb, rc=-rc, rotation=roll, nslice=ns)
+    sbend2 = elements.Sbend(name="sbend2", ds=lb, rc=rc, rotation=roll, nslice=ns)
+
+    # Dipole Edge Focusing elements (rolled by 90 degrees)
+    dipedge1 = elements.DipEdge(
+        name="dipedge1", psi=-psi, rc=-rc, g=0.0, K2=0.0, rotation=roll
+    )
+    dipedge2 = elements.DipEdge(
+        name="dipedge2", psi=psi, rc=rc, g=0.0, K2=0.0, rotation=roll
+    )
+
+    return [sbend1, dipedge1, dr1, dipedge2, sbend2, dr2]
+
+
+def assert_final_beam(moments):
+    """Check the final beam against the dogleg reference values: the same
+    final-beam properties that the horizontal dogleg checks in
+    ``analysis_dogleg.py``, with x <-> y exchanged. The 90-degree roll makes the
+    dogleg generate its dispersion in the vertical (y) plane, so it must show up
+    in ``dispersion_y`` (and x <-> y throughout). Accepts the moments dict from
+    either the envelope or the particle beam."""
+    assert np.allclose(
+        [
+            moments["sigma_x"],
+            moments["sigma_y"],
+            moments["sigma_t"],
+            moments["emittance_x"],
+            moments["emittance_y"],
+            moments["emittance_t"],
+            moments["alpha_x"],
+            moments["beta_x"],
+            moments["alpha_y"],
+            moments["beta_y"],
+            moments["dispersion_y"],
+        ],
+        [
+            2.166654e-05,
+            1.922660e-03,
+            1.101353e-04,
+            1.020439e-10,
+            8.561046e-09,
+            8.569865e-09,
+            -1.347910e00,
+            4.600362e00,
+            1.338583e00,
+            1.437407e01,
+            -2.666972e-01,
+        ],
+        rtol=2.0e-2,
+    )
+
+
+# set up the simulation: reference particle, lattice, and diagnostics
+sim = ImpactX()
+sim.space_charge = False
+sim.slice_step_diagnostics = True
+sim.init_grids()
+
+ref = sim.beam.ref
+ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
+
+monitor = elements.BeamMonitor("monitor", backend="h5")
+sim.lattice.append(monitor)
+sim.lattice.extend(dogleg_vertical_lattice())
+sim.lattice.append(monitor)
+
+# The same lattice is run with both solvers; init_envelope() copies the
+# reference particle, so envelope tracking does not disturb the particle run.
+
+# (1) envelope (covariance) tracking: exercises the linear-map (transport-map)
+# path through the rolled elements.
+sim.init_envelope(ref, dogleg_vertical_distribution(), bunch_charge_C)
+sim.track_envelope()
+assert_final_beam(sim.envelope.beam_moments(ref))
+
+# (2) particle tracking: exercises the particle push through the rolled elements.
+sim.add_particles(bunch_charge_C, dogleg_vertical_distribution(), npart)
+sim.track_particles()
+assert_final_beam(sim.beam.beam_moments())
+
+sim.finalize()

--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -269,7 +269,8 @@ namespace impactx::elements
         Map6x6
         transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
-            return Map6x6::Identity();
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(Map6x6::Identity());
         }
 
         Shape m_shape; //! aperture type (rectangular, elliptical)

--- a/src/elements/Buncher.H
+++ b/src/elements/Buncher.H
@@ -170,7 +170,8 @@ namespace impactx::elements
             R(4,3) = kV_r2bg2;
             R(6,5) = neg_kV;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         amrex::ParticleReal m_V; //! normalized (max) RF voltage drop.

--- a/src/elements/CFbend.H
+++ b/src/elements/CFbend.H
@@ -402,7 +402,8 @@ namespace impactx::elements
                 slice_ds * ibetgam2 + (sinx  - omega_x * slice_ds) * igobr :
                 slice_ds * ibetgam2 + (sinhx - omega_x * slice_ds) * igobr;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         amrex::ParticleReal m_rc; //! bend radius in m

--- a/src/elements/ChrDrift.H
+++ b/src/elements/ChrDrift.H
@@ -272,7 +272,8 @@ namespace impactx::elements
             R(3,4) = slice_ds;
             R(5,6) = slice_ds / betgam2;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
       private:

--- a/src/elements/ChrPlasmaLens.H
+++ b/src/elements/ChrPlasmaLens.H
@@ -428,7 +428,8 @@ namespace impactx::elements
                 R(5,6) = slice_ds / betgam2;
             }
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         amrex::ParticleReal m_k; //! focusing strength in 1/m^2 (or T/m)

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -438,7 +438,8 @@ namespace impactx::elements
                 R(5,6) = m_slice_ds / betgam2;
             }
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         amrex::ParticleReal m_k; //! quadrupole strength in 1/m^2 (or T/m)

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -399,7 +399,8 @@ namespace impactx::elements
                 R(4,3) = -alpha * cs / bgf;  R(4,4) =  rbg * c2;
             }
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         amrex::ParticleReal m_ez; //! electric field strength in 1/m

--- a/src/elements/ConstF.H
+++ b/src/elements/ConstF.H
@@ -385,7 +385,8 @@ namespace impactx::elements
             R(6,5) = const_t;
             R(6,6) = cos_ktds;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         amrex::ParticleReal m_kx; //! focusing x strength in 1/m

--- a/src/elements/DipEdge.H
+++ b/src/elements/DipEdge.H
@@ -365,7 +365,8 @@ namespace impactx::elements
             R(2,1) = R21;
             R(4,3) = R43;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         amrex::ParticleReal m_psi; //! pole face angle in rad

--- a/src/elements/Drift.H
+++ b/src/elements/Drift.H
@@ -259,7 +259,8 @@ namespace impactx::elements
             R(3,4) = slice_ds;
             R(5,6) = slice_ds / betgam2;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
     private:

--- a/src/elements/ExactCFbend.H
+++ b/src/elements/ExactCFbend.H
@@ -720,7 +720,8 @@ namespace impactx::elements
                 slice_ds * ibetgam2 + (sinx  - omega_x * slice_ds) * igobr :
                 slice_ds * ibetgam2 + (sinhx - omega_x * slice_ds) * igobr;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
 

--- a/src/elements/ExactDrift.H
+++ b/src/elements/ExactDrift.H
@@ -267,7 +267,8 @@ namespace impactx::elements
             R(3,4) = slice_ds;
             R(5,6) = slice_ds / betgam2;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
       private:

--- a/src/elements/ExactMultipole.H
+++ b/src/elements/ExactMultipole.H
@@ -572,7 +572,8 @@ namespace impactx::elements
                 R(1,2) = slice_ds;
                 R(3,4) = slice_ds;
                 R(5,6) = slice_ds / betgam2;
-                return R;
+                // apply the transverse rotation (roll) alignment error
+                return rotate_aligned_map(R);
             }
 
             amrex::ParticleReal const kplus = kn + kabs;
@@ -612,7 +613,8 @@ namespace impactx::elements
             }
             */
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
 

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -489,7 +489,8 @@ namespace impactx::elements
                 R(5,6) = m_slice_ds / betgam2;
             }
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
 

--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -357,7 +357,8 @@ namespace impactx::elements
                R(5,6) = m_rc * (-theta + sin_theta / (bet * bet));
             }
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
 

--- a/src/elements/Kicker.H
+++ b/src/elements/Kicker.H
@@ -174,7 +174,8 @@ namespace impactx::elements
             // an ideal kick does not affect the linear map
             Map6x6 R = Map6x6::Identity();
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         amrex::ParticleReal m_xkick; //! horizontal kick strength

--- a/src/elements/LinearMap.H
+++ b/src/elements/LinearMap.H
@@ -284,7 +284,8 @@ namespace impactx::elements
             Map6x6 R = Map6x6::Identity();
             R = m_transport_map;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         Map6x6 m_transport_map;  // 6x6 transport map

--- a/src/elements/Multipole.H
+++ b/src/elements/Multipole.H
@@ -332,7 +332,8 @@ namespace impactx::elements
                 R(4,3) = +m_Kn;
             }
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         int m_multipole; //! multipole index

--- a/src/elements/NonlinearLens.H
+++ b/src/elements/NonlinearLens.H
@@ -229,7 +229,8 @@ namespace impactx::elements
             R(2,1) = -k_lin;
             R(4,3) = +k_lin;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         amrex::ParticleReal m_knll; //! integrated strength of the nonlinear lens (m)

--- a/src/elements/PlaneXYRot.H
+++ b/src/elements/PlaneXYRot.H
@@ -174,7 +174,8 @@ namespace impactx::elements
             R(4,2) = sin_phi;
             R(4,4) = cos_phi;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         amrex::ParticleReal m_phi; //! angle of rotation (rad)

--- a/src/elements/PolygonAperture.H
+++ b/src/elements/PolygonAperture.H
@@ -321,7 +321,8 @@ namespace impactx::elements
         Map6x6
         transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
-            return Map6x6::Identity();
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(Map6x6::Identity());
         }
 
         Action m_action; //! action type (transmit, absorb)

--- a/src/elements/Quad.H
+++ b/src/elements/Quad.H
@@ -286,7 +286,8 @@ namespace impactx::elements
                 R(5,6) = slice_ds / betgam2;
             }
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         /** This operator pushes the particle spin.

--- a/src/elements/QuadEdge.H
+++ b/src/elements/QuadEdge.H
@@ -208,7 +208,8 @@ namespace impactx::elements
             // initialize linear map matrix elements
             Map6x6 R = Map6x6::Identity();
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         amrex::ParticleReal m_k;  //! quadrupole focusing strength

--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -405,7 +405,8 @@ namespace impactx::elements
             Map6x6 R = Map6x6::Identity();
             R = refpart.map;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         /** This evaluates the on-axis RF electric field at a fixed location

--- a/src/elements/Sbend.H
+++ b/src/elements/Sbend.H
@@ -337,7 +337,8 @@ namespace impactx::elements
 
             }
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         /** This operator pushes the particle spin.

--- a/src/elements/ShortRF.H
+++ b/src/elements/ShortRF.H
@@ -257,7 +257,8 @@ namespace impactx::elements
             R(6,5) = k*m_V*std::sin(phi)/bgf;
             R(6,6) = bgi/bgf;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         amrex::ParticleReal m_V; //! normalized (max) RF voltage drop.

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -398,7 +398,8 @@ namespace impactx::elements
             Map6x6 R = Map6x6::Identity();
             R = refpart.map;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         /** This evaluates the on-axis magnetic field Bz at a fixed location

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -416,7 +416,8 @@ namespace impactx::elements
             Map6x6 R = Map6x6::Identity();
             R = refpart.map;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         /** This evaluates the on-axis magnetic field Bz at a fixed location

--- a/src/elements/Sol.H
+++ b/src/elements/Sol.H
@@ -358,7 +358,8 @@ namespace impactx::elements
 
             R = Rrotation * Rfocusing;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         amrex::ParticleReal m_ks; //! solenoid strength in 1/m

--- a/src/elements/SpinMap.H
+++ b/src/elements/SpinMap.H
@@ -262,7 +262,8 @@ namespace impactx::elements
         transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
             Map6x6 R = Map6x6::Identity();
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         Vector3 m_spin_rotation_vector;  // 3x1 axis-angle vector for design spin rotation

--- a/src/elements/TaperedPL.H
+++ b/src/elements/TaperedPL.H
@@ -304,7 +304,8 @@ for beam-quality preservation between plasma-accelerator stages",
             R(2,1) = -g;
             R(4,3) = -g;
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         amrex::ParticleReal m_k; //! linear focusing strength (field gradient)

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -221,7 +221,8 @@ namespace impactx::elements
             R(2,6) = -kx * ds / beta;        // chromatic dispersion kick
             R(5,1) = +kx * ds / beta;        // path-length coupling to x
 
-            return R;
+            // apply the transverse rotation (roll) alignment error
+            return rotate_aligned_map(R);
         }
 
         amrex::ParticleReal m_theta;  //! dipole bending angle (rad)

--- a/src/elements/mixin/alignment.H
+++ b/src/elements/mixin/alignment.H
@@ -10,6 +10,7 @@
 #ifndef IMPACTX_ELEMENTS_MIXIN_ALIGNMENT_H
 #define IMPACTX_ELEMENTS_MIXIN_ALIGNMENT_H
 
+#include "particles/CovarianceMatrix.H"
 #include "particles/ImpactXParticleContainer.H"
 
 #include <ablastr/constant.H>
@@ -17,6 +18,7 @@
 #include <AMReX_Math.H>
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
+#include <AMReX_SmallMatrix.H>
 
 
 namespace impactx::elements::mixin
@@ -214,6 +216,55 @@ namespace impactx::elements::mixin
             return (m_dx != amrex::ParticleReal(0)) ||
                    (m_dy != amrex::ParticleReal(0)) ||
                    (m_rotation != amrex::ParticleReal(0));
+        }
+
+        /** 6x6 linear map of the transverse rotation (roll) alignment error.
+         *
+         * Returns the lab-from-element rotation @c A = Rot(theta) acting on
+         * the (x, y) and (px, py) sub-blocks and the identity on (t, pt). It is
+         * the linear-map analogue of @see shift_in / @see shift_out: the
+         * aligned (lab-frame) map of an element is @c A * R * A^T .
+         *
+         * sin/cos are evaluated from @c m_rotation directly rather than the
+         * @see compute_constants cache, because the linear-optics path
+         * (transfer_map, map_trace, envelope tracking) does not call
+         * compute_constants().
+         *
+         * @return the 6x6 transverse-rotation map in (x, px, y, py, t, pt) order
+         */
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
+        Map6x6
+        rotation_map () const
+        {
+            auto const [sin_rotation, cos_rotation] = amrex::Math::sincos(m_rotation);
+
+            Map6x6 A = Map6x6::Identity();
+            A(1, 1) =  cos_rotation;  A(1, 3) = -sin_rotation;
+            A(3, 1) =  sin_rotation;  A(3, 3) =  cos_rotation;
+            A(2, 2) =  cos_rotation;  A(2, 4) = -sin_rotation;
+            A(4, 2) =  sin_rotation;  A(4, 4) =  cos_rotation;
+            return A;
+        }
+
+        /** Apply the transverse rotation (roll) alignment error to an element's
+         *  intrinsic linear transport map.
+         *
+         * Elements call this on their own @c transport_map result just before
+         * returning, so that linear-optics consumers (transfer_map, map_trace,
+         * envelope tracking) see the same roll that the particle push applies
+         * via @see shift_in / @see shift_out. A perfectly roll-aligned element
+         * returns @c R unchanged.
+         *
+         * @param R the element's intrinsic (zero-rotation) 6x6 transport map
+         * @return the lab-frame map @c A * R * A^T (see @see rotation_map)
+         */
+        AMREX_GPU_HOST AMREX_FORCE_INLINE
+        Map6x6
+        rotate_aligned_map (Map6x6 const & R) const
+        {
+            if (m_rotation == amrex::ParticleReal(0)) { return R; }
+            Map6x6 const A = rotation_map();
+            return A * R * A.transpose();
         }
 
         amrex::ParticleReal m_dx = 0; //! horizontal translation error [m]

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -8,6 +8,7 @@
 #include <ImpactX.H>
 #include <diagnostics/FilePrefix.H>
 #include <initialization/InitDistribution.H>
+#include <particles/CovarianceMatrix.H>
 #include <particles/transformation/CoordinateTransformation.H>
 #include <particles/ParticleBoundary.H>
 
@@ -768,6 +769,18 @@ void init_ImpactX (py::module& m)
                 return *ix.amr_data->track_particles.m_particle_container;
             },
             "Access the beam particle container."
+        )
+        .def_property_readonly("envelope",
+            [](ImpactX & ix) -> Envelope & {
+                if (!ix.amr_data->track_envelope.m_env.has_value()) {
+                    throw std::runtime_error(
+                        "sim.envelope is only available after init_envelope()."
+                    );
+                }
+                return ix.amr_data->track_envelope.m_env.value();
+            },
+            "Access the beam envelope (6x6 covariance matrix and beam intensity)\n"
+            "used for envelope tracking. Only available after init_envelope()."
         )
         .def(
             "rho",

--- a/src/python/distribution.cpp
+++ b/src/python/distribution.cpp
@@ -5,6 +5,7 @@
  */
 #include "pyImpactX.H"
 
+#include <diagnostics/ReducedBeamCharacteristics.H>
 #include <particles/distribution/All.H>
 #include <initialization/InitDistribution.H>
 
@@ -209,6 +210,16 @@ void init_distribution(py::module& m)
         .def(py::init<CovarianceMatrix, amrex::ParticleReal>())
         .def_property("envelope", &Envelope::covariance_matrix, &Envelope::set_covariance_matrix)
         .def_property("beam_intensity", &Envelope::beam_intensity, &Envelope::set_beam_intensity)
+        .def("beam_moments",
+            [](Envelope const & env, RefPart const & ref) {
+                return diagnostics::reduced_beam_characteristics(env.covariance_matrix(), ref);
+            },
+            py::arg("ref"),
+            "Calculate beam moments (position and momentum moments, emittances,\n"
+            "Twiss functions, dispersion, ...) from this envelope's covariance\n"
+            "matrix and a reference particle. The envelope counterpart of\n"
+            "ImpactXParticleContainer.beam_moments()."
+        )
     ;
 
     m.def("create_envelope", &initialization::create_envelope);

--- a/src/python/pyImpactX.cpp
+++ b/src/python/pyImpactX.cpp
@@ -46,8 +46,8 @@ PYBIND11_MODULE(impactx_pybind, m) {
     )pbdoc";
 
     // note: order from parent to child classes
-    init_distribution(m);
     init_refparticle(m);
+    init_distribution(m);
     init_impactxparticlecontainer(m);
     init_elements(m);
     init_transformation(m);


### PR DESCRIPTION
Support `rotation` (transverse alignment) in envelope tracking. Enables to model, among others, vertical bends to fix #1505.

Co-authored-by: @cemitch99 & @aeriforme 

- [x] rebase after #1504 was merged
- [x] add a new user-facing example with a vertical dipole: the [dogleg](https://impactx.readthedocs.io/en/latest/usage/examples/dogleg/README.html) example, because it has nonzero dispersion at the end