### PR TITLE
pyImpactX: Only export `_PyInit_impactx_pybind`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,25 @@ if(ImpactX_PYTHON)
         PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/impactx
         COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/impactx
     )
+
+    # The CXX_VISIBILITY_PRESET above only hides pyImpactX's own objects, but
+    # statically-embedded dependencies (HDF5, openPMD, ADIOS2, and the ImpactX
+    # core archive) are compiled without hidden visibility and would otherwise
+    # be re-exported from this extension. If another extension loaded in the
+    # same process also statically embeds them (openpmd_api, WarpX, a second
+    # openPMD/HDF5), the duplicate exported symbols cross-bind, one has two
+    # HDF5/openPMD instances in one process, UBs and crashes.
+    # Export only the module init symbol so each extension keeps its
+    # dependencies private.
+    # Windows does not auto-export and Emscripten links a single namespace, so
+    # neither needs this.
+    if(APPLE)
+        target_link_options(pyImpactX PRIVATE
+            "LINKER:-exported_symbol,_PyInit_impactx_pybind")
+    elseif(NOT WIN32 AND NOT EMSCRIPTEN)
+        target_link_options(pyImpactX PRIVATE "LINKER:--exclude-libs,ALL")
+    endif()
+
     get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
     if(isMultiConfig)
         foreach(CFG IN LISTS CMAKE_CONFIGURATION_TYPES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,21 +250,13 @@ if(ImpactX_PYTHON)
     # openPMD/HDF5), the duplicate exported symbols cross-bind, one has two
     # HDF5/openPMD instances in one process, UBs and crashes.
     # Export only the module init symbol so each extension keeps its
-    # dependencies private. Windows does not auto-export, so it needs nothing.
-    # Emscripten needs -sSIDE_MODULE=2 (Pyodide's default -sSIDE_MODULE=1 whole-
-    # archives and re-exports every symbol, so hidden visibility alone cannot
-    # hide HDF5) together with the static deps built -fvisibility=hidden (see the
-    # wheels builder). AMReX is deliberately NOT exported: it stays shared
-    # because it is built default-visible and pyImpactX imports pyAMReX first, so
-    # our GOT references bind to pyAMReX's exported AMReX.
+    # dependencies private.
+    # Windows does not auto-export and Emscripten links a single namespace, so
+    # neither needs this.
     if(APPLE)
         target_link_options(pyImpactX PRIVATE
             "LINKER:-exported_symbol,_PyInit_impactx_pybind")
-    elseif(EMSCRIPTEN)
-        target_link_options(pyImpactX PRIVATE
-            "SHELL:-sSIDE_MODULE=2"
-            "SHELL:-sEXPORTED_FUNCTIONS=_PyInit_impactx_pybind")
-    elseif(NOT WIN32)
+    elseif(NOT WIN32 AND NOT EMSCRIPTEN)
         target_link_options(pyImpactX PRIVATE "LINKER:--exclude-libs,ALL")
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,11 @@ if(ImpactX_PYTHON)
     if(APPLE)
         target_link_options(pyImpactX PRIVATE
             "LINKER:-exported_symbol,_PyInit_impactx_pybind")
-    elseif(NOT WIN32 AND NOT EMSCRIPTEN)
+    elseif(EMSCRIPTEN)
+        target_link_options(pyImpactX PRIVATE
+            "SHELL:-sSIDE_MODULE=1"
+            "SHELL:-sEXPORTED_FUNCTIONS=_PyInit_impactx_pybind")
+    elseif(NOT WIN32)
         target_link_options(pyImpactX PRIVATE "LINKER:--exclude-libs,ALL")
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,13 +250,21 @@ if(ImpactX_PYTHON)
     # openPMD/HDF5), the duplicate exported symbols cross-bind, one has two
     # HDF5/openPMD instances in one process, UBs and crashes.
     # Export only the module init symbol so each extension keeps its
-    # dependencies private.
-    # Windows does not auto-export and Emscripten links a single namespace, so
-    # neither needs this.
+    # dependencies private. Windows does not auto-export, so it needs nothing.
+    # Emscripten needs -sSIDE_MODULE=2 (Pyodide's default -sSIDE_MODULE=1 whole-
+    # archives and re-exports every symbol, so hidden visibility alone cannot
+    # hide HDF5) together with the static deps built -fvisibility=hidden (see the
+    # wheels builder). AMReX is deliberately NOT exported: it stays shared
+    # because it is built default-visible and pyImpactX imports pyAMReX first, so
+    # our GOT references bind to pyAMReX's exported AMReX.
     if(APPLE)
         target_link_options(pyImpactX PRIVATE
             "LINKER:-exported_symbol,_PyInit_impactx_pybind")
-    elseif(NOT WIN32 AND NOT EMSCRIPTEN)
+    elseif(EMSCRIPTEN)
+        target_link_options(pyImpactX PRIVATE
+            "SHELL:-sSIDE_MODULE=2"
+            "SHELL:-sEXPORTED_FUNCTIONS=_PyInit_impactx_pybind")
+    elseif(NOT WIN32)
         target_link_options(pyImpactX PRIVATE "LINKER:--exclude-libs,ALL")
     endif()
 


### PR DESCRIPTION
Hide all other symbols to avoid clashes when loading transient dependencies in workflows that combine ImpactX, WarpX, and openPMD-api.

Relevant for pip/wheels that do static builds (i.e. Python wheels):
Currently, openPMD-api and ImpactX could not be `import`-ed together because HDF5 would clash.

Used in https://github.com/BLAST-ImpactX/impactx-wheels/pull/26

Not a problem when installing with shared dependencies (of HDF5, openPMD, ABLASTR, etc.), i.e., from conda-forge or Spack.