### PR TITLE
Dashboard: Support Boolean Element Properties

### DIFF
--- a/src/python/impactx/dashboard/Input/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/lattice/ui.py
@@ -48,6 +48,9 @@ def add_lattice_element() -> dict:
     parameters = []
     for name, default_value, default_type in parameters_data:
         value = default_value
+        if default_type == "bool":
+            # real boolean for the checkbox v-model (the string "False" is truthy in JS)
+            value = str(value).strip().lower() == "true"
         if selected_lattice == "BeamMonitor" and name == "name" and not value:
             value = BEAM_MONITOR_DEFAULT_NAME
 
@@ -146,9 +149,14 @@ def process_if_variable(index, parameter_name, ui_input, parameter_type):
 def on_lattice_element_parameter_change(
     index, parameter_name, ui_input, parameter_type
 ):
-    sim_input, bounded_or_pending_variable = process_if_variable(
-        index, parameter_name, ui_input, parameter_type
-    )
+    if parameter_type == "bool":
+        # booleans come from a checkbox and cannot reference variables
+        ui_input = bool(ui_input)
+        sim_input, bounded_or_pending_variable = ui_input, None
+    else:
+        sim_input, bounded_or_pending_variable = process_if_variable(
+            index, parameter_name, ui_input, parameter_type
+        )
 
     key = (id(state.selected_lattice_list[index]), parameter_name)
     if bounded_or_pending_variable is not None:
@@ -279,7 +287,21 @@ class LatticeConfiguration(CardBase):
                         v_for="(parameter, parameterIndex) in latticeElement.parameters",
                         cols="auto",
                     ):
+                        vuetify.VCheckbox(
+                            v_if="parameter.parameter_type === 'bool'",
+                            label=("parameter.parameter_name",),
+                            v_model=("parameter.ui_input",),
+                            id=("parameter.parameter_name + (index + 1)",),
+                            update_modelValue=(
+                                ctrl.updateLatticeElementParameters,
+                                "[index, parameter.parameter_name, $event, parameter.parameter_type]",
+                            ),
+                            error_messages=("parameter.parameter_error_message",),
+                            density="comfortable",
+                            hide_details="auto",
+                        )
                         vuetify.VTextField(
+                            v_if="parameter.parameter_type !== 'bool'",
                             label=("parameter.parameter_name",),
                             v_model=("parameter.ui_input",),
                             id=("parameter.parameter_name + (index + 1)",),

--- a/src/python/impactx/dashboard/Input/validation/inputs.py
+++ b/src/python/impactx/dashboard/Input/validation/inputs.py
@@ -12,9 +12,10 @@ from typing import Union
 from ... import state
 from ..utils import GeneralFunctions
 
-ALLOWED_INPUT_TYPES = {"int", "float", "str"}
+ALLOWED_INPUT_TYPES = {"int", "float", "str", "bool"}
 INT_ERROR_MESSAGE = "Must be an integer"
 FLOAT_ERROR_MESSAGE = "Must be a float"
+BOOL_ERROR_MESSAGE = "Must be a boolean: True or False"
 NON_ZERO_ERROR = "Must be non-zero"
 POSITIVE_ERROR = "Must be positive"
 NEGATIVE_ERROR = "Must be negative"
@@ -63,7 +64,7 @@ class DashboardValidation:
         :param input_name: The name of the input to validate.
         :param input_value: The value to validate.
         :param category: The category of validation (e.g., 'distribution', 'lattice').
-        :param parameter_type: The explicit type to use ('int', 'float', 'str'). If provided, overrides type lookup.
+        :param parameter_type: The explicit type to use ('int', 'float', 'str', 'bool'). If provided, overrides type lookup.
         :return: A list of error messages. An empty list if there are no errors.
         """
         input_type = DashboardValidation._get_input_type(
@@ -77,6 +78,11 @@ class DashboardValidation:
             if not DashboardValidation.is_valid_input_name(str(input_value)):
                 return [PYTHON_IDENTIFIER_ERROR]
             return []
+
+        if input_type == "bool":
+            if str(input_value).strip() in ("True", "False", "true", "false"):
+                return []
+            return [BOOL_ERROR_MESSAGE]
 
         numeric_input = GeneralFunctions.convert_to_numeric(input_value)
         type_errors = DashboardValidation._validate_type(numeric_input, input_type)

--- a/src/python/impactx/dashboard/Run/simulation.py
+++ b/src/python/impactx/dashboard/Run/simulation.py
@@ -69,7 +69,12 @@ def build_lattice_list() -> str:
             param_value = param["sim_input"]
             param_type = param["parameter_type"]
 
-            formatted_value = f'"{param_value}"' if param_type == "str" else param_value
+            if param_type == "str":
+                formatted_value = f'"{param_value}"'
+            elif param_type == "bool":
+                formatted_value = str(param_value).strip().capitalize()
+            else:
+                formatted_value = param_value
             parameter_strings.append(f"{param_name}={formatted_value}")
 
         element_string = f"elements.{name}(" + ", ".join(parameter_strings) + ")"


### PR DESCRIPTION
We already use bool arguments/properties in `Source.active_once` and are about to add more to `BeamMonitor` in a follow-up PR.