### PR TITLE
Modify Gauss2p5d longitudinal scale parameter default

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1077,6 +1077,9 @@ See there ``nslice`` option on lattice elements for slicing.
       current reduced beam characteristics (with :math:`\sigma_z` the RMS bunch length), which is a
       typical value when comparing to a 3D model.  This value minimizes the L2-norm of the error in
       the on-axis field Ez in the case of a long 3D Gaussian bunch.
+      In a perfectly conducting pipe with a long bunch—where the bunch length in  
+      the rest frame is significantly larger than the pipe radius—it is recommended  
+      to set the longitudinal scale length to the pipe radius in the input file.
       In a perfectly conducting pipe with a long bunch—where the bunch length in
       the rest frame is significantly larger than the pipe radius—it is recommended
       to set the longitudinal scale length to the pipe radius in the input file.

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1077,11 +1077,8 @@ See there ``nslice`` option on lattice elements for slicing.
       current reduced beam characteristics (with :math:`\sigma_z` the RMS bunch length), which is a
       typical value when comparing to a 3D model.  This value minimizes the L2-norm of the error in
       the on-axis field Ez in the case of a long 3D Gaussian bunch.
-      In a perfectly conducting pipe with a long bunch—where the bunch length in
-      the rest frame is significantly larger than the pipe radius—it is recommended
-      to set the longitudinal scale length to the pipe radius in the input file.
-      In a perfectly conducting pipe with a long bunch—where the bunch length in
-      the rest frame is significantly larger than the pipe radius—it is recommended
+      In a perfectly conducting pipe with a long bunch, where the bunch length in
+      the rest frame is significantly larger than the pipe radius, it is recommended
       to set the longitudinal scale length to the pipe radius in the input file.
 
     * ``algo.space_charge.gauss_charge_z_bins`` (``int``, default: ``129``)

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1077,8 +1077,8 @@ See there ``nslice`` option on lattice elements for slicing.
       current reduced beam characteristics (with :math:`\sigma_z` the RMS bunch length), which is a
       typical value when comparing to a 3D model.  This value minimizes the L2-norm of the error in
       the on-axis field Ez in the case of a long 3D Gaussian bunch.
-      In a perfectly conducting pipe with a long bunch—where the bunch length in  
-      the rest frame is significantly larger than the pipe radius—it is recommended  
+      In a perfectly conducting pipe with a long bunch—where the bunch length in
+      the rest frame is significantly larger than the pipe radius—it is recommended
       to set the longitudinal scale length to the pipe radius in the input file.
 
     * ``algo.space_charge.gauss_charge_z_bins`` (``int``, default: ``129``)

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1073,9 +1073,10 @@ See there ``nslice`` option on lattice elements for slicing.
 
       Longitudinal space charge scale for the Gauss2p5D space charge model.
       This is an approximation that only influences the longitudinal momentum (``pt``) kick.
-      If not set, it defaults to :math:`6 \cdot \gamma \cdot \sigma_z`, estimated in-situ from the
+      If not set, it defaults to :math:`1.103 \cdot \gamma \cdot \sigma_z`, estimated in-situ from the
       current reduced beam characteristics (with :math:`\sigma_z` the RMS bunch length), which is a
-      typical value when comparing to a 3D model.
+      typical value when comparing to a 3D model.  This value minimizes the L2-norm of the error in
+      the on-axis field Ez in the case of a long 3D Gaussian bunch.
 
     * ``algo.space_charge.gauss_charge_z_bins`` (``int``, default: ``129``)
 

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1077,6 +1077,9 @@ See there ``nslice`` option on lattice elements for slicing.
       current reduced beam characteristics (with :math:`\sigma_z` the RMS bunch length), which is a
       typical value when comparing to a 3D model.  This value minimizes the L2-norm of the error in
       the on-axis field Ez in the case of a long 3D Gaussian bunch.
+      In a perfectly conducting pipe with a long bunch—where the bunch length in  
+      the rest frame is significantly larger than the pipe radius—it is recommended  
+      to set the longitudinal scale length to the pipe radius in the input file.
 
     * ``algo.space_charge.gauss_charge_z_bins`` (``int``, default: ``129``)
 

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -1077,8 +1077,8 @@ See there ``nslice`` option on lattice elements for slicing.
       current reduced beam characteristics (with :math:`\sigma_z` the RMS bunch length), which is a
       typical value when comparing to a 3D model.  This value minimizes the L2-norm of the error in
       the on-axis field Ez in the case of a long 3D Gaussian bunch.
-      In a perfectly conducting pipe with a long bunch—where the bunch length in  
-      the rest frame is significantly larger than the pipe radius—it is recommended  
+      In a perfectly conducting pipe with a long bunch—where the bunch length in
+      the rest frame is significantly larger than the pipe radius—it is recommended
       to set the longitudinal scale length to the pipe radius in the input file.
       In a perfectly conducting pipe with a long bunch—where the bunch length in
       the rest frame is significantly larger than the pipe radius—it is recommended

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -109,8 +109,8 @@ Collective Effects & Overall Simulation Parameters
       current reduced beam characteristics (with :math:`\sigma_z` the RMS bunch length), which is a
       typical value when comparing to a 3D model.  This value minimizes the L2-norm of the error in
       the on-axis field Ez in the case of a long 3D Gaussian bunch.
-      In a perfectly conducting pipe with a long bunch—where the bunch length in the 
-      rest frame is significantly larger than the pipe radius—it is recommended to set 
+      In a perfectly conducting pipe with a long bunch—where the bunch length in the
+      rest frame is significantly larger than the pipe radius—it is recommended to set
       the longitudinal scale length to the pipe radius in the input file.
 
    .. py:property:: space_charge_num_longitudinal_bins

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -109,8 +109,8 @@ Collective Effects & Overall Simulation Parameters
       current reduced beam characteristics (with :math:`\sigma_z` the RMS bunch length), which is a
       typical value when comparing to a 3D model.  This value minimizes the L2-norm of the error in
       the on-axis field Ez in the case of a long 3D Gaussian bunch.
-      In a perfectly conducting pipe with a long bunch—where the bunch length in the
-      rest frame is significantly larger than the pipe radius—it is recommended to set
+      In a perfectly conducting pipe with a long bunch, where the bunch length in the
+      rest frame is significantly larger than the pipe radius, it is recommended to set
       the longitudinal scale length to the pipe radius in the input file.
 
    .. py:property:: space_charge_num_longitudinal_bins

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -105,9 +105,10 @@ Collective Effects & Overall Simulation Parameters
 
       Longitudinal space charge scale for the Gauss2p5D space charge model.
       This is an approximation that only influences the longitudinal momentum (``pt``) kick.
-      If not set, it defaults to :math:`6 \cdot \gamma \cdot \sigma_z`, estimated in-situ from the
+      If not set, it defaults to :math:`1.103 \cdot \gamma \cdot \sigma_z`, estimated in-situ from the
       current reduced beam characteristics (with :math:`\sigma_z` the RMS bunch length), which is a
-      typical value when comparing to a 3D model.
+      typical value when comparing to a 3D model.  This value minimizes the L2-norm of the error in
+      the on-axis field Ez in the case of a long 3D Gaussian bunch.
 
    .. py:property:: space_charge_num_longitudinal_bins
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -109,6 +109,9 @@ Collective Effects & Overall Simulation Parameters
       current reduced beam characteristics (with :math:`\sigma_z` the RMS bunch length), which is a
       typical value when comparing to a 3D model.  This value minimizes the L2-norm of the error in
       the on-axis field Ez in the case of a long 3D Gaussian bunch.
+      In a perfectly conducting pipe with a long bunch—where the bunch length in the 
+      rest frame is significantly larger than the pipe radius—it is recommended to set 
+      the longitudinal scale length to the pipe radius in the input file.
 
    .. py:property:: space_charge_num_longitudinal_bins
 

--- a/src/particles/spacecharge/Gauss2p5dPush.cpp
+++ b/src/particles/spacecharge/Gauss2p5dPush.cpp
@@ -19,6 +19,7 @@
 #include <ablastr/warn_manager/WarnManager.H>
 
 #include <cmath>
+#include <string>
 
 
 namespace impactx::particles::spacecharge
@@ -176,11 +177,13 @@ namespace impactx::particles::spacecharge
         amrex::ParticleReal const aspect_ratio = std::sqrt(sigx*sigx + sigy*sigy) / (beta_gamma * sigt);
 
         if (aspect_ratio > 1_rt) {
-           ablastr::warn_manager::WMRecordWarning(
-               "Impactx::particles::spacecharge::Gauss2p5dPush",
-               "Gauss2p5D model assumes a long bunch, but here sigma_perp / (gamma * sigmaz) > 1. ",
-               ablastr::warn_manager::WarnPriority::medium
-           );
+            ablastr::warn_manager::WMRecordWarning(
+                "Impactx::particles::spacecharge::Gauss2p5dPush",
+                "Gauss2p5D model assumes a long bunch, but here "
+                "sigma_perp / (beta_gamma * sigmaz) = " +
+                std::to_string(aspect_ratio) + " > 1.",
+                ablastr::warn_manager::WarnPriority::medium
+            );
         }
 
         int nint = 101;

--- a/src/particles/spacecharge/Gauss2p5dPush.cpp
+++ b/src/particles/spacecharge/Gauss2p5dPush.cpp
@@ -167,14 +167,22 @@ namespace impactx::particles::spacecharge
         amrex::ParticleReal const mc_SI = pc.GetRefParticle().mass * c0_SI;
         amrex::ParticleReal const pz_ref_SI = pc.GetRefParticle().beta_gamma() * mc_SI;
         amrex::ParticleReal const gamma = pc.GetRefParticle().gamma();
+        amrex::ParticleReal const beta_gamma = pc.GetRefParticle().beta_gamma();
         amrex::ParticleReal const inv_gamma2 = 1.0_prt / (gamma * gamma);
         amrex::ParticleReal const rfpiepslon = c0_SI * c0_SI * 1.0e-7_prt;
 
         amrex::ParticleReal const dt = slice_ds / pc.GetRefParticle().beta() / c0_SI;
+        amrex::ParticleReal const aspect_ratio = std::sqrt(sigx*sigx + sigy*sigy) / (beta_gamma * sigt);
+
+        if (aspect_ratio > 1_rt) {
+           // throw warning:  "Gauss2p5D model assumes a long bunch gamma * sigmaz / sigmar >> 1."
+        }
 
         int nint = 101;
         amrex::Real delta = 0.01_rt;
-        amrex::Real long_scale = 6.0_rt * gamma * sigt;
+        // note: the default value below is the optimal value minimizing the L2-norm
+        // of the error in the on-axis longitudinal field Ez for a 3D Gaussian bunch
+        amrex::Real long_scale = 1.103_rt * beta_gamma * sigt;
         amrex::ParmParse pp_algo("algo.space_charge");
         pp_algo.queryAddWithParser("gauss_nint", nint);
         pp_algo.queryAddWithParser("gauss_taylor_delta", delta);

--- a/src/particles/spacecharge/Gauss2p5dPush.cpp
+++ b/src/particles/spacecharge/Gauss2p5dPush.cpp
@@ -16,6 +16,7 @@
 #include <AMReX_BLProfiler.H>
 #include <AMReX_GpuContainers.H>
 #include <AMReX_ParmParse.H>
+#include <ablastr/warn_manager/WarnManager.H>
 
 #include <cmath>
 
@@ -175,7 +176,11 @@ namespace impactx::particles::spacecharge
         amrex::ParticleReal const aspect_ratio = std::sqrt(sigx*sigx + sigy*sigy) / (beta_gamma * sigt);
 
         if (aspect_ratio > 1_rt) {
-           // throw warning:  "Gauss2p5D model assumes a long bunch gamma * sigmaz / sigmar >> 1."
+           ablastr::warn_manager::WMRecordWarning(
+               "Impactx::particles::spacecharge::Gauss2p5dPush",
+               "Gauss2p5D model assumes a long bunch, but here sigma_perp / (gamma * sigmaz) > 1. ",
+               ablastr::warn_manager::WarnPriority::medium
+           );
         }
 
         int nint = 101;

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -372,7 +372,7 @@ void init_ImpactX (py::module& m)
             },
             "Longitudinal space charge scale for the Gauss2p5D space charge model. "
             "Approximation affecting only the longitudinal momentum (``pt``) kick. "
-            "If not set, it defaults to ``6 * gamma * sigma_z``, estimated in-situ from the current "
+            "If not set, it defaults to ``1.103 * gamma * sigma_z``, estimated in-situ from the current "
             "reduced beam characteristics, which is a typical value when comparing to a 3D model."
         )
         .def_property("space_charge_num_longitudinal_bins",


### PR DESCRIPTION
This PR modifies the default value of the parameter long_scale, replacing this by a value that minimizes the L2-norm of the error in the on-axis field Ez in the case of a 3D Gaussian bunch.