### PR TITLE
Thin Elements: No Collective Kicks

### DIFF
--- a/src/envelope/spacecharge/EnvelopeSpaceChargePush.cpp
+++ b/src/envelope/spacecharge/EnvelopeSpaceChargePush.cpp
@@ -35,6 +35,7 @@ namespace impactx::envelope::spacecharge
 
         // skip calculations for trivial case
         if (current == 0_prt) { return; }
+        if (ds == 0_prt) { return; }
 
         // initialize the linear transport map
         Map6x6 R = Map6x6::Identity();
@@ -83,6 +84,7 @@ namespace impactx::envelope::spacecharge
 
         // skip calculations for trivial case
         if (bunch_charge == 0_prt) { return; }
+        if (ds == 0_prt) { return; }
 
         // initialize the linear transport map
         Map6x6 R = Map6x6::Identity();

--- a/src/particles/spacecharge/HandleSpacecharge.H
+++ b/src/particles/spacecharge/HandleSpacecharge.H
@@ -23,6 +23,8 @@ namespace impactx::particles::spacecharge
     /** Function to handle space charge including charge deposition, Poisson solve,
      * field calculation, interpolation, and particle push.
      *
+     * Returns immediately if slice_ds is zero.
+     *
      * @param[in,out] amr_data AMR data like particle container and fields
      * @param[in] ResizeMesh function to call to resize the mesh
      * @param[in] slice_ds slice spacing along s

--- a/src/particles/spacecharge/HandleSpacecharge.cpp
+++ b/src/particles/spacecharge/HandleSpacecharge.cpp
@@ -33,6 +33,8 @@ namespace impactx::particles::spacecharge
         amrex::Real slice_ds
     )
     {
+        if (slice_ds == 0.0) { return; }
+
         BL_PROFILE("impactx::particles::wakefields::HandleSpacecharge")
 
         auto space_charge = get_space_charge_algo();

--- a/src/particles/wakefields/HandleISR.H
+++ b/src/particles/wakefields/HandleISR.H
@@ -22,6 +22,8 @@ namespace impactx::particles::wakefields
 {
     /** Function to handle ISR in bending dipoles.
      *
+     * Returns immediately if slice_ds is zero.
+     *
      * @param[in] particle_container the particle species container
      * @param[in] element_variant variant type of the lattice element
      * @param[in] slice_ds slice spacing along s
@@ -33,6 +35,8 @@ namespace impactx::particles::wakefields
         amrex::Real slice_ds
     )
     {
+        if (slice_ds == 0.0) { return; }
+
         BL_PROFILE("impactx::particles::wakefields::HandleISR")
 
         amrex::ParmParse pp_algo("algo");

--- a/src/particles/wakefields/HandleWakefield.H
+++ b/src/particles/wakefields/HandleWakefield.H
@@ -26,6 +26,8 @@ namespace impactx::particles::wakefields
     /** Function to handle CSR bending process including charge deposition,
      * mean transverse position calculation, wakefield generation, and convolution.
      *
+     * Returns immediately if slice_ds is zero.
+     *
      * @param[in] particle_container the particle species container
      * @param[in] element_variant variant type of the lattice element
      * @param[in] slice_ds slice spacing along s
@@ -39,6 +41,8 @@ namespace impactx::particles::wakefields
         bool print_wakefield = false
     )
     {
+        if (slice_ds == 0.0) { return; }
+
         BL_PROFILE("impactx::particles::wakefields::HandleWakefield")
 
         amrex::ParmParse pp_algo("algo");


### PR DESCRIPTION
Do no collective kicks in the 1-slice loop when dealing with thin elements. Kicks for those live in the drifts around them. Fix #1531