### PR TITLE
Python: Element `transfer_map(ref)`

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1413,6 +1413,12 @@ comparison methods. They derive directly from each element's ``to_dict()`` outpu
 Lattice Elements
 ----------------
 
+Lattice elements expose multiple methods, including: (i) ``push(pc)`` to advance particles ``pc`` (e.g., ``sim.beam``),
+(ii) ``push(cm, ref)`` to advance a covariance matrix ``cm``, (iii) ``transfer_map(ref)`` that returns the
+element's analytic 6x6 linear transport map (phase-space ordering ``(x, px, y, py, t, pt)``) for the reference
+particle ``ref``, (iv) ``reverse()`` to reverse the element in place, and (v) ``to_dict()`` to serialize it.
+For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/nslice`` slice.
+
 .. py:class:: impactx.elements.CFbend(ds, rc, k, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, nslice=1, name=None)
 
    A combined function bending magnet.  This is an ideal Sbend with a normal quadrupole field component.

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -95,12 +95,52 @@ namespace
         );
     }
 
+    /** Register the transfer_map() method
+     *
+     * Exposes the element's own analytic linear transport map (see the
+     * @c mixin::LinearTransport CRTP mixin). An element that implements a linear map
+     * (@c has_linear_transport) returns it, one that does not throws a uniform,
+     * self-documenting error.
+     *
+     * This is the element's per-slice map (for @c ds/nslice), i.e. the building
+     * block that @c KnownElementsList.transfer_map composes over @c nslice and
+     * over the whole lattice.
+     */
+    template<typename T_PyClass>
+    void register_transfer_map (T_PyClass & cl)
+    {
+        using Element = typename T_PyClass::type;  // py::class<T, options...>
+
+        cl.def("transfer_map",
+            [](Element const & el, RefPart const & ref) -> Map6x6 {
+                if constexpr (Element::has_linear_transport) {
+                    return el.transport_map(ref);
+                } else {
+                    throw std::runtime_error(
+                        std::string(Element::type)
+                        + ": Linear transport map is not yet implemented for this element."
+                    );
+                }
+            },
+            py::arg("ref"),
+            "Return this element's 6x6 linear transport map for the given\n"
+            "reference particle.\n\n"
+            "Phase-space ordering in the returned matrix is (x, px, y, py, t, pt).\n"
+            "For an element with ``nslice`` > 1 this is the map of a single\n"
+            "``ds/nslice`` slice (the building block that the lattice transfer\n"
+            "map composes). Raises for an element whose linear transport map is\n"
+            "not implemented.\n\n"
+            ":param ref: reference particle at the element entrance\n"
+        );
+    }
+
     /** Register push() method overloads */
     template<typename T_PyClass>
     void register_push (T_PyClass & cl)
     {
         register_beamoptics_push(cl);
         register_envelope_push(cl);
+        register_transfer_map(cl);
     }
 
     /** Register reverse() method */


### PR DESCRIPTION
Expose the linear transfer map per element to Python. Useful for debugging envelope tracking simulations.