### PR TITLE
Add sextupole kick test

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2140,3 +2140,11 @@ add_impactx_test(exact-cfbend-spin-scaling.py
     examples/spin_tracking/analysis_cfbend_spin_scaling.py
     OFF  # no plot script yet
 )
+
+# Benchmark a Single Sextupole Kick ###################
+add_impactx_test(sextupole-kick.py
+    examples/multipole/run_sextupole_kick.py
+    ON    # ImpactX MPI-parallel
+    examples/multipole/analysis_sextupole_kick.py
+    OFF  # no plot script yet
+)

--- a/examples/multipole/README.rst
+++ b/examples/multipole/README.rst
@@ -54,7 +54,7 @@ We run the following script to analyze correctness:
 Benchmark a single sextupole kick
 ==================================
 
-This test tracks a set of ... initial conditions through a single, thin sextupole, and compares the result against the kick described in the MAD-X documentation, checking the strength definitions for consistency.
+This test tracks a set of 30 initial conditions through a single, thin sextupole, and compares the result against the kick described in the MAD-X documentation, checking the strength definitions for consistency.
 
 We use a 2 GeV electron beam.  The initial conditions form an increasing sequence of horizontal coordinates x, with y = px = py = pt = 0.
 

--- a/examples/multipole/README.rst
+++ b/examples/multipole/README.rst
@@ -53,7 +53,7 @@ We run the following script to analyze correctness:
 
 Benchmark a single sextupole kick
 ==================================
-      
+
 This test tracks a set of ... initial conditions through a single, thin sextupole, and compares the result against the kick described in the MAD-X documentation, checking the strength definitions for consistency.
 
 We use a 2 GeV electron beam.  The initial conditions form an increasing sequence of horizontal coordinates x, with y = px = py = pt = 0.
@@ -63,29 +63,28 @@ The final momenta (px,py) for each initial condition is compared against its pre
 
 Run
 ---
-          
+
 This example can be run as:
 
 * **Python** script: ``python3 run_multipole.py``
-   
+
 For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
-   
+
 .. tab-set::
 
    .. tab-item:: Python: Script
-      
+
        .. literalinclude:: run_multipole.py
           :language: python3
           :caption: You can copy this file from ``examples/multipole/run_multipole.py``.
 
-Analyze   
+Analyze
 -------
 
-We run the following script to analyze correctness: 
+We run the following script to analyze correctness:
 
 .. dropdown:: Script ``analysis_sextupole_kick.py``
 
    .. literalinclude:: analysis_sextupole_kick.py
       :language: python3
       :caption: You can copy this file from ``examples/multipole/analysis_sextupole_kick.py``.
-

--- a/examples/multipole/README.rst
+++ b/examples/multipole/README.rst
@@ -47,3 +47,45 @@ We run the following script to analyze correctness:
    .. literalinclude:: analysis_multipole.py
       :language: python3
       :caption: You can copy this file from ``examples/multipole/analysis_multipole.py``.
+
+
+.. _examples-sextupole-kick:
+
+Benchmark a single sextupole kick
+==================================
+      
+This test tracks a set of ... initial conditions through a single, thin sextupole, and compares the result against the kick described in the MAD-X documentation, checking the strength definitions for consistency.
+
+We use a 2 GeV electron beam.  The initial conditions form an increasing sequence of horizontal coordinates x, with y = px = py = pt = 0.
+
+The final momenta (px,py) for each initial condition is compared against its predicted value.  The results must agree to within a small relative tolerance (currently 1e-12).
+
+
+Run
+---
+          
+This example can be run as:
+
+* **Python** script: ``python3 run_multipole.py``
+   
+For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+   
+.. tab-set::
+
+   .. tab-item:: Python: Script
+      
+       .. literalinclude:: run_multipole.py
+          :language: python3
+          :caption: You can copy this file from ``examples/multipole/run_multipole.py``.
+
+Analyze   
+-------
+
+We run the following script to analyze correctness: 
+
+.. dropdown:: Script ``analysis_sextupole_kick.py``
+
+   .. literalinclude:: analysis_sextupole_kick.py
+      :language: python3
+      :caption: You can copy this file from ``examples/multipole/analysis_sextupole_kick.py``.
+

--- a/examples/multipole/analysis_sextupole_kick.py
+++ b/examples/multipole/analysis_sextupole_kick.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+import numpy as np
+import openpmd_api as io
+import scipy.constants as sc
+from scipy.special import expi
+
+# initial/final beam
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+last_step = list(series.iterations)[-1]
+beam_initial = series.iterations[1].particles["beam"]
+initial_sort = beam_initial.to_df().set_index("id")
+beam_final = series.iterations[last_step].particles["beam"]
+final_sort = beam_final.to_df().set_index("id")
+
+# Sextupole parameters
+K_normal = 10.0
+K_skew = -2.0
+
+# Initial particle data
+
+xi = initial_sort["position_x"]
+pxi = initial_sort["momentum_x"]
+yi = initial_sort["position_y"]
+pyi = initial_sort["momentum_y"]
+ti = initial_sort["position_t"]
+pti = initial_sort["momentum_t"]
+
+# Predicted momentum kick, from MAD-X user guide
+
+px_predicted = K_normal/2.0 * (yi**2 - xi**2) + K_skew * xi * yi
+py_predicted = K_skew/2.0 * (xi**2 - yi**2) + K_normal * xi * yi
+
+# Maximum momentum kick
+px_max = px_predicted.abs().max()
+py_max = py_predicted.abs().max()
+
+# Final particle data
+
+xf = final_sort["position_x"]
+pxf = final_sort["momentum_x"]
+yf = final_sort["position_y"]
+pyf = final_sort["momentum_y"]
+
+# Difference between value and prediction
+
+dpx_max = (pxf - px_predicted).abs().max()
+dpy_max = (pyf - py_predicted).abs().max()
+
+print()
+print("Difference between predicted and computed final momentum, absolute max:")
+print("dpx_max", dpx_max)
+print("dpy_max", dpy_max)
+
+# Test maximum error:
+atol = 5.1e-12
+print(f"  tol={atol}")
+
+print()
+print("Difference between predicted and computed final momentum (max), relative:")
+print("dpx_max/px_max", dpx_max / px_max)
+print("dpy_max/py_max", dpy_max / py_max)
+
+# Test maximum error:
+atol = 5.1e-12
+print(f"  tol={atol}")
+
+assert np.allclose(
+    [dpx_max / px_max, dpy_max / py_max],
+    [0.0, 0.0],
+    atol=atol,
+)

--- a/examples/multipole/analysis_sextupole_kick.py
+++ b/examples/multipole/analysis_sextupole_kick.py
@@ -7,8 +7,6 @@
 
 import numpy as np
 import openpmd_api as io
-import scipy.constants as sc
-from scipy.special import expi
 
 # initial/final beam
 series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
@@ -33,8 +31,8 @@ pti = initial_sort["momentum_t"]
 
 # Predicted momentum kick, from MAD-X user guide
 
-px_predicted = K_normal/2.0 * (yi**2 - xi**2) + K_skew * xi * yi
-py_predicted = K_skew/2.0 * (xi**2 - yi**2) + K_normal * xi * yi
+px_predicted = K_normal / 2.0 * (yi**2 - xi**2) + K_skew * xi * yi
+py_predicted = K_skew / 2.0 * (xi**2 - yi**2) + K_normal * xi * yi
 
 # Maximum momentum kick
 px_max = px_predicted.abs().max()

--- a/examples/multipole/analysis_sextupole_kick.py
+++ b/examples/multipole/analysis_sextupole_kick.py
@@ -29,7 +29,7 @@ pyi = initial_sort["momentum_y"]
 ti = initial_sort["position_t"]
 pti = initial_sort["momentum_t"]
 
-# Predicted momentum kick, from MAD-X user guide
+# Predicted momentum kick, from MAD-X user guide (equation 1.15)
 
 px_predicted = K_normal / 2.0 * (yi**2 - xi**2) + K_skew * xi * yi
 py_predicted = K_skew / 2.0 * (xi**2 - yi**2) + K_normal * xi * yi

--- a/examples/multipole/run_sextupole_kick.py
+++ b/examples/multipole/run_sextupole_kick.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Ryan Sandberg, Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import amrex.space3d as amr
+from impactx import ImpactX, distribution, elements
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.space_charge = False
+# sim.diagnostics = False  # benchmarking
+sim.slice_step_diagnostics = True
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# load a 2 GeV electron beam with an initial
+# unnormalized rms emittance of  nm
+kin_energy_MeV = 2.0e3  # reference energy
+
+#   reference particle
+ref = sim.beam.ref
+ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
+qm_eev = ref.charge_qe / (ref.mass_MeV * 1.0e6)  # electron charge/mass in e / eV
+
+# set test particles
+pc = sim.particle_container()
+
+#  add test particles
+xmin = 0.0
+xmax = 5.0
+if amr.ParallelDescriptor.IOProcessor():
+    dx = np.linspace(xmin, xmax, 30)
+    zero_arr = np.linspace(0, 0.0, 30)
+    pc.add_n_particles(
+        dx, zero_arr, zero_arr, zero_arr, zero_arr, zero_arr, qm_eev, bunch_charge=0.0
+    )
+
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+
+# design the accelerator lattice
+multipole = [
+    monitor,
+    elements.Multipole(
+        name="thin_sextupole", multipole=3, K_normal=10.0, K_skew=-2.0
+    ),
+    monitor,
+]
+# assign a fodo segment
+sim.lattice.extend(multipole)
+
+# run simulation
+sim.track_particles()
+
+# clean shutdown
+sim.finalize()

--- a/examples/multipole/run_sextupole_kick.py
+++ b/examples/multipole/run_sextupole_kick.py
@@ -7,8 +7,9 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+
 import amrex.space3d as amr
-from impactx import ImpactX, distribution, elements
+from impactx import ImpactX, elements
 
 sim = ImpactX()
 
@@ -48,9 +49,7 @@ monitor = elements.BeamMonitor("monitor", backend="h5")
 # design the accelerator lattice
 multipole = [
     monitor,
-    elements.Multipole(
-        name="thin_sextupole", multipole=3, K_normal=10.0, K_skew=-2.0
-    ),
+    elements.Multipole(name="thin_sextupole", multipole=3, K_normal=10.0, K_skew=-2.0),
     monitor,
 ]
 # assign a fodo segment


### PR DESCRIPTION
The PR add a simple example, in which initial conditions are tracked through a thin sextupole, for the purpose of comparing the resulting kick against the prediction based on MAD-X conventions.  The purpose is to verify consistency in the definitions of the multipole strength.