### PR TITLE
Fix 2D charge projection & 2D/2.5D SC

### DIFF
--- a/src/initialization/AmrCoreData.H
+++ b/src/initialization/AmrCoreData.H
@@ -75,6 +75,9 @@ namespace impactx::initialization
 
             /** charge density per level */
             std::unordered_map<int, amrex::MultiFab> m_rho;
+            /** charge density projected to 2D (x-y) per level, for the 2D
+             *  space-charge models; (re)derived from m_rho on access */
+            std::unordered_map<int, amrex::MultiFab> m_rho_2d;
             /** scalar potential per level */
             std::unordered_map<int, amrex::MultiFab> m_phi;
             /** space charge field (vector) per level */

--- a/src/particles/ChargeDeposition.H
+++ b/src/particles/ChargeDeposition.H
@@ -26,4 +26,19 @@ namespace impactx
         std::unordered_map<int, amrex::MultiFab> const & rho,
         amrex::Box domain_3d
     );
+
+    /** Project a deposited 3D charge density to 2D (x-y).
+     *
+     * Convenience wrapper around flatten_charge_to_2D that keeps only the unique
+     * (charge-conserving) projection per level.
+     *
+     * @param rho the deposited (raw, un-summed) 3D charge per level
+     * @param domain_3d the level-0 simulation domain (cell-centered)
+     * @return the 2D-projected charge per level
+     */
+    std::unordered_map<int, amrex::MultiFab>
+    project_charge_to_2D (
+        std::unordered_map<int, amrex::MultiFab> const & rho,
+        amrex::Box domain_3d
+    );
 } // namespace impactx

--- a/src/particles/ChargeDeposition.cpp
+++ b/src/particles/ChargeDeposition.cpp
@@ -9,6 +9,7 @@
  */
 #include "ImpactXParticleContainer.H"
 #include "ChargeDeposition.H"
+#include "initialization/Algorithms.H"
 
 #include <ablastr/coarsen/average.H>
 #include <ablastr/utils/Communication.H>
@@ -35,19 +36,44 @@ namespace impactx
 
         int const finest_level = rho.size() - 1;
         for (int lev = 0; lev <= finest_level; ++lev) {
-            auto omask = rho.at(lev).OwnerMask();
-            auto const& oma = omask->const_arrays();
-            // flattened rho
-            auto const& ma = rho.at(lev).const_arrays();
-            amrex::Box domain_lev = lev == 0 ? domain_3d : rho.at(lev).boxArray().minimalBox();
+            auto const & rho_at_level = rho.at(lev);
+            amrex::Box const domain_lev = amrex::convert(
+                lev == 0 ? domain_3d : rho_at_level.boxArray().minimalBox(),
+                rho_at_level.ixType()
+            );
+
+            int const z_dir = 2;
+
+            // Project the deposited 3D charge density to x-y for the 2D
+            // space-charge solve. We must include *all* guard cells to conserve
+            // charge:
+            //  - z guards: with a single longitudinal cell and higher-order
+            //    particle shapes, part of each particle's charge is deposited
+            //    outside the valid z nodes: summed into the plane.
+            //  - transverse (x/y) guards at internal box seams: that charge
+            //    belongs to a neighbouring box's valid node and is folded back
+            //    in across the seam.
+            //
+            // The open transverse boundary is non-periodic, so charge deposited
+            // outside the domain is dropped (open BC).
+            //
+            // NOTE: this requires the *raw* deposited rho, i.e. DepositCharge
+            // must NOT SumBoundary it for the 2D path, otherwise the valid nodes
+            // are folded twice and the charge is double counted.
+            auto const & ma = rho_at_level.const_arrays();
+
             rho_2d.erase(lev);
             rho_2d.emplace(
                 lev,
-                amrex::ReduceToPlaneMF2<amrex::ReduceOpSum>
-                (2, domain_lev, rho.at(lev), [=] AMREX_GPU_DEVICE (int b, int i, int j, int k)
-                {
-                    return oma[b](i,j,k) ? ma[b](i,j,k) : amrex::Real(0);
-                })
+                amrex::ReduceToPlaneMF2<amrex::ReduceOpSum>(
+                    z_dir, domain_lev, rho_at_level,
+                    [=] AMREX_GPU_DEVICE (int b, int i, int j, int k)
+                    {
+                        return ma[b](i,j,k);
+                    },
+                    rho_at_level.nGrowVect(),            // include z + transverse guards
+                    amrex::Periodicity::NonPeriodic()    // open transverse boundary
+                )
             );
         }
 
@@ -65,6 +91,17 @@ namespace impactx
 
         if (m_particle_shape.value() < 1)
             throw std::runtime_error("DepositCharge: Particle shape must be >=1");
+
+        // The 2D space-charge model projects rho to x-y in flatten_charge_to_2D,
+        // which folds the (transverse and longitudinal) guard-cell charge into
+        // the valid nodes itself. We must therefore leave rho *un-summed* here:
+        // a SumBoundary would fold the transverse guards a first time and the
+        // 2D projection of ReduceToPlaneMF2 a second time, double counting the
+        // charge at box seams.
+        auto const space_charge = get_space_charge_algo();
+        bool const skip_sum_boundary =
+            (space_charge == SpaceChargeAlgo::True_2D ||
+             space_charge == SpaceChargeAlgo::True_2p5D);
 
         // reset the values in rho to zero
         int const nLevel = this->finestLevel();
@@ -204,17 +241,22 @@ namespace impactx
             //ApplyFilterandSumBoundaryRho(lev, lev, rho[lev-1], 0, 1);
 
             // start async charge communication for this level
-            rho_at_level.SumBoundary_nowait(gm.periodicity());
+            //   (skipped for the 2D model: the 2D projection sums the guards)
+            if (!skip_sum_boundary) {
+                rho_at_level.SumBoundary_nowait(gm.periodicity());
+            }
             //int const comp = 0;
             //rho_at_level.SumBoundary_nowait(comp, comp, rho_at_level.nGrowVect(), gm.periodicity());
 
         } // lev
 
         // finalize communication
-        for (int lev = 0; lev <= nLevel; ++lev)
-        {
-            amrex::MultiFab & rho_at_level = rho.at(lev);
-            rho_at_level.SumBoundary_finish();
+        if (!skip_sum_boundary) {
+            for (int lev = 0; lev <= nLevel; ++lev)
+            {
+                amrex::MultiFab & rho_at_level = rho.at(lev);
+                rho_at_level.SumBoundary_finish();
+            }
         }
     }
 } // namespace impactx

--- a/src/particles/ChargeDeposition.cpp
+++ b/src/particles/ChargeDeposition.cpp
@@ -80,6 +80,20 @@ namespace impactx
         return rho_2d;
     }
 
+    std::unordered_map<int, amrex::MultiFab>
+    project_charge_to_2D (
+        std::unordered_map<int, amrex::MultiFab> const & rho,
+        amrex::Box domain_3d
+    )
+    {
+        std::unordered_map<int, amrex::MultiFab> rho_2d;
+        auto rho_2d_pairs = flatten_charge_to_2D(rho, domain_3d);
+        for (auto & [lev, rho_2d_pair] : rho_2d_pairs) {
+            rho_2d.emplace(lev, std::move(rho_2d_pair.second));
+        }
+        return rho_2d;
+    }
+
     void
     ImpactXParticleContainer::DepositCharge (
         std::unordered_map<int, amrex::MultiFab> & rho,

--- a/src/particles/spacecharge/HandleSpacecharge.cpp
+++ b/src/particles/spacecharge/HandleSpacecharge.cpp
@@ -83,6 +83,7 @@ namespace impactx::particles::spacecharge
             spacecharge::PoissonSolve(
                 *amr_data->track_particles.m_particle_container,
                 amr_data->track_particles.m_rho,
+                amr_data->track_particles.m_rho_2d,
                 amr_data->track_particles.m_phi,
                 amr_data->refRatio()
             );

--- a/src/particles/spacecharge/PoissonSolve.H
+++ b/src/particles/spacecharge/PoissonSolve.H
@@ -26,12 +26,15 @@ namespace impactx::particles::spacecharge
      *
      * @param[in] pc container of the particles that deposited rho
      * @param[in] rho charge per level
+     * @param[out] rho_2d the x-y projected charge per level (populated for the
+     *                    2D space-charge models, e.g. to expose via ``sim.rho``)
      * @param[inout] phi scalar potential per level
      * @param[in] rel_ref_ratio mesh refinement ratio between levels
      */
     void PoissonSolve (
         ImpactXParticleContainer const & pc,
         std::unordered_map<int, amrex::MultiFab> & rho,
+        std::unordered_map<int, amrex::MultiFab> & rho_2d,
         std::unordered_map<int, amrex::MultiFab> & phi,
         amrex::Vector<amrex::IntVect> rel_ref_ratio
     );

--- a/src/particles/spacecharge/PoissonSolve.cpp
+++ b/src/particles/spacecharge/PoissonSolve.cpp
@@ -28,6 +28,7 @@ namespace impactx::particles::spacecharge
     void PoissonSolve (
         ImpactXParticleContainer const & pc,
         std::unordered_map<int, amrex::MultiFab> & rho,
+        std::unordered_map<int, amrex::MultiFab> & rho_2d_out,
         std::unordered_map<int, amrex::MultiFab> & phi,
         amrex::Vector<amrex::IntVect> rel_ref_ratio
     )
@@ -90,12 +91,12 @@ namespace impactx::particles::spacecharge
         pp_algo.queryAddWithParser("mlmg_max_iters", mlmg_max_iters);
         pp_algo.queryAddWithParser("mlmg_verbosity", mlmg_verbosity);
 
-        // flatten rho to 2D
-        std::unordered_map<int, std::pair<amrex::MultiFab, amrex::MultiFab>> rho_2d;  // pair: local & unique boxes
+        // flatten rho to 2D; store it in the output so it can be accessed after
+        // the solve (e.g. via sim.rho), like the solved potential phi
         if (space_charge == SpaceChargeAlgo::True_2D || space_charge == SpaceChargeAlgo::True_2p5D) {
             auto geom_3d = pc.GetParGDB()->Geom();
             amrex::Box domain_3d = geom_3d[0].Domain();  // whole simulation index space (level 0)
-            rho_2d = flatten_charge_to_2D(rho, domain_3d);
+            rho_2d_out = project_charge_to_2D(rho, domain_3d);
         }
 
         // create a vector to our fields, sorted by level
@@ -112,14 +113,14 @@ namespace impactx::particles::spacecharge
                     sorted_phi.emplace_back(&phi[lev]);
                 } else {
                     // 2D phi
-                    auto & r2d = rho_2d[lev].second;
+                    auto & r2d = rho_2d_out[lev];
                     auto nGrow = phi[lev].nGrowVect();
                     nGrow[2] = 0;
                     phi_2d[lev].define(r2d.boxArray(), r2d.DistributionMap(), r2d.nComp(), nGrow);
                     sorted_phi.emplace_back(&phi_2d[lev]);
                 }
 
-                sorted_rho.emplace_back(&rho_2d[lev].second);
+                sorted_rho.emplace_back(&rho_2d_out[lev]);
             }
             else if (space_charge == SpaceChargeAlgo::True_3D) {
                 sorted_rho.emplace_back(&rho[lev]);

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -7,7 +7,9 @@
 
 #include <ImpactX.H>
 #include <diagnostics/FilePrefix.H>
+#include <initialization/Algorithms.H>
 #include <initialization/InitDistribution.H>
+#include <particles/ChargeDeposition.H>
 #include <particles/CovarianceMatrix.H>
 #include <particles/transformation/CoordinateTransformation.H>
 #include <particles/ParticleBoundary.H>
@@ -666,6 +668,20 @@ void init_ImpactX (py::module& m)
                     ix.amr_data->track_particles.m_rho,
                     ix.amr_data->refRatio());
 
+                // for the 2D models, also produce the x-y projected (charge-
+                // conserving) density, so it is available via sim.rho without a
+                // Poisson solve
+                auto const space_charge = get_space_charge_algo();
+                if (space_charge == SpaceChargeAlgo::True_2D ||
+                    space_charge == SpaceChargeAlgo::True_2p5D)
+                {
+                    auto geom_3d = ix.amr_data->track_particles
+                        .m_particle_container->GetParGDB()->Geom();
+                    amrex::Box const domain_3d = geom_3d[0].Domain();
+                    ix.amr_data->track_particles.m_rho_2d = project_charge_to_2D(
+                        ix.amr_data->track_particles.m_rho, domain_3d);
+                }
+
                 // transform from x,y,z to x',y',t
                 transformation::CoordinateTransformation(
                     *(ix.amr_data)->track_particles.m_particle_container,
@@ -784,10 +800,26 @@ void init_ImpactX (py::module& m)
         )
         .def(
             "rho",
-            [](ImpactX & ix, int const lev) { return &ix.amr_data->track_particles.m_rho.at(lev); },
+            [](py::object self, int const lev) -> py::object {
+                ImpactX & ix = self.cast<ImpactX &>();
+                auto & tp = ix.amr_data->track_particles;
+                auto const space_charge = get_space_charge_algo();
+                // The 2D models solve the x-y projected charge density: return
+                // that (stored like the solved potential phi, populated by the
+                // last deposit / Poisson solve); the 3D charge otherwise.
+                auto & rho_per_level =
+                    (space_charge == SpaceChargeAlgo::True_2D ||
+                     space_charge == SpaceChargeAlgo::True_2p5D)
+                    ? tp.m_rho_2d : tp.m_rho;
+                return py::cast(
+                    &rho_per_level.at(lev),
+                    py::return_value_policy::reference_internal, self);
+            },
             py::arg("lev"),
-            py::return_value_policy::reference_internal,
-            "charge density per level"
+            "charge density per level.\n\n"
+            "For the 2D space-charge models (``2D`` / ``2.5D``) this returns the\n"
+            "x-y projected (2D) charge density that is actually solved; for the\n"
+            "3D models it returns the 3D charge density."
         )
         .def(
             "phi",

--- a/tests/python/test_charge_deposition_2D.py
+++ b/tests/python/test_charge_deposition_2D.py
@@ -8,11 +8,13 @@
 # -*- coding: utf-8 -*-
 
 
+import math
+
 import matplotlib.pyplot as plt
 import numpy as np
 from conftest import basepath
 
-from impactx import ImpactX, amr, flatten_charge_to_2D
+from impactx import Config, ImpactX, amr
 
 
 def test_charge_deposition_2D(save_png=True):
@@ -34,12 +36,20 @@ def test_charge_deposition_2D(save_png=True):
     sim.init_lattice_elements_from_inputs()
 
     sim.deposit_charge()
-    rho_2d = flatten_charge_to_2D(sim)
-    rho_2d_lvl0 = rho_2d[0][1]  # level 0 and unique boxes only
+    # for the 2D space-charge model, sim.rho() is the x-y projected charge
+    rho_2d_lvl0 = sim.rho(lev=0)
 
     gm = sim.Geom(lev=0)
     dr = gm.data().CellSize()
     dV = np.prod(dr)
+
+    # the projected charge must be conserved: it equals the beam current
+    # (0.15, static units) and must be independent of grid resolution,
+    # padding (prob_relative) and domain decomposition
+    rs = rho_2d_lvl0.sum_unique(comp=0, local=False)
+    beam_charge = dV * rs  # in static units
+    rel_tol = 1.0e-5 if Config.precision == "SINGLE" else 1.0e-9
+    assert math.isclose(beam_charge, 0.15, rel_tol=rel_tol, abs_tol=0.0)
 
     # plot charge density
     f = plt.figure()
@@ -67,22 +77,19 @@ def test_charge_deposition_2D(save_png=True):
     sim.track_particles()
 
     sim.deposit_charge()
-    # rho = sim.rho(lev=0)
-    # rs = rho.sum_unique(comp=0, local=False)
 
-    rho_2d = flatten_charge_to_2D(sim)
-    rho_2d_lvl0 = rho_2d[0][1]  # level 0 and unique boxes only
-    # rs = rho_2d_lvl0.sum_unique(comp=0, local=False)
+    rho_2d_lvl0 = sim.rho(lev=0)
+    rs = rho_2d_lvl0.sum_unique(comp=0, local=False)
 
     gm = sim.Geom(lev=0)
     dr = gm.data().CellSize()
     dV = np.prod(dr)
 
-    # beam_charge = dV * rs  # in C
-    # if Config.precision == "SINGLE":
-    #    assert math.isclose(beam_charge, -1.0e-9, rel_tol=1e-6)
-    # else:
-    #    assert math.isclose(beam_charge, -1.0e-9, rel_tol=1e-8)
+    # charge is conserved under tracking: the projected charge still equals
+    # the beam current (0.15, static units)
+    beam_charge = dV * rs  # in static units
+    rel_tol = 1.0e-5 if Config.precision == "SINGLE" else 1.0e-9
+    assert math.isclose(beam_charge, 0.15, rel_tol=rel_tol, abs_tol=0.0)
 
     # plot charge density
     f = plt.figure()

--- a/tests/python/test_charge_deposition_2D.py
+++ b/tests/python/test_charge_deposition_2D.py
@@ -47,9 +47,9 @@ def test_charge_deposition_2D(save_png=True):
     # (0.15, static units) and must be independent of grid resolution,
     # padding (prob_relative) and domain decomposition
     rs = rho_2d_lvl0.sum_unique(comp=0, local=False)
-    beam_charge = dV * rs  # in static units
+    beam_current = dV * rs  # in static units
     rel_tol = 1.0e-5 if Config.precision == "SINGLE" else 1.0e-9
-    assert math.isclose(beam_charge, 0.15, rel_tol=rel_tol, abs_tol=0.0)
+    assert math.isclose(beam_current, 0.15, rel_tol=rel_tol, abs_tol=0.0)
 
     # plot charge density
     f = plt.figure()
@@ -87,9 +87,9 @@ def test_charge_deposition_2D(save_png=True):
 
     # charge is conserved under tracking: the projected charge still equals
     # the beam current (0.15, static units)
-    beam_charge = dV * rs  # in static units
+    beam_current = dV * rs  # in static units
     rel_tol = 1.0e-5 if Config.precision == "SINGLE" else 1.0e-9
-    assert math.isclose(beam_charge, 0.15, rel_tol=rel_tol, abs_tol=0.0)
+    assert math.isclose(beam_current, 0.15, rel_tol=rel_tol, abs_tol=0.0)
 
     # plot charge density
     f = plt.figure()


### PR DESCRIPTION
Fix #1512: Our 2D ReduceToPlane forgets about 3.5% of the charge that we deposit in the guards in Z, even with Nz=1...
This sums the missing contributions up and fixes the 2D & 2.5D space charge convergence issues we see in #1512.

Python: `sim.rho` as 2D
Return the 2D density we use for solve, similar to 3D. With the new logic we use for flatten, our 3D rho points are not synchronized anymore and temporary, not a good field to share with users by default.

- [x] needs AMReX post-26.06: https://github.com/AMReX-Codes/amrex/pull/5498