### PR TITLE
`setup.py`: Emscripten

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import sys
+import sysconfig
 
 from setuptools import Extension, setup
 from setuptools.command.build import build
@@ -80,14 +81,30 @@ class CMakeBuild(build_ext):
             extdir += os.path.sep
 
         pyv = sys.version_info
-        cmake_args = [
-            # Python: use the calling interpreter in CMake
-            # https://cmake.org/cmake/help/latest/module/FindPython.html#hints
-            # https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-version-selection
-            f"-DPython_ROOT_DIR={sys.prefix}",
-            f"-DPython_FIND_VERSION={pyv.major}.{pyv.minor}.{pyv.micro}",
-            "-DPython_FIND_VERSION_EXACT=TRUE",
-            "-DPython_FIND_STRATEGY=LOCATION",
+        # cross-compiling (e.g. Pyodide)? host & target Python differ
+        emscripten = sysconfig.get_platform().startswith("emscripten")
+        cmake_args = []
+        # FindPython: pin to the calling interpreter unless the caller
+        # overrides via IMPACTX_CMAKE_Python_*. Cross builds keep these host
+        # hints (to resolve the interpreter/library for Development.Module),
+        # but override the target headers (below) and relax the exact-version
+        # match. See:
+        #   https://cmake.org/cmake/help/latest/module/FindPython.html#hints
+        #   https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-version-selection
+        if emscripten or not any(
+            k.startswith("IMPACTX_CMAKE_Python_") for k in os.environ
+        ):
+            cmake_args += [
+                f"-DPython_ROOT_DIR={sys.prefix}",
+                f"-DPython_FIND_VERSION={pyv.major}.{pyv.minor}.{pyv.micro}",
+                "-DPython_FIND_VERSION_EXACT=" + ("FALSE" if emscripten else "TRUE"),
+                "-DPython_FIND_STRATEGY=LOCATION",
+            ]
+        if emscripten:
+            cmake_args += [
+                "-DPython_INCLUDE_DIR=" + sysconfig.get_config_var("INCLUDEPY")
+            ]
+        cmake_args += [
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + os.path.join(extdir, "impactx"),
             "-DCMAKE_VERBOSE_MAKEFILE=ON",
             "-DCMAKE_PYTHON_OUTPUT_DIRECTORY=" + extdir,


### PR DESCRIPTION
Support a cross-compiled Python include in WASM Pyodide Emscripten builds in `setup.py`. Try to auto-derive from environment hints and platform in the sysconfig of the Python interpreter.

See https://github.com/openPMD/openPMD-api/pull/1893