### PR TITLE
 BeamMonitor: Options `particles` and `beam_moments`

### DIFF
--- a/docs/source/dataanalysis/dataanalysis.rst
+++ b/docs/source/dataanalysis/dataanalysis.rst
@@ -101,6 +101,8 @@ The code writes out the values in an ASCII file prefixed ``reduced_beam_characte
 
 * ``step``
     Iteration within the simulation
+* ``period``
+    Current period (turn or cycle) for periodic lattices (unit: dimensionless)
 * ``s``
     Reference particle coordinate ``s`` (unit: meter)
 * ``mean/min/max_x``, ``mean/min/max_y``, ``mean/min/max_t``

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -407,8 +407,9 @@ If the same element name is used multiple times, then an output series is create
     :type: ``string``
     :default: ``g``
 
-    openPMD `iteration encoding <https://openpmd-api.readthedocs.io/en/0.14.0/usage/concepts.html#iteration-and-series>`__: (v)ariable based, (f)ile based, (g)roup based (default)
-    variable based is an `experimental feature with ADIOS2 <https://openpmd-api.readthedocs.io/en/0.14.0/backends/adios2.html#experimental-new-adios2-schema>`__.
+    openPMD `iteration encoding <https://openpmd-api.readthedocs.io/en/latest/usage/concepts.html#iteration-and-series>`__: (v)ariable based, (f)ile based, (g)roup based (default).
+    Variable based is an `experimental feature with ADIOS2 <https://openpmd-api.readthedocs.io/en/0.14.0/backends/adios2.html#experimental-new-adios2-schema>`__,
+    and `currently requires linear read access <https://github.com/openPMD/openPMD-api/issues/1911>`__ (``Access.read_linear``) in downstream readers.
 
 .. pp:param:: <monitor_name>.period_sample_intervals
     :type: ``integer``
@@ -417,12 +418,26 @@ If the same element name is used multiple times, then an output series is create
     For periodic lattice, only output every Nth period (turn).
     By default, diagnostics are returned every cycle.
 
+.. pp:param:: <monitor_name>.particles
+    :type: ``boolean``
+    :default: ``true``
+
+    Output the individual particles of the beam.
+    When set to ``false``, the beam monitor becomes a fast, small diagnostic that stores only per-output attributes (reference particle and, if enabled, beam moments).
+
+.. pp:param:: <monitor_name>.beam_moments
+    :type: ``boolean``
+    :default: ``true``
+
+    Compute and output the beam moments (reduced beam characteristics) of the whole bunch as openPMD attributes on the ``beam`` particle species.
+
 .. pp:param:: <monitor_name>.nonlinear_lens_invariants
     :type: ``boolean``
     :default: ``false``
 
     Compute and output the invariants H and I within the nonlinear magnetic insert element (see: ``nonlinear_lens``).
     Invariants associated with the nonlinear magnetic insert described by V. Danilov and S. Nagaitsev, PRSTAB 13, 084002 (2010), Sect. V.A.
+    Requires ``<monitor_name>.particles = true``.
 
     .. pp:param:: <monitor_name>.alpha
         :type: ``float``

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1762,7 +1762,7 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
    :param rotation: rotation error in the transverse plane [degrees]
    :param name: an optional name for the element
 
-.. py:class:: impactx.elements.BeamMonitor(name, backend="default", encoding="g", period_sample_intervals=1)
+.. py:class:: impactx.elements.BeamMonitor(name, backend="default", encoding="g", period_sample_intervals=1, particles=True, beam_moments=True)
 
    A beam monitor, writing all beam particles at fixed ``s`` to openPMD files.
 
@@ -1773,21 +1773,33 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
    ``json`` only works with serial/single-rank jobs.
    By default, the first available backend in the order given above is taken.
 
-   openPMD `iteration encoding <https://openpmd-api.readthedocs.io/en/0.14.0/usage/concepts.html#iteration-and-series>`__ determines if multiple files are created for individual output steps or not.
-   Variable based is an `experimental feature with ADIOS2 <https://openpmd-api.readthedocs.io/en/0.14.0/backends/adios2.html#experimental-new-adios2-schema>`__.
+   openPMD `iteration encoding <https://openpmd-api.readthedocs.io/en/latest/usage/concepts.html#iteration-and-series>`__ determines if multiple files are created for individual output steps or not.
+   Variable based is an `experimental feature with ADIOS2 <https://openpmd-api.readthedocs.io/en/0.14.0/backends/adios2.html#experimental-new-adios2-schema>`__ and currently requires linear read access (``Access.read_linear``) in downstream readers.
 
    :param name: name of the series
    :param backend: I/O backend, e.g., ``bp``, ``h5``, ``json``
    :param encoding: openPMD iteration encoding: (v)ariable based, (f)ile based, (g)roup based (default)
    :param period_sample_intervals: for periodic lattice, only output every Nth period (turn)
+   :param particles: output the individual particles of the beam (default: ``True``)
+   :param beam_moments: output the beam moments (reduced beam characteristics) as openPMD attributes (default: ``True``)
 
    .. py:property:: name
 
       name of the series
 
+   .. py:property:: particles
+
+      Output the individual particles of the beam (default: ``True``).
+      When set to ``False``, the beam monitor becomes a fast, small diagnostic that stores only per-output attributes (reference particle and, if enabled, beam moments).
+
+   .. py:property:: beam_moments
+
+      Output the beam moments (reduced beam characteristics) of the whole bunch as openPMD attributes on the ``beam`` particle species (default: ``True``).
+
    .. py:property:: nonlinear_lens_invariants
 
-      Compute and output the invariants H and I within the nonlinear magnetic insert element
+      Compute and output the invariants H and I within the nonlinear magnetic insert element.
+      Requires ``particles=True``.
 
    .. py:property:: alpha
 

--- a/src/diagnostics/DiagnosticOutput.H
+++ b/src/diagnostics/DiagnosticOutput.H
@@ -25,12 +25,14 @@ namespace impactx::diagnostics
      * @param pc container of the particles use for diagnostics
      * @param file_name file base name; the full path is resolved under ``diag.file_prefix``
      * @param step the global step
+     * @param period the current period (turn or cycle) for periodic lattices
      * @param append open a new file with a fresh header (false) or append data to an existing file (true)
      */
     void DiagnosticOutput (
         ImpactXParticleContainer const & pc,
         std::string const & file_name,
         int step = 0,
+        int period = 0,
         bool append = false
     );
 
@@ -42,6 +44,7 @@ namespace impactx::diagnostics
      * @param ref_part reference particle
      * @param file_name file base name; the full path is resolved under ``diag.file_prefix``
      * @param step the global step
+     * @param period the current period (turn or cycle) for periodic lattices
      * @param append open a new file with a fresh header (false) or append data to an existing file (true)
      */
     void DiagnosticOutput (
@@ -49,6 +52,7 @@ namespace impactx::diagnostics
         RefPart const & ref_part,
         std::string const & file_name,
         int step = 0,
+        int period = 0,
         bool append = false
     );
 

--- a/src/diagnostics/DiagnosticOutput.cpp
+++ b/src/diagnostics/DiagnosticOutput.cpp
@@ -55,7 +55,7 @@ namespace
             bool compute_spin_moments = false;
             pp_algo.queryAdd("spin", compute_spin_moments);
 
-            file_handler << "step" << " " << "s" << " "
+            file_handler << "step" << " " << "period" << " " << "s" << " "
                          << "mean_x" << " " << "min_x" << " " << "max_x" << " "
                          << "mean_y" << " " << "min_y" << " " << "max_y" << " "
                          << "mean_t" << " " << "min_t" << " " << "max_t" << " "
@@ -137,7 +137,8 @@ namespace
         amrex::AllPrintToFile & file_handler,
         std::unordered_map<std::string, amrex::ParticleReal> const & rbc,
         amrex::ParticleReal s,
-        int step
+        int step,
+        int period
     )
     {
         // determine whether to output eigenemittances
@@ -150,7 +151,7 @@ namespace
         bool compute_spin_moments = false;
         pp_algo.queryAdd("spin", compute_spin_moments);
 
-        file_handler << step << " " << s << " "
+        file_handler << step << " " << period << " " << s << " "
                 << rbc.at("mean_x") << " " << rbc.at("min_x") << " " << rbc.at("max_x") << " "
                 << rbc.at("mean_y") << " " << rbc.at("min_y") << " " << rbc.at("max_y") << " "
                 << rbc.at("mean_t") << " " << rbc.at("min_t") << " " << rbc.at("max_t") << " "
@@ -188,6 +189,7 @@ namespace impactx::diagnostics
         ImpactXParticleContainer const & pc,
         std::string const & file_name,
         int step,
+        int period,
         bool append
     )
     {
@@ -205,7 +207,7 @@ namespace impactx::diagnostics
         std::unordered_map<std::string, amrex::ParticleReal> const rbc =
             diagnostics::reduced_beam_characteristics(pc);
 
-        write_rbc(file_handler, rbc, s, step);
+        write_rbc(file_handler, rbc, s, step, period);
     }
 
     void DiagnosticOutput (
@@ -213,6 +215,7 @@ namespace impactx::diagnostics
         RefPart const & ref_part,
         std::string const & file_name,
         int step,
+        int period,
         bool append
     )
     {
@@ -226,7 +229,7 @@ namespace impactx::diagnostics
         std::unordered_map<std::string, amrex::ParticleReal> const rbc =
             diagnostics::reduced_beam_characteristics(cm, ref_part);
 
-        write_rbc(file_handler, rbc, s, step);
+        write_rbc(file_handler, rbc, s, step, period);
     }
 
     void DiagnosticOutput (

--- a/src/elements/diagnostics/BeamMonitor.H
+++ b/src/elements/diagnostics/BeamMonitor.H
@@ -75,6 +75,8 @@ namespace detail
         static constexpr char const * DEFAULT_backend = "default";
         static constexpr char const * DEFAULT_encoding = "g";
         static constexpr int DEFAULT_period_sample_intervals = 1;
+        static constexpr bool DEFAULT_particles = true;
+        static constexpr bool DEFAULT_beam_moments = true;
 
         /** This element writes the particle beam out to openPMD data.
          *
@@ -84,12 +86,16 @@ namespace detail
          * @param backend file format backend for openPMD, e.g., "bp5", "bp4", or "h5"
          * @param encoding openPMD iteration encoding: "v"ariable based, "f"ile based, "g"roup based (default)
          * @param period_sample_intervals for periodic lattice, only output every Nth period (turn)
+         * @param particles output the individual particles of the beam (default: true)
+         * @param beam_moments output the beam moments (reduced beam characteristics) as attributes (default: true)
          */
         BeamMonitor (
             std::string series_name,
             std::string backend = DEFAULT_backend,
             std::string encoding = DEFAULT_encoding,
-            int period_sample_intervals = DEFAULT_period_sample_intervals
+            int period_sample_intervals = DEFAULT_period_sample_intervals,
+            bool particles = DEFAULT_particles,
+            bool beam_moments = DEFAULT_beam_moments
         );
 
         BeamMonitor (BeamMonitor const & other) = default;
@@ -188,6 +194,20 @@ namespace detail
         AMREX_FORCE_INLINE
         int period_sample_intervals () const { return m_period_sample_intervals; }
 
+        /** Output the individual particles of the beam */
+        AMREX_FORCE_INLINE
+        bool particles () const { return m_particles; }
+
+        /** Toggle output of the individual particles of the beam */
+        void set_particles (bool particles) { m_particles = particles; }
+
+        /** Output the beam moments (reduced beam characteristics) as openPMD attributes */
+        AMREX_FORCE_INLINE
+        bool beam_moments () const { return m_beam_moments; }
+
+        /** Toggle output of the beam moments */
+        void set_beam_moments (bool beam_moments) { m_beam_moments = beam_moments; }
+
         /** track all openPMD series instances
          *
          * Ensure m_series is the same for the same output path.
@@ -203,6 +223,29 @@ namespace detail
         /** Open the openPMD series (on first access) */
         void open ();
 
+        /** Whether to write through the steps-based openPMD writeIterations() API
+         *
+         * I/O steps are the recommended way to write and are fully supported
+         * by ADIOS2 BP5, HDF5 and JSON, with one exception: the ADIOS2 BP4
+         * engine drops attribute-only iterations written through I/O steps
+         * (verified with openPMD-api 0.16.1 and 0.17.1). Thus, when no
+         * particle data sets are written, use random access for "bp4". The
+         * generic "bp" ending resolves to ADIOS2's default engine, which is
+         * BP5 for ADIOS2 >= 2.9. Variable-based encoding strictly requires
+         * I/O steps (random access overwrites attributes of prior
+         * iterations).
+         * Note: openPMD-api cannot report the selected ADIOS2
+         *   engine (Series::backend() only returns "ADIOS2"), so this checks
+         *   the resolved file ending.
+         *   https://github.com/openPMD/openPMD-api/issues/1913
+         */
+        bool use_io_steps () const
+        {
+            return m_particles ||
+                   m_encoding == "v" ||
+                   m_OpenPMDFileType != "bp4";
+        }
+
         std::string m_series_name; //! openPMD filename
         std::string m_OpenPMDFileType; //! openPMD backend: usually HDF5 (h5) or ADIOS2 (bp/bp4/bp5) or ADIOS2 SST (sst)
         std::string m_encoding; //! openPMD iteration encoding: "v"ariable based, "f"ile based, "g"roup based (default)
@@ -212,7 +255,10 @@ namespace detail
 
         int m_file_min_digits = 6; //! minimum number of digits to iteration number in file name
 
-        int m_period_sample_intervals = 1; //! only output every Nth period (turn or cycle) of periodic lattices
+        int m_period_sample_intervals = DEFAULT_period_sample_intervals; //! only output every Nth period (turn or cycle) of periodic lattices
+
+        bool m_particles = DEFAULT_particles; //! output the individual particles of the beam
+        bool m_beam_moments = DEFAULT_beam_moments; //! output the beam moments as openPMD attributes
 
         /** This rank's offset in the MPI-global particle array, by level
          *

--- a/src/elements/diagnostics/BeamMonitor.cpp
+++ b/src/elements/diagnostics/BeamMonitor.cpp
@@ -327,17 +327,14 @@ namespace detail {
         }
         else
         {
-            // zero-extent constant records: openPMD-api 0.17+ readers reject
+            // zero-extent constant record: openPMD-api 0.17+ readers reject
             // particle species without any component extent by default
+            auto const scalar = openPMD::RecordComponent::SCALAR;
             io::Datatype const dtype_fl = io::determineDatatype<amrex::ParticleReal>();
             auto d_none = io::Dataset(dtype_fl, {0});
 
-            beam["positionOffset"]["x"].resetDataset(d_none);
-            beam["positionOffset"]["x"].makeConstant(ref_part.x);
-            beam["positionOffset"]["y"].resetDataset(d_none);
-            beam["positionOffset"]["y"].makeConstant(ref_part.y);
-            beam["positionOffset"]["t"].resetDataset(d_none);
-            beam["positionOffset"]["t"].makeConstant(ref_part.t);
+            beam["empty"][scalar].resetDataset(d_none);
+            beam["empty"][scalar].makeConstant(amrex::ParticleReal(0.0));
         }
 #else
         amrex::ignore_unused(pc, real_soa_names, int_soa_names, ref_part, step);

--- a/src/elements/diagnostics/BeamMonitor.cpp
+++ b/src/elements/diagnostics/BeamMonitor.cpp
@@ -126,8 +126,21 @@ namespace detail {
 #endif // ImpactX_USE_OPENPMD
     }
 
-    BeamMonitor::BeamMonitor (std::string series_name, std::string backend, std::string encoding, int period_sample_intervals) :
-        m_series_name(std::move(series_name)), m_OpenPMDFileType(std::move(backend)), m_encoding(std::move(encoding)), m_period_sample_intervals(period_sample_intervals) {
+    BeamMonitor::BeamMonitor (
+        std::string series_name,
+        std::string backend,
+        std::string encoding,
+        int period_sample_intervals,
+        bool particles,
+        bool beam_moments
+    ) :
+        m_series_name(std::move(series_name)),
+        m_OpenPMDFileType(std::move(backend)),
+        m_encoding(std::move(encoding)),
+        m_period_sample_intervals(period_sample_intervals),
+        m_particles(particles),
+        m_beam_moments(beam_moments)
+    {
     }
 
     void BeamMonitor::open ()
@@ -227,31 +240,14 @@ namespace detail {
         m_step = step;
 
         // series & iteration
+        //   note: the ADIOS2 BP4 engine drops attribute-only iterations with
+        //         the steps-based writeIterations() API, thus use random
+        //         access when no particle data sets are written
         auto series = std::any_cast<io::Series>(m_series);
-        io::WriteIterations iterations = series.writeIterations();
-        io::Iteration iteration = iterations[m_step];
+        io::Iteration iteration = use_io_steps() ?
+                                  io::Iteration(series.writeIterations()[m_step]) :
+                                  series.iterations[m_step];
         io::ParticleSpecies beam = iteration.particles["beam"];
-
-        // calculate & update particle offset in MPI-global particle array, per level
-        auto const num_levels = pc.finestLevel() + 1;
-        m_offset = std::vector<uint64_t>(num_levels);
-        auto counter = detail::ImpactXParticleCounter(pc);
-        auto const np = counter.GetTotalNumParticles();
-        for (auto currentLevel = 0; currentLevel < num_levels; currentLevel++) {
-            m_offset.at(currentLevel) = static_cast<uint64_t>( counter.m_ParticleOffsetAtRank[currentLevel] );
-        }
-
-        // helpers to parse strings to openPMD
-        auto const scalar = openPMD::RecordComponent::SCALAR;
-        auto const getComponentRecord = [&beam](std::string comp_name) {
-            return detail::get_component_record(beam, std::move(comp_name));
-        };
-
-        // define data set and metadata
-        io::Datatype const dtype_fl = io::determineDatatype<amrex::ParticleReal>();
-        io::Datatype const dtype_ui = io::determineDatatype<uint64_t>();
-        auto d_fl = io::Dataset(dtype_fl, {np});
-        auto d_ui = io::Dataset(dtype_ui, {np});
 
         // openPMD 1.* needs "seconds" here, but we fake it as "s"
         iteration.setTime(ref_part.s);
@@ -279,31 +275,70 @@ namespace detail {
             beam.setAttribute(kv.first, kv.second);
         }
 
-        // openPMD coarse position: for global coordinates
+        // individual particle data
+        if (m_particles)
         {
+            // calculate & update particle offset in MPI-global particle array, per level
+            auto const num_levels = pc.finestLevel() + 1;
+            m_offset = std::vector<uint64_t>(num_levels);
+            auto counter = detail::ImpactXParticleCounter(pc);
+            auto const np = counter.GetTotalNumParticles();
+            for (auto currentLevel = 0; currentLevel < num_levels; currentLevel++) {
+                m_offset.at(currentLevel) = static_cast<uint64_t>( counter.m_ParticleOffsetAtRank[currentLevel] );
+            }
 
-            beam["positionOffset"]["x"].resetDataset(d_fl);
+            // helpers to parse strings to openPMD
+            auto const scalar = openPMD::RecordComponent::SCALAR;
+            auto const getComponentRecord = [&beam](std::string comp_name) {
+                return detail::get_component_record(beam, std::move(comp_name));
+            };
+
+            // define data set and metadata
+            io::Datatype const dtype_fl = io::determineDatatype<amrex::ParticleReal>();
+            io::Datatype const dtype_ui = io::determineDatatype<uint64_t>();
+            auto d_fl = io::Dataset(dtype_fl, {np});
+            auto d_ui = io::Dataset(dtype_ui, {np});
+
+            // openPMD coarse position: for global coordinates
+            {
+
+                beam["positionOffset"]["x"].resetDataset(d_fl);
+                beam["positionOffset"]["x"].makeConstant(ref_part.x);
+                beam["positionOffset"]["y"].resetDataset(d_fl);
+                beam["positionOffset"]["y"].makeConstant(ref_part.y);
+                beam["positionOffset"]["t"].resetDataset(d_fl);
+                beam["positionOffset"]["t"].makeConstant(ref_part.t);
+            }
+
+            // unique, global particle index
+            beam["id"][scalar].resetDataset(d_ui);
+
+            // SoA: Real
+            {
+                for (auto real_idx = 0; real_idx < pc.NumRealComps(); real_idx++) {
+                    auto const component_name = real_soa_names.at(real_idx);
+                    getComponentRecord(component_name).resetDataset(d_fl);
+                }
+            }
+            // SoA: Int
+            static_assert(IntSoA::nattribs == 0); // not yet used
+            if (!int_soa_names.empty())
+                throw std::runtime_error("BeamMonitor: int_soa_names output not yet implemented!");
+        }
+        else
+        {
+            // zero-extent constant records: openPMD-api 0.17+ readers reject
+            // particle species without any component extent by default
+            io::Datatype const dtype_fl = io::determineDatatype<amrex::ParticleReal>();
+            auto d_none = io::Dataset(dtype_fl, {0});
+
+            beam["positionOffset"]["x"].resetDataset(d_none);
             beam["positionOffset"]["x"].makeConstant(ref_part.x);
-            beam["positionOffset"]["y"].resetDataset(d_fl);
+            beam["positionOffset"]["y"].resetDataset(d_none);
             beam["positionOffset"]["y"].makeConstant(ref_part.y);
-            beam["positionOffset"]["t"].resetDataset(d_fl);
+            beam["positionOffset"]["t"].resetDataset(d_none);
             beam["positionOffset"]["t"].makeConstant(ref_part.t);
         }
-
-        // unique, global particle index
-        beam["id"][scalar].resetDataset(d_ui);
-
-        // SoA: Real
-        {
-            for (auto real_idx = 0; real_idx < pc.NumRealComps(); real_idx++) {
-                auto const component_name = real_soa_names.at(real_idx);
-                getComponentRecord(component_name).resetDataset(d_fl);
-            }
-        }
-        // SoA: Int
-        static_assert(IntSoA::nattribs == 0); // not yet used
-        if (!int_soa_names.empty())
-            throw std::runtime_error("BeamMonitor: int_soa_names output not yet implemented!");
 #else
         amrex::ignore_unused(pc, real_soa_names, int_soa_names, ref_part, step);
 #endif // ImpactX_USE_OPENPMD
@@ -330,11 +365,30 @@ namespace detail {
         RefPart & ref_part = pc.GetRefParticle();
 
         // optional: add and calculate additional particle properties
-        add_optional_properties(m_series_name, pc);
+        if (m_particles)
+        {
+            add_optional_properties(m_series_name, pc);
+        }
+        else
+        {
+            // H & I are per-particle columns and cannot be written without particle output
+            bool add_nll_invariants = false;
+            amrex::ParmParse pp_element(m_series_name);
+            pp_element.queryAdd("nonlinear_lens_invariants", add_nll_invariants);
+            if (add_nll_invariants)
+            {
+                throw std::runtime_error(
+                    "BeamMonitor (" + m_series_name +
+                    "): nonlinear_lens_invariants=true requires particles=true");
+            }
+        }
 
         // optional: calculate total particle bunch information
         m_rbc.clear();
-        m_rbc = impactx::diagnostics::reduced_beam_characteristics(pc);
+        if (m_beam_moments)
+        {
+            m_rbc = impactx::diagnostics::reduced_beam_characteristics(pc);
+        }
 
         // component names
         std::vector<std::string> real_soa_names = pc.GetRealSoANames();
@@ -343,7 +397,10 @@ namespace detail {
         // pinned memory copy
         PinnedContainer pinned_pc = pc.make_alike<amrex::PolymorphicArenaAllocator>();
         pinned_pc.SetArena(amrex::The_Pinned_Arena());
-        pinned_pc.copyParticles(pc, true);  // no filtering
+        if (m_particles)
+        {
+            pinned_pc.copyParticles(pc, true);  // no filtering
+        }
 
         // TODO: filtering
         /*
@@ -360,23 +417,29 @@ namespace detail {
         // prepare element access & write reference particle
         this->prepare(pinned_pc, real_soa_names, int_soa_names, ref_part, step);
 
-        // loop over refinement levels
-        int const nLevel = pinned_pc.finestLevel();
-        for (int lev = 0; lev <= nLevel; ++lev)
+        if (m_particles)
         {
-            // loop over all particle boxes
-            //using ParIt = ImpactXParticleContainer::iterator;
-            using ParIt = PinnedContainer::ParIterType;
-            // note: openPMD-api is not thread-safe, so do not run OMP parallel here
-            for (ParIt pti(pinned_pc, lev); pti.isValid(); ++pti) {
-                // write beam particles relative to reference particle
-                this->operator()(pti, real_soa_names, int_soa_names, ref_part);
-            } // end loop over all particle boxes
-        } // end mesh-refinement level loop
+            // loop over refinement levels
+            int const nLevel = pinned_pc.finestLevel();
+            for (int lev = 0; lev <= nLevel; ++lev)
+            {
+                // loop over all particle boxes
+                //using ParIt = ImpactXParticleContainer::iterator;
+                using ParIt = PinnedContainer::ParIterType;
+                // note: openPMD-api is not thread-safe, so do not run OMP parallel here
+                for (ParIt pti(pinned_pc, lev); pti.isValid(); ++pti) {
+                    // write beam particles relative to reference particle
+                    this->operator()(pti, real_soa_names, int_soa_names, ref_part);
+                } // end loop over all particle boxes
+            } // end mesh-refinement level loop
+        }
 
+        //   note: as in prepare(), use random access when no particle data
+        //         sets are written
         auto series = std::any_cast<io::Series>(m_series);
-        io::WriteIterations iterations = series.writeIterations();
-        io::Iteration iteration = iterations[m_step];
+        io::Iteration iteration = use_io_steps() ?
+                                  io::Iteration(series.writeIterations()[m_step]) :
+                                  series.iterations[m_step];
 
         // close iteration
         iteration.close();

--- a/src/elements/diagnostics/BeamMonitor.cpp
+++ b/src/elements/diagnostics/BeamMonitor.cpp
@@ -385,6 +385,7 @@ namespace detail {
         if (m_beam_moments)
         {
             m_rbc = impactx::diagnostics::reduced_beam_characteristics(pc);
+            m_rbc["period"] = period;  // current period (turn or cycle)
         }
 
         // component names

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -575,6 +575,10 @@ element_name) );
             pp_element.queryAdd("encoding", openpmd_encoding);
             int period_sample_intervals = BeamMonitor::DEFAULT_period_sample_intervals;
             pp_element.queryAddWithParser("period_sample_intervals", period_sample_intervals);
+            bool particles = BeamMonitor::DEFAULT_particles;
+            pp_element.queryAdd("particles", particles);
+            bool beam_moments = BeamMonitor::DEFAULT_beam_moments;
+            pp_element.queryAdd("beam_moments", beam_moments);
 
             // optional: add and calculate additional particle properties
             // property: nonlinear lens invariants
@@ -582,6 +586,9 @@ element_name) );
             pp_element.queryAdd("nonlinear_lens_invariants", add_nll_invariants);
             if (add_nll_invariants)
             {
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(particles,
+                    element_name + ".nonlinear_lens_invariants=true requires " + element_name + ".particles=true");
+
                 amrex::ParticleReal alpha = 0.0;
                 pp_element.queryAddWithParser("alpha", alpha);
                 amrex::ParticleReal beta = 1.0;
@@ -592,7 +599,7 @@ element_name) );
                 pp_element.queryAddWithParser("cn", cn);
             }
 
-            m_lattice.emplace_back(BeamMonitor(openpmd_name, openpmd_backend, openpmd_encoding, period_sample_intervals));
+            m_lattice.emplace_back(BeamMonitor(openpmd_name, openpmd_backend, openpmd_encoding, period_sample_intervals, particles, beam_moments));
         } else if (element_type == "source")
         {
             std::string distribution, openpmd_path;

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -941,7 +941,7 @@ void init_ImpactX (py::module& m)
 #ifdef ImpactX_USE_OPENPMD
             openPMD::getVariants()
 #else
-            py::none()
+            py::dict()
 #endif
     ;
     pyImpactXConfig

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -422,16 +422,20 @@ void init_elements(py::module& m)
                      bm,
                      std::make_pair("backend", bm.backend()),
                      std::make_pair("encoding", bm.encoding()),
-                     std::make_pair("period_sample_intervals", bm.period_sample_intervals())
+                     std::make_pair("period_sample_intervals", bm.period_sample_intervals()),
+                     std::make_pair("particles", bm.particles()),
+                     std::make_pair("beam_moments", bm.beam_moments())
                  );
              }
         )
-        .def(py::init<std::string, std::string, std::string, int>(),
+        .def(py::init<std::string, std::string, std::string, int, bool, bool>(),
              py::arg("name"),
              py::arg("backend") = diagnostics::BeamMonitor::DEFAULT_backend,
              py::arg("encoding") = diagnostics::BeamMonitor::DEFAULT_encoding,
              py::arg("period_sample_intervals") =
                  diagnostics::BeamMonitor::DEFAULT_period_sample_intervals,
+             py::arg("particles") = diagnostics::BeamMonitor::DEFAULT_particles,
+             py::arg("beam_moments") = diagnostics::BeamMonitor::DEFAULT_beam_moments,
              "This element writes the particle beam out to openPMD data."
         )
         .def_property_readonly("name",
@@ -451,13 +455,24 @@ void init_elements(py::module& m)
             &diagnostics::BeamMonitor::period_sample_intervals,
             "for periodic lattices, only output every Nth period (turn or cycle)"
         )
+        .def_property("particles",
+            [](diagnostics::BeamMonitor & bm) { return bm.particles(); },
+            [](diagnostics::BeamMonitor & bm, bool particles) { bm.set_particles(particles); },
+            "Output the individual particles of the beam (default: True)"
+        )
+        .def_property("beam_moments",
+            [](diagnostics::BeamMonitor & bm) { return bm.beam_moments(); },
+            [](diagnostics::BeamMonitor & bm, bool beam_moments) { bm.set_beam_moments(beam_moments); },
+            "Output the beam moments (reduced beam characteristics) as openPMD attributes (default: True)"
+        )
         .def_property("nonlinear_lens_invariants",
             [](diagnostics::BeamMonitor & bm) { return detail::get_or_throw<bool>(bm.name(), "nonlinear_lens_invariants"); },
             [](diagnostics::BeamMonitor & bm, bool nonlinear_lens_invariants) {
                 amrex::ParmParse pp_element(bm.name());
                 pp_element.add("nonlinear_lens_invariants", nonlinear_lens_invariants);
             },
-            "Compute and output the invariants H and I within the nonlinear magnetic insert element"
+            "Compute and output the invariants H and I within the nonlinear magnetic insert element. "
+            "Requires particles=True."
         )
         .def_property("alpha",
             [](diagnostics::BeamMonitor & bm) { return detail::get_or_throw<amrex::Real>(bm.name(), "alpha"); },

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -210,7 +210,7 @@ namespace impactx
 
                         // print slice step reduced beam characteristics to file
                         diagnostics::DiagnosticOutput(
-                            cm, ref, "reduced_beam_characteristics", step, true);
+                            cm, ref, "reduced_beam_characteristics", step, period, true);
 
                     }
 
@@ -239,7 +239,7 @@ namespace impactx
 
             // print the final values of the reduced beam characteristics
             diagnostics::DiagnosticOutput(
-                cm, ref, "reduced_beam_characteristics_final", step);
+                cm, ref, "reduced_beam_characteristics_final", step, period);
         }
     }
 } // namespace impactx

--- a/src/tracking/particles.cpp
+++ b/src/tracking/particles.cpp
@@ -167,6 +167,7 @@ namespace impactx
                 diagnostics::DiagnosticOutput(*pc,
                                               "reduced_beam_characteristics",
                                               step_,
+                                              period_,
                                               true);
             }
 
@@ -195,7 +196,8 @@ namespace impactx
             // print the final values of the reduced beam characteristics
             diagnostics::DiagnosticOutput(*amr_data->track_particles.m_particle_container,
                                           "reduced_beam_characteristics_final",
-                                          step);
+                                          step,
+                                          m_tracking_state.m_period);
 
             // output particles lost in apertures
             if (amr_data->track_particles.m_particles_lost->TotalNumberOfParticles() > 0)

--- a/tests/python/test_beam_monitor_options.py
+++ b/tests/python/test_beam_monitor_options.py
@@ -82,8 +82,11 @@ def check_series(name, particles, beam_moments, npart):
             assert attr in beam.attributes
 
         # beam moments attributes: present only if enabled
-        for attr in ("sig_x", "sig_y", "sig_t", "emittance_x", "charge_C"):
+        # this includes the current period (turn)
+        for attr in ("sig_x", "sig_y", "sig_t", "emittance_x", "charge_C", "period"):
             assert (attr in beam.attributes) == beam_moments
+        if beam_moments:
+            assert beam.get_attribute("period") == 0  # single pass
 
         # per-particle records: present only if enabled
         if particles:
@@ -91,9 +94,9 @@ def check_series(name, particles, beam_moments, npart):
             assert "positionOffset" in beam
             assert beam["id"][io.Record_Component.SCALAR].shape == [npart]
         else:
-            # zero-extent constant positionOffset for openPMD-api 0.17+ readers
-            assert sorted(beam) == ["positionOffset"]
-            assert beam["positionOffset"]["x"].shape == [0]
+            # zero-extent constant record for openPMD-api 0.17+ readers
+            assert sorted(beam) == ["empty"]
+            assert beam["empty"][io.Record_Component.SCALAR].shape == [0]
     assert n_iterations == 2
     series.close()
 

--- a/tests/python/test_beam_monitor_options.py
+++ b/tests/python/test_beam_monitor_options.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl, Chad Mitchell, Eric Stern
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+
+import pytest
+
+from impactx import Config, ImpactX, distribution, elements
+
+io = pytest.importorskip("openpmd_api")
+
+if not Config.have_openpmd:
+    pytest.skip("ImpactX was compiled without openPMD support", allow_module_level=True)
+
+
+def build_sim(lattice_elements, npart):
+    """Build a small simulation with the given lattice elements."""
+    sim = ImpactX()
+
+    sim.particle_shape = 2
+    sim.slice_step_diagnostics = False
+    sim.init_grids()
+
+    ref = sim.beam.ref
+    ref.set_species("electron").set_kin_energy_MeV(2.0e3)
+
+    distr = distribution.Waterbag(
+        lambdaX=3.9984884770e-5,
+        lambdaY=3.9984884770e-5,
+        lambdaT=1.0e-3,
+        lambdaPx=2.6623538760e-5,
+        lambdaPy=2.6623538760e-5,
+        lambdaPt=2.0e-3,
+        muxpx=-0.846574929020762,
+        muypy=0.846574929020762,
+        mutpt=0.0,
+    )
+    sim.add_particles(1.0e-9, distr, npart)
+
+    sim.lattice.extend(lattice_elements)
+
+    return sim
+
+
+def track_and_finalize(sim):
+    """Track particles and always finalize the simulation.
+
+    Finalizing in all paths is essential: if tracking raises, pytest keeps
+    the exception traceback (and thus ``sim``) alive beyond this test and
+    beyond this test's AMReX lifetime. A later, delayed ``~ImpactX`` would
+    then call ``amrex::Finalize()`` in the middle of an unrelated test.
+    """
+    try:
+        sim.track_particles()
+    finally:
+        sim.finalize()
+
+
+def check_series(name, particles, beam_moments, npart):
+    """Validate the series written by a monitor with the given flags.
+
+    Reads with linear access, which supports all iteration encodings
+    (variable-based encoding does not support random access reads).
+    """
+    files = sorted(Path("diags/openPMD").glob(f"{name}.*"))
+    assert files, f"no openPMD series found for monitor '{name}'"
+
+    series = io.Series(str(files[0]), io.Access.read_linear)
+    n_iterations = 0
+    for it in series.read_iterations():
+        n_iterations += 1
+        beam = it.particles["beam"]
+
+        # reference particle attributes: always present
+        for attr in ("s_ref", "beta_ref", "gamma_ref", "mass_ref", "charge_ref"):
+            assert attr in beam.attributes
+
+        # beam moments attributes: present only if enabled
+        for attr in ("sig_x", "sig_y", "sig_t", "emittance_x", "charge_C"):
+            assert (attr in beam.attributes) == beam_moments
+
+        # per-particle records: present only if enabled
+        if particles:
+            assert "id" in beam
+            assert "positionOffset" in beam
+            assert beam["id"][io.Record_Component.SCALAR].shape == [npart]
+        else:
+            # zero-extent constant positionOffset for openPMD-api 0.17+ readers
+            assert sorted(beam) == ["positionOffset"]
+            assert beam["positionOffset"]["x"].shape == [0]
+    assert n_iterations == 2
+    series.close()
+
+
+@pytest.mark.parametrize(
+    "particles,beam_moments",
+    [(True, True), (True, False), (False, True), (False, False)],
+)
+def test_beam_monitor_flags(particles, beam_moments):
+    """
+    This tests that particle output and beam-moments output of the
+    BeamMonitor element can be independently turned on and off.
+    """
+    npart = 512
+    name = f"mon_p{int(particles)}_m{int(beam_moments)}"
+
+    monitor = elements.BeamMonitor(
+        name=name, particles=particles, beam_moments=beam_moments
+    )
+    assert monitor.particles == particles
+    assert monitor.beam_moments == beam_moments
+    d = monitor.to_dict()
+    assert d["particles"] == particles
+    assert d["beam_moments"] == beam_moments
+
+    sim = build_sim([monitor, elements.Drift(name="d1", ds=0.25), monitor], npart)
+    track_and_finalize(sim)
+
+    check_series(name, particles, beam_moments, npart)
+
+
+def test_beam_monitor_moments_only_bp4():
+    """
+    The ADIOS2 BP4 engine drops attribute-only iterations written through
+    I/O steps; this tests the random access fall-back used for bp4.
+    """
+    # skip based on the writer library: the reading openpmd_api module
+    # may support ADIOS2 (e.g., PyPI wheels) even if ImpactX does not
+    if not Config.openpmd_backends.get("adios2", False):
+        pytest.skip("ImpactX was compiled without openPMD ADIOS2 support")
+
+    npart = 512
+    name = "mon_bp4"
+    monitor = elements.BeamMonitor(
+        name=name, backend="bp4", encoding="g", particles=False
+    )
+
+    sim = build_sim([monitor, elements.Drift(name="d1", ds=0.25), monitor], npart)
+    track_and_finalize(sim)
+
+    check_series(name, particles=False, beam_moments=True, npart=npart)
+
+
+def test_beam_monitor_invariants_require_particles():
+    """
+    This tests that requesting nonlinear lens invariants (per-particle
+    columns) without particle output fails loudly.
+    """
+    monitor = elements.BeamMonitor(name="mon_err", particles=False)
+    monitor.nonlinear_lens_invariants = True
+
+    sim = build_sim([monitor], npart=512)
+    with pytest.raises(RuntimeError, match="nonlinear_lens_invariants"):
+        track_and_finalize(sim)

--- a/tests/python/test_element_serialization.py
+++ b/tests/python/test_element_serialization.py
@@ -146,9 +146,22 @@ def all_elements():
     )
 
     monitor = elements.BeamMonitor(
-        name="test_monitor", backend="h5", encoding="g", period_sample_intervals=2
+        name="test_monitor",
+        backend="h5",
+        encoding="g",
+        period_sample_intervals=2,
     )
     lattice.append(monitor)
+
+    monitor_nopart = elements.BeamMonitor(
+        name="monitor_nopart",
+        backend="h5",
+        encoding="f",
+        period_sample_intervals=3,
+        particles=False,
+        beam_moments=True,
+    )
+    lattice.append(monitor_nopart)
 
     lattice.append(
         elements.Buncher(


### PR DESCRIPTION
Add two more options to `BeamMonitor`:

- `particles=True`
      Output the individual particles of the beam (default: ``True``).
      When set to ``False``, the beam monitor becomes a fast, small diagnostic that stores only per-output attributes (reference particle and, if enabled, beam moments).

- `beam_moments=True`
      Output the beam moments (reduced beam characteristics) of the whole bunch as openPMD attributes on the ``beam`` particle species (default: ``True``).

This enables that the `BeamMonitor` can be used as a fast, binary monitor for moments, particles, nonlinear invariants of the insertion element, or any subset or combination of those. In particular, one can now use it instead of the slow ASCII files that our reduced beam diagnostics creates.