### PR TITLE
Python: `impactx.Config.openpmd_backends`

### DIFF
--- a/src/elements/diagnostics/BeamMonitor.cpp
+++ b/src/elements/diagnostics/BeamMonitor.cpp
@@ -304,7 +304,7 @@ namespace detail {
         if (!int_soa_names.empty())
             throw std::runtime_error("BeamMonitor: int_soa_names output not yet implemented!");
 #else
-        amrex::ignore_unused(pc, step);
+        amrex::ignore_unused(pc, real_soa_names, int_soa_names, ref_part, step);
 #endif // ImpactX_USE_OPENPMD
     }
 
@@ -380,7 +380,7 @@ namespace detail {
         // close iteration
         iteration.close();
 #else
-        amrex::ignore_unused(pc, step);
+        amrex::ignore_unused(pc, step, period);
 #endif // ImpactX_USE_OPENPMD
     }
 
@@ -459,7 +459,7 @@ namespace detail {
         // TODO at that point, we could also close the iteration/step
         series.flush();
 #else
-        amrex::ignore_unused(pti, ref_part);
+        amrex::ignore_unused(pti, real_soa_names, int_soa_names, ref_part);
 #endif   // ImpactX_USE_OPENPMD
     }
 

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -19,6 +19,10 @@
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_SIMD.H>
 
+#ifdef ImpactX_USE_OPENPMD
+#   include "openPMD/version.hpp"
+#endif
+
 #if defined(AMREX_DEBUG) || defined(DEBUG)
 #   include <cstdio>
 #endif
@@ -871,7 +875,8 @@ void init_ImpactX (py::module& m)
         )
     ;
 
-    py::class_<Config>(m, "Config")
+    py::class_<Config> pyImpactXConfig(m, "Config");
+    pyImpactXConfig
 //        .def_property_readonly_static(
 //            "impactx_version",
 //            [](py::object) { return Version(); },
@@ -930,6 +935,16 @@ void init_ImpactX (py::module& m)
                 return false;
 #endif
         })
+    ;
+    pyImpactXConfig
+        .attr("openpmd_backends") =
+#ifdef ImpactX_USE_OPENPMD
+            openPMD::getVariants()
+#else
+            py::none()
+#endif
+    ;
+    pyImpactXConfig
         .def_property_readonly_static(
             "simd_size",
             [](py::object const &){


### PR DESCRIPTION
Expose similar to
```py
import openpmd_api as io

print(io.variants)
{'adios1': False,
 'adios2': True,
 'hdf5': True,
 'json': True,
 'mpi': True,
 'toml': True}
```

an attribute
```py
import impactx

print(impactx.Config.openpmd_backends)
{'adios1': False,
 'adios2': True,
 'hdf5': True,
 'json': True,
 'mpi': True,
 'toml': True}
```
Returns the same list, but for the _build config of ImpactX_.

Returns `None` if built w/o openPMD support. Update in #1557: will return an empty dictionary.

Follow-up to #1555 which added `impactx.Config.have_openpmd` (`True`/`False`).