### PR TITLE
`Source`: Add `load_ref_particle=True`

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -2047,12 +2047,13 @@ When ImpactX needs to sort particles spatially, it will redistribute them over M
 
     The reference particle state (:math:`s`, positions, momenta, mass, charge and the gyromagnetic anomaly)
     is restored exactly from the iteration the particles are read from.
+    In this case, the :ref:`beam.* input block <running-cpp-parameters-particle>` can be omitted entirely.
     Set to ``false`` to load all particles relative to a manually configured reference particle:
     the relative particle coordinates in the file (in particular the momenta :math:`p_x`, :math:`p_y`
     and :math:`p_t`, which are normalized by the reference particle momentum) are then interpreted
     with respect to the existing reference particle.
     The existing reference particle in that case needs to be manually configured before the tracking loop.
-    This option acts during particle tracking; it has no effect in envelope or reference-particle-only tracking.
+    This option acts during particle tracking, it has no effect in envelope or reference-particle-only tracking.
 
 
 ``spin_map``

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -2039,6 +2039,21 @@ When ImpactX needs to sort particles spatially, it will redistribute them over M
 
     Inject particles only for the first lattice period.
 
+.. pp:param:: <source_name>.load_ref_particle
+    :type: ``boolean``
+    :default: ``true``
+
+    Restore the reference particle from the species metadata of the openPMD file.
+
+    The reference particle state (:math:`s`, positions, momenta, mass, charge and the gyromagnetic anomaly)
+    is restored exactly from the iteration the particles are read from.
+    Set to ``false`` to load all particles relative to a manually configured reference particle:
+    the relative particle coordinates in the file (in particular the momenta :math:`p_x`, :math:`p_y`
+    and :math:`p_t`, which are normalized by the reference particle momentum) are then interpreted
+    with respect to the existing reference particle.
+    The existing reference particle in that case needs to be manually configured before the tracking loop.
+    This option acts during particle tracking; it has no effect in envelope or reference-particle-only tracking.
+
 
 ``spin_map``
 ^^^^^^^^^^^^

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1827,7 +1827,7 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
       :math:`p_y` and :math:`p_t`, which are normalized by the reference particle momentum) are then
       interpreted with respect to the existing reference particle.
       The existing reference particle in that case needs to be manually configured before the tracking loop.
-      This option acts when particles are tracked or pushed (:py:func:`impactx.push`);
+      This option acts when particles are tracked or pushed (:py:func:`impactx.push`),
       it has no effect in envelope or reference-particle-only tracking.
 
    .. attention::

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1807,7 +1807,7 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
 
       Scale factor (in meters^(1/2)) of the IOTA nonlinear magnetic insert element used for computing H and I.
 
-.. py:class:: impactx.elements.Source(distribution, openpmd_path, active_once=True, name=None)
+.. py:class:: impactx.elements.Source(distribution, openpmd_path, active_once=True, load_ref_particle=True, name=None)
 
    A particle source.
    Currently, this only supports openPMD files from our :py:class:`impactx.elements.BeamMonitor`
@@ -1815,7 +1815,20 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
    :param distribution: Distribution type of particles in the source. currently, only ``"openPMD"`` is supported
    :param openpmd_path: path to the openPMD series
    :param active_once: Inject particles only for the first lattice period. Default: ``True``
+   :param load_ref_particle: Restore the reference particle from the species metadata of the openPMD file. Default: ``True``
    :param name: an optional name for the element
+
+   .. note::
+
+      With ``load_ref_particle``, the reference particle state (:math:`s`, positions, momenta, mass, charge
+      and the gyromagnetic anomaly) is restored exactly from the iteration the particles are read from.
+      Set ``load_ref_particle=False`` to load all particles relative to a manually configured reference
+      particle: the relative particle coordinates in the file (in particular the momenta :math:`p_x`,
+      :math:`p_y` and :math:`p_t`, which are normalized by the reference particle momentum) are then
+      interpreted with respect to the existing reference particle.
+      The existing reference particle in that case needs to be manually configured before the tracking loop.
+      This option acts when particles are tracked or pushed (:py:func:`impactx.push`);
+      it has no effect in envelope or reference-particle-only tracking.
 
    .. attention::
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -789,6 +789,20 @@ if(ImpactX_TEST_CLEANUP)
     set_property(TEST solenoid.py.cleanup APPEND PROPERTY DEPENDS "solenoid.restart.py.cleanup")
 endif()
 
+add_impactx_test(solenoid.restart.noref.py
+    examples/solenoid_restart/run_solenoid_noref.py
+    OFF  # ImpactX MPI-parallel
+    examples/solenoid_restart/analysis_solenoid.py
+    OFF  # no plot script yet
+)
+if(ImpactX_PYTHON)
+    set_property(TEST solenoid.restart.noref.py.run APPEND PROPERTY DEPENDS "solenoid.py.run")
+endif()
+if(ImpactX_TEST_CLEANUP)
+    # do not clean up dependency test before current test is completed
+    set_property(TEST solenoid.py.cleanup APPEND PROPERTY DEPENDS "solenoid.restart.noref.py.cleanup")
+endif()
+
 
 # Pole-face rotation ##########################################################
 #

--- a/examples/solenoid_restart/README.rst
+++ b/examples/solenoid_restart/README.rst
@@ -24,6 +24,9 @@ This example can be run **either** as:
 For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
 In MPI-parallel runs, the ``source`` element distributes reading of the particles in the openPMD file over all MPI ranks (each rank reads a different :math:`1/N`-th of the particles).
 
+By default, the ``source`` element also restores the reference particle from the metadata of the openPMD file (:py:class:`load_ref_particle <impactx.elements.Source>` option; see ``run_solenoid.py`` and ``input_solenoid.in``).
+Alternatively, after disabling that option, particles are loaded relative to a manually configured reference particle (``run_solenoid_noref.py``).
+
 .. tab-set::
 
    .. tab-item:: Python: Script
@@ -31,6 +34,12 @@ In MPI-parallel runs, the ``source`` element distributes reading of the particle
        .. literalinclude:: run_solenoid.py
           :language: python3
           :caption: You can copy this file from ``examples/solenoid_restart/run_solenoid.py``.
+
+   .. tab-item:: Python: Script (manually configured reference particle)
+
+       .. literalinclude:: run_solenoid_noref.py
+          :language: python3
+          :caption: You can copy this file from ``examples/solenoid_restart/run_solenoid_noref.py``.
 
    .. tab-item:: Executable: Input File
 

--- a/examples/solenoid_restart/input_solenoid.in
+++ b/examples/solenoid_restart/input_solenoid.in
@@ -1,13 +1,7 @@
 ###############################################################################
 # Reference Particle
 ###############################################################################
-beam.kin_energy = 250.0
-beam.particle = proton
-
-# ignored
-beam.charge = 1.0e-9
-beam.units = static
-beam.distribution = empty
+# Restored from file in the `source` element below.
 
 
 ###############################################################################

--- a/examples/solenoid_restart/input_solenoid.in
+++ b/examples/solenoid_restart/input_solenoid.in
@@ -19,6 +19,8 @@ lattice.nslice = 1
 source.type = source
 source.distribution = openPMD
 source.openpmd_path = "../solenoid/diags/openPMD/m1.h5"
+# the reference particle is restored from the file, too (default):
+#   source.load_ref_particle = true
 
 m1.type = beam_monitor
 m1.backend = h5

--- a/examples/solenoid_restart/run_solenoid.py
+++ b/examples/solenoid_restart/run_solenoid.py
@@ -6,7 +6,11 @@
 #
 # -*- coding: utf-8 -*-
 
+import openpmd_api as io
+
 from impactx import ImpactX, elements, push
+
+source_path = "../solenoid.py/diags/openPMD/m1.h5"
 
 sim = ImpactX()
 
@@ -18,18 +22,37 @@ sim.slice_step_diagnostics = True
 # domain decomposition & space charge mesh
 sim.init_grids()
 
-# load a 250 MeV proton beam with an initial
-# horizontal rms emittance of 1 um and an
-# initial vertical rms emittance of 2 um
-kin_energy_MeV = 250.0  # reference energy
-
-#   reference particle
+# load the particle bunch and the reference particle (a 250 MeV proton beam)
+# from the final beam monitor output of the solenoid example
 beam = sim.beam
-ref = beam.ref
-ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
+push(beam, elements.Source("openPMD", source_path))
 
-#   load particle bunch from file
-push(beam, elements.Source("openPMD", "../solenoid.py/diags/openPMD/m1.h5"))
+# check that the reference particle was restored exactly from the file metadata
+ref = beam.ref
+series = io.Series(source_path, io.Access.read_only)
+last_step = list(series.iterations)[-1]
+beam_md = series.iterations[last_step].particles["beam"]
+for attr, value in [
+    ("s_ref", ref.s),
+    ("x_ref", ref.x),
+    ("y_ref", ref.y),
+    ("z_ref", ref.z),
+    ("t_ref", ref.t),
+    ("px_ref", ref.px),
+    ("py_ref", ref.py),
+    ("pz_ref", ref.pz),
+    ("pt_ref", ref.pt),
+    ("mass_ref", ref.mass),
+    ("charge_ref", ref.charge),
+    ("gyromagnetic_anomaly_ref", ref.gyromagnetic_anomaly),
+]:
+    assert value == beam_md.get_attribute(attr), attr
+series.close()
+
+# this is a 250 MeV proton at the end of the first solenoid channel (one period)
+assert abs(ref.kin_energy_MeV - 250.0) < 1e-11
+assert abs(ref.charge_qe - 1.0) < 1e-14
+assert abs(ref.s - 3.820395) < 1e-11
 
 # add beam diagnostics
 m1 = elements.BeamMonitor("m1", backend="h5")

--- a/examples/solenoid_restart/run_solenoid_noref.py
+++ b/examples/solenoid_restart/run_solenoid_noref.py
@@ -6,7 +6,7 @@
 #
 # -*- coding: utf-8 -*-
 
-from impactx import Config, ImpactX, elements, push
+from impactx import ImpactX, elements, push
 
 sim = ImpactX()
 
@@ -18,19 +18,23 @@ sim.slice_step_diagnostics = True
 # domain decomposition & space charge mesh
 sim.init_grids()
 
-# load the particle bunch and the reference particle (a 250 MeV proton beam)
-# from the final beam monitor output of the solenoid example
-beam = sim.beam
-push(beam, elements.Source("openPMD", "../solenoid.py/diags/openPMD/m1.h5"))
+# load a 250 MeV proton beam with an initial
+# horizontal rms emittance of 1 um and an
+# initial vertical rms emittance of 2 um
+kin_energy_MeV = 250.0  # reference energy
 
-# test only:
-# check that the reference particle was restored exactly from the file metadata
-# this is a 250 MeV proton at the end of the first solenoid channel (one period)
-rtol = 1.0e-13 if Config.precision == "DOUBLE" else 1.0e-5  # a few machine epsilon
+#   reference particle: manually configured, not loaded from the file below
+beam = sim.beam
 ref = beam.ref
-assert abs(ref.kin_energy_MeV - 250.0) < 250.0 * rtol
-assert abs(ref.charge_qe - 1.0) < rtol
-assert abs(ref.s - 3.820395) < 3.820395 * rtol
+ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
+
+#   load particle bunch from file, relative to the reference particle above
+push(
+    beam,
+    elements.Source(
+        "openPMD", "../solenoid.py/diags/openPMD/m1.h5", load_ref_particle=False
+    ),
+)
 
 # add beam diagnostics
 m1 = elements.BeamMonitor("m1", backend="h5")

--- a/src/elements/Source.H
+++ b/src/elements/Source.H
@@ -31,24 +31,29 @@ namespace impactx::elements
         using PType = ImpactXParticleContainer::ParticleType;
 
         static constexpr bool DEFAULT_active_once = true;
+        static constexpr bool DEFAULT_load_ref_particle = true;
 
         /** A particle source
          *
          * @param distribution Must read "openPMD" for this constructor
          * @param openpmd_path path to openPMD series as accepted by openPMD::Series
          * @param active_once inject particles only for the first lattice period
+         * @param load_ref_particle restore the reference particle from the species metadata
+         *        of the openPMD file (particle tracking only)
          * @param name a user defined and not necessarily unique name of the element
          */
         Source (
             std::string distribution,
             std::string openpmd_path,
             bool active_once = DEFAULT_active_once,
+            bool load_ref_particle = DEFAULT_load_ref_particle,
             std::optional<std::string> name = DEFAULT_name
         )
         : Named(std::move(name)),
           m_distribution(distribution),
           m_series_name(std::move(openpmd_path)),
-          m_active_once(active_once)
+          m_active_once(active_once),
+          m_load_ref_particle(load_ref_particle)
         {
             if (distribution != "openPMD") {
                 throw std::runtime_error("Only 'openPMD' distribution is supported if openpmd_path is provided!");
@@ -64,6 +69,8 @@ namespace impactx::elements
         /** Initialize/Load particles.
          *
          * Particles are relative to the reference particle.
+         * If load_ref_particle is set, the reference particle is restored from
+         * the species metadata of the file before the particles are added.
          *
          * @param[in,out] pc particle container to push
          * @param[in] step global step for diagnostics
@@ -97,6 +104,7 @@ namespace impactx::elements
         std::string m_distribution; //! Distribution type of particles in the source
         std::string m_series_name; //! openPMD filename
         bool m_active_once = true; //! Inject particles only for the first lattice period
+        bool m_load_ref_particle = true; //! Restore the reference particle from the file's species metadata
     };
 
 } // namespace impactx

--- a/src/elements/Source.cpp
+++ b/src/elements/Source.cpp
@@ -59,7 +59,35 @@ namespace impactx::elements
 
         int const npart = beam["id"][scalar].getExtent()[0];  // how many particles to read total
 
-        // TODO: read reference particle (optional?)
+        // restore the reference particle from the species metadata
+        if (m_load_ref_particle)
+        {
+            RefPart & ref = pc.GetRefParticle();
+            auto const read_attr = [&beam, this] (std::string const & attr_name) {
+                if (!beam.containsAttribute(attr_name)) {
+                    throw std::runtime_error(
+                        "Source: attribute '" + attr_name + "' not found in " + m_series_name +
+                        " (load_ref_particle requires a file written by an ImpactX beam_monitor;"
+                        " set load_ref_particle=false to keep the current reference particle)"
+                    );
+                }
+                return beam.getAttribute(attr_name).get<amrex::ParticleReal>();
+            };
+
+            ref.s = read_attr("s_ref");
+            ref.x = read_attr("x_ref");
+            ref.y = read_attr("y_ref");
+            ref.z = read_attr("z_ref");
+            ref.t = read_attr("t_ref");
+            ref.px = read_attr("px_ref");
+            ref.py = read_attr("py_ref");
+            ref.pz = read_attr("pz_ref");
+            ref.pt = read_attr("pt_ref");
+            ref.gyromagnetic_anomaly = read_attr("gyromagnetic_anomaly_ref");
+            ref.mass = read_attr("mass_ref");
+            ref.charge = read_attr("charge_ref");
+            // ref.sedge: could be set to ref.s, but should be set anyway in tracking loops on element entry.
+        }
 
         // read the particles
 

--- a/src/initialization/InitDistribution.cpp
+++ b/src/initialization/InitDistribution.cpp
@@ -560,6 +560,14 @@ namespace impactx
         auto space_charge = get_space_charge_algo();
 
         if (track == "particles") {
+            // The beam input block is optional: if omitted, a source element in the
+            // lattice is expected to load the beam (and, by default, the reference
+            // particle) from an openPMD file.
+            if (!pp_dist.contains("distribution")) {
+                amrex::Print() << "No beam.distribution: expecting a source element in the lattice to load the beam." << std::endl;
+                return;
+            }
+
             // set charge and mass and energy of ref particle
             RefPart const ref = initialization::read_reference_particle(pp_dist);
             amr_data->track_particles.m_particle_container->SetRefParticle(ref);

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -606,7 +606,10 @@ element_name) );
             bool active_once = Source::DEFAULT_active_once;
             pp_element.queryAdd("active_once", active_once);
 
-            m_lattice.emplace_back( Source(distribution, openpmd_path, active_once, element_name) );
+            bool load_ref_particle = Source::DEFAULT_load_ref_particle;
+            pp_element.queryAdd("load_ref_particle", load_ref_particle);
+
+            m_lattice.emplace_back( Source(distribution, openpmd_path, active_once, load_ref_particle, element_name) );
         } else if (element_type == "line")
         {
             // Parse the lattice elements for the sub-lattice in the line

--- a/src/initialization/Validate.cpp
+++ b/src/initialization/Validate.cpp
@@ -14,7 +14,7 @@
 #include <AMReX_INT.H>
 
 #include <stdexcept>
-#include <string_view>
+#include <variant>
 
 
 namespace impactx
@@ -23,9 +23,22 @@ namespace impactx
     {
         BL_PROFILE("ImpactX::validate");
 
+        // elements
+        if (m_lattice.empty())
+            throw std::runtime_error("Beamline lattice has zero elements. Not yet initialized?");
+
+        // does a source element at the beginning of the beamline load the
+        // beam and, by default, also the reference particle during tracking?
+        bool source_loads_beam = false;
+        bool source_loads_ref = false;
+        if (auto const * source = std::get_if<elements::Source>(&m_lattice.front())) {
+            source_loads_beam = true;
+            source_loads_ref = source->m_load_ref_particle;
+        }
+
         // reference particle initialized?
         auto const & ref = amr_data->track_particles.m_particle_container->GetRefParticle();
-        if (ref.kin_energy_MeV() == 0.0)
+        if (ref.kin_energy_MeV() == 0.0 && !source_loads_ref)
             throw std::runtime_error("The reference particle energy is zero. Not yet initialized?");
 
         // particles in the beam bunch
@@ -37,24 +50,14 @@ namespace impactx
             for (int lev = 0; lev <= nLevelPC; ++lev) {
                 nParticles += amr_data->track_particles.m_particle_container->NumberOfParticlesAtLevel(lev);
             }
-            if (nParticles == 0)
+            if (nParticles == 0 && !source_loads_beam)
             {
-                // do we have a source element as the first element of the beamline?
-                auto & first_element = m_lattice.front();
-                std::visit([](auto&& element){
-                    if (std::string_view(element.type) != std::string_view("Source")) {
-                        throw std::runtime_error(
-                            "No particles found. "
-                            "Cannot track particles without an initialized beam. "
-                            "Did you forget to call sim.add_particles ?"
-                        );
-                    }
-                }, first_element);
+                throw std::runtime_error(
+                    "No particles found. "
+                    "Cannot track particles without an initialized beam. "
+                    "Did you forget to call sim.add_particles ?"
+                );
             }
         }
-
-        // elements
-        if (m_lattice.empty())
-            throw std::runtime_error("Beamline lattice has zero elements. Not yet initialized?");
     }
 } // namespace impactx

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -2402,7 +2402,8 @@ void init_elements(py::module& m)
                      src,
                      std::make_pair("distribution", src.m_distribution),
                      std::make_pair("openpmd_path", src.m_series_name),
-                     std::make_pair("active_once", src.m_active_once)
+                     std::make_pair("active_once", src.m_active_once),
+                     std::make_pair("load_ref_particle", src.m_load_ref_particle)
                  );
              }
         )
@@ -2412,7 +2413,8 @@ void init_elements(py::module& m)
                     src,
                     std::make_pair("distribution", src.m_distribution),
                     std::make_pair("openpmd_path", src.m_series_name),
-                    std::make_pair("active_once", src.m_active_once)
+                    std::make_pair("active_once", src.m_active_once),
+                    std::make_pair("load_ref_particle", src.m_load_ref_particle)
                 );
             }
         )
@@ -2420,11 +2422,13 @@ void init_elements(py::module& m)
              std::string,
              std::string,
              bool,
+             bool,
              std::optional<std::string>
          >(),
              py::arg("distribution"),
              py::arg("openpmd_path"),
              py::arg("active_once") = Source::DEFAULT_active_once,
+             py::arg("load_ref_particle") = Source::DEFAULT_load_ref_particle,
              py::arg("name") = py::none(),
              "A particle source."
         )
@@ -2442,6 +2446,11 @@ void init_elements(py::module& m)
             [](Source & src) { return src.m_active_once; },
             [](Source & src, bool actice_once) { src.m_active_once = actice_once; },
             "Inject particles only for the first lattice period."
+        )
+        .def_property("load_ref_particle",
+            [](Source & src) { return src.m_load_ref_particle; },
+            [](Source & src, bool load_ref_particle) { src.m_load_ref_particle = load_ref_particle; },
+            "Restore the reference particle from the species metadata of the openPMD file (particle tracking only)."
         )
     ;
     register_push(py_Source);


### PR DESCRIPTION
Support loading the reference particle from the `BeamMonitor`'s openPMD file to perfectly checkpoint-restart a beam + its reference particle: https://impactx--1571.org.readthedocs.build/en/1571/usage/examples/solenoid_restart/README.html

The new option `<source>.load_ref_particle` [can be set](https://impactx--1571.org.readthedocs.build/en/1571/usage/python.html#impactx.elements.Source) to `false` to manually set the reference particle, as before.