### PR TITLE
Fix handling of user apply_longitudinal_kick flag for Gauss2p5d

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2120,6 +2120,12 @@ add_impactx_test(kick-PIC2p5D.py
     examples/space_charge_gaussian_kick/analysis_sc_kick_PIC2p5D.py
     OFF  # no plot script yet
 )
+add_impactx_test(kick-Gauss2p5D-long-kick-off.py
+    examples/space_charge_gaussian_kick/run_sc_kick_Gauss2p5D_long_kick_off.py
+    ON    # ImpactX MPI-parallel
+    examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
+    OFF  # no plot script yet 
+)
 
 # Scaling Test of Spin in an Exact Bend ###################
 file(COPY ${ImpactX_SOURCE_DIR}/examples/spin_tracking/initial_coords_sbend.csv

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2124,7 +2124,7 @@ add_impactx_test(kick-Gauss2p5D-long-kick-off.py
     examples/space_charge_gaussian_kick/run_sc_kick_Gauss2p5D_long_kick_off.py
     ON    # ImpactX MPI-parallel
     examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
-    OFF  # no plot script yet 
+    OFF  # no plot script yet
 )
 
 # Scaling Test of Spin in an Exact Bend ###################

--- a/examples/space_charge_gaussian_kick/README.rst
+++ b/examples/space_charge_gaussian_kick/README.rst
@@ -61,7 +61,7 @@ We run the following script to analyze correctness:
 
 
 .. _examples-kick-Gauss2p5D-long-kick-off:
-   
+
 Turning Off the Longitudinal Kick in the 2.5D Gaussian Space Charge Model
 =========================================================================
 

--- a/examples/space_charge_gaussian_kick/README.rst
+++ b/examples/space_charge_gaussian_kick/README.rst
@@ -58,3 +58,13 @@ We run the following script to analyze correctness:
       .. literalinclude:: run_sc_kick_PIC2p5D.py
          :language: python3
          :caption: You can copy this file from ``examples/space_charge_gaussian_kick/analysis_sc_kick_PIC2p5D.py``.
+
+
+.. _examples-kick-Gauss2p5D-long-kick-off:
+   
+Turning Off the Longitudinal Kick in the 2.5D Gaussian Space Charge Model
+=========================================================================
+
+This test is identical to the test examples-kick-Gauss2p5D, except that the longitudinal space charge kick is turned off.
+
+The initial and final values of pt should agree to within a small tolerance.

--- a/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
+++ b/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
@@ -143,7 +143,7 @@ print()
 print("Difference between predicted and computed final momentum (max), relative:")
 print("dpx_max/px_max", dpx_max / px_max)
 print("dpy_max/py_max", dpy_max / py_max)
-print("dpt_max/pt_max", dpt_max / pt_max)
+print("dpt_max", dpt_max)
 
 # Test maximum error:
 atol = 5.1e-2

--- a/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
+++ b/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
@@ -56,6 +56,7 @@ yi = initial_sort["position_y"]
 pyi = initial_sort["momentum_y"]
 ti = initial_sort["position_t"]
 pti = initial_sort["momentum_t"]
+zi = -beta * ti
 
 # Predicted momentum kick, from J. Qiang, Phys. Rev. Accel. Beams 28, 114602 (2025), eqs. (31-32)
 

--- a/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
+++ b/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+
+import numpy as np
+import openpmd_api as io
+import scipy.constants as sc
+from scipy.special import expi
+
+# initial/final beam
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+last_step = list(series.iterations)[-1]
+beam_initial = series.iterations[1].particles["beam"]
+initial_sort = beam_initial.to_df().set_index("id")
+beam_final = series.iterations[last_step].particles["beam"]
+final_sort = beam_final.to_df().set_index("id")
+
+# Physical constants
+qe = sc.elementary_charge
+me = sc.electron_mass
+clite = sc.speed_of_light
+eps0 = sc.epsilon_0
+me_eV = me * clite**2 / qe
+
+# Basic beam parameters
+bunch_charge_C = 1.0e-9
+kin_energy_MeV = 100
+gamma = 1.0e6 * kin_energy_MeV / me_eV + 1.0
+beta_gamma_2 = gamma**2 - 1.0
+beta = np.sqrt(beta_gamma_2) / gamma
+
+# Space charge intensity parameter (units of length, meters)
+Kscale = (
+    qe * bunch_charge_C / (4.0 * np.pi * eps0 * me * clite**2 * beta_gamma_2 * gamma)
+)
+
+# Beam distribution parameters
+sigmax = 4.0e-5
+sigmay = 4.0e-5
+sigmact = 1.0e-3
+sigmaz = beta * sigmact
+
+# Simulation slice length
+L = 1.0
+
+# Longitudinal kick scale parameter
+gauss_long_scale = 6.0
+
+# Initial particle data
+
+xi = initial_sort["position_x"]
+pxi = initial_sort["momentum_x"]
+yi = initial_sort["position_y"]
+pyi = initial_sort["momentum_y"]
+ti = initial_sort["position_t"]
+pti = initial_sort["momentum_t"]
+zi = -beta * ti
+
+# Predicted momentum kick, from J. Qiang, Phys. Rev. Accel. Beams 28, 114602 (2025), eqs. (31-32)
+
+ri_2 = xi**2 + yi**2
+gauss_exp = np.exp(-ri_2 / (2.0 * sigmax**2))
+gauss_xy_factor = 2.0 * (1.0 - gauss_exp) / ri_2
+gauss_pdf_z = np.exp(-(zi**2) / (2.0 * sigmaz**2)) / (np.sqrt(2.0 * np.pi) * sigmaz)
+px_predicted = L * Kscale * gauss_pdf_z * xi * gauss_xy_factor
+py_predicted = L * Kscale * gauss_pdf_z * yi * gauss_xy_factor
+
+potential_xy_factor = expi(-ri_2 / (2.0 * sigmax**2)) + np.log(
+    gauss_long_scale**2 / ri_2
+)
+d_gauss_pdf_z = -zi / sigmaz**2 * gauss_pdf_z
+
+pz_predicted = -L * Kscale * potential_xy_factor * d_gauss_pdf_z
+pt_predicted = pti
+
+# Maximum momentum kick
+px_max = px_predicted.abs().max()
+py_max = py_predicted.abs().max()
+pt_max = pt_predicted.abs().max()
+
+# Final particle data
+
+xf = final_sort["position_x"]
+pxf = final_sort["momentum_x"]
+yf = final_sort["position_y"]
+pyf = final_sort["momentum_y"]
+tf = final_sort["position_t"]
+ptf = final_sort["momentum_t"]
+
+# Difference between value and prediction
+
+dpx_max = (pxf - px_predicted).abs().max()
+dpy_max = (pyf - py_predicted).abs().max()
+dpt_max = (ptf - pt_predicted).abs().max()
+
+dpx_rms = np.sqrt(np.mean(np.square(pxf - px_predicted)))
+dpy_rms = np.sqrt(np.mean(np.square(pyf - py_predicted)))
+dpt_rms = np.sqrt(np.mean(np.square(ptf - pt_predicted)))
+
+print()
+print("Difference between predicted and computed final momentum, absolute rms:")
+print("dpx_rms", dpx_rms)
+print("dpy_rms", dpy_rms)
+print("dpt_rms", dpt_rms)
+
+print()
+print("Difference between predicted and computed final momentum, absolute max:")
+print("dpx_max", dpx_max)
+print("dpy_max", dpy_max)
+print("dpt_max", dpt_max)
+
+print()
+print("Difference between predicted and computed final momentum (rms), relative:")
+print("dpx_rms/px_max", dpx_rms / px_max)
+print("dpy_rms/py_max", dpy_rms / py_max)
+print("dpt_rms", dpt_rms)
+
+# Test maximum error:
+atol = 5.1e-2
+print(f"  tol={atol}")
+
+assert np.allclose(
+    [dpx_rms / px_max, dpy_rms / py_max],
+    [0.0, 0.0],
+    atol=atol,
+)
+
+# Longitudinal kick is sensitive to noise (relax tolerance):
+atol = 0.5e-10
+print(f"  tol={atol}")
+
+assert np.allclose(
+    [dpt_rms],
+    [0.0],
+    atol=atol,
+)
+
+
+print()
+print("Difference between predicted and computed final momentum (max), relative:")
+print("dpx_max/px_max", dpx_max / px_max)
+print("dpy_max/py_max", dpy_max / py_max)
+print("dpt_max/pt_max", dpt_max / pt_max)
+
+# Test maximum error:
+atol = 5.1e-2
+print(f"  tol={atol}")
+
+assert np.allclose(
+    [dpx_max / px_max, dpy_max / py_max],
+    [0.0, 0.0],
+    atol=atol,
+)
+
+# Longitudinal kick is sensitive to noise (relax tolerance):
+atol = 1.1e-10
+print(f"  tol={atol}")
+
+assert np.allclose(
+    [dpt_max],
+    [0.0],
+    atol=atol,
+)

--- a/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
+++ b/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
@@ -68,12 +68,6 @@ gauss_pdf_z = np.exp(-(zi**2) / (2.0 * sigmaz**2)) / (np.sqrt(2.0 * np.pi) * sig
 px_predicted = L * Kscale * gauss_pdf_z * xi * gauss_xy_factor
 py_predicted = L * Kscale * gauss_pdf_z * yi * gauss_xy_factor
 
-potential_xy_factor = expi(-ri_2 / (2.0 * sigmax**2)) + np.log(
-    gauss_long_scale**2 / ri_2
-)
-d_gauss_pdf_z = -zi / sigmaz**2 * gauss_pdf_z
-
-pz_predicted = -L * Kscale * potential_xy_factor * d_gauss_pdf_z
 pt_predicted = pti
 
 # Maximum momentum kick

--- a/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
+++ b/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
@@ -57,6 +57,7 @@ pyi = initial_sort["momentum_y"]
 ti = initial_sort["position_t"]
 pti = initial_sort["momentum_t"]
 zi = -beta * ti
+zi = -beta * ti
 
 # Predicted momentum kick, from J. Qiang, Phys. Rev. Accel. Beams 28, 114602 (2025), eqs. (31-32)
 

--- a/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
+++ b/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
@@ -56,7 +56,6 @@ yi = initial_sort["position_y"]
 pyi = initial_sort["momentum_y"]
 ti = initial_sort["position_t"]
 pti = initial_sort["momentum_t"]
-zi = -beta * ti
 
 # Predicted momentum kick, from J. Qiang, Phys. Rev. Accel. Beams 28, 114602 (2025), eqs. (31-32)
 
@@ -66,7 +65,6 @@ gauss_xy_factor = 2.0 * (1.0 - gauss_exp) / ri_2
 gauss_pdf_z = np.exp(-(zi**2) / (2.0 * sigmaz**2)) / (np.sqrt(2.0 * np.pi) * sigmaz)
 px_predicted = L * Kscale * gauss_pdf_z * xi * gauss_xy_factor
 py_predicted = L * Kscale * gauss_pdf_z * yi * gauss_xy_factor
-
 pt_predicted = pti
 
 # Maximum momentum kick

--- a/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
+++ b/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
@@ -8,7 +8,6 @@
 import numpy as np
 import openpmd_api as io
 import scipy.constants as sc
-from scipy.special import expi
 
 # initial/final beam
 series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)

--- a/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
+++ b/examples/space_charge_gaussian_kick/analysis_sc_kick_Gauss2p5D_long_kick_off.py
@@ -57,7 +57,6 @@ pyi = initial_sort["momentum_y"]
 ti = initial_sort["position_t"]
 pti = initial_sort["momentum_t"]
 zi = -beta * ti
-zi = -beta * ti
 
 # Predicted momentum kick, from J. Qiang, Phys. Rev. Accel. Beams 28, 114602 (2025), eqs. (31-32)
 

--- a/examples/space_charge_gaussian_kick/run_sc_kick_Gauss2p5D_long_kick_off.py
+++ b/examples/space_charge_gaussian_kick/run_sc_kick_Gauss2p5D_long_kick_off.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2023 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell, Ji Qiang
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+from impactx import ImpactX, distribution, elements
+
+sim = ImpactX()
+
+# set numerical parameters and IO control
+sim.particle_shape = 2  # B-spline order
+sim.space_charge = "Gauss2p5D"
+sim.space_charge_gauss_nint = 101
+sim.space_charge_gauss_charge_z_bins = 129
+sim.space_charge_gauss_taylor_delta = 0.01
+sim.space_charge_apply_longitudinal_kick = False
+sim.slice_step_diagnostics = True
+
+# domain decomposition & space charge mesh
+sim.init_grids()
+
+# beam energy ad bunch charge
+kin_energy_MeV = 100  # reference energy
+bunch_charge_C = 1.0e-9  # used with space charge
+npart = 100000  # number of macro particles
+
+# intialize reference particle
+ref = sim.beam.ref
+ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
+
+# initialize particle bunch
+distr = distribution.Gaussian(
+    lambdaX=4.0e-5,
+    lambdaY=4.0e-5,
+    lambdaT=1.0e-3,
+    lambdaPx=0.0,
+    lambdaPy=0.0,
+    lambdaPt=0.0,
+    muxpx=0.0,
+    muypy=0.0,
+    mutpt=0.0,
+)
+sim.add_particles(bunch_charge_C, distr, npart)
+
+# add beam diagnostics
+monitor = elements.BeamMonitor("monitor", backend="h5")
+
+# design the accelerator lattice)
+ns = 1  # number of slices per ds in the element
+L = 1.0  # drift length
+sim.lattice.extend([monitor, elements.Drift(name="d1", ds=L, nslice=ns), monitor])
+
+# run simulation
+sim.track_particles()
+
+# clean shutdown
+sim.finalize()

--- a/src/particles/spacecharge/Gauss2p5dPush.cpp
+++ b/src/particles/spacecharge/Gauss2p5dPush.cpp
@@ -201,6 +201,12 @@ namespace impactx::particles::spacecharge
         int tp5d_bins = 129;
         pp_algo.queryAddWithParser("gauss_charge_z_bins", tp5d_bins);
 
+        //bool apply_longitudinal_kick = true;
+        bool apply_longitudinal_kick = true;
+        pp_algo.queryAdd("apply_longitudinal_kick", apply_longitudinal_kick);
+
+        amrex::Print() << "apply_longitudinal_kick = " << apply_longitudinal_kick << "\n";
+
         // Measure beam size, extract the min, max of particle positions
         [[maybe_unused]] auto const [x_min, y_min, t_min, x_max, y_max, t_max] =
             pc.MinAndMaxPositions();
@@ -287,7 +293,7 @@ namespace impactx::particles::spacecharge
                     }
 #endif
                     amrex::ParticleReal const Fxy = beam_profile[idx] * chargesign;
-                    amrex::ParticleReal const Fz = beam_profile_slope[idx] * charge;
+                    amrex::ParticleReal const Fz = (apply_longitudinal_kick)? beam_profile_slope[idx] * charge : 0_prt;
 
                     // push momentum
                     px += eintx * Fxy * push_consts;

--- a/src/particles/spacecharge/Gauss2p5dPush.cpp
+++ b/src/particles/spacecharge/Gauss2p5dPush.cpp
@@ -201,10 +201,8 @@ namespace impactx::particles::spacecharge
         int tp5d_bins = 129;
         pp_algo.queryAddWithParser("gauss_charge_z_bins", tp5d_bins);
 
-        //bool apply_longitudinal_kick = true;
         bool apply_longitudinal_kick = true;
         pp_algo.queryAdd("apply_longitudinal_kick", apply_longitudinal_kick);
-
 
         // Measure beam size, extract the min, max of particle positions
         [[maybe_unused]] auto const [x_min, y_min, t_min, x_max, y_max, t_max] =

--- a/src/particles/spacecharge/Gauss2p5dPush.cpp
+++ b/src/particles/spacecharge/Gauss2p5dPush.cpp
@@ -205,7 +205,6 @@ namespace impactx::particles::spacecharge
         bool apply_longitudinal_kick = true;
         pp_algo.queryAdd("apply_longitudinal_kick", apply_longitudinal_kick);
 
-        amrex::Print() << "apply_longitudinal_kick = " << apply_longitudinal_kick << "\n";
 
         // Measure beam size, extract the min, max of particle positions
         [[maybe_unused]] auto const [x_min, y_min, t_min, x_max, y_max, t_max] =

--- a/src/particles/spacecharge/HandleSpacecharge.cpp
+++ b/src/particles/spacecharge/HandleSpacecharge.cpp
@@ -45,7 +45,7 @@ namespace impactx::particles::spacecharge
         // turn off if less than 2 particles
         if (amr_data->track_particles.m_particle_container->TotalNumberOfParticles(true, false) < 2) { return; }
 
-        if (space_charge != SpaceChargeAlgo::True_2D && space_charge != SpaceChargeAlgo::True_2p5D)
+        if (space_charge != SpaceChargeAlgo::True_2D && space_charge != SpaceChargeAlgo::True_2p5D && space_charge != SpaceChargeAlgo::Gauss2p5D)
         {
             // transform from x',y',t to x,y,z
             transformation::CoordinateTransformation(
@@ -109,7 +109,7 @@ namespace impactx::particles::spacecharge
             );
         }
 
-        if (space_charge != SpaceChargeAlgo::True_2D && space_charge != SpaceChargeAlgo::True_2p5D)
+        if (space_charge != SpaceChargeAlgo::True_2D && space_charge != SpaceChargeAlgo::True_2p5D && space_charge != SpaceChargeAlgo::Gauss2p5D)
         {
             // transform from x,y,z to x',y',t
             transformation::CoordinateTransformation(

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -394,9 +394,9 @@ void init_ImpactX (py::module& m)
              [](ImpactX & /* ix */) {
                  return detail::get_or_throw<bool>("algo.space_charge", "apply_longitudinal_kick");
              },
-             [](ImpactX & /* ix */, bool const apply_longitudinal_kick) {
+             [](ImpactX & /* ix */, bool const enable) {
                  amrex::ParmParse pp_algo("algo.space_charge");
-                 pp_algo.add("apply_longitudinal_kick", apply_longitudinal_kick);
+                 pp_algo.add("apply_longitudinal_kick", enable);
              },
              "Enable or disable longitudinal space charge kick in 2.5D space charge solver (default: enabled).\n"
          )


### PR DESCRIPTION
The user-facing flag `apply_longitudinal_kick` appears to be broken in the special case of the `Gauss2p5d` solver.  This PR addresses this issue.

Note: This flag already works correctly for the `2p5d` solver.

Also, the z-to-t transformation needs to be turned off, which is done here.

- [x] address parsing of C++ input
- [x] address parsing of Python input
- [x] add validation test