### PR TITLE
Restore import of matplotlib for example plotting

### DIFF
--- a/examples/expanding_beam/run_expanding_fft_2D_test_particles.py
+++ b/examples/expanding_beam/run_expanding_fft_2D_test_particles.py
@@ -8,6 +8,7 @@
 
 import numpy as np
 import pandas as pd
+#import matplotlib.pyplot as plt
 
 import amrex.space3d as amr
 from impactx import ImpactX, distribution, elements
@@ -114,12 +115,12 @@ df = pd.DataFrame(test_data, columns=["s", "id", "x", "y"])
 sorted_df = df.sort_values(by="id")
 
 # Uncomment the lines below to generate a plot of the test particle orbits:
-# n = len(sarr)
-# for i in range(0, len(df), n):
+#n = len(sarr)
+#for i in range(0, len(df), n):
 #    subset = sorted_df.iloc[i : i + n]
 #    plt.scatter(subset["s"], subset["x"], s=5)
-#
-# plt.xlabel("s [m]", fontsize=12)
-# plt.ylabel("x [mm]", fontsize=12)
-# plt.title("Test Particles: Horizontal Coordinates")
-# plt.show()
+
+#plt.xlabel("s [m]", fontsize=12)
+#plt.ylabel("x [mm]", fontsize=12)
+#plt.title("Test Particles: Horizontal Coordinates")
+#plt.show()

--- a/examples/expanding_beam/run_expanding_fft_2D_test_particles.py
+++ b/examples/expanding_beam/run_expanding_fft_2D_test_particles.py
@@ -127,8 +127,8 @@ if do_plot:
 
     n = len(sarr)
     for i in range(0, len(df), n):
-       subset = sorted_df.iloc[i : i + n]
-       plt.scatter(subset["s"], subset["x"], s=5)
+        subset = sorted_df.iloc[i : i + n]
+        plt.scatter(subset["s"], subset["x"], s=5)
 
     plt.xlabel("s [m]", fontsize=12)
     plt.ylabel("x [mm]", fontsize=12)

--- a/examples/expanding_beam/run_expanding_fft_2D_test_particles.py
+++ b/examples/expanding_beam/run_expanding_fft_2D_test_particles.py
@@ -9,7 +9,6 @@
 import numpy as np
 import pandas as pd
 
-# import matplotlib.pyplot as plt
 import amrex.space3d as amr
 from impactx import ImpactX, distribution, elements
 
@@ -122,5 +121,16 @@ sorted_df = df.sort_values(by="id")
 
 # plt.xlabel("s [m]", fontsize=12)
 # plt.ylabel("x [mm]", fontsize=12)
-# plt.title("Test Particles: Horizontal Coordinates")
+do_plot = False  # True to generate a plot of the test particle orbits
+if do_plot:
+    import matplotlib.pyplot as plt
+
+    n = len(sarr)
+    for i in range(0, len(df), n):
+       subset = sorted_df.iloc[i : i + n]
+       plt.scatter(subset["s"], subset["x"], s=5)
+
+    plt.xlabel("s [m]", fontsize=12)
+    plt.ylabel("x [mm]", fontsize=12)
+    plt.title("Test Particles: Horizontal Coordinates")
 # plt.show()

--- a/examples/expanding_beam/run_expanding_fft_2D_test_particles.py
+++ b/examples/expanding_beam/run_expanding_fft_2D_test_particles.py
@@ -8,8 +8,8 @@
 
 import numpy as np
 import pandas as pd
-#import matplotlib.pyplot as plt
 
+# import matplotlib.pyplot as plt
 import amrex.space3d as amr
 from impactx import ImpactX, distribution, elements
 
@@ -115,12 +115,12 @@ df = pd.DataFrame(test_data, columns=["s", "id", "x", "y"])
 sorted_df = df.sort_values(by="id")
 
 # Uncomment the lines below to generate a plot of the test particle orbits:
-#n = len(sarr)
-#for i in range(0, len(df), n):
+# n = len(sarr)
+# for i in range(0, len(df), n):
 #    subset = sorted_df.iloc[i : i + n]
 #    plt.scatter(subset["s"], subset["x"], s=5)
 
-#plt.xlabel("s [m]", fontsize=12)
-#plt.ylabel("x [mm]", fontsize=12)
-#plt.title("Test Particles: Horizontal Coordinates")
-#plt.show()
+# plt.xlabel("s [m]", fontsize=12)
+# plt.ylabel("x [mm]", fontsize=12)
+# plt.title("Test Particles: Horizontal Coordinates")
+# plt.show()


### PR DESCRIPTION
To run the plotting feature in this example, matplotlib needs to be imported.  Although plotting is commented, this PR restores the appropriate line.