### PR TITLE
Performance: Optimize (Chr)Quad

### DIFF
--- a/src/elements/ChrPlasmaLens.H
+++ b/src/elements/ChrPlasmaLens.H
@@ -171,48 +171,54 @@ namespace impactx::elements
             T_Real const p1 = px;
             T_Real const p2 = py;
 
-            if (m_g != 0_prt)
+            if (m_g > 0_prt)
             {
-                // Focusing and defocusing differ only by the trig family
-                // (sin/cos vs. sinh/cosh), the sign of the momentum kick, and
-                // the sign of the q^2 w^2 term in the longitudinal update. The
-                // m_g sign is uniform across particles and delta1 > 0 always,
-                // so we select the trig factors branch-free. Only raw trig
-                // values are selected, so the arithmetic order matches the
-                // original branches byte-for-byte. The m_g == 0 drift case is
-                // handled separately below to avoid the 1/(omega*delta1)
-                // division.
-                bool const focusing = m_g > 0_prt;
                 auto const [sin_ods, cos_ods] = amrex::Math::sincos(omega*m_slice_ds);
-                T_Real const sinh_ods = sinh(omega*m_slice_ds);
-                T_Real const cosh_ods = cosh(omega*m_slice_ds);
-                T_Real const c = focusing ? cos_ods : cosh_ods;
-                T_Real const s = focusing ? sin_ods : sinh_ods;
-                // momentum kick sign: -1 (focusing) / +1 (defocusing)
-                T_Real const a = focusing ? -1_prt : 1_prt;
 
-                // advance transverse position and momentum (both planes alike)
-                xout = c * x + s / (omega * delta1) * px;
-                pxout = a * omega * delta1 * s * x + c * px;
+                // advance transverse position and momentum (focusing)
+                xout = cos_ods * x + sin_ods / (omega * delta1) * px;
+                pxout = -omega * delta1 * sin_ods * x + cos_ods * px;
 
-                yout = c * y + s / (omega * delta1) * py;
-                pyout = a * omega * delta1 * s * y + c * py;
+                yout = cos_ods * y + sin_ods / (omega * delta1) * py;
+                pyout = -omega * delta1 * sin_ods * y + cos_ods * py;
 
-                // the corresponding symplectic update to t (both x and y)
+                // the corresponding symplectic update to t (focusing both x and y)
                 T_Real const term = pt + delta/m_beta;
                 T_Real const t0 = t - term*m_slice_ds/delta1;
 
-                // 2*omega*slice trig: sin/cos (focusing) vs. sinh/cosh (defocusing)
-                T_Real const s2 = focusing ? sin(2_prt*m_slice_ds*omega) : sinh(2_prt*m_slice_ds*omega);
-                T_Real const c2 = focusing ? cos(2_prt*m_slice_ds*omega) : cosh(2_prt*m_slice_ds*omega);
-                // sign of the q^2 w^2 contribution: -1 (focusing) / +1 (defocusing)
-                T_Real const sgn2 = focusing ? -1_prt : 1_prt;
+                T_Real const w = omega*delta1;
+                T_Real const term1 = -(powi<2>(p2) - powi<2>(q2) * powi<2>(w)) * sin(2_prt*m_slice_ds*omega);
+                T_Real const term2 = -(powi<2>(p1) - powi<2>(q1) * powi<2>(w)) * sin(2_prt*m_slice_ds*omega);
+                T_Real const term3 = -2_prt * q2 * p2 * w * cos(2_prt*m_slice_ds*omega);
+                T_Real const term4 = -2_prt * q1 * p1 * w * cos(2_prt*m_slice_ds*omega);
+                T_Real const term5 = 2_prt * omega * (q1*p1*delta1 + q2*p2*delta1
+                    -(powi<2>(p1) + powi<2>(p2))*m_slice_ds - (powi<2>(q1) + powi<2>(q2)) * powi<2>(w)*m_slice_ds);
+                tout = t0 + (-1_prt+m_beta*pt)
+                          / (8_prt*m_beta * powi<3>(delta1)*omega)
+                          * (term1+term2+term3+term4+term5);
+
+            }
+            else if (m_g < 0_prt)
+            {
+                auto const sinh_ods = sinh(omega*m_slice_ds);
+                auto const cosh_ods = cosh(omega*m_slice_ds);
+
+                // advance transverse position and momentum (defocusing)
+                xout = cosh_ods * x + sinh_ods / (omega * delta1) * px;
+                pxout = +omega * delta1 * sinh_ods * x + cosh_ods * px;
+
+                yout = cosh_ods * y + sinh_ods / (omega * delta1) * py;
+                pyout = +omega * delta1 * sinh_ods * y + cosh_ods * py;
+
+                // the corresponding symplectic update to t (defocusing both x and y)
+                T_Real const term = pt + delta/m_beta;
+                T_Real const t0 = t - term*m_slice_ds/delta1;
 
                 T_Real const w = omega*delta1;
-                T_Real const term1 = -(powi<2>(p2) + sgn2 * powi<2>(q2) * powi<2>(w)) * s2;
-                T_Real const term2 = -(powi<2>(p1) + sgn2 * powi<2>(q1) * powi<2>(w)) * s2;
-                T_Real const term3 = -2_prt * q2 * p2 * w * c2;
-                T_Real const term4 = -2_prt * q1 * p1 * w * c2;
+                T_Real const term1 = -(powi<2>(p2) + powi<2>(q2) * powi<2>(w)) * sinh(2_prt*m_slice_ds*omega);
+                T_Real const term2 = -(powi<2>(p1) + powi<2>(q1) * powi<2>(w)) * sinh(2_prt*m_slice_ds*omega);
+                T_Real const term3 = -2_prt * q2 * p2 * w * cosh(2_prt*m_slice_ds*omega);
+                T_Real const term4 = -2_prt * q1 * p1 * w * cosh(2_prt*m_slice_ds*omega);
                 T_Real const term5 = 2_prt * omega * (q1*p1*delta1 + q2*p2*delta1
                     -(powi<2>(p1) + powi<2>(p2))*m_slice_ds - (powi<2>(q1) + powi<2>(q2)) * powi<2>(w)*m_slice_ds);
                 tout = t0 + (-1_prt+m_beta*pt)
@@ -319,6 +325,11 @@ namespace impactx::elements
             using namespace std; // for cmath(float)
             using amrex::Math::powi;
 
+            // initialize the three components of the axis-angle vector
+            T_Real lambdax = 0_prt;
+            T_Real lambday = 0_prt;
+            T_Real lambdaz = 0_prt;
+
             // compute particle momentum deviation delta + 1
             T_Real const delta1 = sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
             T_Real const inv_delta1 = 1_prt / delta1;
@@ -336,24 +347,23 @@ namespace impactx::elements
             T_Real const sinh_omega_ds = sinh(omega*m_slice_ds);
             T_Real const cosh_omega_ds = cosh(omega*m_slice_ds);
 
-            // A plasma lens focuses (or defocuses) both transverse planes
-            // identically, so the x- and y-generators share the same factor and
-            // differ only by an overall sign. The focusing/defocusing/drift
-            // selection depends only on the (particle-uniform) sign of m_g, so
-            // we select the trig factors branch-free. omega is real
-            // (delta1 > 0 always); only raw trig values are selected so the
-            // arithmetic order matches the original branches byte-for-byte. For
-            // m_g == 0, omega == 0 makes (1-cos), sin, (cosh-1), sinh vanish, so
-            // the generator is identically zero (drift) with no division by omega.
-            bool const focusing = m_g > 0.0_prt;
-            T_Real const fac = focusing ? (1_prt - cos_omega_ds) : (cosh_omega_ds - 1_prt);
-            T_Real const sin_sel = focusing ? sin_omega_ds : sinh_omega_ds;
-            // sign of lambdax: +gyro when focusing, -gyro when defocusing/drift
-            T_Real const sgn = focusing ? gyro_const : -gyro_const;
+            if (m_g > 0.0_prt)
+            {
 
-            T_Real const lambdax =  sgn * ( py*inv_delta1*fac + y*omega*sin_sel );
-            T_Real const lambday = -sgn * ( px*inv_delta1*fac + x*omega*sin_sel );
-            T_Real const lambdaz = 0_prt;
+                // horizontally focusing quad case
+                lambdax = +gyro_const * ( py*inv_delta1*(1_prt - cos_omega_ds) + y*omega*sin_omega_ds );
+                lambday = -gyro_const * ( px*inv_delta1*(1_prt - cos_omega_ds) + x*omega*sin_omega_ds );
+
+            } else if (m_g < 0.0_prt)
+            {
+
+                // horizontally defocusing quad case
+                lambdax = -gyro_const * ( py*inv_delta1*(cosh_omega_ds - 1_prt) + y*omega*sinh_omega_ds );
+                lambday = +gyro_const * ( px*inv_delta1*(cosh_omega_ds - 1_prt) + x*omega*sinh_omega_ds );
+
+            } else {
+                // treat as a drift
+            }
 
             // push the spin vector using the generator just determined
             rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);

--- a/src/elements/ChrPlasmaLens.H
+++ b/src/elements/ChrPlasmaLens.H
@@ -171,54 +171,48 @@ namespace impactx::elements
             T_Real const p1 = px;
             T_Real const p2 = py;
 
-            if (m_g > 0_prt)
+            if (m_g != 0_prt)
             {
+                // Focusing and defocusing differ only by the trig family
+                // (sin/cos vs. sinh/cosh), the sign of the momentum kick, and
+                // the sign of the q^2 w^2 term in the longitudinal update. The
+                // m_g sign is uniform across particles and delta1 > 0 always,
+                // so we select the trig factors branch-free. Only raw trig
+                // values are selected, so the arithmetic order matches the
+                // original branches byte-for-byte. The m_g == 0 drift case is
+                // handled separately below to avoid the 1/(omega*delta1)
+                // division.
+                bool const focusing = m_g > 0_prt;
                 auto const [sin_ods, cos_ods] = amrex::Math::sincos(omega*m_slice_ds);
+                T_Real const sinh_ods = sinh(omega*m_slice_ds);
+                T_Real const cosh_ods = cosh(omega*m_slice_ds);
+                T_Real const c = focusing ? cos_ods : cosh_ods;
+                T_Real const s = focusing ? sin_ods : sinh_ods;
+                // momentum kick sign: -1 (focusing) / +1 (defocusing)
+                T_Real const a = focusing ? -1_prt : 1_prt;
 
-                // advance transverse position and momentum (focusing)
-                xout = cos_ods * x + sin_ods / (omega * delta1) * px;
-                pxout = -omega * delta1 * sin_ods * x + cos_ods * px;
+                // advance transverse position and momentum (both planes alike)
+                xout = c * x + s / (omega * delta1) * px;
+                pxout = a * omega * delta1 * s * x + c * px;
 
-                yout = cos_ods * y + sin_ods / (omega * delta1) * py;
-                pyout = -omega * delta1 * sin_ods * y + cos_ods * py;
+                yout = c * y + s / (omega * delta1) * py;
+                pyout = a * omega * delta1 * s * y + c * py;
 
-                // the corresponding symplectic update to t (focusing both x and y)
+                // the corresponding symplectic update to t (both x and y)
                 T_Real const term = pt + delta/m_beta;
                 T_Real const t0 = t - term*m_slice_ds/delta1;
 
-                T_Real const w = omega*delta1;
-                T_Real const term1 = -(powi<2>(p2) - powi<2>(q2) * powi<2>(w)) * sin(2_prt*m_slice_ds*omega);
-                T_Real const term2 = -(powi<2>(p1) - powi<2>(q1) * powi<2>(w)) * sin(2_prt*m_slice_ds*omega);
-                T_Real const term3 = -2_prt * q2 * p2 * w * cos(2_prt*m_slice_ds*omega);
-                T_Real const term4 = -2_prt * q1 * p1 * w * cos(2_prt*m_slice_ds*omega);
-                T_Real const term5 = 2_prt * omega * (q1*p1*delta1 + q2*p2*delta1
-                    -(powi<2>(p1) + powi<2>(p2))*m_slice_ds - (powi<2>(q1) + powi<2>(q2)) * powi<2>(w)*m_slice_ds);
-                tout = t0 + (-1_prt+m_beta*pt)
-                          / (8_prt*m_beta * powi<3>(delta1)*omega)
-                          * (term1+term2+term3+term4+term5);
-
-            }
-            else if (m_g < 0_prt)
-            {
-                auto const sinh_ods = sinh(omega*m_slice_ds);
-                auto const cosh_ods = cosh(omega*m_slice_ds);
-
-                // advance transverse position and momentum (defocusing)
-                xout = cosh_ods * x + sinh_ods / (omega * delta1) * px;
-                pxout = +omega * delta1 * sinh_ods * x + cosh_ods * px;
-
-                yout = cosh_ods * y + sinh_ods / (omega * delta1) * py;
-                pyout = +omega * delta1 * sinh_ods * y + cosh_ods * py;
-
-                // the corresponding symplectic update to t (defocusing both x and y)
-                T_Real const term = pt + delta/m_beta;
-                T_Real const t0 = t - term*m_slice_ds/delta1;
+                // 2*omega*slice trig: sin/cos (focusing) vs. sinh/cosh (defocusing)
+                T_Real const s2 = focusing ? sin(2_prt*m_slice_ds*omega) : sinh(2_prt*m_slice_ds*omega);
+                T_Real const c2 = focusing ? cos(2_prt*m_slice_ds*omega) : cosh(2_prt*m_slice_ds*omega);
+                // sign of the q^2 w^2 contribution: -1 (focusing) / +1 (defocusing)
+                T_Real const sgn2 = focusing ? -1_prt : 1_prt;
 
                 T_Real const w = omega*delta1;
-                T_Real const term1 = -(powi<2>(p2) + powi<2>(q2) * powi<2>(w)) * sinh(2_prt*m_slice_ds*omega);
-                T_Real const term2 = -(powi<2>(p1) + powi<2>(q1) * powi<2>(w)) * sinh(2_prt*m_slice_ds*omega);
-                T_Real const term3 = -2_prt * q2 * p2 * w * cosh(2_prt*m_slice_ds*omega);
-                T_Real const term4 = -2_prt * q1 * p1 * w * cosh(2_prt*m_slice_ds*omega);
+                T_Real const term1 = -(powi<2>(p2) + sgn2 * powi<2>(q2) * powi<2>(w)) * s2;
+                T_Real const term2 = -(powi<2>(p1) + sgn2 * powi<2>(q1) * powi<2>(w)) * s2;
+                T_Real const term3 = -2_prt * q2 * p2 * w * c2;
+                T_Real const term4 = -2_prt * q1 * p1 * w * c2;
                 T_Real const term5 = 2_prt * omega * (q1*p1*delta1 + q2*p2*delta1
                     -(powi<2>(p1) + powi<2>(p2))*m_slice_ds - (powi<2>(q1) + powi<2>(q2)) * powi<2>(w)*m_slice_ds);
                 tout = t0 + (-1_prt+m_beta*pt)
@@ -325,11 +319,6 @@ namespace impactx::elements
             using namespace std; // for cmath(float)
             using amrex::Math::powi;
 
-            // initialize the three components of the axis-angle vector
-            T_Real lambdax = 0_prt;
-            T_Real lambday = 0_prt;
-            T_Real lambdaz = 0_prt;
-
             // compute particle momentum deviation delta + 1
             T_Real const delta1 = sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
             T_Real const inv_delta1 = 1_prt / delta1;
@@ -347,23 +336,24 @@ namespace impactx::elements
             T_Real const sinh_omega_ds = sinh(omega*m_slice_ds);
             T_Real const cosh_omega_ds = cosh(omega*m_slice_ds);
 
-            if (m_g > 0.0_prt)
-            {
+            // A plasma lens focuses (or defocuses) both transverse planes
+            // identically, so the x- and y-generators share the same factor and
+            // differ only by an overall sign. The focusing/defocusing/drift
+            // selection depends only on the (particle-uniform) sign of m_g, so
+            // we select the trig factors branch-free. omega is real
+            // (delta1 > 0 always); only raw trig values are selected so the
+            // arithmetic order matches the original branches byte-for-byte. For
+            // m_g == 0, omega == 0 makes (1-cos), sin, (cosh-1), sinh vanish, so
+            // the generator is identically zero (drift) with no division by omega.
+            bool const focusing = m_g > 0.0_prt;
+            T_Real const fac = focusing ? (1_prt - cos_omega_ds) : (cosh_omega_ds - 1_prt);
+            T_Real const sin_sel = focusing ? sin_omega_ds : sinh_omega_ds;
+            // sign of lambdax: +gyro when focusing, -gyro when defocusing/drift
+            T_Real const sgn = focusing ? gyro_const : -gyro_const;
 
-                // horizontally focusing quad case
-                lambdax = +gyro_const * ( py*inv_delta1*(1_prt - cos_omega_ds) + y*omega*sin_omega_ds );
-                lambday = -gyro_const * ( px*inv_delta1*(1_prt - cos_omega_ds) + x*omega*sin_omega_ds );
-
-            } else if (m_g < 0.0_prt)
-            {
-
-                // horizontally defocusing quad case
-                lambdax = -gyro_const * ( py*inv_delta1*(cosh_omega_ds - 1_prt) + y*omega*sinh_omega_ds );
-                lambday = +gyro_const * ( px*inv_delta1*(cosh_omega_ds - 1_prt) + x*omega*sinh_omega_ds );
-
-            } else {
-                // treat as a drift
-            }
+            T_Real const lambdax =  sgn * ( py*inv_delta1*fac + y*omega*sin_sel );
+            T_Real const lambday = -sgn * ( px*inv_delta1*fac + x*omega*sin_sel );
+            T_Real const lambdaz = 0_prt;
 
             // push the spin vector using the generator just determined
             rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -173,32 +173,38 @@ namespace impactx::elements
             T_Real p1 = px;
             T_Real p2 = py;
 
-            if (m_g > 0_prt)
+            if (m_g != 0_prt)
             {
-               // advance transverse position and momentum (focusing quad)
-               x = cos(omega*m_slice_ds) * xout +
-                   sin(omega*m_slice_ds) / (omega*delta1)*px;
-               pxout = -omega * delta1 * sin(omega*m_slice_ds) * xout + cos(omega * m_slice_ds) * px;
+               // advance transverse position and momentum (focusing/defocusing
+               // quad). The two cases differ only by which plane is oscillatory
+               // vs. hyperbolic; the m_g sign is uniform across particles and
+               // delta1 > 0 always, so we select the trig factors branch-free.
+               // Only raw trig values are selected, so the arithmetic order
+               // matches the original branches byte-for-byte.
+               bool const focusing = m_g > 0_prt;
+               // x-plane: cos/sin for focusing, cosh/sinh for defocusing
+               T_Real const cx = focusing ? cos(omega*m_slice_ds) : cosh(omega*m_slice_ds);
+               T_Real const sx = focusing ? sin(omega*m_slice_ds) : sinh(omega*m_slice_ds);
+               // y-plane: cosh/sinh for focusing, cos/sin for defocusing
+               T_Real const cy = focusing ? cosh(omega*m_slice_ds) : cos(omega*m_slice_ds);
+               T_Real const sy = focusing ? sinh(omega*m_slice_ds) : sin(omega*m_slice_ds);
+               // sign on the px,py focusing kick: -1 (x focusing) / +1 (x defocusing)
+               T_Real const ax = focusing ? -1_prt : 1_prt;
+               T_Real const ay = -ax;
 
-               y = cosh(omega*m_slice_ds) * yout +
-                   sinh(omega*m_slice_ds) / (omega*delta1)*py;
-               pyout = omega * delta1 * sinh(omega*m_slice_ds) * yout + cosh(omega * m_slice_ds) * py;
+               x = cx * xout + sx / (omega*delta1)*px;
+               pxout = ax * omega * delta1 * sx * xout + cx * px;
 
-            } else if (m_g < 0_prt)
-            {
-               // advance transverse position and momentum (defocusing quad)
-               x = cosh(omega*m_slice_ds) * xout +
-                   sinh(omega*m_slice_ds) / (omega*delta1)*px;
-               pxout = omega * delta1 * sinh(omega*m_slice_ds) * xout + cosh(omega * m_slice_ds) * px;
+               y = cy * yout + sy / (omega*delta1)*py;
+               pyout = ay * omega * delta1 * sy * yout + cy * py;
 
-               y = cos(omega*m_slice_ds) * yout +
-                   sin(omega*m_slice_ds) / (omega*delta1) * py;
-               pyout = -omega * delta1 * sin(omega*m_slice_ds) * yout + cos(omega * m_slice_ds) * py;
-
-               q1 = yout;
-               q2 = xout;
-               p1 = py;
-               p2 = px;
+               // For the longitudinal update below, (q1,p1) is the oscillatory
+               // plane and (q2,p2) the hyperbolic plane. For focusing that is
+               // (x,px) and (y,py); for defocusing the planes swap.
+               q1 = focusing ? xout : yout;
+               q2 = focusing ? yout : xout;
+               p1 = focusing ? px : py;
+               p2 = focusing ? py : px;
             } else
             {
                // advance transverse position and momentum (zero focusing strength = drift)
@@ -320,11 +326,6 @@ namespace impactx::elements
             using amrex::Math::powi;
             using namespace std; // for cmath(float)
 
-            // initialize the three components of the axis-angle vector
-            T_Real lambdax = 0_prt;
-            T_Real lambday = 0_prt;
-            T_Real lambdaz = 0_prt;
-
             // compute particle momentum deviation delta + 1
             T_Real const delta1 = sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
             T_Real const inv_delta1 = 1_prt / delta1;
@@ -342,35 +343,28 @@ namespace impactx::elements
             T_Real const sinh_omega_ds = sinh(omega*m_slice_ds);
             T_Real const cosh_omega_ds = cosh(omega*m_slice_ds);
 
-            if (m_g > 0.0_prt)
-            {
+            // The focusing/defocusing/drift cases differ only by which plane is
+            // oscillatory vs. hyperbolic and by an overall sign. omega is real
+            // (delta1 > 0 always) and the m_g sign is uniform across particles,
+            // so we select the per-plane factors branch-free. Only the raw
+            // trig values are selected; the surrounding arithmetic order is
+            // kept identical to the original branches so the result is
+            // byte-identical. For m_g == 0, omega == 0 makes all of (1-cos),
+            // sin, (cosh-1), sinh vanish, so the generator is identically zero
+            // (drift) with no division by omega anywhere.
+            bool const focusing = m_g > 0.0_prt;
+            // "1 - cos"-type factors multiplying p*inv_delta1, per plane
+            T_Real const fac_x = focusing ? (1_prt - cos_omega_ds) : (cosh_omega_ds - 1_prt);
+            T_Real const fac_y = focusing ? (cosh_omega_ds - 1_prt) : (1_prt - cos_omega_ds);
+            // raw "sin"-type trig multiplying q*omega, per plane
+            T_Real const sin_x = focusing ? sin_omega_ds : sinh_omega_ds;
+            T_Real const sin_y = focusing ? sinh_omega_ds : sin_omega_ds;
+            // overall sign: -gyro for focusing, +gyro for defocusing/drift
+            T_Real const sgn = focusing ? -gyro_const : gyro_const;
 
-                // horizontally focusing quad case
-                lambdax = -gyro_const * (
-                    py * inv_delta1 * (cosh_omega_ds - 1_prt) +
-                    y * omega * sinh_omega_ds
-                );
-                lambday = -gyro_const * (
-                    px * inv_delta1 * (1_prt - cos_omega_ds) +
-                    x * omega * sin_omega_ds
-                );
-
-            } else if (m_g < 0.0_prt)
-            {
-
-                // horizontally defocusing quad case
-                lambdax = gyro_const * (
-                    py * inv_delta1 * (1_prt - cos_omega_ds) +
-                    y * omega * sin_omega_ds
-                );
-                lambday = gyro_const * (
-                    px * inv_delta1 * (cosh_omega_ds - 1_prt) +
-                    x * omega * sinh_omega_ds
-                );
-
-            } else {
-                // treat as a drift
-            }
+            T_Real const lambdax = sgn * ( py * inv_delta1 * fac_y + y * omega * sin_y );
+            T_Real const lambday = sgn * ( px * inv_delta1 * fac_x + x * omega * sin_x );
+            T_Real const lambdaz = 0_prt;
 
             // push the spin vector using the generator just determined
             rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -155,97 +155,95 @@ namespace impactx::elements
             T_Real const tout = t;
 
             // compute particle momentum deviation delta + 1
-            T_Real const delta1 = sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
+            T_Real const delta1 = sqrt(1_prt - 2_prt * pt / m_beta + powi<2>(pt));
             T_Real const delta = delta1 - 1_prt;
 
             // compute phase advance per unit length in s (in rad/m)
             // chromatic dependence on delta is included
-            T_Real const omega = sqrt(abs(m_g)/delta1);
+            T_Real const omega = sqrt(abs(m_g) / delta1);
 
             // initialize output values of momenta
             T_Real pxout = px;
             T_Real pyout = py;
             // T_Real const ptout = pt;
 
-            // paceholder variables
-            T_Real q1 = xout;
-            T_Real q2 = yout;
-            T_Real p1 = px;
-            T_Real p2 = py;
-
             if (m_g != 0_prt)
             {
-               // advance transverse position and momentum (focusing/defocusing
-               // quad). The two cases differ only by which plane is oscillatory
-               // vs. hyperbolic; the m_g sign is uniform across particles and
-               // delta1 > 0 always, so we select the trig factors branch-free.
-               // Only raw trig values are selected, so the arithmetic order
-               // matches the original branches byte-for-byte.
-               bool const focusing = m_g > 0_prt;
-               // x-plane: cos/sin for focusing, cosh/sinh for defocusing
-               T_Real const cx = focusing ? cos(omega*m_slice_ds) : cosh(omega*m_slice_ds);
-               T_Real const sx = focusing ? sin(omega*m_slice_ds) : sinh(omega*m_slice_ds);
-               // y-plane: cosh/sinh for focusing, cos/sin for defocusing
-               T_Real const cy = focusing ? cosh(omega*m_slice_ds) : cos(omega*m_slice_ds);
-               T_Real const sy = focusing ? sinh(omega*m_slice_ds) : sin(omega*m_slice_ds);
-               // sign on the px,py focusing kick: -1 (x focusing) / +1 (x defocusing)
-               T_Real const ax = focusing ? -1_prt : 1_prt;
-               T_Real const ay = -ax;
+                // Advance transverse position and momentum.
 
-               x = cx * xout + sx / (omega*delta1)*px;
-               pxout = ax * omega * delta1 * sx * xout + cx * px;
+                // Focusing/defocusing quad:
+                //   The two cases differ only by which plane is oscillatory
+                //   vs. hyperbolic; the m_g sign is uniform across particles and
+                //   delta1 > 0 always, so we select the trig factors branch-free.
+                bool const focusing = m_g > 0_prt;
+                // raw off-diagonal trig: oscillatory (sin) for the focusing plane,
+                // hyperbolic (sinh) for the defocusing plane (delta1 > 0 always).
+                T_Real const sx = focusing ? sin(omega  * m_slice_ds) : sinh(omega * m_slice_ds);
+                T_Real const sy = focusing ? sinh(omega * m_slice_ds) : sin(omega  * m_slice_ds);
+                // sign on the px,py kick: -1 (x focusing) / +1 (x defocusing)
+                T_Real const ax = focusing ? -1_prt : 1_prt;
 
-               y = cy * yout + sy / (omega*delta1)*py;
-               pyout = ay * omega * delta1 * sy * yout + cy * py;
+                // per-particle 2x2 transfer-map blocks. omega is chromatic (it depends
+                // on delta1), so unlike our linear Quad these cannot be cached in compute_constants.
+                T_Real const w = omega * delta1;
+                T_Real const R11 = focusing ? cos(omega * m_slice_ds) : cosh(omega * m_slice_ds);
+                T_Real const R12 = sx / w;
+                T_Real const R21 = ax * w * sx;
+                T_Real const R22 = R11;
+                T_Real const R33 = focusing ? cosh(omega * m_slice_ds) : cos(omega * m_slice_ds);
+                T_Real const R34 = sy / w;
+                T_Real const R43 = -ax * w * sy;
+                T_Real const R44 = R33;
 
-               // For the longitudinal update below, (q1,p1) is the oscillatory
-               // plane and (q2,p2) the hyperbolic plane. For focusing that is
-               // (x,px) and (y,py); for defocusing the planes swap.
-               q1 = focusing ? xout : yout;
-               q2 = focusing ? yout : xout;
-               p1 = focusing ? px : py;
-               p2 = focusing ? py : px;
-            } else
-            {
-               // advance transverse position and momentum (zero focusing strength = drift)
-               x = xout + m_slice_ds * px / delta1;
-               // pxout = px;
-               y = yout + m_slice_ds * py / delta1;
-               // pyout = py;
-            }
+                x     = R11 * xout + R12 * px;
+                pxout = R21 * xout + R22 * px;
+                y     = R33 * yout + R34 * py;
+                pyout = R43 * yout + R44 * py;
 
+                // For the longitudinal update below, (q1,p1) is the oscillatory
+                // plane and (q2,p2) the hyperbolic plane. For focusing that is
+                // (x,px) and (y,py), for defocusing the planes swap.
+                T_Real const q1 = focusing ? xout : yout;
+                T_Real const q2 = focusing ? yout : xout;
+                T_Real const p1 = focusing ? px : py;
+                T_Real const p2 = focusing ? py : px;
 
-            // advance longitudinal position and momentum
-
-            if (m_g == 0.0)
-            {
-               // the corresponding symplectic update to t (zero strength = drift)
-               T_Real term = 2_prt * powi<2>(pt) + powi<2>(px) + powi<2>(py);
-               term = 2_prt - 4_prt * m_beta * pt + powi<2>(m_beta) * term;
-               term = -2_prt + powi<2>(refpart.gamma())*term;
-               term = (-1_prt + m_beta * pt) * term;
-               term = term * m_const1;
-               t = tout - m_slice_ds * (1_prt / m_beta + term / powi<3>(delta1));
-               // ptout = pt;
-
-            } else
-            {
                 // the corresponding symplectic update to t (nonzero strength)
                 T_Real const term = pt + delta / m_beta;
                 T_Real const t0 = tout - term * m_slice_ds / delta1;
 
-                T_Real const w = omega * delta1;
-                T_Real const term1 = -(powi<2>(p2) + powi<2>(q2) * powi<2>(w)) * sinh(2_prt*m_slice_ds*omega);
-                T_Real const term2 = -(powi<2>(p1) - powi<2>(q1) * powi<2>(w)) * sin(2_prt*m_slice_ds*omega);
-                T_Real const term3 = -2_prt * q2 * p2 * w * cosh(2_prt*m_slice_ds*omega);
-                T_Real const term4 = -2_prt * q1 * p1 * w * cos(2_prt*m_slice_ds*omega);
-                T_Real const term5 =  2_prt * omega * (q1*p1*delta1 + q2*p2*delta1
-                    -(powi<2>(p1) + powi<2>(p2))*m_slice_ds - (powi<2>(q1)-powi<2>(q2)) * powi<2>(w)*m_slice_ds);
-                t = t0 + (-1_prt+m_beta*pt)
-                       / (8_prt*m_beta * powi<3>(delta1)*omega)
-                       * (term1+term2+term3+term4+term5);
-               // ptout = pt;
-             }
+                T_Real const term1 = -(powi<2>(p2) + powi<2>(q2) * powi<2>(w)) * sinh(2_prt * m_slice_ds * omega);
+                T_Real const term2 = -(powi<2>(p1) - powi<2>(q1) * powi<2>(w)) * sin(2_prt  * m_slice_ds * omega);
+                T_Real const term3 = -2_prt * q2 * p2 * w * cosh(2_prt * m_slice_ds * omega);
+                T_Real const term4 = -2_prt * q1 * p1 * w * cos(2_prt  * m_slice_ds * omega);
+                T_Real const term5 =  2_prt * omega * (
+                    q1 * p1 * delta1 + q2 * p2 * delta1
+                    -(powi<2>(p1) + powi<2>(p2)) * m_slice_ds
+                    -(powi<2>(q1) - powi<2>(q2)) * powi<2>(w) * m_slice_ds
+                );
+                t = t0 + (-1_prt + m_beta * pt)
+                         / (8_prt * m_beta * powi<3>(delta1) * omega)
+                         * (term1 + term2 + term3 + term4 + term5);
+                // ptout = pt;
+
+            } else // drift
+            {
+                // advance transverse position and momentum (zero focusing strength = drift)
+                x = xout + m_slice_ds * px / delta1;
+                // pxout = px;
+                y = yout + m_slice_ds * py / delta1;
+                // pyout = py;
+
+                // advance longitudinal position and momentum
+                //   the corresponding symplectic update to t (zero strength = drift)
+                T_Real term = 2_prt * powi<2>(pt) + powi<2>(px) + powi<2>(py);
+                term = 2_prt - 4_prt * m_beta * pt + powi<2>(m_beta) * term;
+                term = -2_prt + powi<2>(refpart.gamma()) * term;
+                term = (-1_prt + m_beta * pt) * term;
+                term = term * m_const1;
+                t = tout - m_slice_ds * (1_prt / m_beta + term / powi<3>(delta1));
+                // ptout = pt;
+            }
 
             // assign updated momenta
             px = pxout;
@@ -260,7 +258,7 @@ namespace impactx::elements
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void operator() (RefPart & AMREX_RESTRICT refpart) const
         {
-            using namespace amrex::literals; // for _rt and _prt
+            using namespace amrex::literals;  // for _rt and _prt
             using amrex::Math::powi;
 
             // assign input reference particle values
@@ -278,18 +276,17 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds / std::sqrt(powi<2>(pt)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds / std::sqrt(powi<2>(pt) - 1.0_prt);
 
             // advance position and momentum (straight element)
-            refpart.x = x + step*px;
-            refpart.y = y + step*py;
-            refpart.z = z + step*pz;
-            refpart.t = t - step*pt;
+            refpart.x = x + step * px;
+            refpart.y = y + step * py;
+            refpart.z = z + step * pz;
+            refpart.t = t - step * pt;
 
             // advance integrated path length
             refpart.s = s + slice_ds;
         }
-
 
 
         /** This operator pushes the particle spin.
@@ -322,34 +319,33 @@ namespace impactx::elements
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {
-            using namespace amrex::literals; // for _rt and _prt
+            using namespace amrex::literals;  // for _rt and _prt
             using amrex::Math::powi;
-            using namespace std; // for cmath(float)
+            using namespace std;  // for cmath(float)
 
             // compute particle momentum deviation delta + 1
-            T_Real const delta1 = sqrt(1_prt - 2_prt*pt/m_beta + powi<2>(pt));
+            T_Real const delta1 = sqrt(1_prt - 2_prt * pt / m_beta + powi<2>(pt));
             T_Real const inv_delta1 = 1_prt / delta1;
 
             // compute particle relativistic gamma
-            T_Real const gamma = refpart.gamma() * (1_prt - m_beta*pt);
+            T_Real const gamma = refpart.gamma() * (1_prt - m_beta * pt);
             T_Real const gyro_const = 1_prt + refpart.gyromagnetic_anomaly * gamma;
 
             // compute phase advance per unit length in s (in rad/m)
             // chromatic dependence on delta is included
-            T_Real const omega = sqrt(abs(m_g)*inv_delta1);
+            T_Real const omega = sqrt(abs(m_g) * inv_delta1);
+            T_Real const omega_ds = omega * m_slice_ds;
 
             // compute trigonometric quantities
-            auto const [sin_omega_ds, cos_omega_ds] = amrex::Math::sincos(omega*m_slice_ds);
-            T_Real const sinh_omega_ds = sinh(omega*m_slice_ds);
-            T_Real const cosh_omega_ds = cosh(omega*m_slice_ds);
+            auto const [sin_omega_ds, cos_omega_ds] = amrex::Math::sincos(omega_ds);
+            T_Real const sinh_omega_ds = sinh(omega_ds);
+            T_Real const cosh_omega_ds = cosh(omega_ds);
 
             // The focusing/defocusing/drift cases differ only by which plane is
             // oscillatory vs. hyperbolic and by an overall sign. omega is real
             // (delta1 > 0 always) and the m_g sign is uniform across particles,
-            // so we select the per-plane factors branch-free. Only the raw
-            // trig values are selected; the surrounding arithmetic order is
-            // kept identical to the original branches so the result is
-            // byte-identical. For m_g == 0, omega == 0 makes all of (1-cos),
+            // so we select the per-plane factors branch-free.
+            // For m_g == 0, omega == 0 makes all of (1-cos),
             // sin, (cosh-1), sinh vanish, so the generator is identically zero
             // (drift) with no division by omega anywhere.
             bool const focusing = m_g > 0.0_prt;
@@ -362,16 +358,15 @@ namespace impactx::elements
             // overall sign: -gyro for focusing, +gyro for defocusing/drift
             T_Real const sgn = focusing ? -gyro_const : gyro_const;
 
-            T_Real const lambdax = sgn * ( py * inv_delta1 * fac_y + y * omega * sin_y );
-            T_Real const lambday = sgn * ( px * inv_delta1 * fac_x + x * omega * sin_x );
+            T_Real const lambdax = sgn * (py * inv_delta1 * fac_y + y * omega * sin_y);
+            T_Real const lambday = sgn * (px * inv_delta1 * fac_x + x * omega * sin_x);
             T_Real const lambdaz = 0_prt;
 
             // push the spin vector using the generator just determined
-            rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);
+            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
 
             // phase space push
             (*this)(x, y, t, px, py, pt, idcpu, refpart);
-
         }
 
 

--- a/src/elements/Quad.H
+++ b/src/elements/Quad.H
@@ -38,15 +38,18 @@ namespace impactx::elements
       public mixin::Alignment,
       public mixin::PipeAperture,
       public mixin::SpinTransport,
-      public mixin::NoFinalize
-      // At least on Intel AVX512, there is a small overhead to vectorize this element for DP and a gain for SP, see
-      // https://github.com/BLAST-ImpactX/impactx/pull/1002
-#ifdef AMREX_SINGLE_PRECISION_PARTICLES
-      , public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
-#endif
+      public mixin::NoFinalize,
+      public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
     {
         static constexpr auto type = "Quad";
         using PType = ImpactXParticleContainer::ParticleType;
+
+        // The light no-spin push in double precision does not benefit from SIMD,
+        // see https://github.com/BLAST-ImpactX/impactx/pull/1002
+        // This overwrites in mixin::BeamOptic the amrex::simd::Vectorized flag.
+#ifndef AMREX_SINGLE_PRECISION_PARTICLES
+        static constexpr bool simd_ps = false;
+#endif
 
         /** A Quadrupole magnet
          *

--- a/src/elements/Quad.H
+++ b/src/elements/Quad.H
@@ -121,26 +121,29 @@ namespace impactx::elements
             // element, so the per-particle operator() and spin push are
             // branch-free. omega = sqrt(|k|) is independent of the tracked
             // particle, so all trigonometric quantities can be cached.
-            // The transverse map per plane is:
-            //   xout  = m_c*x + m_s*px ;  pxout = m_f*x + m_c*px
+            // The transverse 6x6 transfer-map blocks are:
+            //   xout = m_R11*x + m_R12*px ;  pxout = m_R21*x + m_R22*px
+            //   yout = m_R33*y + m_R34*py ;  pyout = m_R43*y + m_R44*py
             // and the spin generator is:
             //   lambdax = m_spin_py*py + m_spin_y*y
             //   lambday = m_spin_px*px + m_spin_x*x
             amrex::ParticleReal const omega = std::sqrt(std::abs(m_k));
-            amrex::ParticleReal const sin_omega_ds = std::sin(omega*m_slice_ds);
-            amrex::ParticleReal const cos_omega_ds = std::cos(omega*m_slice_ds);
-            amrex::ParticleReal const sinh_omega_ds = std::sinh(omega*m_slice_ds);
-            amrex::ParticleReal const cosh_omega_ds = std::cosh(omega*m_slice_ds);
+            amrex::ParticleReal const sin_omega_ds = std::sin(omega * m_slice_ds);
+            amrex::ParticleReal const cos_omega_ds = std::cos(omega * m_slice_ds);
+            amrex::ParticleReal const sinh_omega_ds = std::sinh(omega * m_slice_ds);
+            amrex::ParticleReal const cosh_omega_ds = std::cosh(omega * m_slice_ds);
 
             if (m_k > 0.0_prt)
             {
                 // horizontally focusing quad (x focusing, y defocusing)
-                m_cx = cos_omega_ds;
-                m_sx = sin_omega_ds / omega;
-                m_fx = -omega * sin_omega_ds;
-                m_cy = cosh_omega_ds;
-                m_sy = sinh_omega_ds / omega;
-                m_fy = omega * sinh_omega_ds;
+                m_R11 = cos_omega_ds;
+                m_R12 = sin_omega_ds / omega;
+                m_R21 = -omega * sin_omega_ds;
+                m_R22 = cos_omega_ds;
+                m_R33 = cosh_omega_ds;
+                m_R34 = sinh_omega_ds / omega;
+                m_R43 = omega * sinh_omega_ds;
+                m_R44 = cosh_omega_ds;
 
                 m_spin_py = -m_gyro_const * (cosh_omega_ds - 1_prt);
                 m_spin_y  = -m_gyro_const * omega * sinh_omega_ds;
@@ -150,12 +153,14 @@ namespace impactx::elements
             else if (m_k < 0.0_prt)
             {
                 // horizontally defocusing quad (x defocusing, y focusing)
-                m_cx = cosh_omega_ds;
-                m_sx = sinh_omega_ds / omega;
-                m_fx = omega * sinh_omega_ds;
-                m_cy = cos_omega_ds;
-                m_sy = sin_omega_ds / omega;
-                m_fy = -omega * sin_omega_ds;
+                m_R11 = cosh_omega_ds;
+                m_R12 = sinh_omega_ds / omega;
+                m_R21 = omega * sinh_omega_ds;
+                m_R22 = cosh_omega_ds;
+                m_R33 = cos_omega_ds;
+                m_R34 = sin_omega_ds / omega;
+                m_R43 = -omega * sin_omega_ds;
+                m_R44 = cos_omega_ds;
 
                 m_spin_py = m_gyro_const * (1_prt - cos_omega_ds);
                 m_spin_y  = m_gyro_const * omega * sin_omega_ds;
@@ -165,12 +170,14 @@ namespace impactx::elements
             else
             {
                 // zero strength = drift
-                m_cx = 1.0_prt;
-                m_sx = m_slice_ds;
-                m_fx = 0.0_prt;
-                m_cy = 1.0_prt;
-                m_sy = m_slice_ds;
-                m_fy = 0.0_prt;
+                m_R11 = 1.0_prt;
+                m_R12 = m_slice_ds;
+                m_R21 = 0.0_prt;
+                m_R22 = 1.0_prt;
+                m_R33 = 1.0_prt;
+                m_R34 = m_slice_ds;
+                m_R43 = 0.0_prt;
+                m_R44 = 1.0_prt;
 
                 m_spin_py = 0.0_prt;
                 m_spin_y  = 0.0_prt;
@@ -207,23 +214,19 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
 
-            // initialize output values
-            // Note: x and y are read before being overwritten below, so we
-            // capture them up front to keep the push branch-free and order
-            // independent.
+            // copies of original input values
             T_Real const xin = x;
             T_Real const yin = y;
 
             // advance position and momentum
-            // The focusing/defocusing/drift selection is fully resolved in
-            // compute_constants(); see the m_c*/m_s*/m_f* coefficients there.
-            x = m_cx*xin + m_sx*px;
-            px = m_fx*xin + m_cx*px;
+            x  = m_R11 * xin + m_R12 * px;
+            px = m_R21 * xin + m_R22 * px;
 
-            y = m_cy*yin + m_sy*py;
-            py = m_fy*yin + m_cy*py;
+            y  = m_R33 * yin + m_R34 * py;
+            py = m_R43 * yin + m_R44 * py;
 
-            t = t + m_slice_bg*pt;
+            // R56 = m_slice_bg ;  R55 = R66 = 1
+            t = t + m_slice_bg * pt;
             // pt unchanged
         }
 
@@ -232,8 +235,8 @@ namespace impactx::elements
          * @param[in,out] refpart reference particle
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void operator() (RefPart & AMREX_RESTRICT refpart) const {  // TODO: update as well, but needs more careful placement of calc_constants
-
+        void operator() (RefPart & AMREX_RESTRICT refpart) const
+        {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
 
@@ -252,7 +255,7 @@ namespace impactx::elements
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
             // assign intermediate parameter
-            amrex::ParticleReal const step = slice_ds / std::sqrt(powi<2>(pt)-1.0_prt);
+            amrex::ParticleReal const step = slice_ds / std::sqrt(powi<2>(pt) - 1.0_prt);
 
             // advance position and momentum (straight element)
             refpart.x = x + step*px;
@@ -270,7 +273,7 @@ namespace impactx::elements
          */
         AMREX_GPU_HOST AMREX_FORCE_INLINE
         Map6x6
-        transport_map (RefPart const & AMREX_RESTRICT refpart) const  // TODO: update as well, but needs more careful placement of calc_constants
+        transport_map (RefPart const & AMREX_RESTRICT refpart) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
@@ -352,13 +355,13 @@ namespace impactx::elements
 
             // the axis-angle vector
             // The focusing/defocusing/drift selection is fully resolved in
-            // compute_constants(); see the m_spin_* coefficients there.
-            T_Real const lambdax = m_spin_py*py + m_spin_y*y;
-            T_Real const lambday = m_spin_px*px + m_spin_x*x;
+            // compute_constants(), see the m_spin_* coefficients there.
+            T_Real const lambdax = m_spin_py * py + m_spin_y * y;
+            T_Real const lambday = m_spin_px * px + m_spin_x * x;
             T_Real const lambdaz = 0_prt;
 
             // push the spin vector using the generator just determined
-            rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);
+            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
 
             // phase space push
             (*this)(x, y, t, px, py, pt, idcpu, refpart);
@@ -375,15 +378,11 @@ namespace impactx::elements
         // see: compute_constants() to refresh
         amrex::ParticleReal m_slice_ds;       //! m_ds / nslice();
         amrex::ParticleReal m_betgam2;        //! beta*gamma^2
-        amrex::ParticleReal m_slice_bg;       //! m_slice_ds / m_betgam2
+        amrex::ParticleReal m_slice_bg;       //! R56 = m_slice_ds / m_betgam2
         amrex::ParticleReal m_gyro_const;     //! (1 + G*gamma) for spin calculation
-        // branch-free transverse map coefficients (per plane), see compute_constants()
-        amrex::ParticleReal m_cx;             //! x,px diagonal coefficient (cos or cosh)
-        amrex::ParticleReal m_sx;             //! x += m_sx*px off-diagonal coefficient
-        amrex::ParticleReal m_fx;             //! px += m_fx*x off-diagonal coefficient
-        amrex::ParticleReal m_cy;             //! y,py diagonal coefficient (cos or cosh)
-        amrex::ParticleReal m_sy;             //! y += m_sy*py off-diagonal coefficient
-        amrex::ParticleReal m_fy;             //! py += m_fy*y off-diagonal coefficient
+        // pre-resolved 6x6 transfer-map elements (transverse blocks), see compute_constants()
+        amrex::ParticleReal m_R11, m_R12, m_R21, m_R22; //! x--px block
+        amrex::ParticleReal m_R33, m_R34, m_R43, m_R44; //! y--py block
         // branch-free spin generator coefficients, see compute_constants()
         amrex::ParticleReal m_spin_px;        //! lambday += m_spin_px*px
         amrex::ParticleReal m_spin_x;         //! lambday += m_spin_x*x

--- a/src/elements/Quad.H
+++ b/src/elements/Quad.H
@@ -110,16 +110,70 @@ namespace impactx::elements
             m_betgam2 = powi<2>(pt_ref) - 1.0_prt;
             m_slice_bg = m_slice_ds / m_betgam2;
 
-            // compute phase advance per unit length in s (in rad/m)
-            m_omega = std::sqrt(std::abs(m_k));
-            m_sin_omega_ds = std::sin(m_omega*m_slice_ds);
-            m_cos_omega_ds = std::cos(m_omega*m_slice_ds);
-            m_sinh_omega_ds = std::sinh(m_omega*m_slice_ds);
-            m_cosh_omega_ds = std::cosh(m_omega*m_slice_ds);
-
             // gyromagnetic constant (used during spin push)
-            amrex::ParticleReal G = refpart.gyromagnetic_anomaly;
+            amrex::ParticleReal const G = refpart.gyromagnetic_anomaly;
             m_gyro_const = 1_prt + G * refpart.gamma();
+
+            // Resolve the focusing/defocusing/drift branch here, once per
+            // element, so the per-particle operator() and spin push are
+            // branch-free. omega = sqrt(|k|) is independent of the tracked
+            // particle, so all trigonometric quantities can be cached.
+            // The transverse map per plane is:
+            //   xout  = m_c*x + m_s*px ;  pxout = m_f*x + m_c*px
+            // and the spin generator is:
+            //   lambdax = m_spin_py*py + m_spin_y*y
+            //   lambday = m_spin_px*px + m_spin_x*x
+            amrex::ParticleReal const omega = std::sqrt(std::abs(m_k));
+            amrex::ParticleReal const sin_omega_ds = std::sin(omega*m_slice_ds);
+            amrex::ParticleReal const cos_omega_ds = std::cos(omega*m_slice_ds);
+            amrex::ParticleReal const sinh_omega_ds = std::sinh(omega*m_slice_ds);
+            amrex::ParticleReal const cosh_omega_ds = std::cosh(omega*m_slice_ds);
+
+            if (m_k > 0.0_prt)
+            {
+                // horizontally focusing quad (x focusing, y defocusing)
+                m_cx = cos_omega_ds;
+                m_sx = sin_omega_ds / omega;
+                m_fx = -omega * sin_omega_ds;
+                m_cy = cosh_omega_ds;
+                m_sy = sinh_omega_ds / omega;
+                m_fy = omega * sinh_omega_ds;
+
+                m_spin_py = -m_gyro_const * (cosh_omega_ds - 1_prt);
+                m_spin_y  = -m_gyro_const * omega * sinh_omega_ds;
+                m_spin_px = -m_gyro_const * (1_prt - cos_omega_ds);
+                m_spin_x  = -m_gyro_const * omega * sin_omega_ds;
+            }
+            else if (m_k < 0.0_prt)
+            {
+                // horizontally defocusing quad (x defocusing, y focusing)
+                m_cx = cosh_omega_ds;
+                m_sx = sinh_omega_ds / omega;
+                m_fx = omega * sinh_omega_ds;
+                m_cy = cos_omega_ds;
+                m_sy = sin_omega_ds / omega;
+                m_fy = -omega * sin_omega_ds;
+
+                m_spin_py = m_gyro_const * (1_prt - cos_omega_ds);
+                m_spin_y  = m_gyro_const * omega * sin_omega_ds;
+                m_spin_px = m_gyro_const * (cosh_omega_ds - 1_prt);
+                m_spin_x  = m_gyro_const * omega * sinh_omega_ds;
+            }
+            else
+            {
+                // zero strength = drift
+                m_cx = 1.0_prt;
+                m_sx = m_slice_ds;
+                m_fx = 0.0_prt;
+                m_cy = 1.0_prt;
+                m_sy = m_slice_ds;
+                m_fy = 0.0_prt;
+
+                m_spin_py = 0.0_prt;
+                m_spin_y  = 0.0_prt;
+                m_spin_px = 0.0_prt;
+                m_spin_x  = 0.0_prt;
+            }
         }
 
         /** This is a quad functor, so that a variable of this type can be used like a quad function.
@@ -151,52 +205,23 @@ namespace impactx::elements
             using namespace amrex::literals; // for _rt and _prt
 
             // initialize output values
-            T_Real xout = x;
-            T_Real yout = y;
-            T_Real tout = t;
-            T_Real pxout = px;
-            T_Real pyout = py;
-            // T_Real const ptout = pt;
+            // Note: x and y are read before being overwritten below, so we
+            // capture them up front to keep the push branch-free and order
+            // independent.
+            T_Real const xin = x;
+            T_Real const yin = y;
 
-            if (m_k > 0.0_prt)
-            {
-                // advance position and momentum (focusing quad)
-                xout = m_cos_omega_ds*x + m_sin_omega_ds/m_omega*px;
-                pxout = -m_omega*m_sin_omega_ds*x + m_cos_omega_ds*px;
+            // advance position and momentum
+            // The focusing/defocusing/drift selection is fully resolved in
+            // compute_constants(); see the m_c*/m_s*/m_f* coefficients there.
+            x = m_cx*xin + m_sx*px;
+            px = m_fx*xin + m_cx*px;
 
-                yout = m_cosh_omega_ds*y + m_sinh_omega_ds/m_omega*py;
-                pyout = m_omega*m_sinh_omega_ds*y + m_cosh_omega_ds*py;
+            y = m_cy*yin + m_sy*py;
+            py = m_fy*yin + m_cy*py;
 
-                tout = t + (m_slice_bg)*pt;
-                // ptout = pt;
-            } else if (m_k < 0.0_prt)
-            {
-                // advance position and momentum (defocusing quad)
-                xout = m_cosh_omega_ds*x + m_sinh_omega_ds/m_omega*px;
-                pxout = m_omega*m_sinh_omega_ds*x + m_cosh_omega_ds*px;
-
-                yout = m_cos_omega_ds*y + m_sin_omega_ds/m_omega*py;
-                pyout = -m_omega*m_sin_omega_ds*y + m_cos_omega_ds*py;
-
-                tout = t + m_slice_bg*pt;
-                // ptout = pt;
-            } else {
-                // advance position and momentum (zero strength = drift)
-                xout = x + m_slice_ds * px;
-                // pxout = px;
-                yout = y + m_slice_ds * py;
-                // pyout = py;
-                tout = t + m_slice_bg * pt;
-                // ptout = pt;
-            }
-
-            // assign updated values
-            x = xout;
-            y = yout;
-            t = tout;
-            px = pxout;
-            py = pyout;
-            // pt = ptout;
+            t = t + m_slice_bg*pt;
+            // pt unchanged
         }
 
         /** This pushes the reference particle.
@@ -322,28 +347,12 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
 
-            // initialize the three components of the axis-angle vector
-            T_Real lambdax = 0_prt;
-            T_Real lambday = 0_prt;
-            T_Real lambdaz = 0_prt;
-
-            if (m_k > 0.0_prt)
-            {
-
-                // horizontally focusing quad case
-                lambdax = -m_gyro_const * ( py*(m_cosh_omega_ds - 1_prt) + y*m_omega*m_sinh_omega_ds );
-                lambday = -m_gyro_const * ( px*(1_prt - m_cos_omega_ds) + x*m_omega*m_sin_omega_ds );
-
-            } else if (m_k < 0.0_prt)
-            {
-
-                // horizontally defocusing quad case
-                lambdax = m_gyro_const * ( py*(1_prt - m_cos_omega_ds) + y*m_omega*m_sin_omega_ds );
-                lambday = m_gyro_const * ( px*(m_cosh_omega_ds - 1_prt) + x*m_omega*m_sinh_omega_ds );
-
-            } else {
-                // treat as a drift
-            }
+            // the axis-angle vector
+            // The focusing/defocusing/drift selection is fully resolved in
+            // compute_constants(); see the m_spin_* coefficients there.
+            T_Real const lambdax = m_spin_py*py + m_spin_y*y;
+            T_Real const lambday = m_spin_px*px + m_spin_x*x;
+            T_Real const lambdaz = 0_prt;
 
             // push the spin vector using the generator just determined
             rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);
@@ -364,12 +373,19 @@ namespace impactx::elements
         amrex::ParticleReal m_slice_ds;       //! m_ds / nslice();
         amrex::ParticleReal m_betgam2;        //! beta*gamma^2
         amrex::ParticleReal m_slice_bg;       //! m_slice_ds / m_betgam2
-        amrex::ParticleReal m_omega;          //! std::sqrt(std::abs(m_k)) compute phase advance per unit length in s (in rad/m)
-        amrex::ParticleReal m_sin_omega_ds;   //! std::sin(omega*slice_ds)
-        amrex::ParticleReal m_cos_omega_ds;   //! std::cos(omega*slice_ds)
-        amrex::ParticleReal m_sinh_omega_ds;  //! std::sinh(omega*slice_ds)
-        amrex::ParticleReal m_cosh_omega_ds;  //! std::cosh(omega*slice_ds)
         amrex::ParticleReal m_gyro_const;     //! (1 + G*gamma) for spin calculation
+        // branch-free transverse map coefficients (per plane), see compute_constants()
+        amrex::ParticleReal m_cx;             //! x,px diagonal coefficient (cos or cosh)
+        amrex::ParticleReal m_sx;             //! x += m_sx*px off-diagonal coefficient
+        amrex::ParticleReal m_fx;             //! px += m_fx*x off-diagonal coefficient
+        amrex::ParticleReal m_cy;             //! y,py diagonal coefficient (cos or cosh)
+        amrex::ParticleReal m_sy;             //! y += m_sy*py off-diagonal coefficient
+        amrex::ParticleReal m_fy;             //! py += m_fy*y off-diagonal coefficient
+        // branch-free spin generator coefficients, see compute_constants()
+        amrex::ParticleReal m_spin_px;        //! lambday += m_spin_px*px
+        amrex::ParticleReal m_spin_x;         //! lambday += m_spin_x*x
+        amrex::ParticleReal m_spin_py;        //! lambdax += m_spin_py*py
+        amrex::ParticleReal m_spin_y;         //! lambdax += m_spin_y*y
 
     };
 

--- a/src/elements/mixin/beamoptic.H
+++ b/src/elements/mixin/beamoptic.H
@@ -30,14 +30,15 @@ namespace impactx
      *  depending on whether the element type T_Element is vectorized.
      *
      * @tparam T_Element the element type
+     * @tparam UseSimd default-on if AMREX_USE_SIMD is set, allows disabling SIMD for performance corner cases
      * @tparam F the functor type
      * @param n the number of items to iterate over
      * @param f the functor to execute
      */
-    template <typename T_Element, typename F>
+    template <typename T_Element, bool UseSimd = true, typename F>
     void ParallelFor (int n, F&& f) {
 #ifdef AMREX_USE_SIMD
-        if constexpr (amrex::simd::is_vectorized<T_Element>) {
+        if constexpr (UseSimd && amrex::simd::is_vectorized<T_Element>) {
             amrex::ParallelForSIMD<T_Element::simd_width>(n, std::forward<F>(f));
         } else
 #endif
@@ -51,6 +52,30 @@ namespace impactx::elements::mixin
 {
 namespace detail
 {
+    /** Per-push SIMD policy.
+     *
+     * Whether an element's phase space push (`operator()`) or spin
+     * (`spin_and_phasespace_push`) push should be vectorized on CPU.
+     *
+     * By default a push follows the element's overall vectorization
+     * (@see amrex::simd::is_vectorized). An element may override the choice
+     * independently per push kind by declaring a `static constexpr bool`
+     * member `simd_ps` and/or `simd_spin`. This allows, e.g., vectorizing
+     * the heavy spin push while keeping a light no-spin push
+     * scalar in double precision (where SIMD has a small overhead).
+     */
+    template <typename T, typename = void>
+    struct push_simd_ps : std::bool_constant<amrex::simd::is_vectorized<T>> {};
+    template <typename T>
+    struct push_simd_ps<T, std::void_t<decltype(T::simd_ps)>>
+        : std::bool_constant<T::simd_ps> {};
+
+    template <typename T, typename = void>
+    struct push_simd_spin : std::bool_constant<amrex::simd::is_vectorized<T>> {};
+    template <typename T>
+    struct push_simd_spin<T, std::void_t<decltype(T::simd_spin)>>
+        : std::bool_constant<T::simd_spin> {};
+
     /** Load particle data from array pointers
      *
      * On GPU and CPU w/o SIMD, this dereferences a particle property at the
@@ -137,7 +162,10 @@ namespace detail
     )
     {
 #ifdef AMREX_USE_SIMD
-        if constexpr (!std::is_integral_v<IndexType>) {
+        // a non-integral index means a SIMD lane-batch was loaded into registers
+        constexpr bool is_simd = !std::is_integral_v<IndexType>;
+
+        if constexpr (is_simd) {
             if constexpr (ForceWriteback || amrex::simd::is_nth_arg_non_const(P_Method, N)) {
                 // write back to memory
                 // TODO stdx::vector_aligned needs alignment guarantees
@@ -238,6 +266,11 @@ namespace detail
             decltype(auto) sz = load_pdata(m_part_sz, i);
             decltype(auto) idcpu = load_pdata(m_part_idcpu, i);
 
+#ifdef AMREX_USE_SIMD
+            // a non-integral index means a SIMD lane-batch was loaded into registers
+            constexpr bool is_simd = !std::is_integral_v<IndexType>;
+#endif
+
             // pre/post-push functionality declared by mixin classes
             constexpr bool has_alignment = std::is_base_of_v<mixin::Alignment, T_Element> && T_DoAlignment;
             constexpr bool has_aperture = std::is_base_of_v<mixin::PipeAperture, T_Element>;
@@ -264,7 +297,7 @@ namespace detail
 
             // SIMD: write back to memory
 #ifdef AMREX_USE_SIMD
-            if constexpr (amrex::simd::is_vectorized<T_Element>)
+            if constexpr (is_simd)
             {
                 using RealType = std::decay_t<decltype(x)>;
                 using IdCpuType = std::decay_t<decltype(idcpu)>;
@@ -384,6 +417,11 @@ namespace detail
             decltype(auto) pt = load_pdata(m_part_pt, i);
             decltype(auto) idcpu = load_pdata(m_part_idcpu, i);
 
+#ifdef AMREX_USE_SIMD
+            // a non-integral index means a SIMD lane-batch was loaded into registers
+            constexpr bool is_simd = !std::is_integral_v<IndexType>;
+#endif
+
             // pre/post-push functionality declared by mixin classes
             constexpr bool has_alignment = std::is_base_of_v<mixin::Alignment, T_Element> && T_DoAlignment;
             constexpr bool has_aperture = std::is_base_of_v<mixin::PipeAperture, T_Element>;
@@ -408,7 +446,7 @@ namespace detail
 
             // write back to memory
 #ifdef AMREX_USE_SIMD
-            if constexpr (amrex::simd::is_vectorized<T_Element>)
+            if constexpr (is_simd)
             {
                 using RealType = std::decay_t<decltype(x)>;
                 using IdCpuType = std::decay_t<decltype(idcpu)>;
@@ -502,7 +540,7 @@ namespace detail
                 dispatch_misalignment(element, [&](auto do_alignment) {
                     detail::PushSingleParticleSpin<T_Element, decltype(do_alignment)::value> const pushSingleParticle(
                         element, part_x, part_y, part_t, part_px, part_py, part_pt, part_sx, part_sy, part_sz, part_idcpu, ref_part);
-                    impactx::ParallelFor<T_Element>(np, pushSingleParticle);
+                    impactx::ParallelFor<T_Element, detail::push_simd_spin<T_Element>::value>(np, pushSingleParticle);
                 });
             } else {
                 throw std::runtime_error("Spin transport requested but element does not implement the `SpinTransport` interface class!");
@@ -513,7 +551,7 @@ namespace detail
             dispatch_misalignment(element, [&](auto do_alignment) {
                 detail::PushSingleParticle<T_Element, decltype(do_alignment)::value> const pushSingleParticle(
                     element, part_x, part_y, part_t, part_px, part_py, part_pt, part_idcpu, ref_part);
-                impactx::ParallelFor<T_Element>(np, pushSingleParticle);
+                impactx::ParallelFor<T_Element, detail::push_simd_ps<T_Element>::value>(np, pushSingleParticle);
             });
         }
     }


### PR DESCRIPTION
Reduce/eliminate branching in Quad and ChrQuad ~and ChrPlasmaLens~.

- [x] draft & test
- [x] CPU DP: vectorize `Quad[spin]`, continue to skip `Quad[nospin]` which is not worth vectorizing (-19% penalty)
- [x] clean-up

## GPU performance (element push micro-benchmarks)

Branch vs `development`, NVIDIA RTX A2000 (laptop, Ampere SM 8.6), CUDA, 1M particles, `tests/python/test_benchmark_elements.py`. Times are the median push over 5 rounds (kernel-synchronized); speedup = `development` / this PR.

### Double precision

| element | `development` | this PR | speedup |
|---|--:|--:|--:|
| Quad (no spin)    |    751 µs |    539 µs | **1.40×** |
| Quad (spin)       |  3,086 µs |  2,406 µs | **1.28×** |
| ChrQuad (no spin) |  6,808 µs |  5,284 µs | **1.29×** |
| ChrQuad (spin)    | 15,480 µs | 13,236 µs | **1.17×** |

### Single precision

| element | `development` | this PR | speedup |
|---|--:|--:|--:|
| Quad (no spin)    | 270 µs | 273 µs | 0.99× |
| Quad (spin)       | 416 µs | 414 µs | 1.01× |
| ChrQuad (no spin) | 268 µs | 273 µs | 0.98× |
| ChrQuad (spin)    | 418 µs | 421 µs | 0.99× |

**Caveat — consumer-GPU artifact.** On this non-Tesla GPU FP64 throughput is ~1/64 of FP32, so the DP kernels are strongly *compute-bound* (the branch-free push shows up directly) while in SP they become *memory-bound* (all elements collapse to ~270 µs, dominated by particle SoA traffic, so the arithmetic savings are hidden). On an HPC GPU where DP is ~0.5× of SP FLOP/s the opposite is expected: and SP->DP would make a kernel even more memory-bound.