### PR TITLE
Python: Config for openPMD

### DIFF
--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -922,6 +922,15 @@ void init_ImpactX (py::module& m)
 #endif
         })
         .def_property_readonly_static(
+            "have_openpmd",
+            [](py::object const &){
+#ifdef ImpactX_USE_OPENPMD
+                return true;
+#else
+                return false;
+#endif
+        })
+        .def_property_readonly_static(
             "simd_size",
             [](py::object const &){
                 return amrex::simd::native_simd_size_particlereal;


### PR DESCRIPTION
Check if openPMD was compiled in at runtime from Python. Same as all other compile-time options. Great for use in tests.