### PR TITLE
`ChargeBinning`: `amrex::For`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,7 @@ Commits should limit any formatting changes of unchanged code.
 - Space-charge and CSR solvers and many utilities come from `ABLASTR` (shared with WarpX, fetched into `build/_deps/fetchedablastr-src/`)
 - Python bindings are generated via `pybind11` and `pyAMReX`; after C++ changes, rebuild with the `pip_install` target
 - The independent variable of motion is the reference trajectory path length `s` (not time); all integrators are symplectic
+- `amrex::ParallelFor` promises the compiler that loop iterations are independent (it applies a CPU SIMD pragma). Kernels where different iterations can write the same memory location (e.g. deposition, histogram bins, shared counters, etc.) must use `amrex::For` instead, and whole-loop sums/maxima the `amrex::Reduce` functions. `amrex::Gpu::Atomic` and `amrex::HostDevice::Atomic` operations are plain non-atomic updates on serial CPU builds and do not make a `ParallelFor` safe. See https://github.com/BLAST-WarpX/warpx/issues/7097
 
 ## C++ Style
 

--- a/docs/source/developers/implementation.rst
+++ b/docs/source/developers/implementation.rst
@@ -6,3 +6,23 @@ Implementation Details
 .. note::
 
    TODO :-)
+
+Kernel Launches
+---------------
+
+Compute kernels are launched through AMReX's portable constructs, which compile to loops on CPU and kernel launches on GPU.
+The constructs differ in the promises they make to the compiler, and picking the wrong one compiles and runs but can produce silently wrong results:
+
+* ``amrex::ParallelFor`` promises the compiler that loop iterations are **independent**: on CPU, the loop is marked with a SIMD pragma (e.g., ``#pragma GCC ivdep``) that hints to the compiler that it may vectorize across iterations.
+  Use it only when no two iterations can touch the same memory location, e.g., per-particle pushes or per-cell field updates.
+* ``amrex::For`` is identical on GPU but carries no SIMD pragma on CPU.
+  Use it whenever different iterations may write the same location (e.g. deposition, histogram bins, etc.).
+  Note that ``amrex::Gpu::Atomic`` and ``amrex::HostDevice::Atomic`` operations are plain, non-atomic updates on serial CPU builds and therefore do not make a ``ParallelFor`` loop safe.
+* ``amrex::ParallelForSIMD<WIDTH>``: explicitly vectorized CPU loops.
+  Rather than relying on compiler auto-vectorization (which ``ParallelFor`` only hints to the compiler), the loop runs in chunks of the compile-time SIMD width and the kernel receives an ``amrex::SIMDindex<WIDTH>`` to perform explicit SIMD loads and stores (with scalar iterations for the remainder).
+  ImpactX uses this heavily for the per-particle element pushes: the ``impactx::ParallelFor`` wrapper (``src/elements/mixin/beamoptic.H``) dispatches to ``amrex::ParallelForSIMD<T_Element::simd_width>`` for elements marked as vectorized and falls back to ``amrex::ParallelFor`` otherwise.
+  When compiled for GPU, explicit SIMD is inactive (``ImpactX_SIMD`` is a CPU feature) and the dispatch falls back to a regular ``amrex::ParallelFor`` kernel launch, where each GPU thread processes one particle with a scalar index.
+* Whole-loop reductions (sums, maxima) should use the ``amrex::ReduceSIMD`` (or ``amrex::Reduce``) functions.
+  When compiled for GPU, the ``ReduceSIMD`` code path is inactive and the standard ``amrex::Reduce`` device reduction is used.
+
+Getting ``amrex::ParallelFor`` and atomics wrong is compiler-dependent and silent; see the analysis in `WarpX issue #7097 <https://github.com/BLAST-WarpX/warpx/issues/7097>`__ and the corresponding `WarpX developer documentation on portability <https://warpx.readthedocs.io/en/latest/developers/portability.html>`__ for details.

--- a/src/particles/wakefields/ChargeBinning.cpp
+++ b/src/particles/wakefields/ChargeBinning.cpp
@@ -51,7 +51,7 @@ namespace impactx::particles::wakefields
                     amrex::ParticleReal* const AMREX_RESTRICT pos_z = soa.GetRealData(impactx::RealSoA::z).dataPtr();
 
                     // Parallel loop over particles
-                    amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE(int i)
+                    amrex::For(np, [=] AMREX_GPU_DEVICE(int i)
                     {
                         // Access particle z-position directly
                         amrex::ParticleReal const z = pos_z[i];  // (Macro)Particle longitudinal position at i
@@ -155,7 +155,7 @@ namespace impactx::particles::wakefields
                     amrex::Real* const AMREX_RESTRICT pos_z = soa.GetRealData(impactx::RealSoA::z).dataPtr();
                     amrex::Real* const AMREX_RESTRICT d_w = soa.GetRealData(impactx::RealSoA::w).dataPtr();
 
-                    amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE(int i)
+                    amrex::For(np, [=] AMREX_GPU_DEVICE(int i)
                     {
                         amrex::Real const w = d_w[i];
                         amrex::Real const x = pos_x[i];


### PR DESCRIPTION
The 1D charge binning histograms perform a scatter-add into bins based on particle locations. When auto-vectorized with modern compilers like GCC 15 to to the `amrex::ParallelFor` intrinsic `AMREX_PRAGMA_SIMD` the memory locations can be shared and race, which will discard all but one update from a SIMD lane group in the worst case.

`amrex::For` does not declare index space operations independent of each other and is the right choice here:
https://amrex-codes.github.io/amrex/docs_html/GPU.html?highlight=simd#launching-c-nested-loops

CPU performance stays scalar and GPU performance is unaffected.

First seen as a WarpX bug by @RemiLehe in https://github.com/BLAST-WarpX/warpx/issues/7097 :tada: 
Note: not related to the explicit "SIMD" feature of ImpactX. This is a "scalar" auto-vectorization in the core AMReX `ParallelFor` and has always been here.

Fix #1574