### PR TITLE
Treat special case Ez=0 for ChrAcc element.

### DIFF
--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -111,7 +111,6 @@ namespace impactx::elements
 
             // compute focusing constant (1/m) and rotation angle (in rad)
             m_alpha = m_bz * 0.5_prt;
-            m_alpha_iez = m_ez == 0_prt ? 0_prt : m_alpha / m_ez;
 
             // dimensionless acceleration parameter (change in gamma)
             m_acc = m_ez * m_slice_ds;
@@ -172,11 +171,13 @@ namespace impactx::elements
                 T_Real const denom = -pti_tot + pzi_tot;
 
                 // compute focusing constant (1/m) and rotation angle (in rad)
-                T_Real const theta = (m_acc == 0_prt)? m_alpha * m_slice_ds / pzi_tot : m_alpha_iez * log(numer / denom);
+                T_Real const theta_ialpha = m_acc == 0_prt
+                    ? m_slice_ds / pzi_tot
+                    : log(numer / denom) / m_ez;
+                T_Real const theta = m_alpha * theta_ialpha;
                 auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
                 T_Real const sin_theta_ialpha = m_alpha == 0_prt
-                    ? (m_acc == 0_prt ? m_slice_ds / pzi_tot
-                                      : log(numer / denom) / m_ez)
+                    ? theta_ialpha
                     : sin_theta / m_alpha;
 
                 // initialize output values
@@ -423,7 +424,7 @@ namespace impactx::elements
         // see: compute_constants() to refresh
         amrex::ParticleReal m_slice_ds;  //! m_ds / nslice();
         amrex::ParticleReal m_ptf_ref, m_pti_ref, m_bgf, m_bgi;
-        amrex::ParticleReal m_alpha, m_alpha_iez, m_acc;
+        amrex::ParticleReal m_alpha, m_acc;
     };
 
 } // namespace impactx

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -194,7 +194,7 @@ namespace impactx::elements
                 T_Real Pxy_mech2 = powi<2>(py - m_alpha * x) + powi<2>(px + m_alpha * y);
                 if (m_acc == 0_prt) {
                    // In this case, t-update coincides with that of a ChrDrift:
-                   tout = t - (pti_tot/pzi_tot + 0.5_prt 
+                   tout = t - (pti_tot/pzi_tot + 0.5_prt
                           * pti_tot/powi<3>(pzi_tot) * Pxy_mech2) * m_slice_ds;
                    tout += m_pti_ref/m_bgi * m_slice_ds;
                 } else {

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -174,6 +174,10 @@ namespace impactx::elements
                 // compute focusing constant (1/m) and rotation angle (in rad)
                 T_Real const theta = (m_acc == 0_prt)? m_alpha * m_slice_ds / pzi_tot : m_alpha_iez * log(numer / denom);
                 auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
+                T_Real const sin_theta_ialpha = m_alpha == 0_prt
+                    ? (m_acc == 0_prt ? m_slice_ds / pzi_tot
+                                      : log(numer / denom) / m_ez)
+                    : sin_theta / m_alpha;
 
                 // initialize output values
                 T_Real xout = x;
@@ -184,10 +188,10 @@ namespace impactx::elements
                 T_Real ptout = pt;
 
                 // advance positions and momenta using map for focusing
-                xout = cos_theta * x + sin_theta / m_alpha * px;
+                xout = cos_theta * x + sin_theta_ialpha * px;
                 pxout = -m_alpha * sin_theta * x + cos_theta * px;
 
-                yout = cos_theta * y + sin_theta / m_alpha * py;
+                yout = cos_theta * y + sin_theta_ialpha * py;
                 pyout = -m_alpha * sin_theta * y + cos_theta * py;
 
                 // the correct symplectic update for t

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -365,7 +365,7 @@ namespace impactx::elements
             // factor is the integrated drift length in dynamic units and
             // is well-defined even when alpha = 0 (no solenoid).
             amrex::ParticleReal const alpha = 0.5_prt * m_bz;
-            amrex::ParticleReal const drift_log = (m_ez==0_prt)? slice_ds / pzf_ref : 
+            amrex::ParticleReal const drift_log = (m_ez==0_prt)? slice_ds / pzf_ref :
                 std::log((pzf_ref - ptf_ref) / (pzi_ref - pti_ref)) / m_ez;
             amrex::ParticleReal const rbg = bgi / bgf;
 

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -111,7 +111,7 @@ namespace impactx::elements
 
             // compute focusing constant (1/m) and rotation angle (in rad)
             m_alpha = m_bz * 0.5_prt;
-            m_alpha_iez = m_alpha / m_ez;
+            m_alpha_iez = m_ez == 0_prt ? 0_prt : m_alpha / m_ez;
 
             // dimensionless acceleration parameter (change in gamma)
             m_acc = m_ez * m_slice_ds;

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -267,7 +267,8 @@ namespace impactx::elements
             amrex::ParticleReal const bgf = std::sqrt(powi<2>(ptf) - 1.0_prt);
 
             // update t
-            refpart.t = (m_acc==0_prt)? t - pt/bgi*slice_ds : t + (bgf - bgi)/m_ez;
+            //refpart.t = (m_ez==0_prt)? t - 0.5_prt*(pt/bgi + ptf/bgf)*slice_ds : t + (bgf - bgi)/m_ez;
+            refpart.t = t + (bgf - bgi)/m_ez;
 
             // advance position (x,y,z)
             refpart.x = x + slice_ds*px/bgi;

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -267,8 +267,7 @@ namespace impactx::elements
             amrex::ParticleReal const bgf = std::sqrt(powi<2>(ptf) - 1.0_prt);
 
             // update t
-            //refpart.t = (m_ez==0_prt)? t - 0.5_prt*(pt/bgi + ptf/bgf)*slice_ds : t + (bgf - bgi)/m_ez;
-            refpart.t = t + (bgf - bgi)/m_ez;
+            refpart.t = (m_ez==0_prt)? t - 0.5_prt*(pt/bgi + ptf/bgf)*slice_ds : t + (bgf - bgi)/m_ez;
 
             // advance position (x,y,z)
             refpart.x = x + slice_ds*px/bgi;

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -112,6 +112,9 @@ namespace impactx::elements
             // compute focusing constant (1/m) and rotation angle (in rad)
             m_alpha = m_bz * 0.5_prt;
             m_alpha_iez = m_alpha / m_ez;
+
+            // dimensionless acceleration parameter (change in gamma)
+            m_acc = m_ez * m_slice_ds;
         }
 
         /** This is a chracc functor, so that a variable of this type can be used like a chracc function.
@@ -169,7 +172,7 @@ namespace impactx::elements
                 T_Real const denom = -pti_tot + pzi_tot;
 
                 // compute focusing constant (1/m) and rotation angle (in rad)
-                T_Real const theta = m_alpha_iez * log(numer / denom);
+                T_Real const theta = (m_acc == 0_prt)? m_alpha * m_slice_ds / pzi_tot : m_alpha_iez * log(numer / denom);
                 auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
 
                 // initialize output values
@@ -188,11 +191,17 @@ namespace impactx::elements
                 pyout = -m_alpha * sin_theta * y + cos_theta * py;
 
                 // the correct symplectic update for t
-                tout = t + (pzf_tot - pzf_ref - pzi_tot + pzi_ref) / m_ez;
-                tout += (1_prt/pzi_tot - 1_prt/pzf_tot)
-                      * (powi<2>(py - m_alpha * x) +
-                         powi<2>(px + m_alpha * y))
-                      / (2_prt * m_ez);
+                T_Real Pxy_mech2 = powi<2>(py - m_alpha * x) + powi<2>(px + m_alpha * y);
+                if (m_acc == 0_prt) {
+                   // In this case, t-update coincides with that of a ChrDrift:
+                   tout = t - (pti_tot/pzi_tot + 0.5_prt 
+                          * pti_tot/powi<3>(pzi_tot) * Pxy_mech2) * m_slice_ds;
+                   tout += m_pti_ref/m_bgi * m_slice_ds;
+                } else {
+                   tout = t + (pzf_tot - pzf_ref - pzi_tot + pzi_ref) / m_ez;
+                   tout  += (1_prt/pzi_tot - 1_prt/pzf_tot)
+                         * Pxy_mech2 / (2_prt * m_ez);
+                }
                 ptout = pt;
 
                 // assign intermediate momenta
@@ -410,7 +419,7 @@ namespace impactx::elements
         // see: compute_constants() to refresh
         amrex::ParticleReal m_slice_ds;  //! m_ds / nslice();
         amrex::ParticleReal m_ptf_ref, m_pti_ref, m_bgf, m_bgi;
-        amrex::ParticleReal m_alpha, m_alpha_iez;
+        amrex::ParticleReal m_alpha, m_alpha_iez, m_acc;
     };
 
 } // namespace impactx

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -267,7 +267,7 @@ namespace impactx::elements
             amrex::ParticleReal const bgf = std::sqrt(powi<2>(ptf) - 1.0_prt);
 
             // update t
-            refpart.t = t + (bgf - bgi)/m_ez;
+            refpart.t = (m_acc==0_prt)? t - pt/bgi*slice_ds : t + (bgf - bgi)/m_ez;
 
             // advance position (x,y,z)
             refpart.x = x + slice_ds*px/bgi;
@@ -365,7 +365,7 @@ namespace impactx::elements
             // factor is the integrated drift length in dynamic units and
             // is well-defined even when alpha = 0 (no solenoid).
             amrex::ParticleReal const alpha = 0.5_prt * m_bz;
-            amrex::ParticleReal const drift_log =
+            amrex::ParticleReal const drift_log = (m_ez==0_prt)? slice_ds / pzf_ref : 
                 std::log((pzf_ref - ptf_ref) / (pzi_ref - pti_ref)) / m_ez;
             amrex::ParticleReal const rbg = bgi / bgf;
 
@@ -373,7 +373,7 @@ namespace impactx::elements
 
             // t couples to pt only: symplectic correction to the
             // time-of-flight, linearized at pt = 0.
-            R(5,6) = bgi * (ptf_ref / pzf_ref - pti_ref / pzi_ref) / m_ez;
+            R(5,6) = (m_ez==0_prt)? slice_ds / (bgi*bgi) : bgi * (ptf_ref / pzf_ref - pti_ref / pzi_ref) / m_ez;
             // pt scales by the static<->dynamic unit change bgi/bgf.
             R(6,6) = rbg;
 

--- a/tests/python/test_chracc_Ez0.py
+++ b/tests/python/test_chracc_Ez0.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import pytest
+
+import amrex.space3d as amr
+from impactx import ImpactX, distribution, elements
+
+def test_element_push():
+    """
+    This tests using ImpactX without a lattice.
+    """
+    sim = ImpactX()
+
+    # set numerical parameters and IO control
+    sim.space_charge = False
+    sim.slice_step_diagnostics = True
+
+    # domain decomposition & space charge mesh
+    sim.init_grids()
+
+    # basic beam parameters
+    kin_energy_MeV = 2000.0  # reference energy (kinetic)
+    bunch_charge_C = 25.0e-12  # used with space charge
+
+    # set reference particle
+    ref = sim.beam.ref
+    ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
+    qm_eev = ref.charge_qe / (ref.mass_MeV * 1.0e6)  # electron charge/mass in e / eV
+
+    # set test particles
+    pc = sim.beam
+
+    #npart = 50
+    npart = 20
+
+    ptmin = -3.0e-3
+    ptmax = 3.0e-3
+
+    #  add test particles   
+    if amr.ParallelDescriptor.IOProcessor():
+        dpt = np.linspace(ptmin, ptmax, npart)
+        zero_arr = np.linspace(0, 0.0, npart)
+        pc.add_n_particles(
+            zero_arr, zero_arr, zero_arr, zero_arr, zero_arr, dpt, qm_eev, bunch_charge=0.0
+        )
+
+    # store initial particles
+    df_initial = pc.to_df()
+
+    # design the accelerator lattice
+    ns = 50  # number of slices per ds in the element
+
+    # add beam diagnostics
+    monitor = elements.BeamMonitor("monitor", backend="h5")
+
+    # bend radius (> 0)
+    ks_value = 1.0
+
+    # length for this test should be one period
+    ds_value = 2.0 * np.pi / (ref.gyromagnetic_anomaly * ks_value)
+
+    idrift_chr = elements.ChrDrift(name="idrift_chr", ds=-ds_value, nslice=ns)
+
+    bz_value = ks_value * ref.beta_gamma
+    ez_value = 0.0
+    sol_chr = elements.ChrAcc(name="sol_chr", ds=ds_value, ez=ez_value, bz=bz_value, nslice=ns) 
+
+    # set the lattice
+    sim.lattice.append(monitor)
+    sim.lattice.append(sol_chr)
+    sim.lattice.append(idrift_chr)
+    sim.lattice.append(monitor)
+
+    # run simulation
+    sim.track_particles()
+
+    pc = sim.beam
+    df_final = pc.to_df()
+
+    PHASE_COLS = [
+        "position_x",
+        "position_y",
+        "position_t",
+        "momentum_x",
+        "momentum_y",
+        "momentum_t",
+    ]
+
+    for c in PHASE_COLS:
+        np.testing.assert_allclose(
+            df_final[c].to_numpy(),
+            df_initial[c].to_numpy(),
+            atol=1.0e-12,
+            rtol=0,
+            err_msg=f"Roundtrip mismatch in {c}",
+        )
+
+    # clean shutdown
+    sim.finalize()

--- a/tests/python/test_chracc_Ez0.py
+++ b/tests/python/test_chracc_Ez0.py
@@ -62,7 +62,7 @@ def test_element_push():
     df_initial = pc.to_df()
 
     # design the accelerator lattice
-    ns = 50  # number of slices per ds in the element
+    ns = 1  # number of slices per ds in the element
 
     # add beam diagnostics
     monitor = elements.BeamMonitor("monitor", backend="h5")

--- a/tests/python/test_chracc_Ez0.py
+++ b/tests/python/test_chracc_Ez0.py
@@ -7,12 +7,14 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+import pytest
 
 import amrex.space3d as amr
 from impactx import ImpactX, elements
 
 
-def test_element_push():
+@pytest.mark.parametrize("bz_scale", [0.0, 1.0], ids=["no-bz", "bz"])
+def test_element_push(bz_scale):
     """
     This tests using ImpactX without a lattice.
     """
@@ -73,7 +75,7 @@ def test_element_push():
 
     idrift_chr = elements.ChrDrift(name="idrift_chr", ds=-ds_value, nslice=ns)
 
-    bz_value = ks_value * ref.beta_gamma
+    bz_value = bz_scale * ks_value * ref.beta_gamma
     ez_value = 0.0
     sol_chr = elements.ChrAcc(
         name="sol_chr", ds=ds_value, ez=ez_value, bz=bz_value, nslice=ns

--- a/tests/python/test_chracc_Ez0.py
+++ b/tests/python/test_chracc_Ez0.py
@@ -34,7 +34,7 @@ def test_element_push(bz_scale):
     ref = sim.beam.ref
     ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
     qm_eev = ref.charge_qe / (ref.mass_MeV * 1.0e6)  # electron charge/mass in e / eV
-    initial_ref = ref
+    initial_ref = ref.copy()
 
     # set test particles
     pc = sim.beam

--- a/tests/python/test_chracc_Ez0.py
+++ b/tests/python/test_chracc_Ez0.py
@@ -36,8 +36,6 @@ def test_element_push():
 
     # set test particles
     pc = sim.beam
-
-    # npart = 50
     npart = 20
 
     ptmin = -3.0e-3
@@ -103,6 +101,12 @@ def test_element_push():
     ]
 
     REF_COLS = ["x", "y", "z", "t", "px", "py", "pz", "pt", "s"]
+
+    print('reference particle:')
+    tref = getattr(sim.beam.ref, "t")
+    ptref = getattr(sim.beam.ref, "pt")
+    pzref = getattr(sim.beam.ref, "pz")
+    print(tref, ptref, pzref)
 
     for c in PHASE_COLS:
         np.testing.assert_allclose(

--- a/tests/python/test_chracc_Ez0.py
+++ b/tests/python/test_chracc_Ez0.py
@@ -13,6 +13,46 @@ import amrex.space3d as amr
 from impactx import ImpactX, elements
 
 
+def expected_ez0_transport_map(ds, bz, beta_gamma):
+    """Return the analytic ChrAcc transport map for zero Ez."""
+    alpha = 0.5 * bz
+    drift_factor = ds / beta_gamma
+
+    matrix = np.eye(6)
+    matrix[4, 5] = ds / beta_gamma**2
+
+    if alpha == 0.0:
+        matrix[0, 1] = ds
+        matrix[2, 3] = ds
+        return matrix
+
+    theta = alpha * drift_factor
+    sin_theta = np.sin(theta)
+    cos_theta = np.cos(theta)
+    sin2 = sin_theta**2
+    cos2 = cos_theta**2
+    sin_cos = sin_theta * cos_theta
+
+    matrix[0, 0] = cos2
+    matrix[0, 1] = beta_gamma * sin_cos / alpha
+    matrix[0, 2] = sin_cos
+    matrix[0, 3] = beta_gamma * sin2 / alpha
+    matrix[1, 0] = -alpha * sin_cos / beta_gamma
+    matrix[1, 1] = cos2
+    matrix[1, 2] = -alpha * sin2 / beta_gamma
+    matrix[1, 3] = sin_cos
+    matrix[2, 0] = -sin_cos
+    matrix[2, 1] = -beta_gamma * sin2 / alpha
+    matrix[2, 2] = cos2
+    matrix[2, 3] = beta_gamma * sin_cos / alpha
+    matrix[3, 0] = alpha * sin2 / beta_gamma
+    matrix[3, 1] = -sin_cos
+    matrix[3, 2] = -alpha * sin_cos / beta_gamma
+    matrix[3, 3] = cos2
+
+    return matrix
+
+
 @pytest.mark.parametrize("bz_scale", [0.0, 1.0], ids=["no-bz", "bz"])
 def test_element_push(bz_scale):
     """
@@ -43,16 +83,25 @@ def test_element_push(bz_scale):
     ptmin = -3.0e-3
     ptmax = 3.0e-3
 
-    #  add test particles
+    # Add off-axis particles in the field-free case so that the transverse
+    # contribution to the zero-Ez t update is exercised. The finite-Bz case
+    # remains on axis so that the inverse ChrDrift isolates the t update.
     if amr.ParallelDescriptor.IOProcessor():
         dpt = np.linspace(ptmin, ptmax, npart)
-        zero_arr = np.linspace(0, 0.0, npart)
+        zero_arr = np.zeros(npart)
+        if bz_scale == 0.0:
+            x = np.linspace(-1.0e-3, 1.0e-3, npart)
+            y = np.linspace(0.75e-3, -0.75e-3, npart)
+            px = np.linspace(-2.0e-4, 2.0e-4, npart)
+            py = np.linspace(1.5e-4, -1.5e-4, npart)
+        else:
+            x = y = px = py = zero_arr
         pc.add_n_particles(
+            x,
+            y,
             zero_arr,
-            zero_arr,
-            zero_arr,
-            zero_arr,
-            zero_arr,
+            px,
+            py,
             dpt,
             qm_eev,
             bunch_charge=0.0,
@@ -80,6 +129,12 @@ def test_element_push(bz_scale):
     sol_chr = elements.ChrAcc(
         name="sol_chr", ds=ds_value, ez=ez_value, bz=bz_value, nslice=ns
     )
+    np.testing.assert_allclose(
+        sol_chr.transfer_map(initial_ref).to_numpy(),
+        expected_ez0_transport_map(ds=ds_value, bz=bz_value, beta_gamma=ref.beta_gamma),
+        atol=1.0e-12,
+        rtol=0.0,
+    )
 
     # set the lattice
     sim.lattice.append(monitor)
@@ -103,12 +158,6 @@ def test_element_push(bz_scale):
     ]
 
     REF_COLS = ["x", "y", "z", "t", "px", "py", "pz", "pt", "s"]
-
-    print("reference particle:")
-    tref = getattr(sim.beam.ref, "t")
-    ptref = getattr(sim.beam.ref, "pt")
-    pzref = getattr(sim.beam.ref, "pz")
-    print(tref, ptref, pzref)
 
     for c in PHASE_COLS:
         np.testing.assert_allclose(

--- a/tests/python/test_chracc_Ez0.py
+++ b/tests/python/test_chracc_Ez0.py
@@ -119,7 +119,7 @@ def test_element_push():
             atol=1.0e-12,
             rtol=0,
             err_msg=f"Reference-particle roundtrip mismatch in {c}",
-        )   
+        )
 
     # clean shutdown
     sim.finalize()

--- a/tests/python/test_chracc_Ez0.py
+++ b/tests/python/test_chracc_Ez0.py
@@ -102,7 +102,7 @@ def test_element_push():
 
     REF_COLS = ["x", "y", "z", "t", "px", "py", "pz", "pt", "s"]
 
-    print('reference particle:')
+    print("reference particle:")
     tref = getattr(sim.beam.ref, "t")
     ptref = getattr(sim.beam.ref, "pt")
     pzref = getattr(sim.beam.ref, "pz")

--- a/tests/python/test_chracc_Ez0.py
+++ b/tests/python/test_chracc_Ez0.py
@@ -7,10 +7,10 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import pytest
 
 import amrex.space3d as amr
-from impactx import ImpactX, distribution, elements
+from impactx import ImpactX, elements
+
 
 def test_element_push():
     """
@@ -37,18 +37,25 @@ def test_element_push():
     # set test particles
     pc = sim.beam
 
-    #npart = 50
+    # npart = 50
     npart = 20
 
     ptmin = -3.0e-3
     ptmax = 3.0e-3
 
-    #  add test particles   
+    #  add test particles
     if amr.ParallelDescriptor.IOProcessor():
         dpt = np.linspace(ptmin, ptmax, npart)
         zero_arr = np.linspace(0, 0.0, npart)
         pc.add_n_particles(
-            zero_arr, zero_arr, zero_arr, zero_arr, zero_arr, dpt, qm_eev, bunch_charge=0.0
+            zero_arr,
+            zero_arr,
+            zero_arr,
+            zero_arr,
+            zero_arr,
+            dpt,
+            qm_eev,
+            bunch_charge=0.0,
         )
 
     # store initial particles
@@ -70,7 +77,9 @@ def test_element_push():
 
     bz_value = ks_value * ref.beta_gamma
     ez_value = 0.0
-    sol_chr = elements.ChrAcc(name="sol_chr", ds=ds_value, ez=ez_value, bz=bz_value, nslice=ns) 
+    sol_chr = elements.ChrAcc(
+        name="sol_chr", ds=ds_value, ez=ez_value, bz=bz_value, nslice=ns
+    )
 
     # set the lattice
     sim.lattice.append(monitor)

--- a/tests/python/test_chracc_Ez0.py
+++ b/tests/python/test_chracc_Ez0.py
@@ -32,6 +32,7 @@ def test_element_push():
     ref = sim.beam.ref
     ref.set_species("proton").set_kin_energy_MeV(kin_energy_MeV)
     qm_eev = ref.charge_qe / (ref.mass_MeV * 1.0e6)  # electron charge/mass in e / eV
+    initial_ref = ref
 
     # set test particles
     pc = sim.beam
@@ -101,6 +102,8 @@ def test_element_push():
         "momentum_t",
     ]
 
+    REF_COLS = ["x", "y", "z", "t", "px", "py", "pz", "pt", "s"]
+
     for c in PHASE_COLS:
         np.testing.assert_allclose(
             df_final[c].to_numpy(),
@@ -109,6 +112,14 @@ def test_element_push():
             rtol=0,
             err_msg=f"Roundtrip mismatch in {c}",
         )
+    for c in REF_COLS:
+        np.testing.assert_allclose(
+            getattr(sim.beam.ref, c),
+            getattr(initial_ref, c),
+            atol=1.0e-12,
+            rtol=0,
+            err_msg=f"Reference-particle roundtrip mismatch in {c}",
+        )   
 
     # clean shutdown
     sim.finalize()

--- a/tests/python/test_chracc_Ez0.py
+++ b/tests/python/test_chracc_Ez0.py
@@ -27,7 +27,6 @@ def test_element_push():
 
     # basic beam parameters
     kin_energy_MeV = 2000.0  # reference energy (kinetic)
-    bunch_charge_C = 25.0e-12  # used with space charge
 
     # set reference particle
     ref = sim.beam.ref


### PR DESCRIPTION
The ChrAcc element map (uniform Ez + Bz field) requires special handling for the edge case that Ez=0.  This PR adds the necessary changes.

- [x] modify push
- [x] add a benchmark test

This partially addresses Issue #1573 