### PR TITLE
Fix: `ExactSbend::transport_map`

### DIFF
--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -328,33 +328,37 @@ namespace impactx::elements
             amrex::ParticleReal const pt_ref = refpart.pt;
             amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1_prt;
             amrex::ParticleReal const bet = refpart.beta();
+            amrex::ParticleReal const inv_bet = 1_prt / bet;
 
             // initialize linear map matrix elements
             Map6x6 R = Map6x6::Identity();
 
             // treat the special case of zero field
-            if (m_rc==0.0_prt) {
+            if (m_phi == 0.0_prt && m_B == 0.0_prt)
+            {
                R(1,2) = slice_ds;
                R(3,4) = slice_ds;
                R(5,6) = slice_ds / betgam2;
-
-            } else {
+            } else
+            {
+               // reference particle's orbital radius
+               amrex::ParticleReal const rc = this->rc(refpart);
 
                // calculate expensive terms once
-               amrex::ParticleReal const theta = slice_ds/m_rc;
+               amrex::ParticleReal const theta = slice_ds / rc;
                auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
 
                // assign linear map matrix elements
                R(1,1) = cos_theta;
-               R(1,2) = m_rc * sin_theta;
-               R(1,6) = - ( m_rc / bet) * (1_prt - cos_theta);
-               R(2,1) = -sin_theta / m_rc;
+               R(1,2) = rc * sin_theta;
+               R(1,6) = -rc * inv_bet * (1_prt - cos_theta);
+               R(2,1) = -sin_theta / rc;
                R(2,2) = cos_theta;
-               R(2,6) = - sin_theta / bet;
-               R(3,4) = m_rc * theta;
-               R(5,1) = sin_theta / bet;
-               R(5,2) = m_rc / bet * (1_prt - cos_theta);
-               R(5,6) = m_rc * (-theta + sin_theta / (bet * bet));
+               R(2,6) = -sin_theta * inv_bet;
+               R(3,4) = rc * theta;
+               R(5,1) = sin_theta * inv_bet;
+               R(5,2) = rc * inv_bet * (1_prt - cos_theta);
+               R(5,6) = rc * (sin_theta * inv_bet * inv_bet - theta);
             }
 
             // apply the transverse rotation (roll) alignment error


### PR DESCRIPTION
Fix the linear transport map for `ExactSbend`, which returned NaNs / undefined values / UB.

The linear transport map relied on cached element values, but we only populate them for particle tracking. Also adds minor cleanups besides the fix of `m_rc` -> `rc`.

Fix #1523