### PR TITLE
`BeamMonitor`: gyromagnetic anomaly

### DIFF
--- a/docs/source/dataanalysis/dataanalysis.rst
+++ b/docs/source/dataanalysis/dataanalysis.rst
@@ -36,11 +36,12 @@ Reference particle:
 * ``x_ref`` horizontal position x, in meters
 * ``y_ref`` vertical position y, in meters
 * ``z_ref`` longitudinal position z, in meters
-* ``t_ref`` clock time * c in meters
+* ``t_ref`` clock time * c, in meters
 * ``px_ref`` momentum in x, normalized to mass*c, :math:`p_x = \gamma \beta_x`
 * ``py_ref`` momentum in y, normalized to mass*c, :math:`p_y = \gamma \beta_y`
 * ``pz_ref`` momentum in z, normalized to mass*c, :math:`p_z = \gamma \beta_z`
 * ``pt_ref`` energy, normalized by rest energy, :math:`p_t = -\gamma`
+* ``gyromagnetic_anomaly_ref`` `anomalous magnetic moment <https://en.wikipedia.org/wiki/Anomalous_magnetic_dipole_moment>`__, unitless
 * ``mass_ref`` reference rest mass, in kg
 * ``charge_ref`` reference charge, in C
 

--- a/src/elements/diagnostics/BeamMonitor.cpp
+++ b/src/elements/diagnostics/BeamMonitor.cpp
@@ -269,6 +269,7 @@ namespace detail {
         beam.setAttribute( "py_ref", ref_part.py );
         beam.setAttribute( "pz_ref", ref_part.pz );
         beam.setAttribute( "pt_ref", ref_part.pt );
+        beam.setAttribute( "gyromagnetic_anomaly_ref", ref_part.gyromagnetic_anomaly );
         beam.setAttribute( "mass_ref", ref_part.mass );
         beam.setAttribute( "charge_ref", ref_part.charge );
 


### PR DESCRIPTION
Write the anomalous magnetic dipole moment of the reference particle to openPMD beam monitor data, too.

Needed to restore for the reference particle in a follow-up PR.