### PR TITLE
Prepare Particle Tracking Loop for Strang Splitting

### DIFF
--- a/src/tracking/TrackingDirection.H
+++ b/src/tracking/TrackingDirection.H
@@ -1,0 +1,26 @@
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl, Chad Mitchell
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_TRACKING_DIRECTION_H
+#define IMPACTX_TRACKING_DIRECTION_H
+
+
+namespace impactx
+{
+    /** Direction in which the lattice is traversed.
+     *
+     * ``Forward`` is ordinary tracking (entrance to exit). ``Backward`` traverses
+     * the periods, elements and space-charge slices in reverse, inverts each element's map,
+     * and applies the per-slice operations in mirrored order, i.e. time-symmetric back-tracking.
+     */
+    enum class TrackingDirection { Forward, Backward };
+
+} // namespace impactx
+
+#endif // IMPACTX_TRACKING_DIRECTION_H

--- a/src/tracking/TrackingState.H
+++ b/src/tracking/TrackingState.H
@@ -1,15 +1,17 @@
-/* Copyright 2022-2023 The Regents of the University of California, through Lawrence
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
  *           Berkeley National Laboratory (subject to receipt of any required
  *           approvals from the U.S. Dept. of Energy). All rights reserved.
  *
  * This file is part of ImpactX.
  *
- * Authors: Axel Huebl, Chad Mitchell * License: BSD-3-Clause-LBNL
+ * Authors: Axel Huebl, Chad Mitchell
+ * License: BSD-3-Clause-LBNL
  */
 #ifndef IMPACTX_TRACKING_STATE_H
 #define IMPACTX_TRACKING_STATE_H
 
 #include "elements/All.H"
+#include "tracking/TrackingDirection.H"
 
 #include <optional>
 
@@ -35,9 +37,14 @@ namespace impactx
         /** For tracking hooks/callbacks, the current lattice element */
         std::optional<elements::KnownElements*> m_element;
 
+        /** Tracking direction in the lattice */
+        TrackingDirection m_direction = TrackingDirection::Forward;
+
         void set_no_element () { m_element = std::nullopt; }
+
+        bool forward () const { return m_direction == TrackingDirection::Forward; }
     };
 
 } // namespace impactx
 
-#endif // IMPACT_X_H
+#endif // IMPACTX_TRACKING_STATE_H

--- a/src/tracking/particles.H
+++ b/src/tracking/particles.H
@@ -1,0 +1,203 @@
+/* Copyright 2022-2025 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl, Chad Mitchell
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_TRACKING_PARTICLES_H
+#define IMPACTX_TRACKING_PARTICLES_H
+
+#include "elements/All.H"
+#include "particles/ImpactXParticleContainer.H"
+#include "tracking/TrackingDirection.H"
+#include "tracking/TrackingState.H"
+
+#include <AMReX_BLProfiler.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_Print.H>
+#include <AMReX_REAL.H>
+
+#include <list>
+#include <string>
+#include <variant>
+
+
+namespace impactx
+{
+    /** Traverse the lattice for particle (beam + reference) tracking, applying the
+     *  per-slice physics as two composable operations.
+     *
+     *  This function performs the nested lattice traversal (looping over periods,
+     *  then over the beamline elements in each period, then over the
+     *  collective-effect slices within each element). It also maintains the
+     *  user-defined hooks, the reference-particle edge update and the global step
+     *  counter.
+     *  The caller supplies the per-slice physics as a @p collective_kicks
+     *  (space charge, CSR, ISR, ...) and an @p element_push
+     *  (the external-field of an element). Keeping the kick and the transport as
+     *  separate, composable operations isolates the collective-effect composition:
+     *  forward, this applies ``K`` then ``M`` per slice (first order).
+     *  Planned: second-order Strang split ``K(1/2) [M K]^(n-1) M K(1/2)``.
+     *
+     *  Hooks, the reference-particle edge update, the step counter and the
+     *  tracking-state element pointer are maintained on ``Forward`` tracking only.
+     *
+     *  The number of periods (``lattice.periods``) and verbosity (``impactx.verbose``)
+     *  are read from the inputs. The step counter is advanced from its current value,
+     *  so the caller is expected to reset it (to 0) before a forward run.
+     *
+     *  @tparam HookFn callable ``void (std::string const & name)`` invoking a named hook
+     *  @tparam CollectiveKicks callable, see @p ElementPush for the signature
+     *  @tparam ElementPush callable
+     *    ``void (elements::KnownElements & element, int element_index, int slice_step,
+     *            int nslice, amrex::ParticleReal slice_ds, int step, int period)``
+     *  @param[in,out] lattice the beamline elements to traverse
+     *  @param[in,out] pc beam particle container (reference particle / edge update)
+     *  @param[in,out] tracking_state tracking state shared with hooks (element, step, period);
+     *                 its ``m_direction`` selects the traversal direction
+     *  @param[in] call_hook registry for user-specified callback hooks
+     *  @param[in] collective_kicks applied collective effect kicks (SC, CSR, ISR, etc.), per-slice
+     *  @param[in] element_push applied the external-field of an element, per-slice
+     */
+    template <typename HookFn, typename CollectiveKicks, typename ElementPush>
+    void track_lattice_particles (
+        std::list<elements::KnownElements> & lattice,
+        ImpactXParticleContainer & pc,
+        TrackingState & tracking_state,
+        HookFn const & call_hook,
+        CollectiveKicks && collective_kicks,
+        ElementPush && element_push
+    )
+    {
+        bool const forward = tracking_state.forward();
+
+        // periods through the lattice (turns/cycles) and verbosity
+        int num_periods = 1;
+        amrex::ParmParse("lattice").queryAddWithParser("periods", num_periods);
+        int verbose = 1;
+        amrex::ParmParse("impactx").queryAddWithParser("verbose", verbose);
+
+        int & step = tracking_state.m_step;
+
+        // visit one element for all of its space-charge slices
+        auto visit_element = [&] (
+            elements::KnownElements & element_variant,
+            int period
+        )
+        {
+            if (forward)
+            {
+                // update element edge of the reference particle
+                pc.SetRefParticleEdge();
+
+                // book-keeping: currently visited element reference
+                tracking_state.m_element = &element_variant;
+
+                // optional, user-defined function call
+                call_hook("before_element");
+            }
+            else
+            {
+                // back-tracking: invert this element's map in place so the element
+                // transport below applies the inverse map.
+                std::visit([](auto && element){ element.reverse(); }, element_variant);
+            }
+
+            // number of slices used for the application of space charge
+            int nslice = 1;
+            amrex::ParticleReal slice_ds = 0; // in meters
+            std::visit([&nslice, &slice_ds](auto && element) {
+                nslice = element.nslice();
+                slice_ds = element.ds() / nslice;
+            }, element_variant);
+
+            // sub-steps for space charge within the element
+            for (int s = 0; s < nslice; ++s)
+            {
+                BL_PROFILE("ImpactX::evolve::slice_step");
+                int const slice_step = forward ? s : (nslice - 1 - s);
+
+                if (forward)
+                {
+                    step++;
+                    if (verbose > 0) {
+                        amrex::Print() << "\n++++ Starting step=" << step
+                                       << " slice_step=" << slice_step;
+                    }
+
+                    // optional, user-defined function call
+                    call_hook("before_slice");
+                }
+
+                // TODO: Strang-split here (#846 / #920)
+                if (forward)
+                {
+                    collective_kicks(element_variant, slice_ds);
+                    element_push(element_variant, step, period);
+                }
+                else
+                {
+                    element_push(element_variant, step, period);
+                    collective_kicks(element_variant, slice_ds);
+                }
+            }
+
+            if (forward)
+            {
+                // optional, user-defined function call
+                call_hook("after_element");
+            }
+            else
+            {
+                // restore the forward element map (reverse() is an involution)
+                std::visit([](auto && element){ element.reverse(); }, element_variant);
+            }
+        };
+
+        // loop over channel periods or ring turns
+        for (int p = 0; p < num_periods; ++p)
+        {
+            int const period = forward ? p : (num_periods - 1 - p);
+
+            if (forward)
+            {
+                // book-keeping update
+                tracking_state.m_period = period;
+                tracking_state.m_element = &lattice.front();
+
+                // optional, user-defined function call
+                call_hook("before_period");
+            }
+
+            // loop over lattice elements
+            if (forward)
+            {
+                for (auto & element_variant : lattice)
+                {
+                    visit_element(element_variant, period);
+                }
+            }
+            else
+            {
+                for (auto it = lattice.rbegin(); it != lattice.rend(); ++it)
+                {
+                    visit_element(*it, period);
+                }
+            }
+
+            // optional, user-defined function call
+            if (forward) { call_hook("after_period"); }
+        }
+
+        if (forward)
+        {
+            // avoid dangling references if users manipulate the lattice
+            tracking_state.set_no_element();
+        }
+    }
+} // namespace impactx
+
+#endif // IMPACTX_TRACKING_PARTICLES_H

--- a/src/tracking/particles.cpp
+++ b/src/tracking/particles.cpp
@@ -18,6 +18,7 @@
 #include "particles/spacecharge/HandleSpacecharge.H"
 #include "particles/wakefields/HandleISR.H"
 #include "particles/wakefields/HandleWakefield.H"
+#include "tracking/particles.H"
 
 #include <AMReX.H>
 #include <AMReX_AmrParGDB.H>
@@ -42,14 +43,12 @@ namespace impactx
         int verbose = 1;
         pp_impactx.queryAddWithParser("verbose", verbose);
 
-        // a global step for diagnostics including space charge slice steps in elements
+        // book-keeping:
+        //   a global step for diagnostics including space charge slice steps in elements
         //   before we start the tracking loop, we are in "step 0" (initial state)
         int & step = m_tracking_state.m_step;
         step = 0;
-
-        // period in the lattice (e.g., turns)
-        int & period = m_tracking_state.m_period;
-        period = 0;
+        m_tracking_state.m_direction = TrackingDirection::Forward;
 
         // check typos in inputs after step 1
         bool early_params_checked = false;
@@ -111,106 +110,80 @@ namespace impactx
             amrex::Print() << " Spin tracking: " << spin << "\n";
         }
 
-        // periods through the lattice
-        int num_periods = 1;
-        amrex::ParmParse("lattice").queryAddWithParser("periods", num_periods);
+        // collective effect kicks applied per element slice:
+        // space charge, coherent and incoherent synchrotron radiation, etc.
+        auto collective_kicks = [this, &pc] (
+            elements::KnownElements & element_variant,
+            amrex::ParticleReal slice_ds
+        )
+        {
+            // Wakefield calculation: call wakefield function to apply wake effects
+            particles::wakefields::HandleWakefield(*pc, element_variant, slice_ds);
 
-        for (period=0; period < num_periods; ++period) {
-            // optional, user-defined function call
-            m_tracking_state.m_element = &m_lattice.front();
-            call_hook("before_period");
+            // ISR calculation: call ISR function to apply incoherent synchrotron radiation effects
+            particles::wakefields::HandleISR(*pc, element_variant, slice_ds);
 
-            // loop over all beamline elements
-            for (auto &element_variant: m_lattice) {
-                // update element edge of the reference particle
-                amr_data->track_particles.m_particle_container->SetRefParticleEdge();
+            // Space-charge calculation
+            particles::spacecharge::HandleSpacecharge(amr_data, [this](){ this->ResizeMesh(); }, slice_ds);
+        };
 
-                // optional, user-defined function call
-                m_tracking_state.m_element = &element_variant;
-                call_hook("before_element");
+        // the per-slice external-field transport map and per-slice housekeeping
+        auto element_push = [this, &pc, verbose, &pp_diag, diag_enable, &early_params_checked] (
+            elements::KnownElements & element_variant,
+            int step_,
+            int period_
+        )
+        {
+            // push all particles with external maps
+            push(*pc, element_variant, step_, period_);
 
-                // number of slices used for the application of space charge
-                int nslice = 1;
-                amrex::ParticleReal slice_ds; // in meters
-                std::visit([&nslice, &slice_ds](auto &&element) {
-                    nslice = element.nslice();
-                    slice_ds = element.ds() / nslice;
-                }, element_variant);
+            // Apply optional particle boundary conditions
+            particles::ParticleBoundary(*pc);
 
-                // sub-steps for space charge within the element
-                for (int slice_step = 0; slice_step < nslice; ++slice_step) {
-                    BL_PROFILE("ImpactX::evolve::slice_step");
-                    step++;
-                    if (verbose > 0) {
-                        amrex::Print() << "\n++++ Starting step=" << step
-                                       << " slice_step=" << slice_step;
-                    }
+            // move "lost" particles to another particle container
+            collect_lost_particles(*pc);
 
-                    // optional, user-defined function call
-                    call_hook("before_slice");
+            // just prints an empty newline at the end of the slice_step
+            if (verbose > 0) {
+                amrex::Print() << "\n";
+            }
 
-                    // Wakefield calculation: call wakefield function to apply wake effects
-                    particles::wakefields::HandleWakefield(*amr_data->track_particles.m_particle_container, element_variant, slice_ds);
+            // slice-step diagnostics
+            bool slice_step_diagnostics = false;
+            pp_diag.queryAdd("slice_step_diagnostics", slice_step_diagnostics);
 
-                    // ISR calculation: call ISR function to apply incoherent synchrotron radiation effects
-                    particles::wakefields::HandleISR(*amr_data->track_particles.m_particle_container, element_variant, slice_ds);
+            if (pc->store_beam_moments) {
+                pc->record_beam_moments();
+            }
 
-                    // Space-charge calculation
-                    particles::spacecharge::HandleSpacecharge(amr_data, [this](){ this->ResizeMesh(); }, slice_ds);
+            if (diag_enable && slice_step_diagnostics) {
+                // print slice step reference particle to file
+                diagnostics::DiagnosticOutput(pc->GetRefParticle(),
+                                              "ref_particle",
+                                              step_,
+                                              true);
 
-                    // push all particles with external maps
-                    push(*amr_data->track_particles.m_particle_container, element_variant, step, period);
+                // print slice step reduced beam characteristics to file
+                diagnostics::DiagnosticOutput(*pc,
+                                              "reduced_beam_characteristics",
+                                              step_,
+                                              true);
+            }
 
-                    // Apply optional particle boundary conditions
-                    particles::ParticleBoundary(*amr_data->track_particles.m_particle_container);
+            // inputs: unused parameters (e.g. typos) check after step 1 has finished
+            if (!early_params_checked) { early_params_checked = early_param_check(); }
+        };
 
-                    // move "lost" particles to another particle container
-                    collect_lost_particles(*amr_data->track_particles.m_particle_container);
-
-                    // just prints an empty newline at the end of the slice_step
-                    if (verbose > 0) {
-                        amrex::Print() << "\n";
-                    }
-
-                    // slice-step diagnostics
-                    bool slice_step_diagnostics = false;
-                    pp_diag.queryAdd("slice_step_diagnostics", slice_step_diagnostics);
-
-                    if (amr_data->track_particles.m_particle_container->store_beam_moments) {
-                        amr_data->track_particles.m_particle_container->record_beam_moments();
-                    }
-
-                    if (diag_enable && slice_step_diagnostics) {
-                        // print slice step reference particle to file
-                        diagnostics::DiagnosticOutput(amr_data->track_particles.m_particle_container->GetRefParticle(),
-                                                      "ref_particle",
-                                                      step,
-                                                      true);
-
-                        // print slice step reduced beam characteristics to file
-                        diagnostics::DiagnosticOutput(*amr_data->track_particles.m_particle_container,
-                                                      "reduced_beam_characteristics",
-                                                      step,
-                                                      true);
-
-                    }
-
-                    // inputs: unused parameters (e.g. typos) check after step 1 has finished
-                    if (!early_params_checked) { early_params_checked = early_param_check(); }
-
-                } // end in-element space-charge slice-step loop
-
-                // optional, user-defined function call
-                call_hook("after_element");
-
-            } // end beamline element loop
-
-            // optional, user-defined function call
-            call_hook("after_period");
-        } // end periods though the lattice loop
-
-        // avoid dangling references if users manipulate the lattice
-        m_tracking_state.set_no_element();
+        // traverse the lattice, applying the collective kick and the
+        // element transport per element slice (\see track_lattice_particles)
+        track_lattice_particles(
+            m_lattice,
+            *pc,
+            m_tracking_state,
+            [this](std::string const & name) { call_hook(name); },
+            collective_kicks,
+            element_push
+        );
 
         if (diag_enable)
         {


### PR DESCRIPTION
Split the book-keeping and control logic in the particle tracking loop into finer control units, so we can re-use it and can easily implement strang splitting (#846 / #920).