### PR TITLE
 Space Charge: Less Guards in `phi` & next-best padding

### DIFF
--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -183,10 +183,10 @@ set(ImpactX_ablastr_branch "759c5cb11a417187edc764b853cfb68018b91fce"
     "Repository branch for ImpactX_ablastr_repo if(ImpactX_ablastr_internal)")
 
 # AMReX is transitively pulled through ABLASTR
-set(ImpactX_amrex_repo "https://github.com/WeiqunZhang/amrex.git"
+set(ImpactX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(ImpactX_amrex_internal)")
-set(ImpactX_amrex_branch "fft_padding"
+set(ImpactX_amrex_branch "c5d27c8ff1b7b32238ebc75a9642a3fc36e65e9c"
     CACHE STRING
     "Repository branch for ImpactX_amrex_repo if(ImpactX_amrex_internal)")
 

--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -178,7 +178,7 @@ set(ImpactX_openpmd_src ""
 set(ImpactX_ablastr_repo "https://github.com/BLAST-WarpX/warpx.git"
     CACHE STRING
     "Repository URI to pull and build ABLASTR from if(ImpactX_ablastr_internal)")
-set(ImpactX_ablastr_branch "26.06"
+set(ImpactX_ablastr_branch "759c5cb11a417187edc764b853cfb68018b91fce"
     CACHE STRING
     "Repository branch for ImpactX_ablastr_repo if(ImpactX_ablastr_internal)")
 

--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -183,10 +183,10 @@ set(ImpactX_ablastr_branch "759c5cb11a417187edc764b853cfb68018b91fce"
     "Repository branch for ImpactX_ablastr_repo if(ImpactX_ablastr_internal)")
 
 # AMReX is transitively pulled through ABLASTR
-set(ImpactX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
+set(ImpactX_amrex_repo "https://github.com/WeiqunZhang/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(ImpactX_amrex_internal)")
-set(ImpactX_amrex_branch "26.06"
+set(ImpactX_amrex_branch "fft_padding"
     CACHE STRING
     "Repository branch for ImpactX_amrex_repo if(ImpactX_amrex_internal)")
 

--- a/cmake/dependencies/pyAMReX.cmake
+++ b/cmake/dependencies/pyAMReX.cmake
@@ -80,7 +80,7 @@ option(ImpactX_pyamrex_internal "Download & build pyAMReX" ON)
 set(ImpactX_pyamrex_repo "https://github.com/AMReX-Codes/pyamrex.git"
     CACHE STRING
     "Repository URI to pull and build pyamrex from if(ImpactX_pyamrex_internal)")
-set(ImpactX_pyamrex_branch "26.06"
+set(ImpactX_pyamrex_branch "0952566bbd3477fc2c556bc892657bbf9314cf3c"
     CACHE STRING
     "Repository branch for ImpactX_pyamrex_repo if(ImpactX_pyamrex_internal)")
 

--- a/src/initialization/AmrCoreData.cpp
+++ b/src/initialization/AmrCoreData.cpp
@@ -12,6 +12,7 @@
 #include "initialization/InitMeshRefinement.H"
 
 #include <AMReX.H>
+#include <AMReX_ParmParse.H>
 
 
 namespace impactx::initialization
@@ -148,7 +149,15 @@ namespace impactx::initialization
 
         // scalar potential
         int const num_components_phi = 1;
-        amrex::IntVect num_guards_phi{num_guards_rho + 1}; // todo: I think this just depends on max(MLMG, force calc)
+        // Guard cells for phi.
+        //   The space-charge force calculation (ForceFromSelfFields) uses a
+        //   centered difference stencil phi(i+-1), thus requiring one guard cell.
+        std::string poisson_solver = "multigrid";
+        {
+            amrex::ParmParse pp_algo("algo");
+            pp_algo.queryAdd("poisson_solver", poisson_solver);
+        }
+        amrex::IntVect num_guards_phi{poisson_solver == "fft" ? 1 : num_guards_rho + 1};
         amrex::BoxArray phi_ba = cba;
         if (space_charge == SpaceChargeAlgo::True_2D || space_charge == SpaceChargeAlgo::True_2p5D) {
             num_guards_phi[2] = 0;


### PR DESCRIPTION
Reduce from `n_cell+7` per direction to `n_cell+1` each. We only need one guard cell for our finite difference force calculation.

Fix #1500

## Step 1
- [x] rebase after #1510

<img width="600" alt="step 1 improvements: 47%" src="https://github.com/user-attachments/assets/f4a78435-9538-4ed2-a7ce-5aaae55235a3" />

## Step 2: (needs post 26.06-release WarpX/ABLASTR version)
- [x] also add https://github.com/BLAST-WarpX/warpx/pull/6952

<img width="600" height="step 2 improvements: 75%" alt="image" src="https://github.com/user-attachments/assets/24987392-4f6d-4b4a-abe8-d18d0698a038" />

## Step 3: (needs post 26.06-release AMReX version)
- [x] also add AMReX next-good-size: https://github.com/AMReX-Codes/amrex/pull/5494
- [x] wait for that PR to be merged and switch to the last commit sha on AMReX `development`

<img width="600" alt="step 3 improvements: padding to next-best FFT size in powers of small primes" src="https://github.com/user-attachments/assets/0dd81dbc-41dc-43c1-b6a2-6c618d3e7888" />
