### PR TITLE
Add QuadEdge spin push.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2170,8 +2170,8 @@ add_impactx_test(sextupole-kick.py
 
 # Reversibility Test for Spin in a Quadrupole with Fringe Fields ###########
 add_impactx_test(reversibility-quad-fringe-spin.py
-    examples/spin_tracking/run_reversibility-quad-fringe-spin.py
+    examples/spin_tracking/run_reversibility_quad_fringe_spin.py
     ON    # ImpactX MPI-parallel
-    examples/spin_tracking/analysis_reversibility-quad-fringe-spin.py
+    examples/spin_tracking/analysis_reversibility_quad_fringe_spin.py
     OFF  # no plot script yet
 )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2167,3 +2167,11 @@ add_impactx_test(sextupole-kick.py
     examples/multipole/analysis_sextupole_kick.py
     OFF  # no plot script yet
 )
+
+# Reversibility Test for Spin in a Quadrupole with Fringe Fields ###########
+add_impactx_test(reversibility-quad-fringe-spin.py
+    examples/spin_tracking/run_reversibility-quad-fringe-spin.py
+    ON    # ImpactX MPI-parallel
+    examples/spin_tracking/analysis_reversibility-quad-fringe-spin.py
+    OFF  # no plot script yet
+)

--- a/examples/spin_tracking/README.rst
+++ b/examples/spin_tracking/README.rst
@@ -595,5 +595,3 @@ The analysis can be run using:
    .. literalinclude:: analysis_reversibility_quad_fringe_spin.py
       :language: python3
       :caption: You can copy this file from ``examples/spin_tracking/analysis_reversibility_quad_fringe_spin.py``.
-
-

--- a/examples/spin_tracking/README.rst
+++ b/examples/spin_tracking/README.rst
@@ -548,3 +548,52 @@ The analysis can be run using the following script:
    .. literalinclude:: analysis_cfbend_spin_scaling.py
       :language: python3
       :caption: You can copy this file from ``examples/spin_tracking/analysis_cfbend_spin_scaling.py``.
+
+
+.. _examples-reversibility-quad-fringe-spin:
+
+Reversibility Test for Spin in a Quadrupole with Fringe Fields
+================================================================
+
+This example tests the reversibility of particle spin and orbit tracking through a quadrupole with nonlinear entry and exit fringe fields.
+
+Particle are tracked forward through a quadrupole with fringe fields, and then backward through the same physical fields.
+
+In this test, the initial and final values of all six phase space variables, as well as the three spin variables, must coincide.
+
+Note:  Because the exact inverse of the quadrupole fringe field map is not yet implemented, the test will pass only if a large tolerance value is specified.
+This value will be tightened once the exact inverse is implemented, and the test input modified accordingly.
+
+
+Run
+---
+
+This example can be run as:
+
+* **Python** script: ``python3 run_reversibility_quad_fringe_spin.py``
+
+For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+
+.. tab-set::
+
+   .. tab-item:: Python: Script
+
+       .. literalinclude:: run_reversibility_quad_fringe_spin.py
+          :language: python3
+          :caption: You can copy this file from ``examples/spin_tracking/run_reversibility_quad_fringe_spin.py``.
+
+
+
+Analyze
+-------
+
+The analysis can be run using:
+
+
+.. dropdown:: Script ``analysis_reversibility_quad_fringe_spin.py``
+
+   .. literalinclude:: analysis_reversibility_quad_fringe_spin.py
+      :language: python3
+      :caption: You can copy this file from ``examples/spin_tracking/analysis_reversibility_quad_fringe_spin.py``.
+
+

--- a/examples/spin_tracking/README.rst
+++ b/examples/spin_tracking/README.rst
@@ -553,7 +553,7 @@ The analysis can be run using the following script:
 .. _examples-reversibility-quad-fringe-spin:
 
 Reversibility Test for Spin in a Quadrupole with Fringe Fields
-================================================================
+==============================================================
 
 This example tests the reversibility of particle spin and orbit tracking through a quadrupole with nonlinear entry and exit fringe fields.
 
@@ -561,8 +561,10 @@ Particle are tracked forward through a quadrupole with fringe fields, and then b
 
 In this test, the initial and final values of all six phase space variables, as well as the three spin variables, must coincide.
 
-Note:  Because the exact inverse of the quadrupole fringe field map is not yet implemented, the test will pass only if a large tolerance value is specified.
-This value will be tightened once the exact inverse is implemented, and the test input modified accordingly.
+.. note::
+
+   Because the exact inverse of the quadrupole fringe field map is not yet implemented, the test will pass only if a large tolerance value is specified.
+   This value will be tightened once the exact inverse is implemented, and the test input modified accordingly.
 
 
 Run

--- a/examples/spin_tracking/analysis_reversibility_quad_fringe_spin.py
+++ b/examples/spin_tracking/analysis_reversibility_quad_fringe_spin.py
@@ -7,8 +7,6 @@
 
 import numpy as np
 import openpmd_api as io
-import scipy.constants as sc
-from scipy.special import expi
 
 # initial/final beam
 series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
@@ -68,11 +66,11 @@ pt_max = pti.abs().max()
 
 print()
 print("Absolute max initial values:")
-print("x_max", x_max)  
+print("x_max", x_max)
 print("px_max", px_max)
-print("y_max", y_max)  
+print("y_max", y_max)
 print("py_max", py_max)
-print("t_max", t_max)  
+print("t_max", t_max)
 print("pt_max", pt_max)
 
 print()
@@ -85,7 +83,9 @@ print("dt_max", dt_max)
 print("dpt_max", dpt_max)
 
 # Test maximum error:
-atol = 5.1e11  # large tolerance here, because orbit reversibility is not yet implemented
+atol = (
+    5.1e11  # large tolerance here, because orbit reversibility is not yet implemented
+)
 print(f"  tol={atol}")
 
 assert np.allclose(
@@ -97,7 +97,7 @@ assert np.allclose(
 print("Change in the spin:")
 print("||delta s||_max", dspinmax)
 
-atol = 2.0  #large tolerance here, because orbit reversiblity is not yet implemented
+atol = 2.0  # large tolerance here, because orbit reversiblity is not yet implemented
 print(f"  atol={atol}")
 
 assert np.allclose(
@@ -107,5 +107,3 @@ assert np.allclose(
     ],
     atol=atol,
 )
-
-

--- a/examples/spin_tracking/analysis_reversibility_quad_fringe_spin.py
+++ b/examples/spin_tracking/analysis_reversibility_quad_fringe_spin.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+import numpy as np
+import openpmd_api as io
+import scipy.constants as sc
+from scipy.special import expi
+
+# initial/final beam
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+last_step = list(series.iterations)[-1]
+beam_initial = series.iterations[1].particles["beam"]
+initial_sort = beam_initial.to_df().set_index("id")
+beam_final = series.iterations[last_step].particles["beam"]
+final_sort = beam_final.to_df().set_index("id")
+
+# Initial particle data
+
+xi = initial_sort["position_x"]
+pxi = initial_sort["momentum_x"]
+yi = initial_sort["position_y"]
+pyi = initial_sort["momentum_y"]
+ti = initial_sort["position_t"]
+pti = initial_sort["momentum_t"]
+
+sxi = initial_sort["spin_x"]
+syi = initial_sort["spin_y"]
+szi = initial_sort["spin_z"]
+
+# Final particle data
+
+xf = final_sort["position_x"]
+pxf = final_sort["momentum_x"]
+yf = final_sort["position_y"]
+pyf = final_sort["momentum_y"]
+tf = final_sort["position_t"]
+ptf = final_sort["momentum_t"]
+
+sxf = final_sort["spin_x"]
+syf = final_sort["spin_y"]
+szf = final_sort["spin_z"]
+
+# Difference between initial and final values
+
+dx_max = (xf - xi).abs().max()
+dpx_max = (pxf - pxi).abs().max()
+dy_max = (yf - yi).abs().max()
+dpy_max = (pyf - pyi).abs().max()
+dt_max = (tf - ti).abs().max()
+dpt_max = (ptf - pti).abs().max()
+
+dspin2 = (sxf - sxi) ** 2 + (syf - syi) ** 2 + (szf - szi) ** 2
+dspin = np.sqrt(dspin2)
+dspinmax = dspin.max()
+
+# Maximum values (initial)
+
+x_max = xi.abs().max()
+px_max = pxi.abs().max()
+y_max = yi.abs().max()
+py_max = pyi.abs().max()
+t_max = ti.abs().max()
+pt_max = pti.abs().max()
+
+print()
+print("Absolute max initial values:")
+print("x_max", x_max)  
+print("px_max", px_max)
+print("y_max", y_max)  
+print("py_max", py_max)
+print("t_max", t_max)  
+print("pt_max", pt_max)
+
+print()
+print("Difference between predicted and computed final momentum, absolute max:")
+print("dx_max", dx_max)
+print("dpx_max", dpx_max)
+print("dy_max", dy_max)
+print("dpy_max", dpy_max)
+print("dt_max", dt_max)
+print("dpt_max", dpt_max)
+
+# Test maximum error:
+atol = 5.1e11  # large tolerance here, because orbit reversibility is not yet implemented
+print(f"  tol={atol}")
+
+assert np.allclose(
+    [dx_max, dpx_max, dy_max, dpy_max, dt_max, dpt_max],
+    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    atol=atol,
+)
+
+print("Change in the spin:")
+print("||delta s||_max", dspinmax)
+
+atol = 2.0  #large tolerance here, because orbit reversiblity is not yet implemented
+print(f"  atol={atol}")
+
+assert np.allclose(
+    [dspinmax],
+    [
+        0.0,
+    ],
+    atol=atol,
+)
+
+

--- a/examples/spin_tracking/run_reversibility_quad_fringe_spin.py
+++ b/examples/spin_tracking/run_reversibility_quad_fringe_spin.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+
+from impactx import ImpactX, distribution, elements
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.space_charge = False
+sim.spin = True
+sim.slice_step_diagnostics = False
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# basic beam parameters
+kin_energy_MeV = 2.0e3  # reference energy (kinetic)
+bunch_charge_C = 1.0e-9  # used with space charge
+npart = 100000  # number of macro particles
+
+# set reference particle
+ref = sim.beam.ref
+ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
+
+#   particle bunch
+distr = distribution.Gaussian(
+    lambdaX=5.0e-6,
+    lambdaY=8.0e-6,
+    lambdaT=0.0599584916,
+    lambdaPx=2.5543422003e-9,
+    lambdaPy=1.5964638752e-9,
+    lambdaPt=9.0e-4,
+    muxpx=0.0,
+    muypy=0.0,
+    mutpt=0.0,
+)
+spin = distribution.SpinvMF(
+    0.4,
+    0.9,
+    0.1,
+)
+
+sim.add_particles(bunch_charge_C, distr, npart, spin)
+
+# design the accelerator lattice
+ns = 1  # number of slices per ds in the element
+
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+
+# parameters
+L = 1.5
+kquad = 60.0
+
+quad1 = elements.Quad(name="quad1", ds=L, k=kquad, nslice=ns)
+inv_quad1 = elements.Quad(name="inv_quad1", ds=-L, k=kquad, nslice=ns)
+quad_edge_in = elements.QuadEdge(name="quad_edge1", k=kquad, flag="entry")
+quad_edge_out = elements.QuadEdge(name="quad_edge1", k=kquad, flag="exit")
+
+# set the lattice
+sim.lattice.append(monitor)
+
+# sequence 1 (quad only):
+sim.lattice.append(quad1)
+sim.lattice.append(inv_quad1)
+
+# sequence 2 (edge only):
+sim.lattice.append(quad_edge_out)
+sim.lattice.append(quad_edge_in)
+
+# sequence 3 (inner sequence):
+sim.lattice.append(quad1)
+sim.lattice.append(quad_edge_out)
+sim.lattice.append(quad_edge_in)
+sim.lattice.append(inv_quad1)
+
+# sequence 4 (full sequence):
+# sim.lattice.append(quad_edge_in)
+# sim.lattice.append(quad1)
+# sim.lattice.append(quad_edge_out)
+# sim.lattice.append(quad_edge_in)
+# sim.lattice.append(inv_quad1)
+# sim.lattice.append(quad_edge_out)
+
+sim.lattice.append(monitor)
+
+# run simulation
+sim.track_particles()
+
+# clean shutdown
+sim.finalize()

--- a/examples/spin_tracking/run_reversibility_quad_fringe_spin.py
+++ b/examples/spin_tracking/run_reversibility_quad_fringe_spin.py
@@ -79,7 +79,7 @@ sim.lattice.append(quad1)
 sim.lattice.append(quad_edge_out)
 sim.lattice.append(quad_edge_in)
 sim.lattice.append(inv_quad1)
-# Note: Sequence 1 and Sequence 2 each work to high precision (that is, yield the identity). Yet, # their composite in Sequence 3 fails (unless the tolerance is very loose).  This is due to the 
+# Note: Sequence 1 and Sequence 2 each work to high precision (that is, yield the identity). Yet, # their composite in Sequence 3 fails (unless the tolerance is very loose).  This is due to the
 # fact that the orbit in QuadEdge is not reversed simply by taking entry->exit. See Issue #1562 .
 
 # sequence 4 (full sequence):

--- a/examples/spin_tracking/run_reversibility_quad_fringe_spin.py
+++ b/examples/spin_tracking/run_reversibility_quad_fringe_spin.py
@@ -79,6 +79,8 @@ sim.lattice.append(quad1)
 sim.lattice.append(quad_edge_out)
 sim.lattice.append(quad_edge_in)
 sim.lattice.append(inv_quad1)
+# Note: Sequence 1 and Sequence 2 each work to high precision (that is, yield the identity). Yet, # their composite in Sequence 3 fails (unless the tolerance is very loose).  This is due to the 
+# fact that the orbit in QuadEdge is not reversed simply by taking entry->exit. See Issue #1562 .
 
 # sequence 4 (full sequence):
 # sim.lattice.append(quad_edge_in)

--- a/examples/spin_tracking/run_reversibility_quad_fringe_spin.py
+++ b/examples/spin_tracking/run_reversibility_quad_fringe_spin.py
@@ -79,7 +79,8 @@ sim.lattice.append(quad1)
 sim.lattice.append(quad_edge_out)
 sim.lattice.append(quad_edge_in)
 sim.lattice.append(inv_quad1)
-# Note: Sequence 1 and Sequence 2 each work to high precision (that is, yield the identity). Yet, # their composite in Sequence 3 fails (unless the tolerance is very loose).  This is due to the
+# Note: Sequence 1 and Sequence 2 each work to high precision (that is, yield the identity). Yet,
+# their composite in Sequence 3 fails (unless the tolerance is very loose).  This is due to the
 # fact that the orbit in QuadEdge is not reversed simply by taking entry->exit. See Issue #1562 .
 
 # sequence 4 (full sequence):

--- a/src/elements/QuadEdge.H
+++ b/src/elements/QuadEdge.H
@@ -15,6 +15,7 @@
 #include "mixin/beamoptic.H"
 #include "mixin/thin.H"
 #include "mixin/lineartransport.H"
+#include "mixin/spintransport.H"
 #include "mixin/named.H"
 #include "mixin/nofinalize.H"
 
@@ -35,6 +36,7 @@ namespace impactx::elements
       public mixin::LinearTransport<QuadEdge>,
       public mixin::Thin,
       public mixin::Alignment,
+      public mixin::SpinTransport,
       public mixin::NoFinalize,
       public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
     {
@@ -120,6 +122,7 @@ namespace impactx::elements
 
             // the global scale constant; sign depends on entry or exit
             m_a = static_cast<amrex::ParticleReal>(m_flag) * (-1_prt * m_g / 12.0_prt);
+
         }
 
         /** This is a quadedge functor, so that a variable of this type can be used like a
@@ -192,6 +195,60 @@ namespace impactx::elements
 
         /** This pushes the reference particle. */
         using Thin::operator();
+
+
+        /** This operator pushes the particle spin.
+         *
+         * @param x particle position in x
+         * @param y particle position in y
+         * @param t particle position in t
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param sx particle spin x-component
+         * @param sy particle spin y-component
+         * @param sz particle spin z-component
+         * @param idcpu particle global index
+         * @param refpart reference particle
+         */
+        template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void spin_and_phasespace_push (
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            // initialize the three components of the axis-angle vector
+            T_Real lambdax = 0_prt;
+            T_Real lambday = 0_prt;
+            T_Real lambdaz = 0_prt;
+
+            amrex::ParticleReal G = refpart.gyromagnetic_anomaly;
+
+            // The model used here for the rotation vector is taken from eq (41) of:
+            // D. T. Abell et al, "Accurate and efficient spin integration for particle accelerators,"
+            // Phys. Rev. Accel. Beams 18, 024001 (2015).
+
+            lambdaz = -(m_flag) * m_g * (1_prt + G) * x * y;
+
+            // push the spin vector using the generator just determined
+            rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);
+
+            // phase space push
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+        }
+
 
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();

--- a/src/elements/QuadEdge.H
+++ b/src/elements/QuadEdge.H
@@ -240,7 +240,7 @@ namespace impactx::elements
             // D. T. Abell et al, "Accurate and efficient spin integration for particle accelerators,"
             // Phys. Rev. Accel. Beams 18, 024001 (2015).
 
-            lambdaz = -(m_flag) * m_g * (1_prt + G) * x * y;
+            lambdaz = -static_cast<amrex::ParticleReal>(m_flag) * m_g * (1_prt + G) * x * y;
 
             // push the spin vector using the generator just determined
             rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);

--- a/src/elements/QuadEdge.H
+++ b/src/elements/QuadEdge.H
@@ -122,7 +122,6 @@ namespace impactx::elements
 
             // the global scale constant; sign depends on entry or exit
             m_a = static_cast<amrex::ParticleReal>(m_flag) * (-1_prt * m_g / 12.0_prt);
-
         }
 
         /** This is a quadedge functor, so that a variable of this type can be used like a

--- a/tests/python/test_reversibility_elements.py
+++ b/tests/python/test_reversibility_elements.py
@@ -667,6 +667,7 @@ def test_RFCavity(sim):
     ],
     ids=["linear-zero-gap", "linear-finite-gap", "nonlinear-finite-gap"],
 )
+# WARNING:  The orbit in QuadEdge is not reversed simply by taking entry->exit. The inverse map needs to be fixed.  See Issue #1562.
 def test_DipEdge(sim, model, g, K2):
     rc = 10.3462283686195526
     psi = 0.048345620280243
@@ -686,6 +687,7 @@ def test_DipEdge(sim, model, g, K2):
 
 @pytest.mark.parametrize(("unit", "k"), [(0, 1.0), (1, 3.5)], ids=["madx", "marylie"])
 @pytest.mark.parametrize("flag", ["entry", "exit"])
+# WARNING:  The orbit in QuadEdge is not reversed simply by taking entry->exit. The inverse map needs to be fixed.  See Issue #1562.
 def test_QuadEdge(sim, flag, unit, k):
     roundtrip(
         elements.QuadEdge(k=k, unit=unit, flag=flag, **ALIGNMENT_KWARGS),

--- a/tests/python/test_reversibility_elements.py
+++ b/tests/python/test_reversibility_elements.py
@@ -667,7 +667,7 @@ def test_RFCavity(sim):
     ],
     ids=["linear-zero-gap", "linear-finite-gap", "nonlinear-finite-gap"],
 )
-# WARNING:  The orbit in QuadEdge is not reversed simply by taking entry->exit. The inverse map needs to be fixed.  See Issue #1562.
+# WARNING:  The orbit in DipEdge is not reversed simply by taking entry->exit. The inverse map needs to be fixed.  See Issue #1562.
 def test_DipEdge(sim, model, g, K2):
     rc = 10.3462283686195526
     psi = 0.048345620280243


### PR DESCRIPTION
Add the spin push through a quadrupole fringe field (`QuadEdge`).  The model used is taken from eq. (41) of: 

D. T. Abell et al, "Accurate and efficient spin integration for particle accelerators,"
Phys. Rev. Accel. Beams 18, 024001 (2015).

- [x] add spin push

Follow-up:  Add benchmark tests involving spin for elements with fringe fields.
The issue with reversibility has been added as Issue #1562 
