### PR TITLE
[WIP] Optimize Performance of Beam Moments Calculation: Specialized Reductions

### DIFF
--- a/src/diagnostics/BeamMomentsSelection.H
+++ b/src/diagnostics/BeamMomentsSelection.H
@@ -1,0 +1,84 @@
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl, Chad Mitchell
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_BEAM_MOMENTS_SELECTION_H
+#define IMPACTX_BEAM_MOMENTS_SELECTION_H
+
+#include <string>
+#include <vector>
+
+
+namespace impactx::diagnostics
+{
+    /** Reduction profiles, ordered by increasing coverage; each is a superset of
+     *  the previous one: Positions < Sizes < Twiss < Full.
+     *
+     * A profile is the set of weighted power sums a single-pass reduction has to
+     * accumulate; lighter profiles read fewer SoA arrays and reduce fewer values.
+     * The runtime resolver picks the smallest profile whose reduced quantities
+     * cover a requested set of output names.
+     *
+     * - Positions: means and sigmas of x, y, t (and charge)
+     * - Sizes:     + means and sigmas of px, py, pt
+     * - Twiss:     + emittances, dispersion and (dispersion-corrected) Twiss
+     * - Full:      + full 6x6 covariance for eigenemittances
+     */
+    enum class MomentsProfile : int { Positions = 0, Sizes, Twiss, Full };
+
+    /** A resolved beam-moments selection.
+     *
+     * Describes which compile-time reduction profile to run, whether to also
+     * reduce the spin and min/max quantities, whether to compute eigenemittances,
+     * and which output keys to emit.
+     *
+     * @param profile the smallest reduction profile covering the request
+     * @param spin    also reduce the spin first and second moments
+     * @param minmax  also reduce the per-coordinate minima and maxima
+     * @param eigen   also compute the eigenemittances (implies profile == Full)
+     * @param keys    output keys to emit; if empty, every key the profile covers
+     *                is emitted (used for the "all" and lighter-default selections)
+     */
+    struct MomentsSelection
+    {
+        MomentsProfile profile = MomentsProfile::Full;
+        bool spin = true;
+        bool minmax = true;
+        bool eigen = false;
+        std::vector<std::string> keys {};
+    };
+
+    /** Resolve a list of requested output names into the fastest selection that
+     *  can deliver them.
+     *
+     * Deprecated aliases (e.g. ``x_mean``, ``sig_x``, ``pt_min``) are accepted and
+     * map to their canonical requirement; the emitted key keeps the requested
+     * spelling. The special token ``"all"`` requests the full set (empty ``keys``).
+     * An unknown name throws ``std::runtime_error``.
+     *
+     * @param names        requested output names (or {"all"})
+     * @param eigen_default eigenemittances flag used when ``"all"`` is requested
+     */
+    MomentsSelection
+    resolve_beam_moments_selection (std::vector<std::string> const & names, bool eigen_default);
+
+    /** The full selection (all outputs). Used by backward-compatible callers
+     *  (space charge, ASCII diagnostics, the deprecated Python binding).
+     */
+    MomentsSelection
+    all_beam_moments_selection (bool eigen);
+
+    /** The default selection: every output except min/max, and except the spin
+     *  moments when spin tracking is off. Eigenemittances follow the eigen flag.
+     */
+    MomentsSelection
+    default_beam_moments_selection (bool spin_on, bool eigen);
+
+} // namespace impactx::diagnostics
+
+#endif // IMPACTX_BEAM_MOMENTS_SELECTION_H

--- a/src/diagnostics/ReducedBeamCharacteristics.H
+++ b/src/diagnostics/ReducedBeamCharacteristics.H
@@ -10,6 +10,7 @@
 #ifndef IMPACTX_REDUCED_BEAM_CHARACTERISTICS_H
 #define IMPACTX_REDUCED_BEAM_CHARACTERISTICS_H
 
+#include "BeamMomentsSelection.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/CovarianceMatrix.H"
 
@@ -27,6 +28,19 @@ namespace impactx::diagnostics
      */
     std::unordered_map<std::string, amrex::ParticleReal>
     reduced_beam_characteristics (ImpactXParticleContainer const & pc);
+
+    /** Compute a selected subset of the moments of the beam distribution
+     *
+     * Computes only the outputs the selection requests, using the fastest
+     * reduction profile that covers them. This uses an MPI Allreduce and returns
+     * a result on all ranks.
+     *
+     * @param pc        the particle container
+     * @param selection the resolved moment selection (see BeamMomentsSelection.H)
+     */
+    std::unordered_map<std::string, amrex::ParticleReal>
+    reduced_beam_characteristics (ImpactXParticleContainer const & pc,
+                                  MomentsSelection const & selection);
 
     /** Compute moments of the beam distribution from covariance matrix
      */

--- a/src/diagnostics/ReducedBeamCharacteristics.cpp
+++ b/src/diagnostics/ReducedBeamCharacteristics.cpp
@@ -16,6 +16,7 @@
 #include "EmittanceInvariants.H"
 
 #include <AMReX_BLProfiler.H>           // for TinyProfiler
+#include <AMReX_GpuDevice.H>            // for dtoh_memcpy
 #include <AMReX_GpuQualifiers.H>        // for AMREX_GPU_DEVICE
 #include <AMReX_ParallelDescriptor.H>   // for ParallelDescriptor
 #include <AMReX_ParticleReduce.H>       // for ParticleReduce
@@ -24,7 +25,9 @@
 #include <AMReX_SmallMatrix.H>          // for SmallMatrix
 #include <AMReX_TypeList.H>             // for TypeMultiplier
 
+#include <array>
 #include <limits>
+#include <vector>
 
 
 namespace impactx::diagnostics
@@ -47,263 +50,227 @@ namespace impactx::diagnostics
         // preparing access to particle data: SoA
         using PType = typename ImpactXParticleContainer::SuperParticleType;
 
+        /* The reduced beam characteristics are computed in a single pass over the
+         * particles from raw (weighted) power sums. For beams that are off-center
+         * from the reference orbit, accumulating the sums relative to a shift near
+         * the beam centroid keeps them at the O(rms^2) scale instead of O(offset^2).
+         * The recovered central moments then carry a relative error ~eps*(offset/rms):
+         * linear, as in a mean-subtracted two-pass reduction, rather than the
+         * ~eps*(offset/rms)^2 of a raw <u^2> - <u>^2, which would lose accuracy in
+         * single precision. The essential point is that we square the (small)
+         * deviation from the shift, not the (large) coordinate.
+         *
+         * Any global constant is exact under the parallel-axis theorem. Sampling the
+         * first particle needs only offset/rms (i.e. to land within ~rms of the
+         * centroid), not the true mean, and makes no assumption on the beam shape.
+         * (In the offset >> rms limit the leading digits of the subtraction cancel
+         * exactly per Sterbenz's lemma, but that is an asymptotic bonus, not the
+         * mechanism.)
+         */
+        constexpr int comps[9] = {
+            RealSoA::x, RealSoA::y, RealSoA::t,
+            RealSoA::px, RealSoA::py, RealSoA::pt,
+            RealSoA::sx, RealSoA::sy, RealSoA::sz
+        };
+        std::array shift = {0._prt, 0._prt, 0._prt, 0._prt, 0._prt, 0._prt, 0._prt, 0._prt, 0._prt};
+        {
+            // Sample the first particle held locally, then agree on a single global
+            // shift taken from the lowest rank that actually owns a particle. Any
+            // global constant is exact under the parallel-axis theorem, so a rank
+            // with no particles (e.g. one MPI rank of many, or a container that is
+            // momentarily empty right after a restart) simply contributes nothing.
+            // For a globally empty beam the zero shift is kept.
+            bool found = false;
+            for (int lev = 0; lev <= pc.finestLevel() && !found; ++lev) {
+                for (auto const & kv : pc.GetParticles(lev)) {
+                    auto const & ptile = kv.second;
+                    if (ptile.numParticles() > 0) {
+                        auto const & soa = ptile.GetStructOfArrays().GetRealData();
+                        for (int c = 0; c < 9; ++c) {
+                            amrex::Gpu::dtoh_memcpy(
+                                &shift[c], soa[comps[c]].dataPtr(), sizeof(amrex::ParticleReal));
+                        }
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            int src_rank = found ? amrex::ParallelDescriptor::MyProc()
+                                 : amrex::ParallelDescriptor::NProcs();
+            amrex::ParallelAllReduce::Min(src_rank, amrex::ParallelDescriptor::Communicator());
+            if (src_rank < amrex::ParallelDescriptor::NProcs()) {
+                amrex::ParallelDescriptor::Bcast(shift.data(), shift.size(), src_rank);
+            }
+        }
+        amrex::ParticleReal const shift_x  = shift[0];
+        amrex::ParticleReal const shift_y  = shift[1];
+        amrex::ParticleReal const shift_t  = shift[2];
+        amrex::ParticleReal const shift_px = shift[3];
+        amrex::ParticleReal const shift_py = shift[4];
+        amrex::ParticleReal const shift_pt = shift[5];
+        amrex::ParticleReal const shift_sx = shift[6];
+        amrex::ParticleReal const shift_sy = shift[7];
+        amrex::ParticleReal const shift_sz = shift[8];
+
         /* The variables below need to be static to work around an MSVC bug
          * https://stackoverflow.com/questions/55136414/constexpr-variable-captured-inside-lambda-loses-its-constexpr-ness
          */
-        // numbers of same type reduction operations in first concurrent batch
-        static constexpr std::size_t num_red_ops_1_sum = 10;  // summation
-        static constexpr std::size_t num_red_ops_1_min = 6;  // minimum
-        static constexpr std::size_t num_red_ops_1_max = 6;  // maximum
+        // numbers of same-type reduction operations, fused into a single pass:
+        //   Sum(w), 9 weighted first moments, 24 weighted (shifted) second moments,
+        //   and the min/max of the 6 phase-space coordinates.
+        static constexpr std::size_t num_sum = 34;
+        static constexpr std::size_t num_min = 6;
+        static constexpr std::size_t num_max = 6;
 
-        // prepare reduction operations for calculation of mean and min/max values in 6D phase space
         amrex::TypeMultiplier<amrex::ReduceOps,
-            amrex::ReduceOpSum[num_red_ops_1_sum],  // preparing mean values for w, x, y, t, px, py, pt, sx, sy, sz
-            amrex::ReduceOpMin[num_red_ops_1_min],  // preparing min values for x, y, t, px, py, pt
-            amrex::ReduceOpMax[num_red_ops_1_max]   // preparing max values for x, y, t, px, py, pt
-        > reduce_ops_1;
-        using ReducedDataT1 = amrex::TypeMultiplier<amrex::ReduceData, amrex::ParticleReal[num_red_ops_1_sum + num_red_ops_1_min + num_red_ops_1_max]>;
+            amrex::ReduceOpSum[num_sum],  // Sum(w) + first and second (shifted) moments
+            amrex::ReduceOpMin[num_min],  // min of x, y, t, px, py, pt
+            amrex::ReduceOpMax[num_max]   // max of x, y, t, px, py, pt
+        > reduce_ops;
+        using ReducedDataT = amrex::TypeMultiplier<amrex::ReduceData, amrex::ParticleReal[num_sum + num_min + num_max]>;
 
-        auto r1 = amrex::ParticleReduce<ReducedDataT1>(
+        auto r = amrex::ParticleReduce<ReducedDataT>(
             pc,
-            [=] AMREX_GPU_DEVICE(const PType& p) noexcept -> ReducedDataT1::Type
+            [=] AMREX_GPU_DEVICE(const PType& p) noexcept -> ReducedDataT::Type
             {
-                // access particle position data
+                // access SoA particle position, momentum, spin data and weighting
+                const amrex::ParticleReal p_w = p.rdata(RealSoA::w);
                 const amrex::ParticleReal p_x = p.rdata(RealSoA::x);
                 const amrex::ParticleReal p_y = p.rdata(RealSoA::y);
                 const amrex::ParticleReal p_t = p.rdata(RealSoA::t);
-
-                // access SoA particle momentum data and weighting
-                const amrex::ParticleReal p_w = p.rdata(RealSoA::w);
                 const amrex::ParticleReal p_px = p.rdata(RealSoA::px);
                 const amrex::ParticleReal p_py = p.rdata(RealSoA::py);
                 const amrex::ParticleReal p_pt = p.rdata(RealSoA::pt);
-
-                // access particle spin data
                 const amrex::ParticleReal p_sx = p.rdata(RealSoA::sx);
                 const amrex::ParticleReal p_sy = p.rdata(RealSoA::sy);
                 const amrex::ParticleReal p_sz = p.rdata(RealSoA::sz);
 
-                // prepare mean position values
-                const amrex::ParticleReal p_x_mean = p_x * p_w;
-                const amrex::ParticleReal p_y_mean = p_y * p_w;
-                const amrex::ParticleReal p_t_mean = p_t * p_w;
+                // deviations from the shift: O(rms) rather than O(coordinate), which
+                // keeps the (weighted) second moments below well-conditioned
+                const amrex::ParticleReal dx  = p_x  - shift_x;
+                const amrex::ParticleReal dy  = p_y  - shift_y;
+                const amrex::ParticleReal dt  = p_t  - shift_t;
+                const amrex::ParticleReal dpx = p_px - shift_px;
+                const amrex::ParticleReal dpy = p_py - shift_py;
+                const amrex::ParticleReal dpt = p_pt - shift_pt;
+                const amrex::ParticleReal dsx = p_sx - shift_sx;
+                const amrex::ParticleReal dsy = p_sy - shift_sy;
+                const amrex::ParticleReal dsz = p_sz - shift_sz;
 
-                const amrex::ParticleReal p_px_mean = p_px * p_w;
-                const amrex::ParticleReal p_py_mean = p_py * p_w;
-                const amrex::ParticleReal p_pt_mean = p_pt * p_w;
-
-                const amrex::ParticleReal p_sx_mean = p_sx * p_w;
-                const amrex::ParticleReal p_sy_mean = p_sy * p_w;
-                const amrex::ParticleReal p_sz_mean = p_sz * p_w;
-
-                return {p_w,
-                        p_x_mean, p_y_mean, p_t_mean,
-                        p_px_mean, p_py_mean, p_pt_mean,
-                        p_sx_mean, p_sy_mean, p_sz_mean,
-                        p_x, p_y, p_t, p_px, p_py, p_pt,
-                        p_x, p_y, p_t, p_px, p_py, p_pt};
+                return {
+                    // Sum(w)
+                    p_w,
+                    // weighted first moments (shifted): x, y, t, px, py, pt, sx, sy, sz
+                    dx*p_w, dy*p_w, dt*p_w, dpx*p_w, dpy*p_w, dpt*p_w,
+                    dsx*p_w, dsy*p_w, dsz*p_w,
+                    // weighted second moments (shifted): diagonal x, y, t, px, py, pt
+                    dx*dx*p_w, dy*dy*p_w, dt*dt*p_w, dpx*dpx*p_w, dpy*dpy*p_w, dpt*dpt*p_w,
+                    // same-plane correlations: xpx, ypy, tpt
+                    dx*dpx*p_w, dy*dpy*p_w, dt*dpt*p_w,
+                    // dispersive correlations: xpt, pxpt, ypt, pypt
+                    dx*dpt*p_w, dpx*dpt*p_w, dy*dpt*p_w, dpy*dpt*p_w,
+                    // cross-plane correlations: xy, xpy, xt, pxy, pxpy, pxt, yt, pyt
+                    dx*dy*p_w, dx*dpy*p_w, dx*dt*p_w, dpx*dy*p_w, dpx*dpy*p_w, dpx*dt*p_w, dy*dt*p_w, dpy*dt*p_w,
+                    // spin second moments (diagonal): sx, sy, sz
+                    dsx*dsx*p_w, dsy*dsy*p_w, dsz*dsz*p_w,
+                    // min of x, y, t, px, py, pt
+                    p_x, p_y, p_t, p_px, p_py, p_pt,
+                    // max of x, y, t, px, py, pt
+                    p_x, p_y, p_t, p_px, p_py, p_pt
+                };
             },
-            reduce_ops_1
+            reduce_ops
         );
 
-        std::vector<amrex::ParticleReal> values_per_rank_1st(num_red_ops_1_sum);
-
-        /* contains in this order:
-         * w, x_mean, y_mean, t_mean
-         * px_mean, py_mean, pt_mean
-         * sx_mean, sy_mean, sz_mean
-         */
-        amrex::constexpr_for<0, num_red_ops_1_sum> ([&](auto i) {
-            values_per_rank_1st[i] = amrex::get<i>(r1);
+        // extract this rank's partial sums, minima and maxima
+        std::vector<amrex::ParticleReal> values_sum(num_sum);
+        amrex::constexpr_for<0, num_sum> ([&](auto i) {
+            values_sum[i] = amrex::get<i>(r);
+        });
+        std::vector<amrex::ParticleReal> values_min(num_min);
+        amrex::constexpr_for<0, num_min> ([&](auto i) {
+            constexpr std::size_t idx = i + num_sum;
+            values_min[i] = amrex::get<idx>(r);
+        });
+        std::vector<amrex::ParticleReal> values_max(num_max);
+        amrex::constexpr_for<0, num_max> ([&](auto i) {
+            constexpr std::size_t idx = i + num_sum + num_min;
+            values_max[i] = amrex::get<idx>(r);
         });
 
-        // reduced sum over mpi ranks (allreduce)
+        // reduce across MPI ranks (allreduce)
         amrex::ParallelAllReduce::Sum(
-            values_per_rank_1st.data(),
-            values_per_rank_1st.size(),
-            amrex::ParallelDescriptor::Communicator()
-        );
-
-        amrex::ParticleReal const w_sum   = values_per_rank_1st.at(0);
-        amrex::ParticleReal const mean_x  = values_per_rank_1st.at(1) /= w_sum;
-        amrex::ParticleReal const mean_y  = values_per_rank_1st.at(2) /= w_sum;
-        amrex::ParticleReal const mean_t  = values_per_rank_1st.at(3) /= w_sum;
-        amrex::ParticleReal const mean_px = values_per_rank_1st.at(4) /= w_sum;
-        amrex::ParticleReal const mean_py = values_per_rank_1st.at(5) /= w_sum;
-        amrex::ParticleReal const mean_pt = values_per_rank_1st.at(6) /= w_sum;
-        amrex::ParticleReal const mean_sx = values_per_rank_1st.at(7) /= w_sum;
-        amrex::ParticleReal const mean_sy = values_per_rank_1st.at(8) /= w_sum;
-        amrex::ParticleReal const mean_sz = values_per_rank_1st.at(9) /= w_sum;
-
-        std::vector<amrex::ParticleReal> values_per_rank_min(num_red_ops_1_min);
-
-        /* contains in this order:
-         * x_min, y_min, t_min
-         * px_min, py_min, pt_min
-         */
-        amrex::constexpr_for<0, num_red_ops_1_min> ([&](auto i) {
-            constexpr std::size_t idx = i + num_red_ops_1_sum;
-            values_per_rank_min[i] = amrex::get<idx>(r1);
-        });
-
-        std::vector<amrex::ParticleReal> values_per_rank_max(num_red_ops_1_max);
-
-        /* contains in this order:
-         * x_max, y_max, t_max
-         * px_max, py_max, pt_max
-         */
-        amrex::constexpr_for<0, num_red_ops_1_max> ([&](auto i) {
-            constexpr std::size_t idx = i + num_red_ops_1_sum + num_red_ops_1_min;
-            values_per_rank_max[i] = amrex::get<idx>(r1);
-        });
-
-        // reduced sum over mpi ranks (allreduce)
+            values_sum.data(), values_sum.size(), amrex::ParallelDescriptor::Communicator());
         amrex::ParallelAllReduce::Min(
-                values_per_rank_min.data(),
-                values_per_rank_min.size(),
-                amrex::ParallelDescriptor::Communicator()
-        );
-
-        // reduced sum over mpi ranks (allreduce)
+            values_min.data(), values_min.size(), amrex::ParallelDescriptor::Communicator());
         amrex::ParallelAllReduce::Max(
-                values_per_rank_max.data(),
-                values_per_rank_max.size(),
-                amrex::ParallelDescriptor::Communicator()
-        );
+            values_max.data(), values_max.size(), amrex::ParallelDescriptor::Communicator());
 
-        /* The variable below needs to be static to work around an MSVC bug
-         * https://stackoverflow.com/questions/55136414/constexpr-variable-captured-inside-lambda-loses-its-constexpr-ness
-         */
-        // number of reduction operations in second concurrent batch
-        static constexpr std::size_t num_red_ops_2 = 25;
-        // prepare reduction operations for calculation of mean square and correlation values
-        amrex::TypeMultiplier<amrex::ReduceOps, amrex::ReduceOpSum[num_red_ops_2]> reduce_ops_2;
-        using ReducedDataT2 = amrex::TypeMultiplier<amrex::ReduceData, amrex::ParticleReal[num_red_ops_2]>;
-
-        auto r2 = amrex::ParticleReduce<ReducedDataT2>(
-                pc,
-                [=] AMREX_GPU_DEVICE(const PType& p) noexcept
-            -> ReducedDataT2::Type
-            {
-                // access SoA particle momentum data and weighting
-                const amrex::ParticleReal p_w = p.rdata(RealSoA::w);
-                const amrex::ParticleReal p_px = p.rdata(RealSoA::px);
-                const amrex::ParticleReal p_py = p.rdata(RealSoA::py);
-                const amrex::ParticleReal p_pt = p.rdata(RealSoA::pt);
-                // access position data
-                const amrex::ParticleReal p_x = p.rdata(RealSoA::x);
-                const amrex::ParticleReal p_y = p.rdata(RealSoA::y);
-                const amrex::ParticleReal p_t = p.rdata(RealSoA::t);
-                // access spin data
-                const amrex::ParticleReal p_sx = p.rdata(RealSoA::sx);
-                const amrex::ParticleReal p_sy = p.rdata(RealSoA::sy);
-                const amrex::ParticleReal p_sz = p.rdata(RealSoA::sz);
-                // prepare mean square for positions
-                const amrex::ParticleReal p_x_ms = (p_x-mean_x)*(p_x-mean_x)*p_w;
-                const amrex::ParticleReal p_y_ms = (p_y-mean_y)*(p_y-mean_y)*p_w;
-                const amrex::ParticleReal p_t_ms = (p_t-mean_t)*(p_t-mean_t)*p_w;
-                // prepare mean square for momenta
-                const amrex::ParticleReal p_px_ms = (p_px-mean_px)*(p_px-mean_px)*p_w;
-                const amrex::ParticleReal p_py_ms = (p_py-mean_py)*(p_py-mean_py)*p_w;
-                const amrex::ParticleReal p_pt_ms = (p_pt-mean_pt)*(p_pt-mean_pt)*p_w;
-                // prepare mean square for spin
-                const amrex::ParticleReal p_sx_ms = (p_sx-mean_sx)*(p_sx-mean_sx)*p_w;
-                const amrex::ParticleReal p_sy_ms = (p_sy-mean_sy)*(p_sy-mean_sy)*p_w;
-                const amrex::ParticleReal p_sz_ms = (p_sz-mean_sz)*(p_sz-mean_sz)*p_w;
-                // prepare position-momentum correlations
-                const amrex::ParticleReal p_xpx = (p_x-mean_x)*(p_px-mean_px)*p_w;
-                const amrex::ParticleReal p_ypy = (p_y-mean_y)*(p_py-mean_py)*p_w;
-                const amrex::ParticleReal p_tpt = (p_t-mean_t)*(p_pt-mean_pt)*p_w;
-                // prepare correlations for dispersion (4 required)
-                const amrex::ParticleReal p_xpt = (p_x-mean_x)*(p_pt-mean_pt)*p_w;
-                const amrex::ParticleReal p_pxpt = (p_px-mean_px)*(p_pt-mean_pt)*p_w;
-                const amrex::ParticleReal p_ypt = (p_y-mean_y)*(p_pt-mean_pt)*p_w;
-                const amrex::ParticleReal p_pypt = (p_py-mean_py)*(p_pt-mean_pt)*p_w;
-                // prepare additional cross-plane correlations (8 required)
-                const amrex::ParticleReal p_xy = (p_x-mean_x)*(p_y-mean_y)*p_w;
-                const amrex::ParticleReal p_xpy = (p_x-mean_x)*(p_py-mean_py)*p_w;
-                const amrex::ParticleReal p_xt = (p_x-mean_x)*(p_t-mean_t)*p_w;
-                const amrex::ParticleReal p_pxy = (p_px-mean_px)*(p_y-mean_y)*p_w;
-                const amrex::ParticleReal p_pxpy = (p_px-mean_px)*(p_py-mean_py)*p_w;
-                const amrex::ParticleReal p_pxt = (p_px-mean_px)*(p_t-mean_t)*p_w;
-                const amrex::ParticleReal p_yt = (p_y-mean_y)*(p_t-mean_t)*p_w;
-                const amrex::ParticleReal p_pyt = (p_py-mean_py)*(p_t-mean_t)*p_w;
-
-                const amrex::ParticleReal p_charge = q_C*p_w;
-
-                return {p_x_ms, p_y_ms, p_t_ms,
-                        p_px_ms, p_py_ms, p_pt_ms,
-                        p_xpx, p_ypy, p_tpt,
-                        p_xpt, p_pxpt, p_ypt, p_pypt,
-                        p_xy, p_xpy, p_xt, p_pxy, p_pxpy, p_pxt, p_yt, p_pyt,
-                        p_charge,
-                        p_sx_ms, p_sy_ms, p_sz_ms};
-            },
-                reduce_ops_2
-        );
-
-        std::vector<amrex::ParticleReal> values_per_rank_2nd(num_red_ops_2);
-
-        /* contains in this order:
-         * x_ms, y_ms, t_ms
-         * px_ms, py_ms, pt_ms,
-         * xpx, ypy, tpt,
-         * p_xpt, p_pxpt, p_ypt, p_pypt,
-         * p_xy, p_xpy, p_xt, p_pxy, p_pxpy, p_pxt, p_yt, p_pyt,
-         * charge,
-         * sx_ms, sy_ms, sz_ms
-         */
-        amrex::constexpr_for<0, num_red_ops_2> ([&](auto i) {
-            values_per_rank_2nd[i] = amrex::get<i>(r2);
-        });
-
-        // reduced sum over mpi ranks (allreduce)
-        amrex::ParallelAllReduce::Sum(
-            values_per_rank_2nd.data(),
-            values_per_rank_2nd.size(),
-            amrex::ParallelDescriptor::Communicator()
-        );
-
+        // Recover the beam moments from the raw (shifted) power sums via the
+        // parallel-axis theorem. The shift keeps every sum at the O(rms^2) scale,
+        // so the central moments below stay well-conditioned even in single precision.
+        amrex::ParticleReal const w_sum = values_sum[0];
+        // shifted means: <u - shift_u>
+        amrex::ParticleReal const dmean_x  = values_sum[1] / w_sum;
+        amrex::ParticleReal const dmean_y  = values_sum[2] / w_sum;
+        amrex::ParticleReal const dmean_t  = values_sum[3] / w_sum;
+        amrex::ParticleReal const dmean_px = values_sum[4] / w_sum;
+        amrex::ParticleReal const dmean_py = values_sum[5] / w_sum;
+        amrex::ParticleReal const dmean_pt = values_sum[6] / w_sum;
+        amrex::ParticleReal const dmean_sx = values_sum[7] / w_sum;
+        amrex::ParticleReal const dmean_sy = values_sum[8] / w_sum;
+        amrex::ParticleReal const dmean_sz = values_sum[9] / w_sum;
+        // means
+        amrex::ParticleReal const mean_x  = shift_x  + dmean_x;
+        amrex::ParticleReal const mean_y  = shift_y  + dmean_y;
+        amrex::ParticleReal const mean_t  = shift_t  + dmean_t;
+        amrex::ParticleReal const mean_px = shift_px + dmean_px;
+        amrex::ParticleReal const mean_py = shift_py + dmean_py;
+        amrex::ParticleReal const mean_pt = shift_pt + dmean_pt;
+        amrex::ParticleReal const mean_sx = shift_sx + dmean_sx;
+        amrex::ParticleReal const mean_sy = shift_sy + dmean_sy;
+        amrex::ParticleReal const mean_sz = shift_sz + dmean_sz;
         // minimum values
-        amrex::ParticleReal const min_x = values_per_rank_min.at(0);
-        amrex::ParticleReal const min_y = values_per_rank_min.at(1);
-        amrex::ParticleReal const min_t = values_per_rank_min.at(2);
-        amrex::ParticleReal const min_px = values_per_rank_min.at(3);
-        amrex::ParticleReal const min_py = values_per_rank_min.at(4);
-        amrex::ParticleReal const min_pt = values_per_rank_min.at(5);
+        amrex::ParticleReal const min_x = values_min.at(0);
+        amrex::ParticleReal const min_y = values_min.at(1);
+        amrex::ParticleReal const min_t = values_min.at(2);
+        amrex::ParticleReal const min_px = values_min.at(3);
+        amrex::ParticleReal const min_py = values_min.at(4);
+        amrex::ParticleReal const min_pt = values_min.at(5);
         // maximum values
-        amrex::ParticleReal const max_x = values_per_rank_max.at(0);
-        amrex::ParticleReal const max_y = values_per_rank_max.at(1);
-        amrex::ParticleReal const max_t = values_per_rank_max.at(2);
-        amrex::ParticleReal const max_px = values_per_rank_max.at(3);
-        amrex::ParticleReal const max_py = values_per_rank_max.at(4);
-        amrex::ParticleReal const max_pt = values_per_rank_max.at(5);
-        // mean square and correlation values
-        amrex::ParticleReal const x_ms   = values_per_rank_2nd.at(0) /= w_sum;
-        amrex::ParticleReal const y_ms   = values_per_rank_2nd.at(1) /= w_sum;
-        amrex::ParticleReal const t_ms   = values_per_rank_2nd.at(2) /= w_sum;
-        amrex::ParticleReal const px_ms  = values_per_rank_2nd.at(3) /= w_sum;
-        amrex::ParticleReal const py_ms  = values_per_rank_2nd.at(4) /= w_sum;
-        amrex::ParticleReal const pt_ms  = values_per_rank_2nd.at(5) /= w_sum;
-        amrex::ParticleReal const xpx    = values_per_rank_2nd.at(6) /= w_sum;
-        amrex::ParticleReal const ypy    = values_per_rank_2nd.at(7) /= w_sum;
-        amrex::ParticleReal const tpt    = values_per_rank_2nd.at(8) /= w_sum;
-        amrex::ParticleReal const xpt    = values_per_rank_2nd.at(9) /= w_sum;
-        amrex::ParticleReal const pxpt   = values_per_rank_2nd.at(10) /= w_sum;
-        amrex::ParticleReal const ypt    = values_per_rank_2nd.at(11) /= w_sum;
-        amrex::ParticleReal const pypt   = values_per_rank_2nd.at(12) /= w_sum;
-        amrex::ParticleReal const xy     = values_per_rank_2nd.at(13) /= w_sum;
-        amrex::ParticleReal const xpy    = values_per_rank_2nd.at(14) /= w_sum;
-        amrex::ParticleReal const xt     = values_per_rank_2nd.at(15) /= w_sum;
-        amrex::ParticleReal const pxy    = values_per_rank_2nd.at(16) /= w_sum;
-        amrex::ParticleReal const pxpy   = values_per_rank_2nd.at(17) /= w_sum;
-        amrex::ParticleReal const pxt    = values_per_rank_2nd.at(18) /= w_sum;
-        amrex::ParticleReal const yt     = values_per_rank_2nd.at(19) /= w_sum;
-        amrex::ParticleReal const pyt    = values_per_rank_2nd.at(20) /= w_sum;
-        amrex::ParticleReal const charge = values_per_rank_2nd.at(21);
-        amrex::ParticleReal const sx_ms  = values_per_rank_2nd.at(22) /= w_sum;
-        amrex::ParticleReal const sy_ms  = values_per_rank_2nd.at(23) /= w_sum;
-        amrex::ParticleReal const sz_ms  = values_per_rank_2nd.at(24) /= w_sum;
+        amrex::ParticleReal const max_x = values_max.at(0);
+        amrex::ParticleReal const max_y = values_max.at(1);
+        amrex::ParticleReal const max_t = values_max.at(2);
+        amrex::ParticleReal const max_px = values_max.at(3);
+        amrex::ParticleReal const max_py = values_max.at(4);
+        amrex::ParticleReal const max_pt = values_max.at(5);
+        // mean square and correlation values (central moments via parallel-axis theorem)
+        amrex::ParticleReal const x_ms   = values_sum[10] / w_sum - dmean_x  * dmean_x;
+        amrex::ParticleReal const y_ms   = values_sum[11] / w_sum - dmean_y  * dmean_y;
+        amrex::ParticleReal const t_ms   = values_sum[12] / w_sum - dmean_t  * dmean_t;
+        amrex::ParticleReal const px_ms  = values_sum[13] / w_sum - dmean_px * dmean_px;
+        amrex::ParticleReal const py_ms  = values_sum[14] / w_sum - dmean_py * dmean_py;
+        amrex::ParticleReal const pt_ms  = values_sum[15] / w_sum - dmean_pt * dmean_pt;
+        amrex::ParticleReal const xpx    = values_sum[16] / w_sum - dmean_x  * dmean_px;
+        amrex::ParticleReal const ypy    = values_sum[17] / w_sum - dmean_y  * dmean_py;
+        amrex::ParticleReal const tpt    = values_sum[18] / w_sum - dmean_t  * dmean_pt;
+        amrex::ParticleReal const xpt    = values_sum[19] / w_sum - dmean_x  * dmean_pt;
+        amrex::ParticleReal const pxpt   = values_sum[20] / w_sum - dmean_px * dmean_pt;
+        amrex::ParticleReal const ypt    = values_sum[21] / w_sum - dmean_y  * dmean_pt;
+        amrex::ParticleReal const pypt   = values_sum[22] / w_sum - dmean_py * dmean_pt;
+        amrex::ParticleReal const xy     = values_sum[23] / w_sum - dmean_x  * dmean_y;
+        amrex::ParticleReal const xpy    = values_sum[24] / w_sum - dmean_x  * dmean_py;
+        amrex::ParticleReal const xt     = values_sum[25] / w_sum - dmean_x  * dmean_t;
+        amrex::ParticleReal const pxy    = values_sum[26] / w_sum - dmean_px * dmean_y;
+        amrex::ParticleReal const pxpy   = values_sum[27] / w_sum - dmean_px * dmean_py;
+        amrex::ParticleReal const pxt    = values_sum[28] / w_sum - dmean_px * dmean_t;
+        amrex::ParticleReal const yt     = values_sum[29] / w_sum - dmean_y  * dmean_t;
+        amrex::ParticleReal const pyt    = values_sum[30] / w_sum - dmean_py * dmean_t;
+        amrex::ParticleReal const sx_ms  = values_sum[31] / w_sum - dmean_sx * dmean_sx;
+        amrex::ParticleReal const sy_ms  = values_sum[32] / w_sum - dmean_sy * dmean_sy;
+        amrex::ParticleReal const sz_ms  = values_sum[33] / w_sum - dmean_sz * dmean_sz;
+        // beam charge
+        amrex::ParticleReal const charge = q_C * w_sum;
         // standard deviations of positions
         amrex::ParticleReal const sigma_x = std::sqrt(x_ms);
         amrex::ParticleReal const sigma_y = std::sqrt(y_ms);

--- a/src/diagnostics/ReducedBeamCharacteristics.cpp
+++ b/src/diagnostics/ReducedBeamCharacteristics.cpp
@@ -32,6 +32,277 @@
 
 namespace impactx::diagnostics
 {
+namespace
+{
+    /** Central (weighted) beam moments, first moments, per-coordinate extremes
+     *  and beam charge, gathered in one struct so that the derived-quantity
+     *  recovery (sigmas, emittances, Twiss, dispersion, eigenemittances) and the
+     *  output-map assembly are shared between the particle-based and the
+     *  covariance-matrix-based overloads below (single source of truth for the
+     *  parallel-axis recovery math).
+     */
+    struct RawMoments
+    {
+        // second central moments (phase space)
+        amrex::ParticleReal x_ms, y_ms, t_ms, px_ms, py_ms, pt_ms;
+        amrex::ParticleReal xpx, ypy, tpt;
+        amrex::ParticleReal xpt, pxpt, ypt, pypt;
+        amrex::ParticleReal xy, xpy, xt, pxy, pxpy, pxt, yt, pyt;
+        // spin second central moments
+        amrex::ParticleReal sx_ms, sy_ms, sz_ms;
+        // first moments (means)
+        amrex::ParticleReal mean_x, mean_y, mean_t, mean_px, mean_py, mean_pt;
+        amrex::ParticleReal mean_sx, mean_sy, mean_sz;
+        // per-coordinate extremes
+        amrex::ParticleReal min_x, min_y, min_t, min_px, min_py, min_pt;
+        amrex::ParticleReal max_x, max_y, max_t, max_px, max_py, max_pt;
+        // beam charge [C]
+        amrex::ParticleReal charge;
+    };
+
+    /** Recover the derived beam characteristics from the (central) moments and
+     *  assemble the output map. The arithmetic below is unchanged from the
+     *  original inlined recovery; it now lives in exactly one place.
+     */
+    std::unordered_map<std::string, amrex::ParticleReal>
+    derive_and_assemble (RawMoments const & m,
+                         amrex::ParticleReal const bg,
+                         amrex::ParticleReal const bg2)
+    {
+        using namespace amrex::literals; // for _prt
+
+        // unpack the (central) moments recovered by the caller
+        amrex::ParticleReal const x_ms   = m.x_ms;
+        amrex::ParticleReal const y_ms   = m.y_ms;
+        amrex::ParticleReal const t_ms   = m.t_ms;
+        amrex::ParticleReal const px_ms  = m.px_ms;
+        amrex::ParticleReal const py_ms  = m.py_ms;
+        amrex::ParticleReal const pt_ms  = m.pt_ms;
+        amrex::ParticleReal const xpx    = m.xpx;
+        amrex::ParticleReal const ypy    = m.ypy;
+        amrex::ParticleReal const tpt    = m.tpt;
+        amrex::ParticleReal const xpt    = m.xpt;
+        amrex::ParticleReal const pxpt   = m.pxpt;
+        amrex::ParticleReal const ypt    = m.ypt;
+        amrex::ParticleReal const pypt   = m.pypt;
+        amrex::ParticleReal const xy     = m.xy;
+        amrex::ParticleReal const xpy    = m.xpy;
+        amrex::ParticleReal const xt     = m.xt;
+        amrex::ParticleReal const pxy    = m.pxy;
+        amrex::ParticleReal const pxpy   = m.pxpy;
+        amrex::ParticleReal const pxt    = m.pxt;
+        amrex::ParticleReal const yt     = m.yt;
+        amrex::ParticleReal const pyt    = m.pyt;
+        amrex::ParticleReal const sx_ms  = m.sx_ms;
+        amrex::ParticleReal const sy_ms  = m.sy_ms;
+        amrex::ParticleReal const sz_ms  = m.sz_ms;
+        amrex::ParticleReal const mean_x  = m.mean_x;
+        amrex::ParticleReal const mean_y  = m.mean_y;
+        amrex::ParticleReal const mean_t  = m.mean_t;
+        amrex::ParticleReal const mean_px = m.mean_px;
+        amrex::ParticleReal const mean_py = m.mean_py;
+        amrex::ParticleReal const mean_pt = m.mean_pt;
+        amrex::ParticleReal const mean_sx = m.mean_sx;
+        amrex::ParticleReal const mean_sy = m.mean_sy;
+        amrex::ParticleReal const mean_sz = m.mean_sz;
+        amrex::ParticleReal const min_x  = m.min_x;
+        amrex::ParticleReal const min_y  = m.min_y;
+        amrex::ParticleReal const min_t  = m.min_t;
+        amrex::ParticleReal const min_px = m.min_px;
+        amrex::ParticleReal const min_py = m.min_py;
+        amrex::ParticleReal const min_pt = m.min_pt;
+        amrex::ParticleReal const max_x  = m.max_x;
+        amrex::ParticleReal const max_y  = m.max_y;
+        amrex::ParticleReal const max_t  = m.max_t;
+        amrex::ParticleReal const max_px = m.max_px;
+        amrex::ParticleReal const max_py = m.max_py;
+        amrex::ParticleReal const max_pt = m.max_pt;
+        amrex::ParticleReal const charge = m.charge;
+
+        // standard deviations of positions
+        amrex::ParticleReal const sigma_x = std::sqrt(x_ms);
+        amrex::ParticleReal const sigma_y = std::sqrt(y_ms);
+        amrex::ParticleReal const sigma_t = std::sqrt(t_ms);
+        // standard deviations of momenta
+        amrex::ParticleReal const sigma_px = std::sqrt(px_ms);
+        amrex::ParticleReal const sigma_py = std::sqrt(py_ms);
+        amrex::ParticleReal const sigma_pt = std::sqrt(pt_ms);
+        // standard deviations of spin
+        amrex::ParticleReal const sigma_sx = std::sqrt(sx_ms);
+        amrex::ParticleReal const sigma_sy = std::sqrt(sy_ms);
+        amrex::ParticleReal const sigma_sz = std::sqrt(sz_ms);
+        // RMS emittances
+        amrex::ParticleReal const e2_x = x_ms*px_ms-xpx*xpx;
+        amrex::ParticleReal const e2_y = y_ms*py_ms-ypy*ypy;
+        amrex::ParticleReal const e2_t = t_ms*pt_ms-tpt*tpt;
+        amrex::ParticleReal const emittance_x = (e2_x > 0.0)? std::sqrt(e2_x) : 0.0_prt;
+        amrex::ParticleReal const emittance_y = (e2_y > 0.0)? std::sqrt(e2_y) : 0.0_prt;
+        amrex::ParticleReal const emittance_t = (e2_t > 0.0)? std::sqrt(e2_t) : 0.0_prt;
+        // Dispersion and dispersive beam moments
+        amrex::ParticleReal const dispersion_x = ((pt_ms > 0.0) ? (- xpt / pt_ms) : 0.0_prt);
+        amrex::ParticleReal const dispersion_px = ((pt_ms > 0.0) ? (- pxpt / pt_ms) : 0.0_prt);
+        amrex::ParticleReal const dispersion_y = ((pt_ms > 0.0) ? (- ypt / pt_ms) : 0.0_prt);
+        amrex::ParticleReal const dispersion_py = ((pt_ms > 0.0) ? (- pypt / pt_ms) : 0.0_prt);
+        amrex::ParticleReal const x_msd = x_ms - pt_ms*dispersion_x*dispersion_x;
+        amrex::ParticleReal const px_msd = px_ms - pt_ms*dispersion_px*dispersion_px;
+        amrex::ParticleReal const xpx_d = xpx - pt_ms*dispersion_x*dispersion_px;
+        amrex::ParticleReal const emittance_xd = std::sqrt(x_msd*px_msd-xpx_d*xpx_d);
+        amrex::ParticleReal const y_msd = y_ms - pt_ms*dispersion_y*dispersion_y;
+        amrex::ParticleReal const py_msd = py_ms - pt_ms*dispersion_py*dispersion_py;
+        amrex::ParticleReal const ypy_d = ypy - pt_ms*dispersion_y*dispersion_py;
+        amrex::ParticleReal const emittance_yd = std::sqrt(y_msd*py_msd-ypy_d*ypy_d);
+        // Courant-Snyder (Twiss) beta-function
+        amrex::ParticleReal const beta_x = x_msd / emittance_xd;
+        amrex::ParticleReal const beta_y = y_msd / emittance_yd;
+        amrex::ParticleReal const beta_t = t_ms / emittance_t;
+        // Courant-Snyder (Twiss) alpha
+        amrex::ParticleReal const alpha_x = - xpx_d / emittance_xd;
+        amrex::ParticleReal const alpha_y = - ypy_d / emittance_yd;
+        amrex::ParticleReal const alpha_t = - tpt / emittance_t;
+
+        // Calculate normalized emittances
+        amrex::ParticleReal emittance_xn = emittance_x * bg;
+        amrex::ParticleReal emittance_yn = emittance_y * bg;
+        amrex::ParticleReal emittance_tn = emittance_t * bg;
+
+        // Determine whether to calculate eigenemittances, and initialize
+        amrex::ParmParse pp_diag("diag");
+        bool compute_eigenemittances = false;
+        pp_diag.queryAdd("eigenemittances", compute_eigenemittances);
+        amrex::ParticleReal emittance_1 = emittance_xn;
+        amrex::ParticleReal emittance_2 = emittance_yn;
+        amrex::ParticleReal emittance_3 = emittance_tn;
+
+        if (compute_eigenemittances) {
+           // Store the covariance matrix in dynamical variables:
+           amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> Sigma;
+           Sigma(1,1) = x_ms;
+           Sigma(1,2) = xpx * bg;
+           Sigma(1,3) = xy;
+           Sigma(1,4) = xpy * bg;
+           Sigma(1,5) = xt;
+           Sigma(1,6) = xpt * bg;
+           Sigma(2,1) = xpx * bg;
+           Sigma(2,2) = px_ms * bg2;
+           Sigma(2,3) = pxy * bg;
+           Sigma(2,4) = pxpy * bg2;
+           Sigma(2,5) = pxt * bg;
+           Sigma(2,6) = pxpt * bg2;
+           Sigma(3,1) = xy;
+           Sigma(3,2) = pxy * bg;
+           Sigma(3,3) = y_ms;
+           Sigma(3,4) = ypy * bg;
+           Sigma(3,5) = yt;
+           Sigma(3,6) = ypt * bg;
+           Sigma(4,1) = xpy * bg;
+           Sigma(4,2) = pxpy * bg2;
+           Sigma(4,3) = ypy * bg;
+           Sigma(4,4) = py_ms * bg2;
+           Sigma(4,5) = pyt * bg;
+           Sigma(4,6) = pypt * bg2;
+           Sigma(5,1) = xt;
+           Sigma(5,2) = pxt * bg;
+           Sigma(5,3) = yt;
+           Sigma(5,4) = pyt * bg;
+           Sigma(5,5) = t_ms;
+           Sigma(5,6) = tpt * bg;
+           Sigma(6,1) = xpt * bg;
+           Sigma(6,2) = pxpt * bg2;
+           Sigma(6,3) = ypt * bg;
+           Sigma(6,4) = pypt * bg2;
+           Sigma(6,5) = tpt * bg;
+           Sigma(6,6) = pt_ms * bg2;
+           // Calculate eigenemittances
+           std::tuple<amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal> emittances = Eigenemittances(Sigma);
+           emittance_1 = std::get<0>(emittances);
+           emittance_2 = std::get<1>(emittances);
+           emittance_3 = std::get<2>(emittances);
+        }
+
+        std::unordered_map<std::string, amrex::ParticleReal> data;
+        data["mean_x"] = mean_x;
+        data["min_x"] = min_x;
+        data["max_x"] = max_x;
+        data["mean_y"] = mean_y;
+        data["min_y"] = min_y;
+        data["max_y"] = max_y;
+        data["mean_t"] = mean_t;
+        data["min_t"] = min_t;
+        data["max_t"] = max_t;
+        data["sigma_x"] = sigma_x;
+        data["sigma_y"] = sigma_y;
+        data["sigma_t"] = sigma_t;
+        data["mean_px"] = mean_px;
+        data["min_px"] = min_px;
+        data["max_px"] = max_px;
+        data["mean_py"] = mean_py;
+        data["min_py"] = min_py;
+        data["max_py"] = max_py;
+        data["mean_pt"] = mean_pt;
+        data["min_pt"] = min_pt;
+        data["max_pt"] = max_pt;
+        data["sigma_px"] = sigma_px;
+        data["sigma_py"] = sigma_py;
+        data["sigma_pt"] = sigma_pt;
+        // start deprecated attributes
+        data["x_mean"] = mean_x;
+        data["x_min"] = min_x;
+        data["x_max"] = max_x;
+        data["y_mean"] = mean_y;
+        data["y_min"] = min_y;
+        data["y_max"] = max_y;
+        data["t_mean"] = mean_t;
+        data["t_min"] = min_t;
+        data["t_max"] = max_t;
+        data["sig_x"] = sigma_x;
+        data["sig_y"] = sigma_y;
+        data["sig_t"] = sigma_t;
+        data["px_mean"] = mean_px;
+        data["px_min"] = min_px;
+        data["px_max"] = max_px;
+        data["py_mean"] = mean_py;
+        data["py_min"] = min_py;
+        data["py_max"] = max_py;
+        data["pt_mean"] = mean_pt;
+        data["pt_min"] = min_pt;
+        data["pt_max"] = max_pt;
+        data["sig_px"] = sigma_px;
+        data["sig_py"] = sigma_py;
+        data["sig_pt"] = sigma_pt;
+        // end deprecated attributes
+        data["emittance_x"] = emittance_x;
+        data["emittance_y"] = emittance_y;
+        data["emittance_t"] = emittance_t;
+        data["alpha_x"] = alpha_x;
+        data["alpha_y"] = alpha_y;
+        data["alpha_t"] = alpha_t;
+        data["beta_x"] = beta_x;
+        data["beta_y"] = beta_y;
+        data["beta_t"] = beta_t;
+        data["dispersion_x"] = dispersion_x;
+        data["dispersion_px"] = dispersion_px;
+        data["dispersion_y"] = dispersion_y;
+        data["dispersion_py"] = dispersion_py;
+        data["emittance_xn"] = emittance_xn;
+        data["emittance_yn"] = emittance_yn;
+        data["emittance_tn"] = emittance_tn;
+        if (compute_eigenemittances) {
+           data["emittance_1"] = emittance_1;
+           data["emittance_2"] = emittance_2;
+           data["emittance_3"] = emittance_3;
+        }
+        data["charge_C"] = charge;
+        data["mean_sx"] = mean_sx;
+        data["mean_sy"] = mean_sy;
+        data["mean_sz"] = mean_sz;
+        data["sigma_sx"] = sigma_sx;
+        data["sigma_sy"] = sigma_sy;
+        data["sigma_sz"] = sigma_sz;
+
+        return data;
+    }
+} // namespace
+
     std::unordered_map<std::string, amrex::ParticleReal>
     reduced_beam_characteristics (ImpactXParticleContainer const & pc)
     {
@@ -271,187 +542,20 @@ namespace impactx::diagnostics
         amrex::ParticleReal const sz_ms  = values_sum[33] / w_sum - dmean_sz * dmean_sz;
         // beam charge
         amrex::ParticleReal const charge = q_C * w_sum;
-        // standard deviations of positions
-        amrex::ParticleReal const sigma_x = std::sqrt(x_ms);
-        amrex::ParticleReal const sigma_y = std::sqrt(y_ms);
-        amrex::ParticleReal const sigma_t = std::sqrt(t_ms);
-        // standard deviations of momenta
-        amrex::ParticleReal const sigma_px = std::sqrt(px_ms);
-        amrex::ParticleReal const sigma_py = std::sqrt(py_ms);
-        amrex::ParticleReal const sigma_pt = std::sqrt(pt_ms);
-        // standard deviations of spin
-        amrex::ParticleReal const sigma_sx = std::sqrt(sx_ms);
-        amrex::ParticleReal const sigma_sy = std::sqrt(sy_ms);
-        amrex::ParticleReal const sigma_sz = std::sqrt(sz_ms);
-        // RMS emittances
-        amrex::ParticleReal const e2_x = x_ms*px_ms-xpx*xpx;
-        amrex::ParticleReal const e2_y = y_ms*py_ms-ypy*ypy;
-        amrex::ParticleReal const e2_t = t_ms*pt_ms-tpt*tpt;
-        amrex::ParticleReal const emittance_x = (e2_x > 0.0)? std::sqrt(e2_x) : 0.0_prt;
-        amrex::ParticleReal const emittance_y = (e2_y > 0.0)? std::sqrt(e2_y) : 0.0_prt;
-        amrex::ParticleReal const emittance_t = (e2_t > 0.0)? std::sqrt(e2_t) : 0.0_prt;
-        // Dispersion and dispersive beam moments
-        amrex::ParticleReal const dispersion_x = ((pt_ms > 0.0) ? (- xpt / pt_ms) : 0.0_prt);
-        amrex::ParticleReal const dispersion_px = ((pt_ms > 0.0) ? (- pxpt / pt_ms) : 0.0_prt);
-        amrex::ParticleReal const dispersion_y = ((pt_ms > 0.0) ? (- ypt / pt_ms) : 0.0_prt);
-        amrex::ParticleReal const dispersion_py = ((pt_ms > 0.0) ? (- pypt / pt_ms) : 0.0_prt);
-        amrex::ParticleReal const x_msd = x_ms - pt_ms*dispersion_x*dispersion_x;
-        amrex::ParticleReal const px_msd = px_ms - pt_ms*dispersion_px*dispersion_px;
-        amrex::ParticleReal const xpx_d = xpx - pt_ms*dispersion_x*dispersion_px;
-        amrex::ParticleReal const emittance_xd = std::sqrt(x_msd*px_msd-xpx_d*xpx_d);
-        amrex::ParticleReal const y_msd = y_ms - pt_ms*dispersion_y*dispersion_y;
-        amrex::ParticleReal const py_msd = py_ms - pt_ms*dispersion_py*dispersion_py;
-        amrex::ParticleReal const ypy_d = ypy - pt_ms*dispersion_y*dispersion_py;
-        amrex::ParticleReal const emittance_yd = std::sqrt(y_msd*py_msd-ypy_d*ypy_d);
-        // Courant-Snyder (Twiss) beta-function
-        amrex::ParticleReal const beta_x = x_msd / emittance_xd;
-        amrex::ParticleReal const beta_y = y_msd / emittance_yd;
-        amrex::ParticleReal const beta_t = t_ms / emittance_t;
-        // Courant-Snyder (Twiss) alpha
-        amrex::ParticleReal const alpha_x = - xpx_d / emittance_xd;
-        amrex::ParticleReal const alpha_y = - ypy_d / emittance_yd;
-        amrex::ParticleReal const alpha_t = - tpt / emittance_t;
 
-        // Calculate normalized emittances
-        amrex::ParticleReal emittance_xn = emittance_x * bg;
-        amrex::ParticleReal emittance_yn = emittance_y * bg;
-        amrex::ParticleReal emittance_tn = emittance_t * bg;
-
-        // Determine whether to calculate eigenemittances, and initialize
-        amrex::ParmParse pp_diag("diag");
-        bool compute_eigenemittances = false;
-        pp_diag.queryAdd("eigenemittances", compute_eigenemittances);
-        amrex::ParticleReal emittance_1 = emittance_xn;
-        amrex::ParticleReal emittance_2 = emittance_yn;
-        amrex::ParticleReal emittance_3 = emittance_tn;
-
-        if (compute_eigenemittances) {
-           // Store the covariance matrix in dynamical variables:
-           amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> Sigma;
-           Sigma(1,1) = x_ms;
-           Sigma(1,2) = xpx * bg;
-           Sigma(1,3) = xy;
-           Sigma(1,4) = xpy * bg;
-           Sigma(1,5) = xt;
-           Sigma(1,6) = xpt * bg;
-           Sigma(2,1) = xpx * bg;
-           Sigma(2,2) = px_ms * bg2;
-           Sigma(2,3) = pxy * bg;
-           Sigma(2,4) = pxpy * bg2;
-           Sigma(2,5) = pxt * bg;
-           Sigma(2,6) = pxpt * bg2;
-           Sigma(3,1) = xy;
-           Sigma(3,2) = pxy * bg;
-           Sigma(3,3) = y_ms;
-           Sigma(3,4) = ypy * bg;
-           Sigma(3,5) = yt;
-           Sigma(3,6) = ypt * bg;
-           Sigma(4,1) = xpy * bg;
-           Sigma(4,2) = pxpy * bg2;
-           Sigma(4,3) = ypy * bg;
-           Sigma(4,4) = py_ms * bg2;
-           Sigma(4,5) = pyt * bg;
-           Sigma(4,6) = pypt * bg2;
-           Sigma(5,1) = xt;
-           Sigma(5,2) = pxt * bg;
-           Sigma(5,3) = yt;
-           Sigma(5,4) = pyt * bg;
-           Sigma(5,5) = t_ms;
-           Sigma(5,6) = tpt * bg;
-           Sigma(6,1) = xpt * bg;
-           Sigma(6,2) = pxpt * bg2;
-           Sigma(6,3) = ypt * bg;
-           Sigma(6,4) = pypt * bg2;
-           Sigma(6,5) = tpt * bg;
-           Sigma(6,6) = pt_ms * bg2;
-           // Calculate eigenemittances
-           std::tuple<amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal> emittances = Eigenemittances(Sigma);
-           emittance_1 = std::get<0>(emittances);
-           emittance_2 = std::get<1>(emittances);
-           emittance_3 = std::get<2>(emittances);
-        }
-
-        std::unordered_map<std::string, amrex::ParticleReal> data;
-        data["mean_x"] = mean_x;
-        data["min_x"] = min_x;
-        data["max_x"] = max_x;
-        data["mean_y"] = mean_y;
-        data["min_y"] = min_y;
-        data["max_y"] = max_y;
-        data["mean_t"] = mean_t;
-        data["min_t"] = min_t;
-        data["max_t"] = max_t;
-        data["sigma_x"] = sigma_x;
-        data["sigma_y"] = sigma_y;
-        data["sigma_t"] = sigma_t;
-        data["mean_px"] = mean_px;
-        data["min_px"] = min_px;
-        data["max_px"] = max_px;
-        data["mean_py"] = mean_py;
-        data["min_py"] = min_py;
-        data["max_py"] = max_py;
-        data["mean_pt"] = mean_pt;
-        data["min_pt"] = min_pt;
-        data["max_pt"] = max_pt;
-        data["sigma_px"] = sigma_px;
-        data["sigma_py"] = sigma_py;
-        data["sigma_pt"] = sigma_pt;
-        // start deprecated attributes
-        data["x_mean"] = mean_x;
-        data["x_min"] = min_x;
-        data["x_max"] = max_x;
-        data["y_mean"] = mean_y;
-        data["y_min"] = min_y;
-        data["y_max"] = max_y;
-        data["t_mean"] = mean_t;
-        data["t_min"] = min_t;
-        data["t_max"] = max_t;
-        data["sig_x"] = sigma_x;
-        data["sig_y"] = sigma_y;
-        data["sig_t"] = sigma_t;
-        data["px_mean"] = mean_px;
-        data["px_min"] = min_px;
-        data["px_max"] = max_px;
-        data["py_mean"] = mean_py;
-        data["py_min"] = min_py;
-        data["py_max"] = max_py;
-        data["pt_mean"] = mean_pt;
-        data["pt_min"] = min_pt;
-        data["pt_max"] = max_pt;
-        data["sig_px"] = sigma_px;
-        data["sig_py"] = sigma_py;
-        data["sig_pt"] = sigma_pt;
-        // end deprecated attributes
-        data["emittance_x"] = emittance_x;
-        data["emittance_y"] = emittance_y;
-        data["emittance_t"] = emittance_t;
-        data["alpha_x"] = alpha_x;
-        data["alpha_y"] = alpha_y;
-        data["alpha_t"] = alpha_t;
-        data["beta_x"] = beta_x;
-        data["beta_y"] = beta_y;
-        data["beta_t"] = beta_t;
-        data["dispersion_x"] = dispersion_x;
-        data["dispersion_px"] = dispersion_px;
-        data["dispersion_y"] = dispersion_y;
-        data["dispersion_py"] = dispersion_py;
-        data["emittance_xn"] = emittance_xn;
-        data["emittance_yn"] = emittance_yn;
-        data["emittance_tn"] = emittance_tn;
-        if (compute_eigenemittances) {
-           data["emittance_1"] = emittance_1;
-           data["emittance_2"] = emittance_2;
-           data["emittance_3"] = emittance_3;
-        }
-        data["charge_C"] = charge;
-        data["mean_sx"] = mean_sx;
-        data["mean_sy"] = mean_sy;
-        data["mean_sz"] = mean_sz;
-        data["sigma_sx"] = sigma_sx;
-        data["sigma_sy"] = sigma_sy;
-        data["sigma_sz"] = sigma_sz;
-
-        return data;
+        RawMoments const raw {
+            x_ms, y_ms, t_ms, px_ms, py_ms, pt_ms,
+            xpx, ypy, tpt,
+            xpt, pxpt, ypt, pypt,
+            xy, xpy, xt, pxy, pxpy, pxt, yt, pyt,
+            sx_ms, sy_ms, sz_ms,
+            mean_x, mean_y, mean_t, mean_px, mean_py, mean_pt,
+            mean_sx, mean_sy, mean_sz,
+            min_x, min_y, min_t, min_px, min_py, min_pt,
+            max_x, max_y, max_t, max_px, max_py, max_pt,
+            charge
+        };
+        return derive_and_assemble(raw, bg, bg2);
     }
 
     std::unordered_map<std::string, amrex::ParticleReal>
@@ -487,185 +591,24 @@ namespace impactx::diagnostics
         amrex::ParticleReal const pxt    = cm(2,5);
         amrex::ParticleReal const yt     = cm(3,5);
         amrex::ParticleReal const pyt    = cm(4,5);
-        // standard deviations of positions
-        amrex::ParticleReal const sig_x = std::sqrt(x_ms);
-        amrex::ParticleReal const sig_y = std::sqrt(y_ms);
-        amrex::ParticleReal const sig_t = std::sqrt(t_ms);
-        // standard deviations of momenta
-        amrex::ParticleReal const sig_px = std::sqrt(px_ms);
-        amrex::ParticleReal const sig_py = std::sqrt(py_ms);
-        amrex::ParticleReal const sig_pt = std::sqrt(pt_ms);
-        // RMS emittances
-        amrex::ParticleReal const e2_x = x_ms*px_ms-xpx*xpx;
-        amrex::ParticleReal const e2_y = y_ms*py_ms-ypy*ypy;
-        amrex::ParticleReal const e2_t = t_ms*pt_ms-tpt*tpt;
-        amrex::ParticleReal const emittance_x = (e2_x > 0.0)? std::sqrt(e2_x) : 0.0_prt;
-        amrex::ParticleReal const emittance_y = (e2_y > 0.0)? std::sqrt(e2_y) : 0.0_prt;
-        amrex::ParticleReal const emittance_t = (e2_t > 0.0)? std::sqrt(e2_t) : 0.0_prt;
-        // Dispersion and dispersive beam moments
-        amrex::ParticleReal const dispersion_x = ((pt_ms > 0.0) ? (- xpt / pt_ms) : 0.0_prt);
-        amrex::ParticleReal const dispersion_px = ((pt_ms > 0.0) ? (- pxpt / pt_ms) : 0.0_prt);
-        amrex::ParticleReal const dispersion_y = ((pt_ms > 0.0) ? (- ypt / pt_ms) : 0.0_prt);
-        amrex::ParticleReal const dispersion_py = ((pt_ms > 0.0) ? (- pypt / pt_ms) : 0.0_prt);
-        amrex::ParticleReal const x_msd = x_ms - pt_ms*dispersion_x*dispersion_x;
-        amrex::ParticleReal const px_msd = px_ms - pt_ms*dispersion_px*dispersion_px;
-        amrex::ParticleReal const xpx_d = xpx - pt_ms*dispersion_x*dispersion_px;
-        amrex::ParticleReal const emittance_xd = std::sqrt(x_msd*px_msd-xpx_d*xpx_d);
-        amrex::ParticleReal const y_msd = y_ms - pt_ms*dispersion_y*dispersion_y;
-        amrex::ParticleReal const py_msd = py_ms - pt_ms*dispersion_py*dispersion_py;
-        amrex::ParticleReal const ypy_d = ypy - pt_ms*dispersion_y*dispersion_py;
-        amrex::ParticleReal const emittance_yd = std::sqrt(y_msd*py_msd-ypy_d*ypy_d);
-        // Courant-Snyder (Twiss) beta-function
-        amrex::ParticleReal const beta_x = x_msd / emittance_xd;
-        amrex::ParticleReal const beta_y = y_msd / emittance_yd;
-        amrex::ParticleReal const beta_t = t_ms / emittance_t;
-        // Courant-Snyder (Twiss) alpha
-        amrex::ParticleReal const alpha_x = - xpx_d / emittance_xd;
-        amrex::ParticleReal const alpha_y = - ypy_d / emittance_yd;
-        amrex::ParticleReal const alpha_t = - tpt / emittance_t;
-
-        // Calculate normalized emittances
-        amrex::ParticleReal emittance_xn = emittance_x * bg;
-        amrex::ParticleReal emittance_yn = emittance_y * bg;
-        amrex::ParticleReal emittance_tn = emittance_t * bg;
-
-        // Determine whether to calculate eigenemittances, and initialize
-        amrex::ParmParse pp_diag("diag");
-        bool compute_eigenemittances = false;
-        pp_diag.queryAdd("eigenemittances", compute_eigenemittances);
-        amrex::ParticleReal emittance_1 = emittance_xn;
-        amrex::ParticleReal emittance_2 = emittance_yn;
-        amrex::ParticleReal emittance_3 = emittance_tn;
-
-        if (compute_eigenemittances) {
-           // Store the covariance matrix in dynamical variables:
-           amrex::SmallMatrix<amrex::ParticleReal, 6, 6, amrex::Order::F, 1> Sigma;
-           Sigma(1,1) = x_ms;
-           Sigma(1,2) = xpx * bg;
-           Sigma(1,3) = xy;
-           Sigma(1,4) = xpy * bg;
-           Sigma(1,5) = xt;
-           Sigma(1,6) = xpt * bg;
-           Sigma(2,1) = xpx * bg;
-           Sigma(2,2) = px_ms * bg2;
-           Sigma(2,3) = pxy * bg;
-           Sigma(2,4) = pxpy * bg2;
-           Sigma(2,5) = pxt * bg;
-           Sigma(2,6) = pxpt * bg2;
-           Sigma(3,1) = xy;
-           Sigma(3,2) = pxy * bg;
-           Sigma(3,3) = y_ms;
-           Sigma(3,4) = ypy * bg;
-           Sigma(3,5) = yt;
-           Sigma(3,6) = ypt * bg;
-           Sigma(4,1) = xpy * bg;
-           Sigma(4,2) = pxpy * bg2;
-           Sigma(4,3) = ypy * bg;
-           Sigma(4,4) = py_ms * bg2;
-           Sigma(4,5) = pyt * bg;
-           Sigma(4,6) = pypt * bg2;
-           Sigma(5,1) = xt;
-           Sigma(5,2) = pxt * bg;
-           Sigma(5,3) = yt;
-           Sigma(5,4) = pyt * bg;
-           Sigma(5,5) = t_ms;
-           Sigma(5,6) = tpt * bg;
-           Sigma(6,1) = xpt * bg;
-           Sigma(6,2) = pxpt * bg2;
-           Sigma(6,3) = ypt * bg;
-           Sigma(6,4) = pypt * bg2;
-           Sigma(6,5) = tpt * bg;
-           Sigma(6,6) = pt_ms * bg2;
-           // Calculate eigenemittances
-           std::tuple<amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal> emittances = Eigenemittances(Sigma);
-           emittance_1 = std::get<0>(emittances);
-           emittance_2 = std::get<1>(emittances);
-           emittance_3 = std::get<2>(emittances);
-        }
-
         auto const nan = std::numeric_limits<amrex::ParticleReal>::quiet_NaN();
 
-        std::unordered_map<std::string, amrex::ParticleReal> data;
-        data["mean_x"] = 0.0_prt;
-        data["min_x"] = nan;
-        data["max_x"] = nan;
-        data["mean_y"] = 0.0_prt;
-        data["min_y"] = nan;
-        data["max_y"] = nan;
-        data["mean_t"] = 0.0_prt;
-        data["min_t"] = nan;
-        data["max_t"] = nan;
-        data["sigma_x"] = sig_x;
-        data["sigma_y"] = sig_y;
-        data["sigma_t"] = sig_t;
-        data["mean_px"] = 0.0_prt;
-        data["min_px"] = nan;
-        data["max_px"] = nan;
-        data["mean_py"] = 0.0_prt;
-        data["min_py"] = nan;
-        data["max_py"] = nan;
-        data["mean_pt"] = 0.0_prt;
-        data["min_pt"] = nan;
-        data["max_pt"] = nan;
-        data["sigma_px"] = sig_px;
-        data["sigma_py"] = sig_py;
-        data["sigma_pt"] = sig_pt;
-        // start deprecated attributes
-        data["x_mean"] = 0.0_prt;
-        data["x_min"] = nan;
-        data["x_max"] = nan;
-        data["y_mean"] = 0.0_prt;
-        data["y_min"] = nan;
-        data["y_max"] = nan;
-        data["t_mean"] = 0.0_prt;
-        data["t_min"] = nan;
-        data["t_max"] = nan;
-        data["sig_x"] = sig_x;
-        data["sig_y"] = sig_y;
-        data["sig_t"] = sig_t;
-        data["px_mean"] = 0.0_prt;
-        data["px_min"] = nan;
-        data["px_max"] = nan;
-        data["py_mean"] = 0.0_prt;
-        data["py_min"] = nan;
-        data["py_max"] = nan;
-        data["pt_mean"] = 0.0_prt;
-        data["pt_min"] = nan;
-        data["pt_max"] = nan;
-        data["sig_px"] = sig_px;
-        data["sig_py"] = sig_py;
-        data["sig_pt"] = sig_pt;
-        // end deprecated attributes
-        data["emittance_x"] = emittance_x;
-        data["emittance_y"] = emittance_y;
-        data["emittance_t"] = emittance_t;
-        data["alpha_x"] = alpha_x;
-        data["alpha_y"] = alpha_y;
-        data["alpha_t"] = alpha_t;
-        data["beta_x"] = beta_x;
-        data["beta_y"] = beta_y;
-        data["beta_t"] = beta_t;
-        data["dispersion_x"] = dispersion_x;
-        data["dispersion_px"] = dispersion_px;
-        data["dispersion_y"] = dispersion_y;
-        data["dispersion_py"] = dispersion_py;
-        data["emittance_xn"] = emittance_xn;
-        data["emittance_yn"] = emittance_yn;
-        data["emittance_tn"] = emittance_tn;
-        if (compute_eigenemittances) {
-           data["emittance_1"] = emittance_1;
-           data["emittance_2"] = emittance_2;
-           data["emittance_3"] = emittance_3;
-        }
-        data["charge_C"] = nan;  // TODO: with space charge
-        data["mean_sx"] = nan;
-        data["mean_sy"] = nan;
-        data["mean_sz"] = nan;
-        data["sigma_sx"] = nan;
-        data["sigma_sy"] = nan;
-        data["sigma_sz"] = nan;
-
-        return data;
+        // A covariance matrix carries only the (central) second moments. The
+        // means are zero by construction; per-coordinate extremes, spin moments
+        // and beam charge are unavailable and reported as NaN (as before).
+        RawMoments const raw {
+            x_ms, y_ms, t_ms, px_ms, py_ms, pt_ms,
+            xpx, ypy, tpt,
+            xpt, pxpt, ypt, pypt,
+            xy, xpy, xt, pxy, pxpy, pxt, yt, pyt,
+            nan, nan, nan,
+            0.0_prt, 0.0_prt, 0.0_prt, 0.0_prt, 0.0_prt, 0.0_prt,
+            nan, nan, nan,
+            nan, nan, nan, nan, nan, nan,
+            nan, nan, nan, nan, nan, nan,
+            nan  // charge_C (TODO: with space charge)
+        };
+        return derive_and_assemble(raw, bg, bg2);
     }
 
 } // namespace impactx::diagnostics

--- a/src/diagnostics/ReducedBeamCharacteristics.cpp
+++ b/src/diagnostics/ReducedBeamCharacteristics.cpp
@@ -15,6 +15,7 @@
 #include "particles/CovarianceMatrix.H"
 #include "EmittanceInvariants.H"
 
+#include <AMReX_Array.H>                // for GpuArray
 #include <AMReX_BLProfiler.H>           // for TinyProfiler
 #include <AMReX_GpuDevice.H>            // for dtoh_memcpy
 #include <AMReX_GpuQualifiers.H>        // for AMREX_GPU_DEVICE
@@ -301,6 +302,328 @@ namespace
 
         return data;
     }
+
+    // -----------------------------------------------------------------------
+    // Selective single-pass reduction. One templated kernel body generates the
+    // reduction for every profile; a profile is the ordered list of weighted
+    // power sums (and the coordinates to min/max) needed to recover a requested
+    // subset of moments. Lighter profiles read fewer SoA arrays and reduce fewer
+    // values. The full profile reproduces the previous reduction bit-for-bit.
+    // -----------------------------------------------------------------------
+
+    //! phase-space and spin coordinate identifiers; `none` is a
+    //! multiplicative-identity placeholder used by the generic slot formula
+    enum class Coord : int { x = 0, y, t, px, py, pt, sx, sy, sz, none };
+
+    //! reduction profiles, ordered by increasing coverage; each is a superset of
+    //! the previous: Positions < Sizes < Twiss < Full
+    enum class Profile : int { Positions = 0, Sizes, Twiss, Full };
+
+    //! one reduced (weighted) sum slot: sum over particles of w * dev(a) * dev(b),
+    //! with dev(u) = u - shift_u and dev(none) = 1. Hence {none,none} = Sum(w),
+    //! {a,none} = first moment of a, {a,b} = second moment of a and b.
+    struct SumSpec { Coord a; Coord b; };
+
+    //! Full has 1 + 6 first + 6 diagonal + 3 same-plane + 4 dispersive + 8
+    //! cross-plane = 28 phase-space sums; the spin toggle adds 3 + 3 = 6.
+    static constexpr int max_sums = 34;
+    static constexpr int max_minmax = 6;
+
+    struct ProfileDesc
+    {
+        SumSpec sums[max_sums] {};
+        int n_sums = 0;
+        Coord minmax[max_minmax] {};
+        int n_minmax = 0;
+    };
+
+    /** Compile-time description of a reduction profile: the ordered list of
+     *  weighted-sum slots and the coordinates to reduce min/max over.
+     */
+    constexpr ProfileDesc make_desc (Profile const profile, bool const spin, bool const minmax)
+    {
+        ProfileDesc d {};
+        auto add_sum = [&d] (Coord const a, Coord const b)
+        {
+            d.sums[d.n_sums] = SumSpec{a, b};
+            ++d.n_sums;
+        };
+
+        // Sum(w)
+        add_sum(Coord::none, Coord::none);
+
+        // positions: first moments, then diagonal second moments
+        Coord const pos[3] = {Coord::x, Coord::y, Coord::t};
+        for (Coord const c : pos) { add_sum(c, Coord::none); }
+        for (Coord const c : pos) { add_sum(c, c); }
+
+        // momenta (Sizes and up)
+        if (profile >= Profile::Sizes)
+        {
+            Coord const mom[3] = {Coord::px, Coord::py, Coord::pt};
+            for (Coord const c : mom) { add_sum(c, Coord::none); }
+            for (Coord const c : mom) { add_sum(c, c); }
+        }
+
+        // correlations for emittance, dispersion and (dispersion-corrected) Twiss
+        if (profile >= Profile::Twiss)
+        {
+            // same-plane
+            add_sum(Coord::x, Coord::px);
+            add_sum(Coord::y, Coord::py);
+            add_sum(Coord::t, Coord::pt);
+            // dispersive
+            add_sum(Coord::x, Coord::pt);
+            add_sum(Coord::px, Coord::pt);
+            add_sum(Coord::y, Coord::pt);
+            add_sum(Coord::py, Coord::pt);
+        }
+
+        // cross-plane correlations (only eigenemittances consume these)
+        if (profile >= Profile::Full)
+        {
+            add_sum(Coord::x, Coord::y);
+            add_sum(Coord::x, Coord::py);
+            add_sum(Coord::x, Coord::t);
+            add_sum(Coord::px, Coord::y);
+            add_sum(Coord::px, Coord::py);
+            add_sum(Coord::px, Coord::t);
+            add_sum(Coord::y, Coord::t);
+            add_sum(Coord::py, Coord::t);
+        }
+
+        // spin first and diagonal second moments
+        if (spin)
+        {
+            add_sum(Coord::sx, Coord::none);
+            add_sum(Coord::sy, Coord::none);
+            add_sum(Coord::sz, Coord::none);
+            add_sum(Coord::sx, Coord::sx);
+            add_sum(Coord::sy, Coord::sy);
+            add_sum(Coord::sz, Coord::sz);
+        }
+
+        // min/max over the coordinates the profile already loads
+        if (minmax)
+        {
+            d.minmax[d.n_minmax++] = Coord::x;
+            d.minmax[d.n_minmax++] = Coord::y;
+            d.minmax[d.n_minmax++] = Coord::t;
+            if (profile >= Profile::Sizes)
+            {
+                d.minmax[d.n_minmax++] = Coord::px;
+                d.minmax[d.n_minmax++] = Coord::py;
+                d.minmax[d.n_minmax++] = Coord::pt;
+            }
+        }
+
+        return d;
+    }
+
+    /** SoA component index for a coordinate (compile-time). */
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    constexpr int soa_index (Coord const c)
+    {
+        switch (c)
+        {
+            case Coord::x:  return RealSoA::x;
+            case Coord::y:  return RealSoA::y;
+            case Coord::t:  return RealSoA::t;
+            case Coord::px: return RealSoA::px;
+            case Coord::py: return RealSoA::py;
+            case Coord::pt: return RealSoA::pt;
+            case Coord::sx: return RealSoA::sx;
+            case Coord::sy: return RealSoA::sy;
+            case Coord::sz: return RealSoA::sz;
+            case Coord::none: return RealSoA::x;  // never dereferenced (guarded by deviation)
+        }
+        return RealSoA::x;
+    }
+
+    /** Shifted deviation dev(C) = (C - shift_C), or the exact constant 1 for
+     *  Coord::none so that a first-moment slot {a,none} is dev(a)*1*w and Sum(w)
+     *  is 1*1*w. Multiplying by 1 leaves the value bit-identical.
+     */
+    template <Coord C, typename PType>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    amrex::ParticleReal deviation (
+        PType const & p,
+        amrex::GpuArray<amrex::ParticleReal, 9> const & shift)
+    {
+        if constexpr (C == Coord::none)
+        {
+            return amrex::ParticleReal(1);
+        }
+        else
+        {
+            return p.rdata(soa_index(C)) - shift[static_cast<int>(C)];
+        }
+    }
+
+    /** Reduce a single pass over the particles for the given profile and recover
+     *  the central moments into a RawMoments. The full profile
+     *  (Profile::Full, spin, minmax) reproduces the previous hand-written
+     *  reduction bit-for-bit: every slot is w*dev(a)*dev(b) in the same
+     *  multiplication order, and the parallel-axis recovery keeps the same order
+     *  of operations, keyed off the SumSpec instead of hard-coded indices.
+     */
+    template <Profile P, bool Spin, bool MinMax>
+    RawMoments reduce_and_recover (
+        ImpactXParticleContainer const & pc,
+        std::array<amrex::ParticleReal, 9> const & shift,
+        amrex::ParticleReal const q_C)
+    {
+        using namespace amrex::literals; // for _prt
+        using PType = typename ImpactXParticleContainer::SuperParticleType;
+
+        static constexpr ProfileDesc desc = make_desc(P, Spin, MinMax);
+        static constexpr int n_sum = desc.n_sums;
+        static constexpr int n_mm  = desc.n_minmax;
+
+        amrex::TypeMultiplier<amrex::ReduceOps,
+            amrex::ReduceOpSum[n_sum],
+            amrex::ReduceOpMin[n_mm],
+            amrex::ReduceOpMax[n_mm]
+        > reduce_ops;
+        using ReducedDataT = amrex::TypeMultiplier<amrex::ReduceData,
+            amrex::ParticleReal[n_sum + 2 * n_mm]>;
+
+        amrex::GpuArray<amrex::ParticleReal, 9> shift_d {};
+        for (int i = 0; i < 9; ++i) { shift_d[i] = shift[i]; }
+
+        auto r = amrex::ParticleReduce<ReducedDataT>(
+            pc,
+            [=] AMREX_GPU_DEVICE (PType const & p) noexcept -> typename ReducedDataT::Type
+            {
+                amrex::ParticleReal const p_w = p.rdata(RealSoA::w);
+
+                typename ReducedDataT::Type out;
+                amrex::constexpr_for<0, n_sum>([&] (auto i)
+                {
+                    constexpr SumSpec s = desc.sums[i];
+                    amrex::get<i>(out) =
+                        deviation<s.a>(p, shift_d) * deviation<s.b>(p, shift_d) * p_w;
+                });
+                if constexpr (MinMax)
+                {
+                    amrex::constexpr_for<0, n_mm>([&] (auto j)
+                    {
+                        constexpr Coord c = desc.minmax[j];
+                        amrex::ParticleReal const v = p.rdata(soa_index(c));
+                        amrex::get<n_sum + j>(out) = v;
+                        amrex::get<n_sum + n_mm + j>(out) = v;
+                    });
+                }
+                return out;
+            },
+            reduce_ops
+        );
+
+        // extract this rank's partial sums, minima and maxima
+        std::array<amrex::ParticleReal, n_sum> values_sum {};
+        amrex::constexpr_for<0, n_sum>([&] (auto i) { values_sum[i] = amrex::get<i>(r); });
+        [[maybe_unused]] std::array<amrex::ParticleReal, (MinMax ? max_minmax : 1)> values_min {};
+        [[maybe_unused]] std::array<amrex::ParticleReal, (MinMax ? max_minmax : 1)> values_max {};
+        if constexpr (MinMax)
+        {
+            amrex::constexpr_for<0, n_mm>([&] (auto j)
+            {
+                values_min[j] = amrex::get<n_sum + j>(r);
+                values_max[j] = amrex::get<n_sum + n_mm + j>(r);
+            });
+        }
+
+        // reduce across MPI ranks (allreduce)
+        amrex::ParallelAllReduce::Sum(
+            values_sum.data(), n_sum, amrex::ParallelDescriptor::Communicator());
+        if constexpr (MinMax)
+        {
+            amrex::ParallelAllReduce::Min(
+                values_min.data(), n_mm, amrex::ParallelDescriptor::Communicator());
+            amrex::ParallelAllReduce::Max(
+                values_max.data(), n_mm, amrex::ParallelDescriptor::Communicator());
+        }
+
+        // Recover central moments via the parallel-axis theorem. Each slot is an
+        // independent sum, so slot order does not affect the results; the
+        // recovery is keyed off the SumSpec, matching the previous arithmetic.
+        amrex::ParticleReal w_sum = 0.0_prt;
+        amrex::constexpr_for<0, n_sum>([&] (auto i)
+        {
+            constexpr SumSpec s = desc.sums[i];
+            if constexpr (s.a == Coord::none && s.b == Coord::none) { w_sum = values_sum[i]; }
+        });
+        amrex::ParticleReal dmean[9] = {};
+        amrex::constexpr_for<0, n_sum>([&] (auto i)
+        {
+            constexpr SumSpec s = desc.sums[i];
+            if constexpr (s.a != Coord::none && s.b == Coord::none)
+            {
+                dmean[static_cast<int>(s.a)] = values_sum[i] / w_sum;
+            }
+        });
+        amrex::ParticleReal cov[9][9] = {};
+        amrex::constexpr_for<0, n_sum>([&] (auto i)
+        {
+            constexpr SumSpec s = desc.sums[i];
+            if constexpr (s.a != Coord::none && s.b != Coord::none)
+            {
+                cov[static_cast<int>(s.a)][static_cast<int>(s.b)] =
+                    values_sum[i] / w_sum
+                    - dmean[static_cast<int>(s.a)] * dmean[static_cast<int>(s.b)];
+            }
+        });
+
+        auto const nan = std::numeric_limits<amrex::ParticleReal>::quiet_NaN();
+        amrex::ParticleReal cmin[6] = {nan, nan, nan, nan, nan, nan};
+        amrex::ParticleReal cmax[6] = {nan, nan, nan, nan, nan, nan};
+        if constexpr (MinMax)
+        {
+            amrex::constexpr_for<0, n_mm>([&] (auto j)
+            {
+                constexpr int c = static_cast<int>(desc.minmax[j]);
+                cmin[c] = values_min[j];
+                cmax[c] = values_max[j];
+            });
+        }
+
+        // map into the shared RawMoments layout
+        constexpr int X  = static_cast<int>(Coord::x);
+        constexpr int Y  = static_cast<int>(Coord::y);
+        constexpr int T  = static_cast<int>(Coord::t);
+        constexpr int PX = static_cast<int>(Coord::px);
+        constexpr int PY = static_cast<int>(Coord::py);
+        constexpr int PT = static_cast<int>(Coord::pt);
+        constexpr int SX = static_cast<int>(Coord::sx);
+        constexpr int SY = static_cast<int>(Coord::sy);
+        constexpr int SZ = static_cast<int>(Coord::sz);
+
+        RawMoments m {};
+        m.x_ms  = cov[X][X];   m.y_ms  = cov[Y][Y];   m.t_ms  = cov[T][T];
+        m.px_ms = cov[PX][PX]; m.py_ms = cov[PY][PY]; m.pt_ms = cov[PT][PT];
+        m.xpx = cov[X][PX]; m.ypy = cov[Y][PY]; m.tpt = cov[T][PT];
+        m.xpt = cov[X][PT]; m.pxpt = cov[PX][PT]; m.ypt = cov[Y][PT]; m.pypt = cov[PY][PT];
+        m.xy = cov[X][Y]; m.xpy = cov[X][PY]; m.xt = cov[X][T];
+        m.pxy = cov[PX][Y]; m.pxpy = cov[PX][PY]; m.pxt = cov[PX][T];
+        m.yt = cov[Y][T]; m.pyt = cov[PY][T];
+        m.sx_ms = cov[SX][SX]; m.sy_ms = cov[SY][SY]; m.sz_ms = cov[SZ][SZ];
+        m.mean_x  = shift[X]  + dmean[X];
+        m.mean_y  = shift[Y]  + dmean[Y];
+        m.mean_t  = shift[T]  + dmean[T];
+        m.mean_px = shift[PX] + dmean[PX];
+        m.mean_py = shift[PY] + dmean[PY];
+        m.mean_pt = shift[PT] + dmean[PT];
+        m.mean_sx = shift[SX] + dmean[SX];
+        m.mean_sy = shift[SY] + dmean[SY];
+        m.mean_sz = shift[SZ] + dmean[SZ];
+        m.min_x = cmin[X]; m.min_y = cmin[Y]; m.min_t = cmin[T];
+        m.min_px = cmin[PX]; m.min_py = cmin[PY]; m.min_pt = cmin[PT];
+        m.max_x = cmax[X]; m.max_y = cmax[Y]; m.max_t = cmax[T];
+        m.max_px = cmax[PX]; m.max_py = cmax[PY]; m.max_pt = cmax[PT];
+        m.charge = q_C * w_sum;
+
+        return m;
+    }
 } // namespace
 
     std::unordered_map<std::string, amrex::ParticleReal>
@@ -317,9 +640,6 @@ namespace
         // reference particle relativistic beta*gamma
         amrex::ParticleReal const bg = ref_part.beta_gamma();
         amrex::ParticleReal const bg2 = bg*bg;
-
-        // preparing access to particle data: SoA
-        using PType = typename ImpactXParticleContainer::SuperParticleType;
 
         /* The reduced beam characteristics are computed in a single pass over the
          * particles from raw (weighted) power sums. For beams that are off-center
@@ -373,188 +693,11 @@ namespace
                 amrex::ParallelDescriptor::Bcast(shift.data(), shift.size(), src_rank);
             }
         }
-        amrex::ParticleReal const shift_x  = shift[0];
-        amrex::ParticleReal const shift_y  = shift[1];
-        amrex::ParticleReal const shift_t  = shift[2];
-        amrex::ParticleReal const shift_px = shift[3];
-        amrex::ParticleReal const shift_py = shift[4];
-        amrex::ParticleReal const shift_pt = shift[5];
-        amrex::ParticleReal const shift_sx = shift[6];
-        amrex::ParticleReal const shift_sy = shift[7];
-        amrex::ParticleReal const shift_sz = shift[8];
-
-        /* The variables below need to be static to work around an MSVC bug
-         * https://stackoverflow.com/questions/55136414/constexpr-variable-captured-inside-lambda-loses-its-constexpr-ness
-         */
-        // numbers of same-type reduction operations, fused into a single pass:
-        //   Sum(w), 9 weighted first moments, 24 weighted (shifted) second moments,
-        //   and the min/max of the 6 phase-space coordinates.
-        static constexpr std::size_t num_sum = 34;
-        static constexpr std::size_t num_min = 6;
-        static constexpr std::size_t num_max = 6;
-
-        amrex::TypeMultiplier<amrex::ReduceOps,
-            amrex::ReduceOpSum[num_sum],  // Sum(w) + first and second (shifted) moments
-            amrex::ReduceOpMin[num_min],  // min of x, y, t, px, py, pt
-            amrex::ReduceOpMax[num_max]   // max of x, y, t, px, py, pt
-        > reduce_ops;
-        using ReducedDataT = amrex::TypeMultiplier<amrex::ReduceData, amrex::ParticleReal[num_sum + num_min + num_max]>;
-
-        auto r = amrex::ParticleReduce<ReducedDataT>(
-            pc,
-            [=] AMREX_GPU_DEVICE(const PType& p) noexcept -> ReducedDataT::Type
-            {
-                // access SoA particle position, momentum, spin data and weighting
-                const amrex::ParticleReal p_w = p.rdata(RealSoA::w);
-                const amrex::ParticleReal p_x = p.rdata(RealSoA::x);
-                const amrex::ParticleReal p_y = p.rdata(RealSoA::y);
-                const amrex::ParticleReal p_t = p.rdata(RealSoA::t);
-                const amrex::ParticleReal p_px = p.rdata(RealSoA::px);
-                const amrex::ParticleReal p_py = p.rdata(RealSoA::py);
-                const amrex::ParticleReal p_pt = p.rdata(RealSoA::pt);
-                const amrex::ParticleReal p_sx = p.rdata(RealSoA::sx);
-                const amrex::ParticleReal p_sy = p.rdata(RealSoA::sy);
-                const amrex::ParticleReal p_sz = p.rdata(RealSoA::sz);
-
-                // deviations from the shift: O(rms) rather than O(coordinate), which
-                // keeps the (weighted) second moments below well-conditioned
-                const amrex::ParticleReal dx  = p_x  - shift_x;
-                const amrex::ParticleReal dy  = p_y  - shift_y;
-                const amrex::ParticleReal dt  = p_t  - shift_t;
-                const amrex::ParticleReal dpx = p_px - shift_px;
-                const amrex::ParticleReal dpy = p_py - shift_py;
-                const amrex::ParticleReal dpt = p_pt - shift_pt;
-                const amrex::ParticleReal dsx = p_sx - shift_sx;
-                const amrex::ParticleReal dsy = p_sy - shift_sy;
-                const amrex::ParticleReal dsz = p_sz - shift_sz;
-
-                return {
-                    // Sum(w)
-                    p_w,
-                    // weighted first moments (shifted): x, y, t, px, py, pt, sx, sy, sz
-                    dx*p_w, dy*p_w, dt*p_w, dpx*p_w, dpy*p_w, dpt*p_w,
-                    dsx*p_w, dsy*p_w, dsz*p_w,
-                    // weighted second moments (shifted): diagonal x, y, t, px, py, pt
-                    dx*dx*p_w, dy*dy*p_w, dt*dt*p_w, dpx*dpx*p_w, dpy*dpy*p_w, dpt*dpt*p_w,
-                    // same-plane correlations: xpx, ypy, tpt
-                    dx*dpx*p_w, dy*dpy*p_w, dt*dpt*p_w,
-                    // dispersive correlations: xpt, pxpt, ypt, pypt
-                    dx*dpt*p_w, dpx*dpt*p_w, dy*dpt*p_w, dpy*dpt*p_w,
-                    // cross-plane correlations: xy, xpy, xt, pxy, pxpy, pxt, yt, pyt
-                    dx*dy*p_w, dx*dpy*p_w, dx*dt*p_w, dpx*dy*p_w, dpx*dpy*p_w, dpx*dt*p_w, dy*dt*p_w, dpy*dt*p_w,
-                    // spin second moments (diagonal): sx, sy, sz
-                    dsx*dsx*p_w, dsy*dsy*p_w, dsz*dsz*p_w,
-                    // min of x, y, t, px, py, pt
-                    p_x, p_y, p_t, p_px, p_py, p_pt,
-                    // max of x, y, t, px, py, pt
-                    p_x, p_y, p_t, p_px, p_py, p_pt
-                };
-            },
-            reduce_ops
-        );
-
-        // extract this rank's partial sums, minima and maxima
-        std::vector<amrex::ParticleReal> values_sum(num_sum);
-        amrex::constexpr_for<0, num_sum> ([&](auto i) {
-            values_sum[i] = amrex::get<i>(r);
-        });
-        std::vector<amrex::ParticleReal> values_min(num_min);
-        amrex::constexpr_for<0, num_min> ([&](auto i) {
-            constexpr std::size_t idx = i + num_sum;
-            values_min[i] = amrex::get<idx>(r);
-        });
-        std::vector<amrex::ParticleReal> values_max(num_max);
-        amrex::constexpr_for<0, num_max> ([&](auto i) {
-            constexpr std::size_t idx = i + num_sum + num_min;
-            values_max[i] = amrex::get<idx>(r);
-        });
-
-        // reduce across MPI ranks (allreduce)
-        amrex::ParallelAllReduce::Sum(
-            values_sum.data(), values_sum.size(), amrex::ParallelDescriptor::Communicator());
-        amrex::ParallelAllReduce::Min(
-            values_min.data(), values_min.size(), amrex::ParallelDescriptor::Communicator());
-        amrex::ParallelAllReduce::Max(
-            values_max.data(), values_max.size(), amrex::ParallelDescriptor::Communicator());
-
-        // Recover the beam moments from the raw (shifted) power sums via the
-        // parallel-axis theorem. The shift keeps every sum at the O(rms^2) scale,
-        // so the central moments below stay well-conditioned even in single precision.
-        amrex::ParticleReal const w_sum = values_sum[0];
-        // shifted means: <u - shift_u>
-        amrex::ParticleReal const dmean_x  = values_sum[1] / w_sum;
-        amrex::ParticleReal const dmean_y  = values_sum[2] / w_sum;
-        amrex::ParticleReal const dmean_t  = values_sum[3] / w_sum;
-        amrex::ParticleReal const dmean_px = values_sum[4] / w_sum;
-        amrex::ParticleReal const dmean_py = values_sum[5] / w_sum;
-        amrex::ParticleReal const dmean_pt = values_sum[6] / w_sum;
-        amrex::ParticleReal const dmean_sx = values_sum[7] / w_sum;
-        amrex::ParticleReal const dmean_sy = values_sum[8] / w_sum;
-        amrex::ParticleReal const dmean_sz = values_sum[9] / w_sum;
-        // means
-        amrex::ParticleReal const mean_x  = shift_x  + dmean_x;
-        amrex::ParticleReal const mean_y  = shift_y  + dmean_y;
-        amrex::ParticleReal const mean_t  = shift_t  + dmean_t;
-        amrex::ParticleReal const mean_px = shift_px + dmean_px;
-        amrex::ParticleReal const mean_py = shift_py + dmean_py;
-        amrex::ParticleReal const mean_pt = shift_pt + dmean_pt;
-        amrex::ParticleReal const mean_sx = shift_sx + dmean_sx;
-        amrex::ParticleReal const mean_sy = shift_sy + dmean_sy;
-        amrex::ParticleReal const mean_sz = shift_sz + dmean_sz;
-        // minimum values
-        amrex::ParticleReal const min_x = values_min.at(0);
-        amrex::ParticleReal const min_y = values_min.at(1);
-        amrex::ParticleReal const min_t = values_min.at(2);
-        amrex::ParticleReal const min_px = values_min.at(3);
-        amrex::ParticleReal const min_py = values_min.at(4);
-        amrex::ParticleReal const min_pt = values_min.at(5);
-        // maximum values
-        amrex::ParticleReal const max_x = values_max.at(0);
-        amrex::ParticleReal const max_y = values_max.at(1);
-        amrex::ParticleReal const max_t = values_max.at(2);
-        amrex::ParticleReal const max_px = values_max.at(3);
-        amrex::ParticleReal const max_py = values_max.at(4);
-        amrex::ParticleReal const max_pt = values_max.at(5);
-        // mean square and correlation values (central moments via parallel-axis theorem)
-        amrex::ParticleReal const x_ms   = values_sum[10] / w_sum - dmean_x  * dmean_x;
-        amrex::ParticleReal const y_ms   = values_sum[11] / w_sum - dmean_y  * dmean_y;
-        amrex::ParticleReal const t_ms   = values_sum[12] / w_sum - dmean_t  * dmean_t;
-        amrex::ParticleReal const px_ms  = values_sum[13] / w_sum - dmean_px * dmean_px;
-        amrex::ParticleReal const py_ms  = values_sum[14] / w_sum - dmean_py * dmean_py;
-        amrex::ParticleReal const pt_ms  = values_sum[15] / w_sum - dmean_pt * dmean_pt;
-        amrex::ParticleReal const xpx    = values_sum[16] / w_sum - dmean_x  * dmean_px;
-        amrex::ParticleReal const ypy    = values_sum[17] / w_sum - dmean_y  * dmean_py;
-        amrex::ParticleReal const tpt    = values_sum[18] / w_sum - dmean_t  * dmean_pt;
-        amrex::ParticleReal const xpt    = values_sum[19] / w_sum - dmean_x  * dmean_pt;
-        amrex::ParticleReal const pxpt   = values_sum[20] / w_sum - dmean_px * dmean_pt;
-        amrex::ParticleReal const ypt    = values_sum[21] / w_sum - dmean_y  * dmean_pt;
-        amrex::ParticleReal const pypt   = values_sum[22] / w_sum - dmean_py * dmean_pt;
-        amrex::ParticleReal const xy     = values_sum[23] / w_sum - dmean_x  * dmean_y;
-        amrex::ParticleReal const xpy    = values_sum[24] / w_sum - dmean_x  * dmean_py;
-        amrex::ParticleReal const xt     = values_sum[25] / w_sum - dmean_x  * dmean_t;
-        amrex::ParticleReal const pxy    = values_sum[26] / w_sum - dmean_px * dmean_y;
-        amrex::ParticleReal const pxpy   = values_sum[27] / w_sum - dmean_px * dmean_py;
-        amrex::ParticleReal const pxt    = values_sum[28] / w_sum - dmean_px * dmean_t;
-        amrex::ParticleReal const yt     = values_sum[29] / w_sum - dmean_y  * dmean_t;
-        amrex::ParticleReal const pyt    = values_sum[30] / w_sum - dmean_py * dmean_t;
-        amrex::ParticleReal const sx_ms  = values_sum[31] / w_sum - dmean_sx * dmean_sx;
-        amrex::ParticleReal const sy_ms  = values_sum[32] / w_sum - dmean_sy * dmean_sy;
-        amrex::ParticleReal const sz_ms  = values_sum[33] / w_sum - dmean_sz * dmean_sz;
-        // beam charge
-        amrex::ParticleReal const charge = q_C * w_sum;
-
-        RawMoments const raw {
-            x_ms, y_ms, t_ms, px_ms, py_ms, pt_ms,
-            xpx, ypy, tpt,
-            xpt, pxpt, ypt, pypt,
-            xy, xpy, xt, pxy, pxpy, pxt, yt, pyt,
-            sx_ms, sy_ms, sz_ms,
-            mean_x, mean_y, mean_t, mean_px, mean_py, mean_pt,
-            mean_sx, mean_sy, mean_sz,
-            min_x, min_y, min_t, min_px, min_py, min_pt,
-            max_x, max_y, max_t, max_px, max_py, max_pt,
-            charge
-        };
+        // Single-pass reduction of the full moment set. Selective profiles that
+        // read fewer arrays and reduce fewer values are wired up in a later step;
+        // Profile::Full with spin and min/max reproduces the previous result
+        // bit-for-bit.
+        RawMoments const raw = reduce_and_recover<Profile::Full, true, true>(pc, shift, q_C);
         return derive_and_assemble(raw, bg, bg2);
     }
 

--- a/src/diagnostics/ReducedBeamCharacteristics.cpp
+++ b/src/diagnostics/ReducedBeamCharacteristics.cpp
@@ -10,6 +10,7 @@
 
 #include "ReducedBeamCharacteristics.H"
 
+#include "BeamMomentsSelection.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/ReferenceParticle.H"
 #include "particles/CovarianceMatrix.H"
@@ -26,8 +27,12 @@
 #include <AMReX_SmallMatrix.H>          // for SmallMatrix
 #include <AMReX_TypeList.H>             // for TypeMultiplier
 
+#include <algorithm>
 #include <array>
 #include <limits>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 
@@ -61,6 +66,113 @@ namespace
         amrex::ParticleReal charge;
     };
 
+    //! minimal requirement to compute an output key: the smallest profile plus
+    //! whether the spin / min-max / eigenemittance reductions are also needed
+    struct KeyReq { MomentsProfile profile; bool spin; bool minmax; bool eigen; };
+
+    /** Canonicalize a (possibly deprecated) output name. Deprecated aliases
+     *  (e.g. x_mean, sig_x, pt_min) map to their canonical spelling; any other
+     *  name is returned unchanged.
+     */
+    std::string canonicalize (std::string const & key)
+    {
+        static const std::unordered_map<std::string, std::string> aliases = {
+            {"x_mean", "mean_x"}, {"y_mean", "mean_y"}, {"t_mean", "mean_t"},
+            {"px_mean", "mean_px"}, {"py_mean", "mean_py"}, {"pt_mean", "mean_pt"},
+            {"x_min", "min_x"}, {"y_min", "min_y"}, {"t_min", "min_t"},
+            {"px_min", "min_px"}, {"py_min", "min_py"}, {"pt_min", "min_pt"},
+            {"x_max", "max_x"}, {"y_max", "max_y"}, {"t_max", "max_t"},
+            {"px_max", "max_px"}, {"py_max", "max_py"}, {"pt_max", "max_pt"},
+            {"sig_x", "sigma_x"}, {"sig_y", "sigma_y"}, {"sig_t", "sigma_t"},
+            {"sig_px", "sigma_px"}, {"sig_py", "sigma_py"}, {"sig_pt", "sigma_pt"}
+        };
+        auto const it = aliases.find(key);
+        return (it == aliases.end()) ? key : it->second;
+    }
+
+    /** Requirement to compute a canonical output key. Throws std::runtime_error
+     *  for an unknown key (already canonicalized).
+     */
+    KeyReq key_requirement (std::string const & key)
+    {
+        using P = MomentsProfile;
+        static const std::unordered_map<std::string, KeyReq> table = {
+            // Positions: means/sigmas of x, y, t and the beam charge
+            {"mean_x",   {P::Positions, false, false, false}},
+            {"mean_y",   {P::Positions, false, false, false}},
+            {"mean_t",   {P::Positions, false, false, false}},
+            {"sigma_x",  {P::Positions, false, false, false}},
+            {"sigma_y",  {P::Positions, false, false, false}},
+            {"sigma_t",  {P::Positions, false, false, false}},
+            {"charge_C", {P::Positions, false, false, false}},
+            // Sizes: means/sigmas of px, py, pt
+            {"mean_px",  {P::Sizes, false, false, false}},
+            {"mean_py",  {P::Sizes, false, false, false}},
+            {"mean_pt",  {P::Sizes, false, false, false}},
+            {"sigma_px", {P::Sizes, false, false, false}},
+            {"sigma_py", {P::Sizes, false, false, false}},
+            {"sigma_pt", {P::Sizes, false, false, false}},
+            // per-coordinate min/max (min/max of momenta needs the momenta loaded)
+            {"min_x",  {P::Positions, false, true, false}},
+            {"max_x",  {P::Positions, false, true, false}},
+            {"min_y",  {P::Positions, false, true, false}},
+            {"max_y",  {P::Positions, false, true, false}},
+            {"min_t",  {P::Positions, false, true, false}},
+            {"max_t",  {P::Positions, false, true, false}},
+            {"min_px", {P::Sizes, false, true, false}},
+            {"max_px", {P::Sizes, false, true, false}},
+            {"min_py", {P::Sizes, false, true, false}},
+            {"max_py", {P::Sizes, false, true, false}},
+            {"min_pt", {P::Sizes, false, true, false}},
+            {"max_pt", {P::Sizes, false, true, false}},
+            // Twiss: emittances, dispersion and (dispersion-corrected) Twiss
+            {"emittance_x",   {P::Twiss, false, false, false}},
+            {"emittance_y",   {P::Twiss, false, false, false}},
+            {"emittance_t",   {P::Twiss, false, false, false}},
+            {"emittance_xn",  {P::Twiss, false, false, false}},
+            {"emittance_yn",  {P::Twiss, false, false, false}},
+            {"emittance_tn",  {P::Twiss, false, false, false}},
+            {"alpha_x",       {P::Twiss, false, false, false}},
+            {"alpha_y",       {P::Twiss, false, false, false}},
+            {"alpha_t",       {P::Twiss, false, false, false}},
+            {"beta_x",        {P::Twiss, false, false, false}},
+            {"beta_y",        {P::Twiss, false, false, false}},
+            {"beta_t",        {P::Twiss, false, false, false}},
+            {"dispersion_x",  {P::Twiss, false, false, false}},
+            {"dispersion_px", {P::Twiss, false, false, false}},
+            {"dispersion_y",  {P::Twiss, false, false, false}},
+            {"dispersion_py", {P::Twiss, false, false, false}},
+            // eigenemittances need the full 6x6 covariance
+            {"emittance_1", {P::Full, false, false, true}},
+            {"emittance_2", {P::Full, false, false, true}},
+            {"emittance_3", {P::Full, false, false, true}},
+            // spin first and second moments
+            {"mean_sx",  {P::Positions, true, false, false}},
+            {"mean_sy",  {P::Positions, true, false, false}},
+            {"mean_sz",  {P::Positions, true, false, false}},
+            {"sigma_sx", {P::Positions, true, false, false}},
+            {"sigma_sy", {P::Positions, true, false, false}},
+            {"sigma_sz", {P::Positions, true, false, false}}
+        };
+        auto const it = table.find(key);
+        if (it == table.end())
+        {
+            throw std::runtime_error(
+                "reduced beam characteristics: unknown moment name '" + key + "'");
+        }
+        return it->second;
+    }
+
+    /** Whether a key's requirement is satisfied by a selection. */
+    bool key_covered (std::string const & key, MomentsSelection const & sel)
+    {
+        KeyReq const req = key_requirement(canonicalize(key));
+        return static_cast<int>(req.profile) <= static_cast<int>(sel.profile)
+            && (!req.spin   || sel.spin)
+            && (!req.minmax || sel.minmax)
+            && (!req.eigen  || sel.eigen);
+    }
+
     /** Recover the derived beam characteristics from the (central) moments and
      *  assemble the output map. The arithmetic below is unchanged from the
      *  original inlined recovery; it now lives in exactly one place.
@@ -68,7 +180,8 @@ namespace
     std::unordered_map<std::string, amrex::ParticleReal>
     derive_and_assemble (RawMoments const & m,
                          amrex::ParticleReal const bg,
-                         amrex::ParticleReal const bg2)
+                         amrex::ParticleReal const bg2,
+                         MomentsSelection const & sel)
     {
         using namespace amrex::literals; // for _prt
 
@@ -167,9 +280,7 @@ namespace
         amrex::ParticleReal emittance_tn = emittance_t * bg;
 
         // Determine whether to calculate eigenemittances, and initialize
-        amrex::ParmParse pp_diag("diag");
-        bool compute_eigenemittances = false;
-        pp_diag.queryAdd("eigenemittances", compute_eigenemittances);
+        bool const compute_eigenemittances = sel.eigen;
         amrex::ParticleReal emittance_1 = emittance_xn;
         amrex::ParticleReal emittance_2 = emittance_yn;
         amrex::ParticleReal emittance_3 = emittance_tn;
@@ -300,6 +411,29 @@ namespace
         data["sigma_sy"] = sigma_sy;
         data["sigma_sz"] = sigma_sz;
 
+        // Filter to the requested selection: a non-empty key list keeps exactly
+        // those keys (honoring the requested spelling); an empty list keeps every
+        // key the profile and flags cover (used by the "all" and default
+        // selections).
+        if (sel.keys.empty())
+        {
+            for (auto it = data.begin(); it != data.end(); )
+            {
+                if (key_covered(it->first, sel)) { ++it; }
+                else { it = data.erase(it); }
+            }
+        }
+        else
+        {
+            std::unordered_map<std::string, amrex::ParticleReal> filtered;
+            for (auto const & k : sel.keys)
+            {
+                auto const it = data.find(k);
+                if (it != data.end()) { filtered.emplace(k, it->second); }
+            }
+            data = std::move(filtered);
+        }
+
         return data;
     }
 
@@ -315,9 +449,8 @@ namespace
     //! multiplicative-identity placeholder used by the generic slot formula
     enum class Coord : int { x = 0, y, t, px, py, pt, sx, sy, sz, none };
 
-    //! reduction profiles, ordered by increasing coverage; each is a superset of
-    //! the previous: Positions < Sizes < Twiss < Full
-    enum class Profile : int { Positions = 0, Sizes, Twiss, Full };
+    // (MomentsProfile, the reduction-profile enum, is declared in
+    //  BeamMomentsSelection.H so it can be shared with MomentsSelection.)
 
     //! one reduced (weighted) sum slot: sum over particles of w * dev(a) * dev(b),
     //! with dev(u) = u - shift_u and dev(none) = 1. Hence {none,none} = Sum(w),
@@ -340,7 +473,7 @@ namespace
     /** Compile-time description of a reduction profile: the ordered list of
      *  weighted-sum slots and the coordinates to reduce min/max over.
      */
-    constexpr ProfileDesc make_desc (Profile const profile, bool const spin, bool const minmax)
+    constexpr ProfileDesc make_desc (MomentsProfile const profile, bool const spin, bool const minmax)
     {
         ProfileDesc d {};
         auto add_sum = [&d] (Coord const a, Coord const b)
@@ -358,7 +491,7 @@ namespace
         for (Coord const c : pos) { add_sum(c, c); }
 
         // momenta (Sizes and up)
-        if (profile >= Profile::Sizes)
+        if (profile >= MomentsProfile::Sizes)
         {
             Coord const mom[3] = {Coord::px, Coord::py, Coord::pt};
             for (Coord const c : mom) { add_sum(c, Coord::none); }
@@ -366,7 +499,7 @@ namespace
         }
 
         // correlations for emittance, dispersion and (dispersion-corrected) Twiss
-        if (profile >= Profile::Twiss)
+        if (profile >= MomentsProfile::Twiss)
         {
             // same-plane
             add_sum(Coord::x, Coord::px);
@@ -380,7 +513,7 @@ namespace
         }
 
         // cross-plane correlations (only eigenemittances consume these)
-        if (profile >= Profile::Full)
+        if (profile >= MomentsProfile::Full)
         {
             add_sum(Coord::x, Coord::y);
             add_sum(Coord::x, Coord::py);
@@ -409,7 +542,7 @@ namespace
             d.minmax[d.n_minmax++] = Coord::x;
             d.minmax[d.n_minmax++] = Coord::y;
             d.minmax[d.n_minmax++] = Coord::t;
-            if (profile >= Profile::Sizes)
+            if (profile >= MomentsProfile::Sizes)
             {
                 d.minmax[d.n_minmax++] = Coord::px;
                 d.minmax[d.n_minmax++] = Coord::py;
@@ -460,6 +593,27 @@ namespace
         }
     }
 
+    /** Fill the weighted power-sum slots (the first desc.n_sums tuple entries)
+     *  for a profile. Shared by the with- and without-min/max reduction paths so
+     *  the generic slot formula w*dev(a)*dev(b) lives in exactly one place.
+     */
+    template <MomentsProfile P, bool Spin, typename TupleT, typename PType>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void fill_sum_slots (
+        TupleT & out,
+        PType const & p,
+        amrex::GpuArray<amrex::ParticleReal, 9> const & shift)
+    {
+        static constexpr ProfileDesc desc = make_desc(P, Spin, false);
+        amrex::ParticleReal const p_w = p.rdata(RealSoA::w);
+        amrex::constexpr_for<0, desc.n_sums>([&] (auto i)
+        {
+            constexpr SumSpec s = desc.sums[i];
+            amrex::get<i>(out) =
+                deviation<s.a>(p, shift) * deviation<s.b>(p, shift) * p_w;
+        });
+    }
+
     /** Reduce a single pass over the particles for the given profile and recover
      *  the central moments into a RawMoments. The full profile
      *  (Profile::Full, spin, minmax) reproduces the previous hand-written
@@ -467,7 +621,7 @@ namespace
      *  multiplication order, and the parallel-axis recovery keeps the same order
      *  of operations, keyed off the SumSpec instead of hard-coded indices.
      */
-    template <Profile P, bool Spin, bool MinMax>
+    template <MomentsProfile P, bool Spin, bool MinMax>
     RawMoments reduce_and_recover (
         ImpactXParticleContainer const & pc,
         std::array<amrex::ParticleReal, 9> const & shift,
@@ -480,32 +634,31 @@ namespace
         static constexpr int n_sum = desc.n_sums;
         static constexpr int n_mm  = desc.n_minmax;
 
-        amrex::TypeMultiplier<amrex::ReduceOps,
-            amrex::ReduceOpSum[n_sum],
-            amrex::ReduceOpMin[n_mm],
-            amrex::ReduceOpMax[n_mm]
-        > reduce_ops;
-        using ReducedDataT = amrex::TypeMultiplier<amrex::ReduceData,
-            amrex::ParticleReal[n_sum + 2 * n_mm]>;
-
         amrex::GpuArray<amrex::ParticleReal, 9> shift_d {};
         for (int i = 0; i < 9; ++i) { shift_d[i] = shift[i]; }
 
-        auto r = amrex::ParticleReduce<ReducedDataT>(
-            pc,
-            [=] AMREX_GPU_DEVICE (PType const & p) noexcept -> typename ReducedDataT::Type
-            {
-                amrex::ParticleReal const p_w = p.rdata(RealSoA::w);
+        std::array<amrex::ParticleReal, n_sum> values_sum {};
+        [[maybe_unused]] std::array<amrex::ParticleReal, (MinMax ? max_minmax : 1)> values_min {};
+        [[maybe_unused]] std::array<amrex::ParticleReal, (MinMax ? max_minmax : 1)> values_max {};
 
-                typename ReducedDataT::Type out;
-                amrex::constexpr_for<0, n_sum>([&] (auto i)
+        // A zero-count ReduceOpMin/Max would decay to a bogus pointer op, so the
+        // min/max operations are only ever named on the MinMax path.
+        if constexpr (MinMax)
+        {
+            amrex::TypeMultiplier<amrex::ReduceOps,
+                amrex::ReduceOpSum[n_sum],
+                amrex::ReduceOpMin[n_mm],
+                amrex::ReduceOpMax[n_mm]
+            > reduce_ops;
+            using ReducedDataT = amrex::TypeMultiplier<amrex::ReduceData,
+                amrex::ParticleReal[n_sum + 2 * n_mm]>;
+
+            auto r = amrex::ParticleReduce<ReducedDataT>(
+                pc,
+                [=] AMREX_GPU_DEVICE (PType const & p) noexcept -> typename ReducedDataT::Type
                 {
-                    constexpr SumSpec s = desc.sums[i];
-                    amrex::get<i>(out) =
-                        deviation<s.a>(p, shift_d) * deviation<s.b>(p, shift_d) * p_w;
-                });
-                if constexpr (MinMax)
-                {
+                    typename ReducedDataT::Type out;
+                    fill_sum_slots<P, Spin>(out, p, shift_d);
                     amrex::constexpr_for<0, n_mm>([&] (auto j)
                     {
                         constexpr Coord c = desc.minmax[j];
@@ -513,24 +666,38 @@ namespace
                         amrex::get<n_sum + j>(out) = v;
                         amrex::get<n_sum + n_mm + j>(out) = v;
                     });
-                }
-                return out;
-            },
-            reduce_ops
-        );
+                    return out;
+                },
+                reduce_ops
+            );
 
-        // extract this rank's partial sums, minima and maxima
-        std::array<amrex::ParticleReal, n_sum> values_sum {};
-        amrex::constexpr_for<0, n_sum>([&] (auto i) { values_sum[i] = amrex::get<i>(r); });
-        [[maybe_unused]] std::array<amrex::ParticleReal, (MinMax ? max_minmax : 1)> values_min {};
-        [[maybe_unused]] std::array<amrex::ParticleReal, (MinMax ? max_minmax : 1)> values_max {};
-        if constexpr (MinMax)
-        {
+            amrex::constexpr_for<0, n_sum>([&] (auto i) { values_sum[i] = amrex::get<i>(r); });
             amrex::constexpr_for<0, n_mm>([&] (auto j)
             {
                 values_min[j] = amrex::get<n_sum + j>(r);
                 values_max[j] = amrex::get<n_sum + n_mm + j>(r);
             });
+        }
+        else
+        {
+            amrex::TypeMultiplier<amrex::ReduceOps,
+                amrex::ReduceOpSum[n_sum]
+            > reduce_ops;
+            using ReducedDataT = amrex::TypeMultiplier<amrex::ReduceData,
+                amrex::ParticleReal[n_sum]>;
+
+            auto r = amrex::ParticleReduce<ReducedDataT>(
+                pc,
+                [=] AMREX_GPU_DEVICE (PType const & p) noexcept -> typename ReducedDataT::Type
+                {
+                    typename ReducedDataT::Type out;
+                    fill_sum_slots<P, Spin>(out, p, shift_d);
+                    return out;
+                },
+                reduce_ops
+            );
+
+            amrex::constexpr_for<0, n_sum>([&] (auto i) { values_sum[i] = amrex::get<i>(r); });
         }
 
         // reduce across MPI ranks (allreduce)
@@ -624,12 +791,121 @@ namespace
 
         return m;
     }
+
+    /** Dispatch the spin / min-max flags at a fixed compile-time profile. */
+    template <MomentsProfile P>
+    RawMoments dispatch_flags (
+        ImpactXParticleContainer const & pc,
+        std::array<amrex::ParticleReal, 9> const & shift,
+        amrex::ParticleReal const q_C,
+        MomentsSelection const & sel)
+    {
+        if (sel.spin && sel.minmax)  { return reduce_and_recover<P, true,  true >(pc, shift, q_C); }
+        if (sel.spin && !sel.minmax) { return reduce_and_recover<P, true,  false>(pc, shift, q_C); }
+        if (!sel.spin && sel.minmax) { return reduce_and_recover<P, false, true >(pc, shift, q_C); }
+        return reduce_and_recover<P, false, false>(pc, shift, q_C);
+    }
+
+    /** Run the single-pass reduction for a selection, choosing the compile-time
+     *  profile at runtime. All 4 x 2 x 2 instantiations are generated from the
+     *  one reduce_and_recover kernel body.
+     */
+    RawMoments dispatch_reduce (
+        ImpactXParticleContainer const & pc,
+        std::array<amrex::ParticleReal, 9> const & shift,
+        amrex::ParticleReal const q_C,
+        MomentsSelection const & sel)
+    {
+        switch (sel.profile)
+        {
+            case MomentsProfile::Positions: return dispatch_flags<MomentsProfile::Positions>(pc, shift, q_C, sel);
+            case MomentsProfile::Sizes:     return dispatch_flags<MomentsProfile::Sizes>(pc, shift, q_C, sel);
+            case MomentsProfile::Twiss:     return dispatch_flags<MomentsProfile::Twiss>(pc, shift, q_C, sel);
+            case MomentsProfile::Full:      return dispatch_flags<MomentsProfile::Full>(pc, shift, q_C, sel);
+        }
+        return dispatch_flags<MomentsProfile::Full>(pc, shift, q_C, sel);  // unreachable
+    }
 } // namespace
+
+    MomentsSelection
+    all_beam_moments_selection (bool const eigen)
+    {
+        MomentsSelection sel;
+        sel.profile = MomentsProfile::Full;
+        sel.spin = true;
+        sel.minmax = true;
+        sel.eigen = eigen;
+        sel.keys.clear();  // empty => emit every covered key (i.e. all of them)
+        return sel;
+    }
+
+    MomentsSelection
+    default_beam_moments_selection (bool const spin_on, bool const eigen)
+    {
+        MomentsSelection sel;
+        sel.profile = eigen ? MomentsProfile::Full : MomentsProfile::Twiss;
+        sel.spin = spin_on;
+        sel.minmax = false;
+        sel.eigen = eigen;
+        // empty => emit every covered key: all outputs except min/max, and except
+        // the spin moments when spin tracking is off
+        sel.keys.clear();
+        return sel;
+    }
+
+    MomentsSelection
+    resolve_beam_moments_selection (std::vector<std::string> const & names, bool const eigen_default)
+    {
+        // the "all" token requests the full set
+        if (names.size() == 1 && names[0] == "all")
+        {
+            return all_beam_moments_selection(eigen_default);
+        }
+
+        MomentsSelection sel;
+        sel.profile = MomentsProfile::Positions;
+        sel.spin = false;
+        sel.minmax = false;
+        sel.eigen = false;
+        sel.keys.reserve(names.size());
+        for (auto const & name : names)
+        {
+            KeyReq const req = key_requirement(canonicalize(name));  // throws if unknown
+            if (static_cast<int>(req.profile) > static_cast<int>(sel.profile))
+            {
+                sel.profile = req.profile;
+            }
+            sel.spin   = sel.spin   || req.spin;
+            sel.minmax = sel.minmax || req.minmax;
+            sel.eigen  = sel.eigen  || req.eigen;
+            sel.keys.push_back(name);  // keep the requested spelling for the output
+        }
+        if (sel.eigen && static_cast<int>(sel.profile) < static_cast<int>(MomentsProfile::Full))
+        {
+            sel.profile = MomentsProfile::Full;
+        }
+        return sel;
+    }
 
     std::unordered_map<std::string, amrex::ParticleReal>
     reduced_beam_characteristics (ImpactXParticleContainer const & pc)
     {
         BL_PROFILE("impactx::diagnostics::reduced_beam_characteristics(pc)");
+
+        // full set, for backward-compatible callers (space charge, ASCII output,
+        // deprecated Python binding); eigenemittances follow the diag flag
+        amrex::ParmParse pp_diag("diag");
+        bool eigen = false;
+        pp_diag.queryAdd("eigenemittances", eigen);
+        return reduced_beam_characteristics(pc, all_beam_moments_selection(eigen));
+    }
+
+    std::unordered_map<std::string, amrex::ParticleReal>
+    reduced_beam_characteristics (
+        ImpactXParticleContainer const & pc,
+        MomentsSelection const & selection)
+    {
+        BL_PROFILE("impactx::diagnostics::reduced_beam_characteristics(pc, selection)");
 
         using namespace amrex::literals; // for _prt
 
@@ -693,12 +969,10 @@ namespace
                 amrex::ParallelDescriptor::Bcast(shift.data(), shift.size(), src_rank);
             }
         }
-        // Single-pass reduction of the full moment set. Selective profiles that
-        // read fewer arrays and reduce fewer values are wired up in a later step;
-        // Profile::Full with spin and min/max reproduces the previous result
-        // bit-for-bit.
-        RawMoments const raw = reduce_and_recover<Profile::Full, true, true>(pc, shift, q_C);
-        return derive_and_assemble(raw, bg, bg2);
+        // Single-pass reduction using the fastest profile that covers the
+        // requested selection, then recover and assemble the requested outputs.
+        RawMoments const raw = dispatch_reduce(pc, shift, q_C, selection);
+        return derive_and_assemble(raw, bg, bg2, selection);
     }
 
     std::unordered_map<std::string, amrex::ParticleReal>
@@ -751,7 +1025,10 @@ namespace
             nan, nan, nan, nan, nan, nan,
             nan  // charge_C (TODO: with space charge)
         };
-        return derive_and_assemble(raw, bg, bg2);
+        amrex::ParmParse pp_diag("diag");
+        bool eigen = false;
+        pp_diag.queryAdd("eigenemittances", eigen);
+        return derive_and_assemble(raw, bg, bg2, all_beam_moments_selection(eigen));
     }
 
 } // namespace impactx::diagnostics

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -26,8 +26,10 @@
 
 #include <list>
 #include <optional>
+#include <string>
 #include <tuple>
 #include <unordered_map>
+#include <vector>
 
 
 namespace impactx
@@ -324,13 +326,37 @@ namespace impactx
         /** In situ calculate and store the beam moments for every simulation step */
         bool store_beam_moments = false;
 
+        /** Set the selection of beam-moment outputs to compute.
+         *
+         * @param names requested output names (e.g. {"sigma_x","dispersion_x"}),
+         *              or {"all"} for the full set; an empty list resets to the
+         *              default (all outputs except min/max, and except the spin
+         *              moments when spin tracking is off).
+         */
+        void
+        set_beam_moments_selection (std::vector<std::string> const & names);
+
+        /** Get the currently requested beam-moment output names (empty when the
+         *  default selection is in effect).
+         */
+        std::vector<std::string>
+        beam_moments_selection () const;
+
         /** Calculate & record the beam moments at current s */
         void
         record_beam_moments ();
 
-        /** Calculate beam moments at current s */
+        /** Calculate beam moments at current s (using the stored selection) */
         std::unordered_map<std::string, amrex::ParticleReal>
         beam_moments ();
+
+        /** Calculate a selected subset of the beam moments at current s
+         *
+         * @param names requested output names; an empty list uses the stored
+         *              selection (or the default)
+         */
+        std::unordered_map<std::string, amrex::ParticleReal>
+        beam_moments (std::vector<std::string> const & names);
 
         /** Get the history of beam moments */
         std::list<std::unordered_map<std::string, amrex::ParticleReal> >
@@ -356,6 +382,10 @@ namespace impactx
 
         //! history of the beam moments over s
         std::list<std::unordered_map<std::string, amrex::ParticleReal> > m_beam_moments;
+
+        //! requested beam-moment output names (unset => the default selection);
+        //! resolved to a selection in the .cpp to keep this header dependency-free
+        std::optional<std::vector<std::string>> m_beam_moments_select_names;
 
         //! the RF bucket length for particles in the particle container
         //!   only active if algo.particle_bc is not set to "open" (default)

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -467,12 +467,56 @@ namespace impactx
         m_coordsystem = coord_system;
     }
 
+    namespace
+    {
+        //! the selection to use: resolve the stored requested names, or build the
+        //! default from the current spin-tracking and eigenemittance flags
+        diagnostics::MomentsSelection
+        effective_selection (std::optional<std::vector<std::string>> const & names)
+        {
+            amrex::ParmParse pp_diag("diag");
+            bool eigen = false;
+            pp_diag.query("eigenemittances", eigen);
+
+            if (names.has_value())
+            {
+                return diagnostics::resolve_beam_moments_selection(names.value(), eigen);
+            }
+
+            amrex::ParmParse pp_algo("algo");
+            bool spin = false;
+            pp_algo.query("spin", spin);
+            return diagnostics::default_beam_moments_selection(spin, eigen);
+        }
+    }
+
+    void
+    ImpactXParticleContainer::set_beam_moments_selection (std::vector<std::string> const & names)
+    {
+        if (names.empty())
+        {
+            m_beam_moments_select_names.reset();  // back to the default selection
+        }
+        else
+        {
+            m_beam_moments_select_names = names;
+        }
+    }
+
+    std::vector<std::string>
+    ImpactXParticleContainer::beam_moments_selection () const
+    {
+        if (m_beam_moments_select_names.has_value()) { return m_beam_moments_select_names.value(); }
+        return {};
+    }
+
     void
     ImpactXParticleContainer::record_beam_moments ()
     {
         BL_PROFILE("ImpactXParticleContainer::record_beam_moments");
 
-        auto rbc = diagnostics::reduced_beam_characteristics(*this);
+        auto rbc = diagnostics::reduced_beam_characteristics(
+            *this, effective_selection(m_beam_moments_select_names));
         amrex::ParticleReal const s = this->GetRefParticle().s;
         rbc["s"] = s;
 
@@ -484,7 +528,33 @@ namespace impactx
     {
         BL_PROFILE("ImpactXParticleContainer::beam_moments");
 
-        auto rbc = diagnostics::reduced_beam_characteristics(*this);
+        auto rbc = diagnostics::reduced_beam_characteristics(
+            *this, effective_selection(m_beam_moments_select_names));
+        amrex::ParticleReal const s = this->GetRefParticle().s;
+        rbc["s"] = s;
+
+        return rbc;
+    }
+
+    std::unordered_map<std::string, amrex::ParticleReal>
+    ImpactXParticleContainer::beam_moments (std::vector<std::string> const & names)
+    {
+        BL_PROFILE("ImpactXParticleContainer::beam_moments");
+
+        diagnostics::MomentsSelection sel;
+        if (names.empty())
+        {
+            sel = effective_selection(m_beam_moments_select_names);
+        }
+        else
+        {
+            amrex::ParmParse pp_diag("diag");
+            bool eigen = false;
+            pp_diag.query("eigenemittances", eigen);
+            sel = diagnostics::resolve_beam_moments_selection(names, eigen);
+        }
+
+        auto rbc = diagnostics::reduced_beam_characteristics(*this, sel);
         amrex::ParticleReal const s = this->GetRefParticle().s;
         rbc["s"] = s;
 

--- a/src/python/ImpactXParticleContainer.cpp
+++ b/src/python/ImpactXParticleContainer.cpp
@@ -15,6 +15,7 @@
 #include <AMReX_ParticleContainer.H>
 
 #include <algorithm>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -161,11 +162,15 @@ void init_impactxparticlecontainer(py::module& m)
              "Compute reduced beam characteristics like the position and momentum moments of the particle distribution, as well as emittance and Twiss parameters."
         )
         .def("beam_moments",
-             [](ImpactXParticleContainer & pc) {
+             [](ImpactXParticleContainer & pc, std::optional<std::vector<std::string>> const & select) {
+                 if (select.has_value()) { return pc.beam_moments(select.value()); }
                  return pc.beam_moments();
              },
+             py::arg("select") = std::nullopt,
              "Calculate beam moments at current ``s`` like the position and momentum moments of the particle "
-             "distribution, as well as emittance and Twiss parameters."
+             "distribution, as well as emittance and Twiss parameters.\n\n"
+             "If ``select`` is given (a list of output names, or ``[\"all\"]``), only those outputs are "
+             "computed, using the fastest reduction that covers them."
         )
         .def("beam_moments_history_list",
              [](ImpactXParticleContainer & pc) {
@@ -189,6 +194,14 @@ void init_impactxparticlecontainer(py::module& m)
             [](ImpactXParticleContainer & pc){ return pc.store_beam_moments; },
             [](ImpactXParticleContainer & pc, bool record){ pc.store_beam_moments = record; },
             "In situ calculate and store the beam moments for every simulation step."
+        )
+        .def_property("beam_moments_select",
+            [](ImpactXParticleContainer & pc){ return pc.beam_moments_selection(); },
+            [](ImpactXParticleContainer & pc, std::vector<std::string> const & names){ pc.set_beam_moments_selection(names); },
+            "The selection of beam-moment outputs to compute for ``beam_moments()`` and "
+            "``store_beam_moments``: a list of output names (e.g. ``[\"sigma_x\", \"dispersion_x\"]``), "
+            "or ``[\"all\"]`` for the full set. An empty list resets to the default (all outputs except "
+            "min/max, and except the spin moments when spin tracking is off)."
         )
 
         // TODO: cleverly pass the list of rho multifabs as references

--- a/src/python/impactx/extensions/ImpactXParticleContainer.py
+++ b/src/python/impactx/extensions/ImpactXParticleContainer.py
@@ -29,8 +29,9 @@ def ix_pc_plot_mpl_phasespace(self, num_bins=50, root_rank=0):
     import numpy as np
     from quantiphy import Quantity
 
-    # Beam Characteristics
-    rbc = self.beam_moments()
+    # Beam Characteristics (this phase-space plot needs the full set: min/max
+    # for the histogram ranges and the Twiss parameters for the labels)
+    rbc = self.beam_moments(["all"])
 
     # update for plot unit system
     m2mm = 1.0e3


### PR DESCRIPTION
Implement specialized reduction paths for subsequently more-expensive beam moment calculation.
Let the user choose the moments they need and picks automatically the right reduction set.
Removes min/max from the defaults (small gain on GPU), because typically not needed.

- [ ] rebase after #1561
- [ ] rebase after #1564
- [ ] finalize manual clean-up