### PR TITLE
[WIP] Implement Progress Bar

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -2844,3 +2844,32 @@ Overall simulation parameters
 
     Controls how much information is printed to the terminal, when running ImpactX.
     Use ``0`` for silent; higher is more verbose.
+
+.. pp:param:: impactx.progress
+    :type: ``string``
+    :optional:
+    :default: ``auto``
+
+    Controls the tracking progress indicator that is shown while ``track_particles``,
+    ``track_envelope`` or ``track_reference`` run. Allowed values:
+
+    * ``auto``: show a live, single-line progress bar (percent, path length ``s``, ETA and
+      the current element) when the output is an interactive terminal, and one
+      ``++++ Starting step=<N> of <T> ...`` status line per step otherwise (e.g. when the
+      output is redirected to a file, in batch jobs, or in the dashboard).
+    * ``on``: always show the live progress bar, even when the output is not a terminal.
+    * ``off``: always print per-step status lines and never the live bar.
+
+    On an interactive terminal the live bar is pinned to the bottom line, so other output
+    that appears during tracking (for example the space-charge solver's residuals or
+    warnings) scrolls above it instead of overwriting it. Requires :pp:param:`impactx.verbose`
+    ``> 0``; with ``impactx.verbose >= 2`` the detailed per-step status lines are always used.
+
+.. pp:param:: impactx.progress_ascii
+    :type: ``boolean``
+    :optional:
+
+    If ``1`` (true), the live progress bar is drawn with plain ASCII characters instead of
+    Unicode block glyphs. The default is derived from the process locale (ASCII unless the
+    locale advertises UTF-8), and is only relevant when :pp:param:`impactx.progress` shows the
+    live bar.

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -416,6 +416,27 @@ Collective Effects & Overall Simulation Parameters
       Controls how much information is printed to the terminal, when running ImpactX.
       ``0`` for silent, higher is more verbose. Default is ``1``.
 
+   .. py:property:: progress
+
+      Controls the tracking progress indicator shown while ``track_particles``,
+      ``track_envelope`` or ``track_reference`` run.
+
+      * ``"auto"`` (default): a live, single-line progress bar (percent, path length ``s``,
+        ETA and current element) on an interactive terminal, and one
+        ``++++ Starting step=<N> of <T> ...`` line per step otherwise (redirected output,
+        batch jobs, the dashboard).
+      * ``"on"``: always show the live bar, even when the output is not a terminal.
+      * ``"off"``: always print per-step status lines and never the live bar.
+
+      On a terminal the live bar is pinned to the bottom line, so other output during
+      tracking (e.g. space-charge solver residuals) scrolls above it. Requires
+      ``verbose > 0``; ``verbose >= 2`` always uses the detailed per-step lines.
+
+   .. py:property:: progress_ascii
+
+      If ``True``, the live progress bar uses plain ASCII characters instead of Unicode
+      block glyphs. Defaults to a value derived from the process locale.
+
    .. py:property:: tiny_profiler
 
       This parameter can be used to disable tiny profiling including CArena memory profiling at runtime.

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -613,6 +613,38 @@ void init_ImpactX (py::module& m)
             "``0`` for silent, higher is more verbose. Default is ``1``."
         )
 
+        .def_property("progress",
+            [](ImpactX & /* ix */){
+                std::string progress = "auto";
+                amrex::ParmParse pp_impactx("impactx");
+                pp_impactx.query("progress", progress);
+                return progress;
+            },
+            [](ImpactX & /* ix */, std::string const & progress) {
+                amrex::ParmParse pp_impactx("impactx");
+                pp_impactx.add("progress", progress);
+            },
+            "Controls the tracking progress bar / status line.\n"
+            "``\"auto\"`` (default) shows a live, single-line progress bar on an interactive\n"
+            "terminal and per-step status lines otherwise; ``\"on\"`` always shows the live bar;\n"
+            "``\"off\"`` always shows per-step status lines. Requires ``verbose > 0``."
+        )
+
+        .def_property("progress_ascii",
+            [](ImpactX & /* ix */){
+                bool ascii = false;
+                amrex::ParmParse pp_impactx("impactx");
+                pp_impactx.query("progress_ascii", ascii);
+                return ascii;
+            },
+            [](ImpactX & /* ix */, bool const ascii) {
+                amrex::ParmParse pp_impactx("impactx");
+                pp_impactx.add("progress_ascii", ascii);
+            },
+            "If ``True``, the progress bar uses plain ASCII glyphs instead of Unicode block\n"
+            "characters. Defaults to a value derived from the process locale."
+        )
+
         .def_property("tiny_profiler",
             [](ImpactX & /* ix */){
                 return detail::get_or_throw<bool>("tiny_profiler", "enabled");

--- a/src/python/impactx/dashboard/Run/executor.py
+++ b/src/python/impactx/dashboard/Run/executor.py
@@ -62,12 +62,18 @@ async def execute_impactx_sim() -> None:
         if "Initializing AMReX" in sim_output_line_decoded:
             start_timer = asyncio.create_task(SimulationProgress.dashboard_timer())
         if "++++ Starting step=" in sim_output_line_decoded:
-            match = re.search(r"\+\+\+\+ Starting step=(\d+)", sim_output_line_decoded)
+            # ImpactX emits "++++ Starting step=<N> of <T> (<P>%) <label>" per step;
+            # <T> is the exact total (num_periods * sum(nslice)) computed by ImpactX.
+            match = re.search(
+                r"\+\+\+\+ Starting step=(\d+) of (\d+)", sim_output_line_decoded
+            )
             if match:
                 state.sim_current_step = int(match.group(1))
-                state.sim_progress = (
-                    state.sim_current_step / state.sim_total_steps
-                ) * 95
+                state.sim_total_steps = int(match.group(2))
+                if state.sim_total_steps > 0:
+                    state.sim_progress = (
+                        state.sim_current_step / state.sim_total_steps
+                    ) * 95
 
         SimulationProgress.print_to_xterm(sim_output_line)
         SimulationHistory.add_to_view_details_log(sim_output_line_decoded)

--- a/src/python/impactx/dashboard/Run/utils.py
+++ b/src/python/impactx/dashboard/Run/utils.py
@@ -177,15 +177,21 @@ class SimulationProgress:
     @staticmethod
     def determine_sim_total_steps(simulation_content_file) -> int:
         """
-        Determines the total step count for the given input file.
+        Estimates the total step count for the given input file.
 
-        Sum of nslices is sim_total_step
+        This is only a pre-run estimate for the very first progress frame; the
+        exact total (num_periods * sum(nslice)) is parsed from the simulation
+        output while it runs (see Run/executor.py).
+
+        Sum of nslices, multiplied by the number of lattice periods.
         """
 
         nslice_matches = re.findall(r"nslice=(\d+)", simulation_content_file)
+        periods_match = re.search(r"periods\s*=\s*(\d+)", simulation_content_file)
+        periods = int(periods_match.group(1)) if periods_match else 1
 
         if nslice_matches:
-            state.sim_total_steps = sum(int(match) for match in nslice_matches)
+            state.sim_total_steps = sum(int(m) for m in nslice_matches) * periods
 
         return state.sim_total_steps
 

--- a/src/tracking/CMakeLists.txt
+++ b/src/tracking/CMakeLists.txt
@@ -2,5 +2,6 @@ target_sources(lib
   PRIVATE
     envelope.cpp
     particles.cpp
+    ProgressBar.cpp
     reference.cpp
 )

--- a/src/tracking/ProgressBar.H
+++ b/src/tracking/ProgressBar.H
@@ -1,0 +1,189 @@
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_TRACKING_PROGRESSBAR_H
+#define IMPACTX_TRACKING_PROGRESSBAR_H
+
+#include "elements/All.H"
+
+#include <cstddef>
+#include <iosfwd>
+#include <list>
+#include <memory>
+#include <string>
+#include <variant>
+
+
+namespace impactx
+{
+    /** Total number of forward slice-steps of a tracking run.
+     *
+     * This equals ``num_periods * sum_over_elements(nslice)`` and is used as the
+     * denominator for the progress bar. It mirrors the global step counter
+     * ``TrackingState::m_step``, which increments once per slice on forward tracking.
+     *
+     * @param lattice the beamline elements to traverse
+     * @param num_periods number of periods (turns/cycles) through the lattice
+     * @return the total number of forward slice-steps (>= 0)
+     */
+    inline int
+    count_total_steps (
+        std::list<elements::KnownElements> const & lattice,
+        int num_periods
+    )
+    {
+        int per_period = 0;
+        for (auto const & element_variant : lattice)
+        {
+            int nslice = 1;
+            std::visit([&nslice](auto && element) { nslice = element.nslice(); },
+                       element_variant);
+            per_period += nslice;
+        }
+        return per_period * num_periods;
+    }
+
+    /** Total reference-trajectory path length ``s`` of a tracking run, in meters.
+     *
+     * This equals ``num_periods * sum_over_elements(ds)`` and is used as the
+     * denominator for the progress bar's ``s`` read-out (and, when positive, drives
+     * the bar fill so it advances with physical distance rather than slice count).
+     *
+     * @param lattice the beamline elements to traverse
+     * @param num_periods number of periods (turns/cycles) through the lattice
+     * @return the total path length in meters (>= 0)
+     */
+    inline double
+    count_total_length (
+        std::list<elements::KnownElements> const & lattice,
+        int num_periods
+    )
+    {
+        double per_period = 0.0;
+        for (auto const & element_variant : lattice)
+        {
+            double ds = 0.0;
+            std::visit([&ds](auto && element) { ds = static_cast<double>(element.ds()); },
+                       element_variant);
+            per_period += ds;
+        }
+        return per_period * static_cast<double>(num_periods);
+    }
+
+    /** Format a wall-clock duration in seconds as ``M:SS`` or ``H:MM:SS``. */
+    std::string
+    format_time (double seconds);
+
+    /** Render a single progress-bar frame (pure, no I/O, no carriage return).
+     *
+     * Kept as a free, side-effect-free function so it is deterministically testable
+     * without a terminal.
+     *
+     * @param frac fraction completed in [0, 1] (drives the bar fill)
+     * @param s_cur current path length ``s`` in meters (shown if @p s_tot > 0)
+     * @param s_tot total path length in meters (values <= 0 hide the ``s`` read-out)
+     * @param bar_width width of the bar body in character cells
+     * @param elapsed wall-clock seconds since the start of tracking
+     * @param label short label for the current element (name or type)
+     * @param ascii use ASCII glyphs instead of Unicode block characters
+     * @return the rendered line (without a trailing newline)
+     */
+    std::string
+    render_bar (
+        double frac,
+        double s_cur,
+        double s_tot,
+        int bar_width,
+        double elapsed,
+        std::string const & label,
+        bool ascii
+    );
+
+    /** A terminal progress bar / status line for the tracking loops.
+     *
+     * The output is MPI-safe: it is only drawn on the I/O rank. The mode is chosen
+     * once at construction from the verbosity (``impactx.verbose``), the
+     * ``impactx.progress`` input and whether ``stdout`` is an interactive terminal:
+     *  - ``Silent``: ``verbose == 0`` (or an empty lattice) -> no output.
+     *  - ``Live``:   interactive terminal, default verbosity -> a single line pinned
+     *                to the bottom of the terminal, redrawn in place.
+     *  - ``Banner``: non-interactive (pipe/file/batch) or ``verbose >= 2`` -> one
+     *                ``++++ Starting step=N of T (P%) label`` line per step.
+     *
+     * In ``Live`` mode the constructor installs a filtering stream buffer on
+     * ``amrex::OutStream()`` (which ``amrex::Print`` writes to). Any other output
+     * that arrives while the bar is up -- e.g. the MLMG space-charge solver's
+     * per-slice residuals, or warnings -- transparently erases the bar, scrolls
+     * above it, and the bar is redrawn on the (new) bottom line. The buffer is
+     * restored in ``finish()`` / the destructor. This coexistence uses ANSI
+     * "erase line" (``\x1b[2K``), which every modern terminal supports.
+     */
+    class ProgressBar
+    {
+    public:
+        /** Output mode, selected once at construction. */
+        enum class Mode
+        {
+            Silent, //!< no output
+            Banner, //!< one "++++ Starting step=N of T ..." line per step (pipe/file)
+            Live    //!< a single status line pinned to the bottom of the terminal
+        };
+
+        /** @param total_steps result of count_total_steps(); values <= 0 disable output
+         *  @param total_length result of count_total_length() (meters); drives the ``s`` read-out
+         *  @param verbose the impactx.verbose level */
+        ProgressBar (int total_steps, double total_length, int verbose);
+
+        /** Restore ``amrex::OutStream()``'s stream buffer if it is still installed. */
+        ~ProgressBar ();
+
+        ProgressBar (ProgressBar const &) = delete;
+        ProgressBar & operator= (ProgressBar const &) = delete;
+
+        /** Report progress for one forward slice-step.
+         *
+         * In ``Live`` mode this redraws the pinned status line (throttled); in
+         * ``Banner`` mode it prints one progress line; in ``Silent`` mode nothing.
+         *
+         * @param step the global step counter (1 .. total)
+         * @param slice_step the slice index within the current element (Banner detail)
+         * @param s reference-trajectory path length in meters at this step
+         * @param label short label of the current element (name or type)
+         */
+        void show (int step, int slice_step, double s, std::string const & label);
+
+        /** Finalize the bar (``Live`` mode only): draw the 100% frame + newline and
+         * restore the stream buffer. */
+        void finish ();
+
+        /** @return true if a live carriage-return bar is drawn */
+        bool is_live () const { return m_mode == Mode::Live; }
+
+        /** @return true if per-step banner lines are emitted */
+        bool wants_banner () const { return m_mode == Mode::Banner; }
+
+        /** Erase the pinned bar and restore ``amrex::OutStream()``'s stream buffer. */
+        void uninstall ();
+
+        Mode m_mode = Mode::Silent;
+        int m_verbose = 1;
+        int m_total = 0;         //!< total forward slice-steps (bar denominator fallback)
+        double m_total_s = 0.0;  //!< total path length in meters (for the ``s`` read-out)
+        int m_bar_width = 24;
+        int m_last_bucket = -1;  //!< throttle: redraw only when this changes
+        bool m_ascii = false;
+        bool m_io = false;       //!< this is the I/O rank (only it draws)
+        double m_start_time = 0.0;             //!< amrex::second() at construction (Live)
+        std::streambuf * m_saved_streambuf = nullptr; //!< amrex::OutStream() buffer to restore
+        std::unique_ptr<std::streambuf> m_bar_buf;    //!< bottom-pinned filtering buffer (Live)
+    };
+
+} // namespace impactx
+
+#endif // IMPACTX_TRACKING_PROGRESSBAR_H

--- a/src/tracking/ProgressBar.H
+++ b/src/tracking/ProgressBar.H
@@ -168,8 +168,20 @@ namespace impactx
         /** @return true if per-step banner lines are emitted */
         bool wants_banner () const { return m_mode == Mode::Banner; }
 
+    private:
         /** Erase the pinned bar and restore ``amrex::OutStream()``'s stream buffer. */
         void uninstall ();
+
+        /** Render a frame that fits into @p max_cols terminal columns.
+         *
+         * Never returns a line wider than ``max_cols`` (a wrapped line could not be
+         * erased with a carriage return): the bar is shrunk first, then the element
+         * label is dropped, then the line is hard-truncated.
+         */
+        std::string render_fit (
+            double frac, double s_cur, double elapsed,
+            std::string const & label, int max_cols
+        ) const;
 
         Mode m_mode = Mode::Silent;
         int m_verbose = 1;
@@ -177,6 +189,7 @@ namespace impactx
         double m_total_s = 0.0;  //!< total path length in meters (for the ``s`` read-out)
         int m_bar_width = 24;
         int m_last_bucket = -1;  //!< throttle: redraw only when this changes
+        int m_last_cols = -1;    //!< terminal width at the last redraw (resize detection)
         bool m_ascii = false;
         bool m_io = false;       //!< this is the I/O rank (only it draws)
         double m_start_time = 0.0;             //!< amrex::second() at construction (Live)

--- a/src/tracking/ProgressBar.cpp
+++ b/src/tracking/ProgressBar.cpp
@@ -17,7 +17,12 @@
 
 #if defined(_WIN32)
 #   include <io.h>
+#   ifndef WIN32_LEAN_AND_MEAN
+#       define WIN32_LEAN_AND_MEAN
+#   endif
+#   include <windows.h>
 #else
+#   include <sys/ioctl.h>
 #   include <unistd.h>
 #endif
 
@@ -77,6 +82,58 @@ namespace
             label = label.substr(0, width - 2) + "..";
         }
         return label;
+    }
+
+    /** Current terminal width in columns, or 0 if unknown (not a terminal). */
+    int
+    terminal_columns ()
+    {
+#if defined(_WIN32)
+        CONSOLE_SCREEN_BUFFER_INFO info;
+        if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info) != 0)
+        {
+            return static_cast<int>(info.srWindow.Right - info.srWindow.Left + 1);
+        }
+        return 0;
+#else
+        struct winsize w;
+        if (ioctl(fileno(stdout), TIOCGWINSZ, &w) == 0)
+        {
+            return static_cast<int>(w.ws_col);
+        }
+        return 0;
+#endif
+    }
+
+    /** Number of terminal columns of a rendered bar line.
+     *
+     * Counts UTF-8 code points; all glyphs the bar uses occupy one column each.
+     */
+    std::size_t
+    utf8_columns (std::string const & s)
+    {
+        std::size_t n = 0;
+        for (unsigned char const c : s)
+        {
+            if ((c & 0xC0) != 0x80) { ++n; } // count code-point start bytes
+        }
+        return n;
+    }
+
+    /** The longest prefix of @p s that occupies at most @p ncols terminal columns. */
+    std::string
+    utf8_prefix (std::string const & s, std::size_t ncols)
+    {
+        std::size_t n = 0;
+        for (std::size_t i = 0; i < s.size(); ++i)
+        {
+            if ((static_cast<unsigned char>(s[i]) & 0xC0) != 0x80)
+            {
+                if (n == ncols) { return s.substr(0, i); }
+                ++n;
+            }
+        }
+        return s;
     }
 
     /** A filtering stream buffer that keeps a status line pinned to the bottom.
@@ -268,8 +325,12 @@ namespace
         std::string suffix;
         if (s_tot > 0.0)
         {
-            char sb[80];
-            std::snprintf(sb, sizeof(sb), "s=%.2f/%.2f m  ", s_cur, s_tot);
+            // pad the running s to the width of the total, so the field width (and
+            // with it the whole line layout) stays constant while the digits grow
+            char tot[32];
+            int const tot_width = std::snprintf(tot, sizeof(tot), "%.2f", s_tot);
+            char sb[96];
+            std::snprintf(sb, sizeof(sb), "s=%*.2f/%s m  ", tot_width, s_cur, tot);
             suffix += sb;
         }
         {
@@ -402,15 +463,17 @@ namespace
         // changes (clock-free), then repaint the bottom-pinned bar
         if (!m_io || !m_bar_buf) { return; }
 
+        // re-query the terminal width every redraw: it tracks window resizes
+        int const cols = terminal_columns();
+
         int const bucket = static_cast<int>(frac * 8.0 * m_bar_width);
-        if (bucket == m_last_bucket && frac < 1.0) { return; }
+        if (bucket == m_last_bucket && cols == m_last_cols && frac < 1.0) { return; }
         m_last_bucket = bucket;
+        m_last_cols = cols;
 
         double const elapsed = amrex::second() - m_start_time;
-        std::string const line = render_bar(frac, s, m_total_s, m_bar_width, elapsed,
-                                            truncate_label(label, 24), m_ascii);
-
-        static_cast<BottomBar *>(m_bar_buf.get())->set_bar(line);
+        static_cast<BottomBar *>(m_bar_buf.get())->set_bar(
+            render_fit(frac, s, elapsed, label, cols));
     }
 
 
@@ -420,11 +483,67 @@ namespace
         if (m_mode != Mode::Live || !m_io || !m_bar_buf) { return; }
 
         double const elapsed = amrex::second() - m_start_time;
-        std::string const line = render_bar(1.0, m_total_s, m_total_s, m_bar_width,
-                                            elapsed, "done", m_ascii);
-        static_cast<BottomBar *>(m_bar_buf.get())->finish_bar(line);
+        static_cast<BottomBar *>(m_bar_buf.get())->finish_bar(
+            render_fit(1.0, m_total_s, elapsed, "done", terminal_columns()));
 
         uninstall();
+    }
+
+
+    std::string
+    ProgressBar::render_fit (
+        double frac, double s_cur, double elapsed,
+        std::string const & label, int max_cols
+    ) const
+    {
+        // unknown width (e.g. a forced bar in a pipe): assume a classic 80-column line
+        if (max_cols <= 0) { max_cols = 80; }
+        // never draw into the last column: writing there triggers auto-wrap, and a
+        // wrapped line cannot be erased with a carriage return anymore
+        int const usable = std::max(max_cols - 1, 8);
+
+        // The layout is computed from content-independent field reserves, NOT from the
+        // rendered text: element labels, the running s digits and the ETA all change
+        // from step to step, and a layout derived from them would make the bar body
+        // change its width from frame to frame (a "fluctuating" bar).
+        int const overhead = 9 + 2 + 2; // "Tracking " + bar caps + "  " separator
+        int const pct_cols = 6;         // "100%  "
+        int const time_cols = 12;       // "time H:MM:SS" / "ETA ..." reserve
+        int s_cols = 0;
+        if (m_total_s > 0.0)
+        {
+            char tot[32];
+            // "s=" + total + "/" + total + " m" + "  "
+            s_cols = 2 * std::snprintf(tot, sizeof(tot), "%.2f", m_total_s) + 7;
+        }
+        int const fixed = overhead + pct_cols + time_cols;
+
+        // prefer the full-width bar; the element label gets the leftover columns
+        double s_tot = m_total_s;
+        int const label_cols = usable - fixed - s_cols - m_bar_width;
+        std::string lab;
+        if (label_cols >= 4)
+        {
+            lab = truncate_label(label, static_cast<std::size_t>(std::min(label_cols, 24)));
+        }
+
+        // narrow: drop the label, then the s read-out, before shrinking the bar
+        int bar_width = std::min(m_bar_width, usable - fixed - s_cols);
+        if (bar_width < 8)
+        {
+            s_tot = 0.0;
+            bar_width = std::min(m_bar_width, usable - fixed);
+        }
+        bar_width = std::max(bar_width, 8);
+
+        std::string line = render_bar(frac, s_cur, s_tot, bar_width, elapsed, lab, m_ascii);
+
+        // last resort (very narrow terminal): hard-truncate at the column limit
+        if (utf8_columns(line) > static_cast<std::size_t>(usable))
+        {
+            line = utf8_prefix(line, static_cast<std::size_t>(usable));
+        }
+        return line;
     }
 
 } // namespace impactx

--- a/src/tracking/ProgressBar.cpp
+++ b/src/tracking/ProgressBar.cpp
@@ -160,6 +160,7 @@ namespace
         {
             erase();
             m_bar = bar;
+            m_bar_cols = utf8_columns(bar);
             raw(m_bar);
             m_shown = !m_bar.empty();
             m_dest->pubsync();
@@ -172,6 +173,7 @@ namespace
             raw(bar);
             raw("\n");
             m_bar.clear();
+            m_bar_cols = 0;
             m_shown = false;
             m_dest->pubsync();
         }
@@ -181,6 +183,7 @@ namespace
         {
             erase();
             m_bar.clear();
+            m_bar_cols = 0;
             m_shown = false;
             m_dest->pubsync();
         }
@@ -218,6 +221,24 @@ namespace
             if (m_shown)
             {
                 raw("\r\x1b[2K"); // carriage return + ANSI "erase entire line"
+
+                // If the terminal was shrunk below the drawn bar's width, the bar has
+                // re-wrapped onto multiple rows; the erase above only cleared the
+                // bottom one. Clear the remaining wrapped rows above it as well.
+                int const cols = terminal_columns();
+                if (cols > 0 && m_bar_cols > static_cast<std::size_t>(cols))
+                {
+                    std::size_t const extra =
+                        (m_bar_cols - 1) / static_cast<std::size_t>(cols);
+                    for (std::size_t i = 0; i < extra; ++i)
+                    {
+                        raw("\x1b[1A\x1b[2K"); // cursor up + erase that row
+                    }
+                    // return to the bar's bottom row: drawing at the top row instead
+                    // would migrate the bar one row up on every shrink, until it
+                    // reaches (and glitches at) the top of the terminal
+                    raw("\x1b[" + std::to_string(extra) + "B"); // cursor down
+                }
                 m_shown = false;
             }
         }
@@ -238,9 +259,10 @@ namespace
             }
         }
 
-        std::streambuf * m_dest;  //!< the real terminal buffer we forward to
-        std::string m_bar;        //!< current pinned bar text (no trailing newline)
-        bool m_shown = false;     //!< is the bar currently on the terminal's last line?
+        std::streambuf * m_dest;      //!< the real terminal buffer we forward to
+        std::string m_bar;            //!< current pinned bar text (no trailing newline)
+        std::size_t m_bar_cols = 0;   //!< terminal columns the pinned bar occupies
+        bool m_shown = false;         //!< is the bar currently on the terminal's last line?
     };
 } // namespace
 

--- a/src/tracking/ProgressBar.cpp
+++ b/src/tracking/ProgressBar.cpp
@@ -1,0 +1,430 @@
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "tracking/ProgressBar.H"
+
+#include <AMReX.H>
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_Print.H>
+#include <AMReX_Utility.H>
+
+#if defined(_WIN32)
+#   include <io.h>
+#else
+#   include <unistd.h>
+#endif
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <ostream>
+#include <streambuf>
+#include <string>
+
+
+namespace impactx
+{
+namespace
+{
+    /** Return true if stdout is connected to an interactive terminal. */
+    bool
+    stdout_is_tty ()
+    {
+#if defined(_WIN32)
+        return _isatty(_fileno(stdout)) != 0;
+#else
+        return isatty(fileno(stdout)) != 0;
+#endif
+    }
+
+    /** Return true if the process locale indicates UTF-8 output. */
+    bool
+    locale_is_utf8 ()
+    {
+        for (char const * name : {"LC_ALL", "LC_CTYPE", "LANG"})
+        {
+            char const * value = std::getenv(name);
+            if (value != nullptr && value[0] != '\0')
+            {
+                std::string v(value);
+                std::transform(v.begin(), v.end(), v.begin(),
+                               [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+                return v.find("utf-8") != std::string::npos ||
+                       v.find("utf8") != std::string::npos;
+            }
+        }
+        // conservative: assume a non-UTF-8 console when the locale is unknown
+        return false;
+    }
+
+    /** Shorten a label to at most @p width characters (ASCII-safe ".." suffix). */
+    std::string
+    truncate_label (std::string label, std::size_t width)
+    {
+        if (width >= 2 && label.size() > width)
+        {
+            label = label.substr(0, width - 2) + "..";
+        }
+        return label;
+    }
+
+    /** A filtering stream buffer that keeps a status line pinned to the bottom.
+     *
+     * Installed on ``amrex::OutStream()`` while a live bar is up. Foreign output
+     * (anything written through ``amrex::Print`` / the wrapped stream) transparently
+     * erases the bar, is forwarded to the real terminal, and the bar is redrawn on
+     * the new bottom line -- so solver residuals, warnings, etc. scroll above a
+     * pinned bar instead of shredding it. The bar itself is drawn via ``set_bar()``,
+     * which writes straight to the wrapped buffer and never re-enters this filter.
+     */
+    class BottomBar final : public std::streambuf
+    {
+    public:
+        explicit BottomBar (std::streambuf * dest)
+            : m_dest(dest)
+        {}
+
+        /** Redraw the pinned bar with new text (erases the previous one). */
+        void set_bar (std::string const & bar)
+        {
+            erase();
+            m_bar = bar;
+            raw(m_bar);
+            m_shown = !m_bar.empty();
+            m_dest->pubsync();
+        }
+
+        /** Draw a final bar, end the line, and stop pinning. */
+        void finish_bar (std::string const & bar)
+        {
+            erase();
+            raw(bar);
+            raw("\n");
+            m_bar.clear();
+            m_shown = false;
+            m_dest->pubsync();
+        }
+
+        /** Erase the pinned bar (if any) and stop pinning, leaving the cursor at col 0. */
+        void remove_bar ()
+        {
+            erase();
+            m_bar.clear();
+            m_shown = false;
+            m_dest->pubsync();
+        }
+
+    protected:
+        int_type overflow (int_type ch) override
+        {
+            if (traits_type::eq_int_type(ch, traits_type::eof())) { return ch; }
+            char const c = traits_type::to_char_type(ch);
+            before_foreign();
+            int_type const r = m_dest->sputc(c);
+            after_foreign(c == '\n');
+            return r;
+        }
+
+        std::streamsize xsputn (char const * s, std::streamsize n) override
+        {
+            if (n <= 0) { return 0; }
+            before_foreign();
+            std::streamsize const r = m_dest->sputn(s, n);
+            after_foreign(s[n - 1] == '\n');
+            return r;
+        }
+
+        int sync () override { return m_dest->pubsync(); }
+
+    private:
+        void raw (std::string const & s)
+        {
+            m_dest->sputn(s.data(), static_cast<std::streamsize>(s.size()));
+        }
+
+        void erase ()
+        {
+            if (m_shown)
+            {
+                raw("\r\x1b[2K"); // carriage return + ANSI "erase entire line"
+                m_shown = false;
+            }
+        }
+
+        /** Called before forwarding foreign output: clear the bar off the line. */
+        void before_foreign ()
+        {
+            erase();
+        }
+
+        /** Called after forwarding foreign output: repin the bar once a line ended. */
+        void after_foreign (bool ended_line)
+        {
+            if (ended_line && !m_bar.empty())
+            {
+                raw(m_bar);
+                m_shown = true;
+            }
+        }
+
+        std::streambuf * m_dest;  //!< the real terminal buffer we forward to
+        std::string m_bar;        //!< current pinned bar text (no trailing newline)
+        bool m_shown = false;     //!< is the bar currently on the terminal's last line?
+    };
+} // namespace
+
+
+    std::string
+    format_time (double seconds)
+    {
+        if (seconds < 0.0) { seconds = 0.0; }
+        auto const total = static_cast<long>(seconds + 0.5);
+        long const h = total / 3600;
+        long const m = (total % 3600) / 60;
+        long const s = total % 60;
+
+        char buffer[32];
+        if (h > 0)
+        {
+            std::snprintf(buffer, sizeof(buffer), "%ld:%02ld:%02ld", h, m, s);
+        }
+        else
+        {
+            std::snprintf(buffer, sizeof(buffer), "%ld:%02ld", m, s);
+        }
+        return std::string(buffer);
+    }
+
+
+    std::string
+    render_bar (
+        double frac,
+        double s_cur,
+        double s_tot,
+        int bar_width,
+        double elapsed,
+        std::string const & label,
+        bool ascii
+    )
+    {
+        frac = std::min(std::max(frac, 0.0), 1.0);
+        if (bar_width < 1) { bar_width = 1; }
+
+        // filled length, measured in eighths of a character cell
+        int const eighths = static_cast<int>(std::lround(frac * 8.0 * bar_width));
+        int const full = eighths / 8;
+        int const rem = eighths % 8;
+
+        std::string bar;
+        std::string left_cap;
+        std::string right_cap;
+        if (ascii)
+        {
+            left_cap = "[";
+            right_cap = "]";
+            int cells = 0;
+            bar.append(static_cast<std::size_t>(full), '#');
+            cells += full;
+            if (full < bar_width && rem > 0)
+            {
+                bar.push_back('+');
+                cells += 1;
+            }
+            bar.append(static_cast<std::size_t>(bar_width - cells), '-');
+        }
+        else
+        {
+            left_cap = "▕";  // right one-eighth block (thin left cap)
+            right_cap = "▏"; // left one-eighth block (thin right cap)
+            static constexpr std::array<char const *, 8> partial = {
+                " ", "▏", "▎", "▍",
+                "▌", "▋", "▊", "▉"
+            };
+            int cells = 0;
+            for (int i = 0; i < full; ++i) { bar += "█"; } // full block
+            cells += full;
+            if (full < bar_width && rem > 0)
+            {
+                bar += partial[static_cast<std::size_t>(rem)];
+                cells += 1;
+            }
+            for (int i = cells; i < bar_width; ++i) { bar += " "; }
+        }
+
+        int const pct = static_cast<int>(std::lround(frac * 100.0));
+
+        // progress read-out: path length s (if known), percent, and ETA / total time
+        std::string suffix;
+        if (s_tot > 0.0)
+        {
+            char sb[80];
+            std::snprintf(sb, sizeof(sb), "s=%.2f/%.2f m  ", s_cur, s_tot);
+            suffix += sb;
+        }
+        {
+            char pb[16];
+            std::snprintf(pb, sizeof(pb), "%3d%%  ", pct);
+            suffix += pb;
+        }
+        if (frac < 1.0)
+        {
+            double const eta = (frac > 0.0) ? elapsed * (1.0 - frac) / frac : 0.0;
+            suffix += "ETA " + format_time(eta) + "  ";
+        }
+        else
+        {
+            suffix += "time " + format_time(elapsed) + "  ";
+        }
+        suffix += label;
+
+        return "Tracking " + left_cap + bar + right_cap + "  " + suffix;
+    }
+
+
+    ProgressBar::ProgressBar (int total_steps, double total_length, int verbose)
+        : m_verbose(verbose), m_total(total_steps), m_total_s(total_length)
+    {
+        m_io = amrex::ParallelDescriptor::IOProcessor();
+
+        std::string progress = "auto";
+        amrex::ParmParse("impactx").queryAdd("progress", progress);
+
+        if (verbose <= 0 || m_total <= 0)
+        {
+            m_mode = Mode::Silent;
+        }
+        else if (progress == "on")
+        {
+            m_mode = Mode::Live; // explicit user override, even into a pipe
+        }
+        else if (progress == "off")
+        {
+            m_mode = Mode::Banner;
+        }
+        else // "auto"
+        {
+            if (verbose >= 2)
+            {
+                m_mode = Mode::Banner;
+            }
+            else
+            {
+                m_mode = stdout_is_tty() ? Mode::Live : Mode::Banner;
+            }
+        }
+
+        bool ascii = !locale_is_utf8();
+        amrex::ParmParse("impactx").queryAdd("progress_ascii", ascii);
+        m_ascii = ascii;
+
+        if (m_mode == Mode::Live && m_io)
+        {
+            m_start_time = amrex::second();
+
+            // pin the bar to the bottom line: install a filter on amrex::Print()'s
+            // stream so any foreign output (solver residuals, warnings, ...) scrolls
+            // above the bar instead of shredding it (see BottomBar).
+            std::ostream & out = amrex::OutStream();
+            m_saved_streambuf = out.rdbuf();
+            m_bar_buf = std::make_unique<BottomBar>(m_saved_streambuf);
+            out.rdbuf(m_bar_buf.get());
+        }
+    }
+
+
+    ProgressBar::~ProgressBar ()
+    {
+        uninstall();
+    }
+
+
+    void
+    ProgressBar::uninstall ()
+    {
+        if (!m_bar_buf) { return; }
+
+        // erase a still-visible bar (e.g. on an exception before finish())
+        static_cast<BottomBar *>(m_bar_buf.get())->remove_bar();
+
+        // restore amrex::OutStream()'s buffer BEFORE the filter buffer is freed
+        if (m_saved_streambuf != nullptr)
+        {
+            amrex::OutStream().rdbuf(m_saved_streambuf);
+            m_saved_streambuf = nullptr;
+        }
+        m_bar_buf.reset();
+    }
+
+
+    void
+    ProgressBar::show (int step, int slice_step, double s, std::string const & label)
+    {
+        if (m_mode == Mode::Silent) { return; }
+
+        // fraction completed: by path length s when known, else by slice-step count
+        double frac = (m_total_s > 0.0)
+            ? s / m_total_s
+            : (m_total > 0 ? static_cast<double>(step) / m_total : 1.0);
+        frac = std::min(std::max(frac, 0.0), 1.0);
+
+        if (m_mode == Mode::Banner)
+        {
+            int const denom = (m_total > 0) ? m_total : 1;
+            int const pct = (std::min(step, denom) * 100) / denom;
+            amrex::Print() << "\n++++ Starting step=" << step
+                           << " of " << m_total
+                           << " (" << pct << "%) " << label;
+            if (m_total_s > 0.0)
+            {
+                char sb[80];
+                std::snprintf(sb, sizeof(sb), "  s=%.2f/%.2f m", s, m_total_s);
+                amrex::Print() << sb;
+            }
+            if (m_verbose >= 2)
+            {
+                amrex::Print() << " slice_step=" << slice_step;
+            }
+            return;
+        }
+
+        // Mode::Live (I/O rank only): throttle redraws to when the rendered state
+        // changes (clock-free), then repaint the bottom-pinned bar
+        if (!m_io || !m_bar_buf) { return; }
+
+        int const bucket = static_cast<int>(frac * 8.0 * m_bar_width);
+        if (bucket == m_last_bucket && frac < 1.0) { return; }
+        m_last_bucket = bucket;
+
+        double const elapsed = amrex::second() - m_start_time;
+        std::string const line = render_bar(frac, s, m_total_s, m_bar_width, elapsed,
+                                            truncate_label(label, 24), m_ascii);
+
+        static_cast<BottomBar *>(m_bar_buf.get())->set_bar(line);
+    }
+
+
+    void
+    ProgressBar::finish ()
+    {
+        if (m_mode != Mode::Live || !m_io || !m_bar_buf) { return; }
+
+        double const elapsed = amrex::second() - m_start_time;
+        std::string const line = render_bar(1.0, m_total_s, m_total_s, m_bar_width,
+                                            elapsed, "done", m_ascii);
+        static_cast<BottomBar *>(m_bar_buf.get())->finish_bar(line);
+
+        uninstall();
+    }
+
+} // namespace impactx

--- a/src/tracking/ProgressBar.cpp
+++ b/src/tracking/ProgressBar.cpp
@@ -20,6 +20,9 @@
 #   ifndef WIN32_LEAN_AND_MEAN
 #       define WIN32_LEAN_AND_MEAN
 #   endif
+#   ifndef NOMINMAX
+#       define NOMINMAX // windows.h: no min/max macros that break std::min/std::max
+#   endif
 #   include <windows.h>
 #else
 #   include <sys/ioctl.h>

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -14,6 +14,7 @@
 #include "initialization/InitAmrCore.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/Push.H"
+#include "tracking/ProgressBar.H"
 
 #include <ablastr/warn_manager/WarnManager.H>
 
@@ -130,6 +131,11 @@ namespace impactx
         int num_periods = 1;
         amrex::ParmParse("lattice").queryAddWithParser("periods", num_periods);
 
+        // progress bar / per-step status line
+        ProgressBar bar(count_total_steps(m_lattice, num_periods),
+                        count_total_length(m_lattice, num_periods),
+                        verbose);
+
         for (period=0; period < num_periods; ++period)
         {
             // optional, user-defined function call
@@ -149,10 +155,13 @@ namespace impactx
                 // number of slices used for the application of space charge
                 int nslice = 1;
                 amrex::ParticleReal slice_ds; // in meters
-                std::visit([&nslice, &slice_ds](auto &&element)
+                std::string element_label; // for the progress bar; once per element
+                std::visit([&nslice, &slice_ds, &element_label](auto &&element)
                 {
                     nslice = element.nslice();
                     slice_ds = element.ds() / nslice;
+                    element_label = element.has_name() ? element.name()
+                                                       : std::string(element.type);
                 }, element_variant);
 
                 // sub-steps for space charge within the element
@@ -160,11 +169,10 @@ namespace impactx
                 {
                     BL_PROFILE("ImpactX::track_envelope::slice_step");
                     step++;
-                    if (verbose > 0)
-                    {
-                        amrex::Print() << "\n++++ Starting step=" << step
-                                       << " slice_step=" << slice_step;
-                    }
+
+                    // progress bar (live) or per-step banner line (non-interactive);
+                    // s is the reference particle's integrated path length in meters
+                    bar.show(step, slice_step, static_cast<double>(ref.s), element_label);
 
                     // optional, user-defined function call
                     call_hook("before_slice");
@@ -192,8 +200,8 @@ namespace impactx
 
                     }, element_variant);
 
-                    // just prints an empty newline at the end of the slice_step
-                    if (verbose > 0)
+                    // close the banner line of this slice step (Banner mode only)
+                    if (bar.wants_banner())
                     {
                         amrex::Print() << "\n";
                     }
@@ -228,6 +236,9 @@ namespace impactx
             call_hook("after_period");
 
         } // end periods though the lattice loop
+
+        // finalize the progress bar (live mode: 100% frame + newline)
+        bar.finish();
 
         // avoid dangling references if users manipulate the lattice
         m_tracking_state.set_no_element();

--- a/src/tracking/particles.H
+++ b/src/tracking/particles.H
@@ -12,6 +12,7 @@
 
 #include "elements/All.H"
 #include "particles/ImpactXParticleContainer.H"
+#include "tracking/ProgressBar.H"
 #include "tracking/TrackingDirection.H"
 #include "tracking/TrackingState.H"
 
@@ -80,6 +81,11 @@ namespace impactx
         int verbose = 1;
         amrex::ParmParse("impactx").queryAddWithParser("verbose", verbose);
 
+        // progress bar / per-step status line (forward tracking only)
+        ProgressBar bar(count_total_steps(lattice, num_periods),
+                        count_total_length(lattice, num_periods),
+                        forward ? verbose : 0);
+
         int & step = tracking_state.m_step;
 
         // visit one element for all of its space-charge slices
@@ -109,9 +115,12 @@ namespace impactx
             // number of slices used for the application of space charge
             int nslice = 1;
             amrex::ParticleReal slice_ds = 0; // in meters
-            std::visit([&nslice, &slice_ds](auto && element) {
+            std::string element_label; // for the progress bar; once per element
+            std::visit([&nslice, &slice_ds, &element_label](auto && element) {
                 nslice = element.nslice();
                 slice_ds = element.ds() / nslice;
+                element_label = element.has_name() ? element.name()
+                                                   : std::string(element.type);
             }, element_variant);
 
             // sub-steps for space charge within the element
@@ -123,10 +132,11 @@ namespace impactx
                 if (forward)
                 {
                     step++;
-                    if (verbose > 0) {
-                        amrex::Print() << "\n++++ Starting step=" << step
-                                       << " slice_step=" << slice_step;
-                    }
+
+                    // progress bar (live) or per-step banner line (non-interactive);
+                    // s is the reference particle's integrated path length in meters
+                    bar.show(step, slice_step,
+                             static_cast<double>(pc.GetRefParticle().s), element_label);
 
                     // optional, user-defined function call
                     call_hook("before_slice");
@@ -142,6 +152,13 @@ namespace impactx
                 {
                     element_push(element_variant, step, period);
                     collective_kicks(element_variant, slice_ds);
+                }
+
+                // close the banner line of this slice step (Banner mode only;
+                // the live bar stays on a single, carriage-return-updated line)
+                if (forward && bar.wants_banner())
+                {
+                    amrex::Print() << "\n";
                 }
             }
 
@@ -194,6 +211,9 @@ namespace impactx
 
         if (forward)
         {
+            // finalize the progress bar (live mode: 100% frame + newline)
+            bar.finish();
+
             // avoid dangling references if users manipulate the lattice
             tracking_state.set_no_element();
         }

--- a/src/tracking/particles.cpp
+++ b/src/tracking/particles.cpp
@@ -128,7 +128,7 @@ namespace impactx
         };
 
         // the per-slice external-field transport map and per-slice housekeeping
-        auto element_push = [this, &pc, verbose, &pp_diag, diag_enable, &early_params_checked] (
+        auto element_push = [this, &pc, &pp_diag, diag_enable, &early_params_checked] (
             elements::KnownElements & element_variant,
             int step_,
             int period_
@@ -143,10 +143,8 @@ namespace impactx
             // move "lost" particles to another particle container
             collect_lost_particles(*pc);
 
-            // just prints an empty newline at the end of the slice_step
-            if (verbose > 0) {
-                amrex::Print() << "\n";
-            }
+            // note: the per-slice status line (progress bar or banner) is emitted
+            //       by track_lattice_particles, which also closes the banner line
 
             // slice-step diagnostics
             bool slice_step_diagnostics = false;

--- a/src/tracking/reference.cpp
+++ b/src/tracking/reference.cpp
@@ -13,6 +13,7 @@
 #include "initialization/InitAmrCore.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/Push.H"
+#include "tracking/ProgressBar.H"
 
 #include <AMReX.H>
 #include <AMReX_AmrParGDB.H>
@@ -89,6 +90,11 @@ namespace impactx
         int num_periods = 1;
         amrex::ParmParse("lattice").queryAddWithParser("periods", num_periods);
 
+        // progress bar / per-step status line
+        ProgressBar bar(count_total_steps(m_lattice, num_periods),
+                        count_total_length(m_lattice, num_periods),
+                        verbose);
+
         for (period=0; period < num_periods; ++period)
         {
             // optional, user-defined function call
@@ -107,10 +113,13 @@ namespace impactx
                 // number of slices through the element
                 int nslice = 1;
                 amrex::ParticleReal slice_ds; // in meters
-                std::visit([&nslice, &slice_ds](auto &&element)
+                std::string element_label; // for the progress bar; once per element
+                std::visit([&nslice, &slice_ds, &element_label](auto &&element)
                 {
                     nslice = element.nslice();
                     slice_ds = element.ds() / nslice;
+                    element_label = element.has_name() ? element.name()
+                                                       : std::string(element.type);
                 }, element_variant);
 
                 // sub-steps within the element
@@ -118,10 +127,10 @@ namespace impactx
                 {
                     BL_PROFILE("ImpactX::track_reference::slice_step");
                     step++;
-                    if (verbose > 0) {
-                        amrex::Print() << "\n++++ Starting step=" << step
-                                       << " slice_step=" << slice_step;
-                    }
+
+                    // progress bar (live) or per-step banner line (non-interactive);
+                    // s is the reference particle's integrated path length in meters
+                    bar.show(step, slice_step, static_cast<double>(ref.s), element_label);
 
                     // optional, user-defined function call
                     call_hook("before_slice");
@@ -129,8 +138,8 @@ namespace impactx
                     // push the reference particle with external maps
                     push(ref, element_variant);
 
-                    // just prints an empty newline at the end of the slice_step
-                    if (verbose > 0)
+                    // close the banner line of this slice step (Banner mode only)
+                    if (bar.wants_banner())
                     {
                         amrex::Print() << "\n";
                     }
@@ -160,6 +169,9 @@ namespace impactx
             call_hook("after_period");
 
         } // end periods though the lattice loop
+
+        // finalize the progress bar (live mode: 100% frame + newline)
+        bar.finish();
 
         // avoid dangling references if users manipulate the lattice
         m_tracking_state.set_no_element();

--- a/tests/python/test_progress.py
+++ b/tests/python/test_progress.py
@@ -268,3 +268,81 @@ def test_progress_live_bar_narrow_terminal(tmp_path):
 
     # the bar was still drawn and finished (shrunk, not disabled)
     assert any("100%" in seg for seg in frames), out
+
+
+# a slowed-down run (per-slice sleep hook), so a terminal resize can land mid-run
+SLOW_DRIVER = DRIVER.replace(
+    "sim.track_particles()",
+    'sim.hook["before_slice"] = lambda s: __import__("time").sleep(0.008)\n'
+    "sim.track_particles()",
+)
+
+
+@requires_pty
+def test_progress_live_bar_shrink_erases_wrapped_rows(tmp_path):
+    """Shrinking the terminal below the drawn bar's width must not leave stale rows.
+
+    When the window shrinks below the drawn line's length, the terminal re-wraps
+    that line onto several rows; erasing only the cursor's row would leave the
+    upper row(s) behind. The erase clears the extra wrapped rows with ANSI
+    "cursor up + erase line" (see BottomBar::erase).
+    """
+    import fcntl
+    import select
+    import signal
+    import struct
+    import termios
+    import time
+
+    script = tmp_path / "progress_driver_slow.py"
+    script.write_text(SLOW_DRIVER)
+
+    def set_cols(fd, cols):
+        fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 24, cols, 0, 0))
+
+    controller, worker = pty.openpty()
+    set_cols(worker, 100)  # start wide: the drawn bar is ~70 columns
+    proc = subprocess.Popen(
+        [sys.executable, str(script), "auto", "1"],
+        cwd=str(tmp_path),
+        stdout=worker,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+    )
+    os.close(worker)
+
+    data = b""
+    resize_offset = None
+    t0 = time.time()
+    while True:
+        readable, _, _ = select.select([controller], [], [], 0.2)
+        if readable:
+            try:
+                chunk = os.read(controller, 65536)
+            except OSError:  # EIO at EOF on Linux
+                break
+            if not chunk:
+                break
+            data += chunk
+        # shrink below the drawn bar's width once tracking is underway
+        if resize_offset is None and b"Tracking" in data and time.time() - t0 > 0.5:
+            set_cols(controller, 40)
+            proc.send_signal(signal.SIGWINCH)
+            resize_offset = len(data)
+    os.close(controller)
+    proc.wait(timeout=300)
+    assert proc.returncode == 0
+
+    if resize_offset is None:
+        pytest.skip("run finished before the resize could land")
+
+    out = data.decode("utf-8", errors="replace")
+    # before the shrink the bar always fits its width: no up-erase needed
+    assert "\x1b[1A" not in out[:resize_offset]
+    # after the shrink, the stale wrapped row is erased with cursor-up + erase-line
+    assert "\x1b[1A\x1b[2K" in out[resize_offset:], out[resize_offset:][:400]
+    # ... and the cursor returns to the bar's bottom row afterwards (cursor-down),
+    # so the bar stays anchored instead of migrating to the top of the terminal
+    assert re.search(
+        r"\x1b\[1A\x1b\[2K(\x1b\[1A\x1b\[2K)*\x1b\[\d+B", out[resize_offset:]
+    )

--- a/tests/python/test_progress.py
+++ b/tests/python/test_progress.py
@@ -1,0 +1,228 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+"""Tests for the tracking progress bar / status line.
+
+The progress bar is emitted from C++ (``src/tracking/ProgressBar.*``). Because it
+writes to the process' real ``stdout`` (via ``amrex::Print``), we exercise it by
+running a tiny simulation as a subprocess and capturing its output. Running under a
+pipe makes ``stdout`` non-interactive, which is exactly the batch/dashboard case.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+import pytest
+
+try:
+    import pty
+except ImportError:  # pragma: no cover - Windows has no pty
+    pty = None
+
+requires_pty = pytest.mark.skipif(
+    pty is None or not hasattr(os, "openpty"),
+    reason="requires a POSIX pseudo-terminal",
+)
+
+# A tiny tracking run with a known step total:
+#   sum(nslice) = 3 + 2 = 5, periods = 2  ->  total = 10 forward steps
+DRIVER = r"""
+import sys
+
+from impactx import ImpactX, distribution, elements
+
+progress = sys.argv[1] if len(sys.argv) > 1 else "auto"
+ascii_flag = len(sys.argv) > 2 and sys.argv[2] == "1"
+space_charge = sys.argv[3] if len(sys.argv) > 3 else "off"
+
+sim = ImpactX()
+sim.particle_shape = 2
+sim.diagnostics = False
+sim.slice_step_diagnostics = False
+
+if space_charge != "off":
+    # mesh-based space charge -> a per-slice MLMG Poisson solve that prints residuals
+    sim.max_level = 0
+    sim.n_cell = [16, 16, 24]
+    sim.blocking_factor_x = [16]
+    sim.blocking_factor_y = [16]
+    sim.blocking_factor_z = [8]
+    sim.space_charge = space_charge
+    sim.dynamic_size = True
+    sim.prob_relative = [3.0]
+else:
+    sim.space_charge = False
+
+sim.init_grids()
+
+# progress bar controls (ParmParse-backed, need AMReX initialized)
+sim.progress = progress
+sim.progress_ascii = ascii_flag
+
+# a 2 GeV electron reference particle
+ref = sim.beam.ref
+ref.set_species("electron").set_kin_energy_MeV(2.0e3)
+
+# a small waterbag beam
+distr = distribution.Waterbag(
+    lambdaX=1.0e-4,
+    lambdaY=1.0e-4,
+    lambdaT=1.0e-3,
+    lambdaPx=1.0e-5,
+    lambdaPy=1.0e-5,
+    lambdaPt=1.0e-3,
+    muxpx=0.0,
+    muypy=0.0,
+    mutpt=0.0,
+)
+sim.add_particles(1.0e-9, distr, 1000)
+
+sim.lattice.extend(
+    [
+        elements.Drift(name="d1", ds=1.0, nslice=3),
+        elements.Quad(name="q1", ds=1.0, k=1.0, nslice=2),
+    ]
+)
+sim.periods = 2
+
+sim.track_particles()
+sim.finalize()
+"""
+
+TOTAL = (3 + 2) * 2  # sum(nslice) * periods  ->  total forward steps
+TOTAL_S = (1.0 + 1.0) * 2  # sum(ds) * periods  ->  total path length s in meters
+
+
+def _run(tmp_path, *args):
+    script = tmp_path / "progress_driver.py"
+    script.write_text(DRIVER)
+    # capture raw bytes (not text=True): universal-newline mode would translate
+    # the live bar's carriage returns "\r" into "\n" and hide them from the test.
+    result = subprocess.run(
+        [sys.executable, str(script), *args],
+        cwd=str(tmp_path),
+        capture_output=True,
+        timeout=300,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    assert result.returncode == 0, (
+        f"driver failed (rc={result.returncode}):\n"
+        f"--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    )
+    return stdout
+
+
+def _run_pty(tmp_path, *args):
+    """Run the driver with stdout attached to a pseudo-terminal (isatty() is True).
+
+    Returns the raw byte stream (including the live bar's carriage returns and ANSI
+    escapes) decoded as text.
+    """
+    script = tmp_path / "progress_driver.py"
+    script.write_text(DRIVER)
+
+    controller, worker = pty.openpty()
+    proc = subprocess.Popen(
+        [sys.executable, str(script), *args],
+        cwd=str(tmp_path),
+        stdout=worker,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+    )
+    os.close(worker)  # only the child keeps the worker end open
+
+    chunks = []
+    while True:
+        try:
+            data = os.read(controller, 65536)
+        except OSError:  # controller raises EIO at EOF on Linux
+            break
+        if not data:
+            break
+        chunks.append(data)
+    os.close(controller)
+    proc.wait(timeout=300)
+
+    out = b"".join(chunks).decode("utf-8", errors="replace")
+    assert proc.returncode == 0, f"driver failed (rc={proc.returncode}):\n{out}"
+    return out
+
+
+def test_progress_banner_non_interactive(tmp_path):
+    """A piped run emits per-step banner lines carrying the exact total.
+
+    This is the contract the Trame dashboard relies on
+    (``dashboard/Run/executor.py`` parses ``step=<N> of <T>``).
+    """
+    out = _run(tmp_path, "auto")
+
+    # no live carriage-return bar should leak into a pipe
+    assert "\r" not in out
+
+    steps = re.findall(r"\+\+\+\+ Starting step=(\d+) of (\d+)", out)
+    assert steps, f"no banner lines found in:\n{out}"
+
+    # every line reports the exact total = periods * sum(nslice)
+    assert {int(total) for _, total in steps} == {TOTAL}
+
+    # exactly one banner per step, counting 1..TOTAL in order
+    assert [int(step) for step, _ in steps] == list(range(1, TOTAL + 1))
+
+    # explicit token endpoints
+    assert f"++++ Starting step=1 of {TOTAL}" in out
+    assert f"++++ Starting step={TOTAL} of {TOTAL}" in out
+
+    # the path length s is reported against the exact total (periods * sum(ds))
+    assert re.search(rf"s=\d+\.\d+/{TOTAL_S:.2f} m", out), out
+
+
+def test_progress_live_forced_ascii(tmp_path):
+    """``progress=on`` forces the live bar even into a pipe; ASCII keeps it deterministic."""
+    out = _run(tmp_path, "on", "1")
+
+    # live frames are drawn with a carriage return using the ASCII renderer
+    assert "\r" in out
+    assert "Tracking [" in out
+
+    # progress is shown in path length s against the exact total
+    assert re.search(rf"s=\d+\.\d+/{TOTAL_S:.2f} m", out), out
+
+    # the final frame reaches 100% at s = total length (bar fully filled)
+    assert re.search(
+        rf"Tracking \[#+\]  s={TOTAL_S:.2f}/{TOTAL_S:.2f} m  100%  time ", out
+    ), out
+
+    # live mode must not also emit the per-step banner
+    assert "++++ Starting step=" not in out
+
+
+@requires_pty
+def test_progress_live_bar_coexists_with_solver(tmp_path):
+    """On a real terminal, the live bar stays pinned while a per-slice solver prints.
+
+    With mesh space charge the MLMG Poisson solve prints residuals every slice. The
+    bar installs a filtering stream buffer (see src/tracking/ProgressBar.cpp) so that
+    output erases the bar, scrolls above it, and the bar is redrawn on the new bottom
+    line -- rather than being shredded or suppressed.
+    """
+    out = _run_pty(tmp_path, "auto", "0", "3D")
+
+    # the live bar and the solver output are both present (coexistence)
+    assert "Tracking " in out, out
+    assert "MLMG:" in out, out
+
+    # the bar is kept at the bottom via ANSI "erase entire line" (\x1b[2K)
+    assert "\x1b[2K" in out
+
+    # the bar is redrawn after solver output (repinned below the scrolled MLMG lines)
+    assert out.rfind("Tracking ") > out.find("MLMG:"), out
+
+    # and it still reaches 100% at s = total length
+    assert re.search(r"100%  time ", out), out

--- a/tests/python/test_progress.py
+++ b/tests/python/test_progress.py
@@ -119,16 +119,23 @@ def _run(tmp_path, *args):
     return stdout
 
 
-def _run_pty(tmp_path, *args):
+def _run_pty(tmp_path, *args, cols=None):
     """Run the driver with stdout attached to a pseudo-terminal (isatty() is True).
 
     Returns the raw byte stream (including the live bar's carriage returns and ANSI
-    escapes) decoded as text.
+    escapes) decoded as text. ``cols`` sets the pseudo-terminal's width.
     """
     script = tmp_path / "progress_driver.py"
     script.write_text(DRIVER)
 
     controller, worker = pty.openpty()
+    if cols is not None:
+        import fcntl
+        import struct
+        import termios
+
+        winsz = struct.pack("HHHH", 24, cols, 0, 0)
+        fcntl.ioctl(worker, termios.TIOCSWINSZ, winsz)
     proc = subprocess.Popen(
         [sys.executable, str(script), *args],
         cwd=str(tmp_path),
@@ -226,3 +233,38 @@ def test_progress_live_bar_coexists_with_solver(tmp_path):
 
     # and it still reaches 100% at s = total length
     assert re.search(r"100%  time ", out), out
+
+
+@requires_pty
+def test_progress_live_bar_narrow_terminal(tmp_path):
+    """On a narrow terminal, every bar frame fits the width (no line wrapping).
+
+    A frame wider than the terminal would wrap, and a wrapped line cannot be erased
+    with a carriage return anymore -- each redraw would then leave a stale row behind
+    (newline spam). The bar re-queries the width at every redraw, so this also covers
+    window resizes mid-run.
+    """
+    ncols = 40
+    out = _run_pty(tmp_path, "auto", "1", cols=ncols)
+
+    frames = [seg for seg in out.split("\r") if "Tracking" in seg]
+    assert frames, out
+
+    ansi = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+    bar_widths = set()
+    for seg in frames:
+        # visible content of this frame: strip ANSI escapes, stop at a newline
+        visible = ansi.sub("", seg).split("\n")[0]
+        assert len(visible) < ncols, (
+            f"frame wider than terminal ({len(visible)} cols): {visible!r}"
+        )
+        bar = re.search(r"\[([#+-]*)\]", visible)
+        if bar:
+            bar_widths.add(len(bar.group(1)))
+
+    # the bar body must not change its width from frame to frame ("fluctuating"
+    # bar): the layout is computed from fixed field reserves, not frame content
+    assert len(bar_widths) == 1, f"bar width fluctuates: {sorted(bar_widths)}"
+
+    # the bar was still drawn and finished (shrunk, not disabled)
+    assert any("100%" in seg for seg in frames), out


### PR DESCRIPTION
Add a low-overhead, intermediate-print friendly progress bar for all three `track_*` loops. Works for executable + input files and Python APIs alike.

- [ ] finish self-review
- [ ] decide if some of this could be upstreamed to ABLASTR or AMReX (could be a follow-up, too)
- [x] test with `python examples/expanding_beam/run_expanding_fft.py` and `python examples/simple_booster/run_simple_booster.py` again
  - [x] fix issues with small width terminals printing multiple lines
 - [ ] test what happens in Jupyter
 - [ ] test what happens in a slurm job