### PR TITLE
Tiny Profiler: default report to `<diag_file_prefix>/performance.txt`

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -2717,6 +2717,20 @@ Diagnostics and output
     If this flag is enabled, the 3 eigenemittances of the 6D beam distribution are computed and written as diagnostics.
     This flag is disabled by default to reduce computational cost.
 
+.. pp:param:: tiny_profiler.output_file
+    :type: ``string``
+    :optional:
+    :default: ``<diag.file_prefix>/performance.txt``
+
+    File name for the AMReX tiny profiler report (an AMReX ``tiny_profiler.*`` parameter).
+    By default, ImpactX writes the report to ``<diag.file_prefix>/performance.txt``
+    (e.g. ``diags/performance.txt``) instead of stdout.
+    When diagnostics are disabled (:pp:param:`diag.enable` is ``false``), the profiler is turned
+    off (``/dev/null``) so that no :pp:param:`diag.file_prefix` folder is created.
+
+    Set this to a path to choose a specific file, to an empty string to dump the report on the
+    default out stream of AMReX (stdout), or to ``/dev/null`` (a special name) to disable the output.
+
 
 .. _running-cpp-parameters-cp-restart:
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -424,14 +424,19 @@ Collective Effects & Overall Simulation Parameters
    .. py:property:: memory_profiler
 
       This parameter can be used to disable tiny profiler's memory arena profiling at runtime.
-      If ```tiny_profiler`` is ``False``, this parameter has no effects.
+      If ``tiny_profiler`` is ``False``, this parameter has no effects.
       Default is ``True``.
 
    .. py:property:: tiny_profiler_file
 
-      If this parameter is empty (default), the output of tiny profiling is dumped on the default out stream of AMReX.
-      If it's not empty, it specifies the file name for the output.
-      Note that ``"/dev/null"`` is a special name that mean no output.
+      File name for the tiny profiler report.
+      If it is not set, ImpactX writes the report to ``<diag_file_prefix>/performance.txt``
+      (e.g. ``diags/performance.txt``) instead of stdout.
+      When diagnostics are disabled (:py:attr:`diagnostics` is ``False``), the profiler is turned
+      off so that no diagnostics folder is created.
+      Set this to a path to choose a specific file, to an empty string (``""``) to dump the report
+      on the default out stream of AMReX (stdout), or to ``"/dev/null"`` (a special name) to
+      disable the output.
 
    .. py:method:: evolve()
 

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -54,7 +54,30 @@ namespace impactx {
             amr_data.reset();
 
             if (amrex::Initialized())
+            {
+                // By default, write the AMReX tiny profiler report into the
+                // diagnostics directory (<diag.file_prefix>/performance.txt)
+                // instead of stdout. When diagnostics are disabled, keep the
+                // profiler silent (/dev/null) so that no diagnostics folder is
+                // created. A user-set tiny_profiler.output_file (input file or
+                // sim.tiny_profiler_file) always takes precedence. AMReX reads
+                // output_file lazily at Finalize, so setting it here is early enough.
+                {
+                    amrex::ParmParse pp_tiny_profiler("tiny_profiler");
+                    std::string output_file;
+                    if (!pp_tiny_profiler.query("output_file", output_file))
+                    {
+                        bool diag_enable = true;
+                        amrex::ParmParse("diag").queryAdd("enable", diag_enable);
+                        output_file = diag_enable
+                            ? diagnostics::FilePrefixPath("performance.txt")
+                            : std::string("/dev/null");
+                        pp_tiny_profiler.add("output_file", output_file);
+                    }
+                }
+
                 amrex::Finalize();
+            }
 
             // only finalize once
             m_grids_initialized = false;

--- a/src/initialization/InitAMReX.cpp
+++ b/src/initialization/InitAMReX.cpp
@@ -43,6 +43,15 @@ namespace impactx::initialization
     void
     default_init_AMReX ()
     {
-        default_init_AMReX(0, nullptr);
+        // Pass a program name (argc = 1) so that AMReX runs ParmParse::Initialize.
+        // With argc = 0 and build_parm_parse = true, AMReX skips ParmParse::Initialize
+        // and never registers ParmParse::Finalize. ParmParse state (the global table)
+        // would then leak across AMReX initialize/finalize cycles, e.g. in persistent
+        // Jupyter notebook kernels that run several simulations in one process.
+        int argc = 1;
+        char arg0[] = "impactx";
+        char* argv_storage[] = {arg0, nullptr};
+        char** argv = argv_storage;
+        default_init_AMReX(argc, argv);
     }
 } // namespace impactx::initialization

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -642,9 +642,12 @@ void init_ImpactX (py::module& m)
                 amrex::ParmParse pp_tiny_profiler("tiny_profiler");
                 pp_tiny_profiler.add("output_file", output_file);
             },
-            "If this parameter is empty, the output of tiny profiling is dumped on the default out stream of AMReX. "
-            "If it's not empty, it specifies the file name for the output. "
-            "Note that /dev/null is a special name that mean a null file."
+            "File name for the tiny profiler output. "
+            "If not set, ImpactX writes the report to ``<diag_file_prefix>/performance.txt`` "
+            "(e.g. ``diags/performance.txt``); when diagnostics are disabled (see ``diagnostics``) "
+            "the profiler is turned off so that no diagnostics folder is created. "
+            "Set to a path to choose a file, to an empty string to dump on the default out stream "
+            "of AMReX (stdout), or to /dev/null (a special name) to disable the output."
         )
         .def_readwrite("hook",
             &ImpactX::m_hook,

--- a/tests/python/test_tiny_profiler.py
+++ b/tests/python/test_tiny_profiler.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+"""
+Tests for the default AMReX tiny profiler report location.
+
+By default ImpactX writes the tiny profiler report to
+``<diag_file_prefix>/performance.txt`` (e.g. ``diags/performance.txt``) instead of
+stdout, and turns the profiler off when diagnostics are disabled so that no
+diagnostics folder is created.
+
+The shared pytest ``conftest.py`` disables the tiny profiler process-wide
+(``tiny_profiler.enabled=0``), so these tests manage their own AMReX lifecycle
+(``manages_amrex``) and enable the profiler explicitly. AMReX re-reads
+``tiny_profiler.output_file`` once per init/finalize cycle, so each test resolves
+its own output location independently.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from impactx import ImpactX, distribution, elements
+
+
+def run_minimal_simulation(sim):
+    """Run a minimal drift simulation on an already-initialized sim."""
+    ref = sim.beam.ref
+    ref.set_species("electron").set_kin_energy_MeV(2.0e3)
+
+    distr = distribution.Waterbag(
+        lambdaX=1.0e-3,
+        lambdaY=1.0e-3,
+        lambdaT=1.0e-3,
+        lambdaPx=1.0e-4,
+        lambdaPy=1.0e-4,
+        lambdaPt=1.0e-3,
+    )
+    sim.add_particles(1.0e-9, distr, 100)
+
+    sim.lattice.append(elements.Drift(name="d1", ds=0.25))
+    sim.track_particles()
+
+
+@pytest.mark.manages_amrex
+def test_performance_file_default():
+    """By default, the profiler report is written to diags/performance.txt."""
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.tiny_profiler = True
+    sim.init_grids()
+
+    run_minimal_simulation(sim)
+
+    sim.finalize()
+
+    performance = Path("diags") / "performance.txt"
+    assert performance.exists()
+    assert performance.stat().st_size > 0
+
+
+@pytest.mark.manages_amrex
+def test_performance_file_custom_prefix():
+    """The profiler report follows a custom diag_file_prefix."""
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.tiny_profiler = True
+    sim.diag_file_prefix = "perf_out"
+    sim.init_grids()
+
+    run_minimal_simulation(sim)
+
+    sim.finalize()
+
+    assert (Path("perf_out") / "performance.txt").exists()
+    assert not Path("diags").exists()
+
+
+@pytest.mark.manages_amrex
+def test_performance_file_diagnostics_disabled():
+    """With diagnostics disabled, the profiler is off and no diags folder is created."""
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.tiny_profiler = True
+    sim.diagnostics = False
+    sim.init_grids()
+
+    run_minimal_simulation(sim)
+
+    sim.finalize()
+
+    assert not Path("diags").exists()
+    assert not Path("performance.txt").exists()
+
+
+@pytest.mark.manages_amrex
+def test_performance_file_explicit_override():
+    """An explicit tiny_profiler_file takes precedence over the default."""
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.tiny_profiler = True
+    sim.tiny_profiler_file = "myperf.txt"
+    sim.init_grids()
+
+    run_minimal_simulation(sim)
+
+    sim.finalize()
+
+    assert Path("myperf.txt").exists()
+    assert not (Path("diags") / "performance.txt").exists()


### PR DESCRIPTION
The tiny profiler output is nice but verbose for many workflows, and many of our Python users fully disable it by default because of the large "scrolling" it causes in many workflows. Change for both modes (exe + input) to keep consistent, so we can request from users their profile consistently when analyzing/helping.

Now, by default, write the AMReX tiny profiler report to `<diag.file_prefix>/performance.txt` (e.g. `diags/performance.txt`) instead of stdout, for both Python- and inputs-file-steered runs. When diagnostics are disabled (`diag.enable` / `sim.diagnostics`), the profiler is turned off (`/dev/null`) so that no diagnostics folder is created. An explicitly set `tiny_profiler.output_file` / `sim.tiny_profiler_file` always takes precedence.

The default is applied in `ImpactX::finalize()` so it follows the final `diag_file_prefix`. The Python init path now initializes AMReX with a program name (`argc = 1`) so that `ParmParse` is initialized/finalized per cycle: otherwise the global `ParmParse` table leaks across AMReX init/finalize cycles (e.g. in Jupyter notebooks running several simulations).

Adds `tests/python/test_tiny_profiler.py` and documents `tiny_profiler.output_file`. Requires the matching AMReX change to re-read `tiny_profiler.output_file` per init/finalize cycle.

- [ ] finalize self-review, add `stdout` docs as in WarpX
- [x] depends on https://github.com/AMReX-Codes/amrex/pull/5572
- [ ] depends on https://github.com/AMReX-Codes/amrex/pull/5585
- [x] synchronize with developer discussion in WarpX (https://github.com/BLAST-WarpX/warpx/pull/7077) and keep logic in sync
- [ ] update docs that reference the tiny profiler table