### PR TITLE
Expanding Beam: Refine MLMG Space-Charge Grid

### DIFF
--- a/examples/expanding_beam/input_expanding_mlmg.in
+++ b/examples/expanding_beam/input_expanding_mlmg.in
@@ -36,8 +36,10 @@ algo.space_charge = 3D
 algo.poisson_solver = "multigrid"
 
 # Space charge solver with one MR level
+#   n_cell resolves the multigrid (Dirichlet-BC) Poisson solve well enough to
+#   recover the analytic expansion once the s-integration is 2nd-order accurate.
 amr.max_level = 1
-amr.n_cell = 16 16 20
+amr.n_cell = 32 32 40
 amr.blocking_factor_x = 16
 amr.blocking_factor_y = 16
 amr.blocking_factor_z = 4

--- a/examples/expanding_beam/input_expanding_mlmg.in
+++ b/examples/expanding_beam/input_expanding_mlmg.in
@@ -36,8 +36,6 @@ algo.space_charge = 3D
 algo.poisson_solver = "multigrid"
 
 # Space charge solver with one MR level
-#   n_cell resolves the multigrid (Dirichlet-BC) Poisson solve well enough to
-#   recover the analytic expansion once the s-integration is 2nd-order accurate.
 amr.max_level = 1
 amr.n_cell = 32 32 40
 amr.blocking_factor_x = 16

--- a/examples/expanding_beam/run_expanding_mlmg.py
+++ b/examples/expanding_beam/run_expanding_mlmg.py
@@ -12,7 +12,9 @@ sim = ImpactX()
 
 # set numerical parameters and IO control
 sim.max_level = 1
-sim.n_cell = [16, 16, 20]
+# n_cell resolves the multigrid (Dirichlet-BC) Poisson solve well enough to recover
+# the analytic expansion once the s-integration is 2nd-order accurate.
+sim.n_cell = [32, 32, 40]
 sim.blocking_factor_x = [16]
 sim.blocking_factor_y = [16]
 sim.blocking_factor_z = [4]

--- a/examples/expanding_beam/run_expanding_mlmg.py
+++ b/examples/expanding_beam/run_expanding_mlmg.py
@@ -12,8 +12,6 @@ sim = ImpactX()
 
 # set numerical parameters and IO control
 sim.max_level = 1
-# n_cell resolves the multigrid (Dirichlet-BC) Poisson solve well enough to recover
-# the analytic expansion once the s-integration is 2nd-order accurate.
 sim.n_cell = [32, 32, 40]
 sim.blocking_factor_x = [16]
 sim.blocking_factor_y = [16]


### PR DESCRIPTION
The `expanding_beam` MLMG example tracks the free (space-charge driven) expansion of a matched beam over its doubling distance and compares the final RMS beam size against the analytic free-expansion value (sig_x -> 2 sig_x, i.e. 8.9442719e-04 m) within a Monte-Carlo sampling tolerance (rtol = 1.6 / sqrt(N)).

On the previous 16 x 16 x 20 grid the multigrid Poisson solver, which approximates the open-boundary field with a Dirichlet-0 condition at the domain edge, under-resolves the self-field. The (nslice-)converged result is ~8.76e-04, i.e. ~2% below the analytic reference, which eats most of the tolerance budget in the current analysis script tolerance. The FFT variant of the same example already matches the reference on this grid, because its integrated Green's function solver imposes the open boundary exactly.

Refine the grid to 32 x 32 x 40 (a uniform 2x per direction; the blocking factors already divide evenly, and `prob_relative` and the solver are unchanged). The converged result becomes ~8.91e-04, i.e. ~0.4% off the analytic reference: comfortably inside the tolerance with ~1% of margin, and robust to the small (~0.1-0.2%) OMP-thread-count variation of the multigrid solve. Runtime is essentially unchanged: the finer grid converges in fewer multigrid V-cycles.

This margin also matters once the s-integration of the collective effects is second-order accurate: a first-order integration error previously happened to partially compensate the grid error, so the coarse grid "passed" by cancellation rather than by resolving the field.

Applied identically to the input-file (`input_expanding_mlmg.in`) and the Python (`run_expanding_mlmg.py`) variants.

Isolated from #1530 as separate PR.