### PR TITLE
Doc: MPI `Source` Behavior

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -905,6 +905,10 @@ Typically at the beginning of a beam line.
 
 Currently, this only supports openPMD files from our ``beam_monitor``.
 
+In `MPI-parallel <https://www.mpi-forum.org>`__ runs, reading the particles in the source file is distributed over all MPI ranks:
+each of the :math:`N` ranks reads a contiguous chunk of :math:`1/N`-th of the particles, independent of their position.
+When ImpactX needs to sort particles spatially, it will redistribute them over MPI ranks automatically during tracking.
+
 * ``<element_name>.distribution`` (``string``)
   Distribution type of particles in the source. currently, only ``"openPMD"`` is supported
 * ``<element_name>.openpmd_path`` (``string``)

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -906,7 +906,7 @@ Typically at the beginning of a beam line.
 Currently, this only supports openPMD files from our ``beam_monitor``.
 
 In `MPI-parallel <https://www.mpi-forum.org>`__ runs, reading the particles in the source file is distributed over all MPI ranks:
-each of the :math:`N` ranks reads a contiguous chunk of :math:`1/N`-th of the particles, independent of their position.
+each of the :math:`N` ranks reads a different contiguous chunk of :math:`1/N`-th of the particles, independent of their position.
 When ImpactX needs to sort particles spatially, it will redistribute them over MPI ranks automatically during tracking.
 
 * ``<element_name>.distribution`` (``string``)

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1807,7 +1807,7 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
 
       Scale factor (in meters^(1/2)) of the IOTA nonlinear magnetic insert element used for computing H and I.
 
-.. py:class:: impactx.elements.Source(distribution, openpmd_path, name)
+.. py:class:: impactx.elements.Source(distribution, openpmd_path, active_once=True, name=None)
 
    A particle source.
    Currently, this only supports openPMD files from our :py:class:`impactx.elements.BeamMonitor`
@@ -1816,6 +1816,14 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
    :param openpmd_path: path to the openPMD series
    :param active_once: Inject particles only for the first lattice period. Default: ``True``
    :param name: an optional name for the element
+
+   .. attention::
+
+      In MPI-parallel simulations, reading the particles in the source file is distributed over all MPI ranks:
+      each of the N ranks reads a contiguous chunk of 1/N-th of the particles, independent of their position.
+      This balances the I/O and memory load between the ranks.
+
+      When ImpactX needs to sort particles spatially, it will redistribute them over MPI ranks automatically during tracking.
 
 .. py:class:: impactx.elements.Programmable(ds=0.0, nslice=1, name=None)
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1820,7 +1820,7 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
    .. attention::
 
       In MPI-parallel simulations, reading the particles in the source file is distributed over all MPI ranks:
-      each of the N ranks reads a contiguous chunk of 1/N-th of the particles, independent of their position.
+      each of the :math:`N` ranks reads a different contiguous chunk of :math:`1/N`-th of the particles, independent of their position.
       This balances the I/O and memory load between the ranks.
 
       When ImpactX needs to sort particles spatially, it will redistribute them over MPI ranks automatically during tracking.

--- a/examples/solenoid_restart/README.rst
+++ b/examples/solenoid_restart/README.rst
@@ -22,6 +22,7 @@ This example can be run **either** as:
 * ImpactX **executable** using an input file: ``impactx input_solenoid.in``
 
 For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+In MPI-parallel runs, the ``source`` element distributes reading of the particles in the openPMD file over all MPI ranks (each rank reads :math:`1/N`-th of the particles).
 
 .. tab-set::
 

--- a/examples/solenoid_restart/README.rst
+++ b/examples/solenoid_restart/README.rst
@@ -22,7 +22,7 @@ This example can be run **either** as:
 * ImpactX **executable** using an input file: ``impactx input_solenoid.in``
 
 For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
-In MPI-parallel runs, the ``source`` element distributes reading of the particles in the openPMD file over all MPI ranks (each rank reads :math:`1/N`-th of the particles).
+In MPI-parallel runs, the ``source`` element distributes reading of the particles in the openPMD file over all MPI ranks (each rank reads a different :math:`1/N`-th of the particles).
 
 .. tab-set::
 


### PR DESCRIPTION
Document how we read `Source` particles in parallel, by distributing them automatically and uniquely.