### PR TITLE
The scripts were trying to write into directory $CFS/$proj_g but

### DIFF
--- a/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
@@ -20,9 +20,9 @@ if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in yo
 
 # Check $proj variable is correct and has a corresponding CFS directory #######
 #
-if [ ! -d "${CFS}/${proj%_g}/" ]
+if [ ! -d "${CFS}/${proj}/" ]
 then
-    echo "WARNING: The directory ${CFS}/${proj%_g}/ does not exist!"
+    echo "WARNING: The directory ${CFS}/${proj}/ does not exist!"
     echo "Is the \$proj environment variable of value \"$proj\" correctly set? "
     echo "Please edit line 2 of your perlmutter_gpu_impactx.profile file to continue!"
     exit
@@ -31,7 +31,7 @@ fi
 
 # Remove old dependencies #####################################################
 #
-SW_DIR="${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu"
+SW_DIR="${CFS}/${proj}/${USER}/sw/perlmutter/gpu"
 rm -rf ${SW_DIR}
 mkdir -p ${SW_DIR}
 

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
@@ -1,5 +1,6 @@
 # please set your project account
-export proj=""  # change me! GPU projects must end in "..._g"
+export proj=""  # change me!
+# When you submit a GPU job, the account name will end in "..._g"
 
 # remembers the location of this script
 export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
@@ -13,31 +14,31 @@ module load cmake/3.30.2
 
 # optional: for openPMD support
 module load cray-hdf5-parallel/1.12.2.9
-export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.10.2:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/gpu/adios2-2.10.2:$CMAKE_PREFIX_PATH
 
-export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/c-blosc-1.21.1/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.10.2/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/gpu/c-blosc-1.21.1/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/gpu/adios2-2.10.2/lib64:$LD_LIBRARY_PATH
 
-export PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/adios2-2.10.2/bin:${PATH}
+export PATH=${CFS}/${proj}/${USER}/sw/perlmutter/gpu/adios2-2.10.2/bin:${PATH}
 
 # optional: CCache
-export PATH=${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/ccache-4.10.2:$PATH
+export PATH=${CFS}/${proj}/${USER}/sw/perlmutter/gpu/ccache-4.10.2:$PATH
 
 # optional: for Python bindings or libEnsemble
 module load cray-python/3.11.5
 
-if [ -d "${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/impactx" ]
+if [ -d "${CFS}/${proj}/${USER}/sw/perlmutter/gpu/venvs/impactx" ]
 then
-  source ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/impactx/bin/activate
+  source ${CFS}/${proj}/${USER}/sw/perlmutter/gpu/venvs/impactx/bin/activate
 fi
 
 # an alias to request an interactive batch node for one hour
 #   for parallel execution, start on the batch node: srun <command>
-alias getNode="salloc -N 1 --ntasks-per-node=4 -t 1:00:00 -q interactive -C gpu --gpu-bind=none -c 32 -G 4 -A $proj"
+alias getNode="salloc -N 1 --ntasks-per-node=4 -t 1:00:00 -q interactive -C gpu --gpu-bind=none -c 32 -G 4 -A ${proj}_g"
 # an alias to run a command on a batch node for up to 30min
 #   usage: runNode <command>
-alias runNode="srun -N 1 --ntasks-per-node=4 -t 0:30:00 -q interactive -C gpu --gpu-bind=none -c 32 -G 4 -A $proj"
+alias runNode="srun -N 1 --ntasks-per-node=4 -t 0:30:00 -q interactive -C gpu --gpu-bind=none -c 32 -G 4 -A ${proj}_g"
 
 # necessary to use CUDA-Aware MPI and run a job
 export CRAY_ACCEL_TARGET=nvidia80

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
@@ -1,6 +1,5 @@
 # please set your project account
 export proj=""  # change me!
-# When you submit a GPU job, the account name will end in "..._g"
 
 # remembers the location of this script
 export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
@@ -34,10 +34,10 @@ fi
 
 # an alias to request an interactive batch node for one hour
 #   for parallel execution, start on the batch node: srun <command>
-alias getNode="salloc -N 1 --ntasks-per-node=4 -t 1:00:00 -q interactive -C gpu --gpu-bind=none -c 32 -G 4 -A ${proj}_g"
+alias getNode="salloc -N 1 --ntasks-per-node=4 -t 1:00:00 -q interactive -C gpu --gpu-bind=none -c 32 -G 4 -A ${proj}"
 # an alias to run a command on a batch node for up to 30min
 #   usage: runNode <command>
-alias runNode="srun -N 1 --ntasks-per-node=4 -t 0:30:00 -q interactive -C gpu --gpu-bind=none -c 32 -G 4 -A ${proj}_g"
+alias runNode="srun -N 1 --ntasks-per-node=4 -t 0:30:00 -q interactive -C gpu --gpu-bind=none -c 32 -G 4 -A ${proj}"
 
 # necessary to use CUDA-Aware MPI and run a job
 export CRAY_ACCEL_TARGET=nvidia80

--- a/docs/source/install/hpc/perlmutter.rst
+++ b/docs/source/install/hpc/perlmutter.rst
@@ -54,14 +54,16 @@ On Perlmutter, you can run either on GPU nodes with fast A100 GPUs (recommended)
             :language: bash
 
       Edit the 2nd line of this script, which sets the ``export proj=""`` variable.
-      Perlmutter GPU projects must end in ``..._g``.
       For example, if you are member of the project ``m3239``, then run ``nano $HOME/perlmutter_gpu_impactx.profile`` and edit line 2 to read:
 
       .. code-block:: bash
 
-         export proj="m3239_g"
+         export proj="m3239"
 
       Exit the ``nano`` editor with ``Ctrl`` + ``O`` (save) and then ``Ctrl`` + ``X`` (exit).
+      With that setting, ImpactX will be built and installed under ``$CFS/m3239/$USER/sw/perlmutter/gpu``.
+      Note that for running on GPUs, you will specify the project in run scripts (``-A`` argument) with
+      a ``_g`` suffix, like ``m3239_g``.
 
       .. important::
 
@@ -76,7 +78,7 @@ On Perlmutter, you can run either on GPU nodes with fast A100 GPUs (recommended)
       .. code-block:: bash
 
          bash $HOME/src/impactx/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
-         source ${CFS}/${proj%_g}/${USER}/sw/perlmutter/gpu/venvs/impactx/bin/activate
+         source ${CFS}/${proj}/${USER}/sw/perlmutter/gpu/venvs/impactx/bin/activate
 
       .. dropdown:: Script Details
          :color: light
@@ -106,6 +108,7 @@ On Perlmutter, you can run either on GPU nodes with fast A100 GPUs (recommended)
 
       Edit the 2nd line of this script, which sets the ``export proj=""`` variable.
       For example, if you are member of the project ``m3239``, then run ``nano $HOME/perlmutter_cpu_impactx.profile`` and edit line 2 to read:
+      With that setting, ImpactX will be built and installed under ``$CFS/m3239/$USER/sw/perlmutter/cpu``.
 
       .. code-block:: bash
 

--- a/docs/source/install/hpc/perlmutter.rst
+++ b/docs/source/install/hpc/perlmutter.rst
@@ -62,8 +62,6 @@ On Perlmutter, you can run either on GPU nodes with fast A100 GPUs (recommended)
 
       Exit the ``nano`` editor with ``Ctrl`` + ``O`` (save) and then ``Ctrl`` + ``X`` (exit).
       With that setting, ImpactX will be built and installed under ``$CFS/m3239/$USER/sw/perlmutter/gpu``.
-      Note that for running on GPUs, you will specify the project in run scripts (``-A`` argument) with
-      a ``_g`` suffix, like ``m3239_g``.
 
       .. important::
 


### PR DESCRIPTION
this directory doesn't exist.

We don't need to write into a directory with the _g suffix. The _g suffix is only needed for the Account parameter in job submission. In fact, the software for Perlmutter gpu is built and installed into a directory gpu in its name so it is already separated from a cpu build.

I still have to update the documentation .