### PR TITLE
Warn if too Many (or too Few) Boxes Per Process

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -2368,8 +2368,8 @@ See there ``nslice`` option on lattice elements for slicing.
     (grid) per MPI process. One box per process is the ideal decomposition for
     every simulation, including space charge calculations. The automatically
     chosen mesh size is only suitable for simulations that need no auxiliary
-    field grids, e.g., without space charge calculations, set this parameter
-    to control the field resolution otherwise.
+    field grids, e.g., without space charge calculations. Otherwise, set this
+    parameter to control the field resolution.
 
     If it is set, the mesh is chopped into boxes of at
     most :pp:param:`amr.max_grid_size` cells per direction, independent of the
@@ -2378,10 +2378,12 @@ See there ``nslice`` option on lattice elements for slicing.
 .. pp:param:: amr.max_grid_size
     :type: ``integer, per MR level``
     :optional:
-    :default: ``32``
+    :default: ``32`` on CPU, ``64`` on GPU
 
     The maximum number of grid points per box (`grid <https://amrex-codes.github.io/amrex/docs_html/GridCreation.html>`__) along each direction.
     The mesh on each mesh-refinement level is decomposed into boxes of at most this size.
+
+    If :pp:param:`amr.n_cell` is not set, ImpactX overwrites this default with the `blocking factor <https://amrex-codes.github.io/amrex/docs_html/GridCreation.html>`__ (``8``), which creates exactly one box per MPI process.
 
     For best performance, aim for **exactly one box per parallel (MPI) process**, which is also one box per GPU on accelerated machines.
     More boxes per process cause significant overhead (particle redistribution, communication in field solves, extra kernel launches).
@@ -2395,6 +2397,8 @@ See there ``nslice`` option on lattice elements for slicing.
 
     The maximum number of grid points per box along ``x``, overwriting :pp:param:`amr.max_grid_size`.
     Analogous parameters exist as ``amr.max_grid_size_y`` and ``amr.max_grid_size_z``.
+
+    The per-direction parameters always win over the isotropic :pp:param:`amr.max_grid_size`, independent of the order in which the two are given.
 
 .. pp:param:: amr.max_level
     :type: ``integer``

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -2364,6 +2364,38 @@ See there ``nslice`` option on lattice elements for slicing.
 
     The number of grid points along each direction (on the **coarsest level**).
 
+    If this parameter is not set, the mesh is decomposed into exactly one box
+    (grid) per MPI process. One box per process is the ideal decomposition for
+    every simulation, including space charge calculations. The automatically
+    chosen mesh size is only suitable for simulations that need no auxiliary
+    field grids, e.g., without space charge calculations, set this parameter
+    to control the field resolution otherwise.
+
+    If it is set, the mesh is chopped into boxes of at
+    most :pp:param:`amr.max_grid_size` cells per direction, independent of the
+    number of processes.
+
+.. pp:param:: amr.max_grid_size
+    :type: ``integer, per MR level``
+    :optional:
+    :default: ``32``
+
+    The maximum number of grid points per box (`grid <https://amrex-codes.github.io/amrex/docs_html/GridCreation.html>`__) along each direction.
+    The mesh on each mesh-refinement level is decomposed into boxes of at most this size.
+
+    For best performance, aim for **exactly one box per parallel (MPI) process**, which is also one box per GPU on accelerated machines.
+    More boxes per process cause significant overhead (particle redistribution, communication in field solves, extra kernel launches).
+    Fewer boxes than processes leave processes idle.
+    ImpactX issues a warning at the start of a run if the number of boxes does not match the number of processes.
+
+.. pp:param:: amr.max_grid_size_x
+    :type: ``integer, per MR level``
+    :optional:
+    :default: ``amr.max_grid_size``
+
+    The maximum number of grid points per box along ``x``, overwriting :pp:param:`amr.max_grid_size`.
+    Analogous parameters exist as ``amr.max_grid_size_y`` and ``amr.max_grid_size_z``.
+
 .. pp:param:: amr.max_level
     :type: ``integer``
     :default: ``0``

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -31,6 +31,25 @@ Collective Effects & Overall Simulation Parameters
 
       The number of grid points along each direction on the coarsest level.
 
+   .. py:property:: max_grid_size
+
+      The maximum number of grid points per box (grid) along each direction, as a list with one entry per mesh-refinement level.
+      The mesh is decomposed into boxes of at most this size.
+      For best performance, aim for exactly one box per parallel (MPI) process, which is also one box per GPU on accelerated machines; ImpactX warns at the start of a run if the number of boxes does not match the number of processes.
+
+   .. py:property:: max_grid_size_x
+
+      The maximum number of grid points per box along ``x``, as a list with one entry per mesh-refinement level, overwriting :py:attr:`~max_grid_size`.
+      This property is also set when assigning :py:attr:`~blocking_factor_x`.
+      Analogous properties exist as ``max_grid_size_y`` and ``max_grid_size_z``.
+
+   .. py:property:: blocking_factor_x
+
+      The AMReX blocking factor for the ``x`` direction, as a list with one entry per mesh-refinement level.
+      Box sizes are forced to be a multiple of this value, which must be a power of two.
+      Setting this property also sets :py:attr:`~max_grid_size_x` to the same value, which preserves one box per process in the default decomposition; assign :py:attr:`~max_grid_size_x` afterwards to overwrite.
+      Analogous properties exist as ``blocking_factor_y`` and ``blocking_factor_z``.
+
    .. py:property:: max_level
 
       The maximum mesh-refinement level for the simulation.

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -36,11 +36,14 @@ Collective Effects & Overall Simulation Parameters
       The maximum number of grid points per box (grid) along each direction, as a list with one entry per mesh-refinement level.
       The mesh is decomposed into boxes of at most this size.
       For best performance, aim for exactly one box per parallel (MPI) process, which is also one box per GPU on accelerated machines; ImpactX warns at the start of a run if the number of boxes does not match the number of processes.
+      A direction that is also set through :py:attr:`~max_grid_size_x`, :py:attr:`~max_grid_size_y`, :py:attr:`~max_grid_size_z` or :py:attr:`~blocking_factor_x` keeps the per-direction value, no matter in which order the properties are assigned.
+      Use the per-direction properties in that case.
 
    .. py:property:: max_grid_size_x
 
       The maximum number of grid points per box along ``x``, as a list with one entry per mesh-refinement level, overwriting :py:attr:`~max_grid_size`.
       This property is also set when assigning :py:attr:`~blocking_factor_x`.
+      The per-direction value always wins over :py:attr:`~max_grid_size`, independent of the order of assignment, so assign this property to change ``x``.
       Analogous properties exist as ``max_grid_size_y`` and ``max_grid_size_z``.
 
    .. py:property:: blocking_factor_x
@@ -48,6 +51,7 @@ Collective Effects & Overall Simulation Parameters
       The AMReX blocking factor for the ``x`` direction, as a list with one entry per mesh-refinement level.
       Box sizes are forced to be a multiple of this value, which must be a power of two.
       Setting this property also sets :py:attr:`~max_grid_size_x` to the same value, which preserves one box per process in the default decomposition; assign :py:attr:`~max_grid_size_x` afterwards to overwrite.
+      Assigning the all-direction :py:attr:`~max_grid_size` does not overwrite it, since per-direction values always win.
       Analogous properties exist as ``blocking_factor_y`` and ``blocking_factor_z``.
 
    .. py:property:: max_level

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -108,21 +108,6 @@ function(add_impactx_test name input is_mpi analysis_script plot_script)
         # amrex.the_arena_init_size=0
         impactx_test_set_pythonpath(${name}.run)
     else()
-        # In non-MPI builds, MPI-parallel tests run on a single process. Their
-        # inputs decompose the mesh into one box per MPI process, so force a
-        # single box to keep the domain decomposition efficient (ImpactX warns
-        # otherwise, which impactx.abort_on_warning_threshold=low below
-        # escalates to an abort). 512 is just a large number, larger than any
-        # resolution used in the tests.
-        set(THIS_SERIAL_DECOMP)
-        if(is_mpi AND NOT ImpactX_MPI)
-            set(THIS_SERIAL_DECOMP
-                amr.max_grid_size=512
-                amr.max_grid_size_x=512
-                amr.max_grid_size_y=512
-                amr.max_grid_size_z=512
-            )
-        endif()
         add_test(NAME ${name}.run
                  COMMAND
                     ${THIS_MPI_TEST_EXE} $<TARGET_FILE:app> ${INPUTS_FILE}
@@ -134,7 +119,6 @@ function(add_impactx_test name input is_mpi analysis_script plot_script)
                         amrex.the_arena_init_size=0
                         impactx.always_warn_immediately=1
                         impactx.abort_on_warning_threshold=low
-                        ${THIS_SERIAL_DECOMP}
                         ${INPUTS_ARGS}
                  WORKING_DIRECTORY ${THIS_WORKING_DIR}
         )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -108,6 +108,21 @@ function(add_impactx_test name input is_mpi analysis_script plot_script)
         # amrex.the_arena_init_size=0
         impactx_test_set_pythonpath(${name}.run)
     else()
+        # In non-MPI builds, MPI-parallel tests run on a single process. Their
+        # inputs decompose the mesh into one box per MPI process, so force a
+        # single box to keep the domain decomposition efficient (ImpactX warns
+        # otherwise, which impactx.abort_on_warning_threshold=low below
+        # escalates to an abort). 512 is just a large number, larger than any
+        # resolution used in the tests.
+        set(THIS_SERIAL_DECOMP)
+        if(is_mpi AND NOT ImpactX_MPI)
+            set(THIS_SERIAL_DECOMP
+                amr.max_grid_size=512
+                amr.max_grid_size_x=512
+                amr.max_grid_size_y=512
+                amr.max_grid_size_z=512
+            )
+        endif()
         add_test(NAME ${name}.run
                  COMMAND
                     ${THIS_MPI_TEST_EXE} $<TARGET_FILE:app> ${INPUTS_FILE}
@@ -119,6 +134,7 @@ function(add_impactx_test name input is_mpi analysis_script plot_script)
                         amrex.the_arena_init_size=0
                         impactx.always_warn_immediately=1
                         impactx.abort_on_warning_threshold=low
+                        ${THIS_SERIAL_DECOMP}
                         ${INPUTS_ARGS}
                  WORKING_DIRECTORY ${THIS_WORKING_DIR}
         )

--- a/examples/cfchannel/input_cfchannel_10nC_fft.in
+++ b/examples/cfchannel/input_cfchannel_10nC_fft.in
@@ -42,4 +42,5 @@ algo.poisson_solver = "fft"
 
 amr.n_cell = 48 48 40
 #amr.n_cell = 72 72 64  # optional for increased precision
+amr.max_grid_size = 72  # one box per process: this example runs on a single process
 geometry.prob_relative = 1.1

--- a/examples/cfchannel/input_cfchannel_10nC_mlmg.in
+++ b/examples/cfchannel/input_cfchannel_10nC_mlmg.in
@@ -42,4 +42,5 @@ algo.poisson_solver = "multigrid"
 
 amr.n_cell = 48 48 40
 #amr.n_cell = 72 72 64  # optional for increased precision
+amr.max_grid_size = 72  # one box per process: this example runs on a single process
 geometry.prob_relative = 3.0

--- a/examples/cfchannel/run_cfchannel_10nC_fft.py
+++ b/examples/cfchannel/run_cfchannel_10nC_fft.py
@@ -12,6 +12,7 @@ sim = ImpactX()
 
 # set numerical parameters and IO control
 sim.n_cell = [48, 48, 40]  # [72, 72, 64] for increased precision
+sim.max_grid_size = [72]  # one box per process: this example runs on a single process
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "3D"
 sim.poisson_solver = "fft"

--- a/examples/cfchannel/run_cfchannel_10nC_mlmg.py
+++ b/examples/cfchannel/run_cfchannel_10nC_mlmg.py
@@ -12,6 +12,7 @@ sim = ImpactX()
 
 # set numerical parameters and IO control
 sim.n_cell = [48, 48, 40]  # [72, 72, 64] for increased precision
+sim.max_grid_size = [72]  # one box per process: this example runs on a single process
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "3D"
 sim.poisson_solver = "multigrid"

--- a/examples/epac2004_benchmarks/input_bithermal.in
+++ b/examples/epac2004_benchmarks/input_bithermal.in
@@ -40,6 +40,10 @@ algo.space_charge = 3D
 algo.poisson_solver = "fft"
 
 amr.n_cell = 64 64 64
+# one box per MPI process (this example runs on 2 MPI processes)
+amr.max_grid_size_x = 64
+amr.max_grid_size_y = 64
+amr.max_grid_size_z = 32
 geometry.prob_relative = 1.1
 
 ###############################################################################

--- a/examples/epac2004_benchmarks/input_fodo_rf_SC.in
+++ b/examples/epac2004_benchmarks/input_fodo_rf_SC.in
@@ -121,6 +121,10 @@ algo.space_charge = 3D
 algo.poisson_solver = "multigrid"
 
 amr.n_cell = 56 56 64
+# one box per MPI process (this example runs on 2 MPI processes)
+amr.max_grid_size_x = 56
+amr.max_grid_size_y = 56
+amr.max_grid_size_z = 32
 geometry.prob_relative = 4.0
 
 ###############################################################################

--- a/examples/epac2004_benchmarks/input_thermal.in
+++ b/examples/epac2004_benchmarks/input_thermal.in
@@ -37,6 +37,10 @@ algo.space_charge = 3D
 
 #amr.n_cell = 128 128 128  #full resolution
 amr.n_cell = 64 64 64
+# one box per MPI process (this example runs on 2 MPI processes)
+amr.max_grid_size_x = 64
+amr.max_grid_size_y = 64
+amr.max_grid_size_z = 32
 geometry.prob_relative = 3.0
 
 ###############################################################################

--- a/examples/epac2004_benchmarks/run_bithermal.py
+++ b/examples/epac2004_benchmarks/run_bithermal.py
@@ -12,6 +12,10 @@ sim = ImpactX()
 
 # set numerical parameters and IO control
 sim.n_cell = [64, 64, 64]
+# one box per MPI process (this example runs on 2 MPI processes)
+sim.max_grid_size_x = [64]
+sim.max_grid_size_y = [64]
+sim.max_grid_size_z = [32]
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "3D"
 sim.poisson_solver = "fft"

--- a/examples/epac2004_benchmarks/run_fodo_rf_SC.py
+++ b/examples/epac2004_benchmarks/run_fodo_rf_SC.py
@@ -12,6 +12,7 @@ sim = ImpactX()
 
 # set numerical parameters and IO control
 sim.n_cell = [56, 56, 64]
+sim.max_grid_size = [64]  # one box per process: this example runs on a single process
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "3D"
 sim.poisson_solver = "multigrid"

--- a/examples/epac2004_benchmarks/run_thermal.py
+++ b/examples/epac2004_benchmarks/run_thermal.py
@@ -12,6 +12,7 @@ sim = ImpactX()
 
 # set numerical parameters and IO control
 sim.n_cell = [56, 56, 64]
+sim.max_grid_size = [64]  # one box per process: this example runs on a single process
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "3D"
 sim.dynamic_size = True

--- a/examples/expanding_beam/input_expanding_fft.in
+++ b/examples/expanding_beam/input_expanding_fft.in
@@ -38,6 +38,7 @@ algo.poisson_solver = "fft"
 # Space charge solver with one MR level
 amr.max_level = 1
 amr.n_cell = 16 16 20
+amr.max_grid_size = 64  # one box per level and process: this example runs on a single process
 amr.blocking_factor_x = 16
 amr.blocking_factor_y = 16
 amr.blocking_factor_z = 4

--- a/examples/expanding_beam/input_expanding_fft_2D.in
+++ b/examples/expanding_beam/input_expanding_fft_2D.in
@@ -37,6 +37,8 @@ algo.space_charge = 2D
 algo.poisson_solver = "fft"
 
 amr.n_cell = 32 32 1
+# one box per MPI process (this example runs on 2 MPI processes)
+amr.max_grid_size_x = 16
 amr.blocking_factor_x = 16
 amr.blocking_factor_y = 16
 amr.blocking_factor_z = 1

--- a/examples/expanding_beam/input_expanding_mlmg.in
+++ b/examples/expanding_beam/input_expanding_mlmg.in
@@ -38,6 +38,7 @@ algo.poisson_solver = "multigrid"
 # Space charge solver with one MR level
 amr.max_level = 1
 amr.n_cell = 32 32 40
+amr.max_grid_size = 80  # one box per level and process: this example runs on a single process
 amr.blocking_factor_x = 16
 amr.blocking_factor_y = 16
 amr.blocking_factor_z = 4

--- a/examples/expanding_beam/run_expanding_fft.py
+++ b/examples/expanding_beam/run_expanding_fft.py
@@ -16,6 +16,10 @@ sim.n_cell = [16, 16, 20]
 sim.blocking_factor_x = [16]
 sim.blocking_factor_y = [16]
 sim.blocking_factor_z = [4]
+# one box per level and process: this example runs on a single process
+sim.max_grid_size_x = [64]
+sim.max_grid_size_y = [64]
+sim.max_grid_size_z = [64]
 
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "3D"

--- a/examples/expanding_beam/run_expanding_mlmg.py
+++ b/examples/expanding_beam/run_expanding_mlmg.py
@@ -16,6 +16,10 @@ sim.n_cell = [32, 32, 40]
 sim.blocking_factor_x = [16]
 sim.blocking_factor_y = [16]
 sim.blocking_factor_z = [4]
+# one box per level and process: this example runs on a single process
+sim.max_grid_size_x = [80]
+sim.max_grid_size_y = [80]
+sim.max_grid_size_z = [80]
 
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "3D"

--- a/examples/fodo_space_charge/input_fodo_2d_sc.in
+++ b/examples/fodo_space_charge/input_fodo_2d_sc.in
@@ -48,6 +48,8 @@ algo.space_charge = 2D
 algo.poisson_solver = "fft"
 
 amr.n_cell = 32 32 1
+# one box per MPI process (this example runs on 2 MPI processes)
+amr.max_grid_size_x = 16
 amr.blocking_factor_x = 16
 amr.blocking_factor_y = 16
 amr.blocking_factor_z = 1

--- a/examples/fodo_space_charge/input_fodo_2p5D_KV_sc.in
+++ b/examples/fodo_space_charge/input_fodo_2p5D_KV_sc.in
@@ -51,6 +51,8 @@ algo.space_charge.apply_longitudinal_kick = false
 algo.poisson_solver = "fft"
 
 amr.n_cell = 32 32 1
+# one box per MPI process (this example runs on 2 MPI processes)
+amr.max_grid_size_x = 16
 amr.blocking_factor_x = 16
 amr.blocking_factor_y = 16
 amr.blocking_factor_z = 1

--- a/examples/fodo_space_charge/input_fodo_2p5D_sc.in
+++ b/examples/fodo_space_charge/input_fodo_2p5D_sc.in
@@ -55,6 +55,8 @@ algo.space_charge.apply_longitudinal_kick = true
 algo.poisson_solver = "fft"
 
 amr.n_cell = 32 32 1
+# one box per MPI process (this example runs on 2 MPI processes)
+amr.max_grid_size_x = 16
 amr.blocking_factor_x = 16
 amr.blocking_factor_y = 16
 amr.blocking_factor_z = 1

--- a/examples/fodo_space_charge/run_fodo_2d_sc.py
+++ b/examples/fodo_space_charge/run_fodo_2d_sc.py
@@ -16,6 +16,9 @@ sim.n_cell = [32, 32, 1]
 sim.blocking_factor_x = [16]
 sim.blocking_factor_y = [16]
 sim.blocking_factor_z = [1]
+# one box per MPI process (this example runs on 2 MPI processes)
+sim.max_grid_size_x = [16]
+sim.max_grid_size_y = [32]
 
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "2D"

--- a/examples/fodo_space_charge/run_fodo_2p5D_KV_sc.py
+++ b/examples/fodo_space_charge/run_fodo_2p5D_KV_sc.py
@@ -16,6 +16,9 @@ sim.n_cell = [32, 32, 1]
 sim.blocking_factor_x = [16]
 sim.blocking_factor_y = [16]
 sim.blocking_factor_z = [1]
+# one box per MPI process (this example runs on 2 MPI processes)
+sim.max_grid_size_x = [16]
+sim.max_grid_size_y = [32]
 
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "2p5D"

--- a/examples/fodo_space_charge/run_fodo_2p5D_sc.py
+++ b/examples/fodo_space_charge/run_fodo_2p5D_sc.py
@@ -16,6 +16,9 @@ sim.n_cell = [32, 32, 1]
 sim.blocking_factor_x = [16]
 sim.blocking_factor_y = [16]
 sim.blocking_factor_z = [1]
+# one box per MPI process (this example runs on 2 MPI processes)
+sim.max_grid_size_x = [16]
+sim.max_grid_size_y = [32]
 
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "2p5D"

--- a/examples/kurth/input_kurth_10nC_periodic.in
+++ b/examples/kurth/input_kurth_10nC_periodic.in
@@ -45,4 +45,5 @@ algo.poisson_solver = "multigrid"
 
 amr.n_cell = 48 48 40
 #amr.n_cell = 72 72 72  # optional for increased precision
+amr.max_grid_size = 72  # one box per process: this example runs on a single process
 geometry.prob_relative = 3.0

--- a/examples/kurth/input_kurth_periodic.in
+++ b/examples/kurth/input_kurth_periodic.in
@@ -39,3 +39,4 @@ constf1.kt = constf1.kx
 algo.space_charge = false
 
 amr.n_cell = 40 40 32
+amr.max_grid_size = 40  # one box per process: this example runs on a single process

--- a/examples/kurth/run_kurth_10nC_periodic.py
+++ b/examples/kurth/run_kurth_10nC_periodic.py
@@ -12,6 +12,7 @@ sim = ImpactX()
 
 # set numerical parameters and IO control
 sim.n_cell = [48, 48, 40]  # use [72, 72, 72] for increased precision
+sim.max_grid_size = [72]  # one box per process: this example runs on a single process
 sim.particle_shape = 2  # B-spline order
 sim.space_charge = "3D"
 sim.poisson_solver = "multigrid"

--- a/examples/linac_segment/input_linac_segment.in
+++ b/examples/linac_segment/input_linac_segment.in
@@ -365,6 +365,8 @@ algo.space_charge = 3D
 algo.poisson_solver = "fft"
 #amr.n_cell = 64 64 64  # use this value for high resolution runs
 amr.n_cell = 32 32 32
+# one box per MPI process (this example runs on 2 MPI processes)
+amr.max_grid_size_z = 16
 geometry.prob_relative = 1.1 1.1
 
 ###############################################################################

--- a/examples/scraping_beam/run_scraping.py
+++ b/examples/scraping_beam/run_scraping.py
@@ -16,6 +16,10 @@ sim.n_cell = [16, 16, 20]
 sim.blocking_factor_x = [16]
 sim.blocking_factor_y = [16]
 sim.blocking_factor_z = [4]
+# one box per level and process: this example runs on a single process
+sim.max_grid_size_x = [64]
+sim.max_grid_size_y = [64]
+sim.max_grid_size_z = [64]
 
 sim.space_charge = False
 sim.poisson_solver = "fft"

--- a/examples/space_charge_gaussian_kick/run_sc_kick_PIC2p5D.py
+++ b/examples/space_charge_gaussian_kick/run_sc_kick_PIC2p5D.py
@@ -24,6 +24,9 @@ sim.n_cell = [64, 64, 1]
 sim.blocking_factor_x = [16]
 sim.blocking_factor_y = [16]
 sim.blocking_factor_z = [1]
+# one box per MPI process (this example runs on 2 MPI processes)
+sim.max_grid_size_x = [32]
+sim.max_grid_size_y = [64]
 sim.prob_relative = [1.1]
 
 # beam diagnostics

--- a/examples/space_charge_gaussian_kick/run_sc_kick_PIC2p5D_protons.py
+++ b/examples/space_charge_gaussian_kick/run_sc_kick_PIC2p5D_protons.py
@@ -24,6 +24,9 @@ sim.n_cell = [64, 64, 1]
 sim.blocking_factor_x = [16]
 sim.blocking_factor_y = [16]
 sim.blocking_factor_z = [1]
+# one box per MPI process (this example runs on 2 MPI processes)
+sim.max_grid_size_x = [32]
+sim.max_grid_size_y = [64]
 sim.prob_relative = [1.1]
 
 # beam diagnostics

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -16,6 +16,8 @@
 #include "particles/Push.H"
 #include "particles/wakefields/HandleWakefield.H"
 
+#include <ablastr/warn_manager/WarnManager.H>
+
 #include <AMReX.H>
 #include <AMReX_AmrParGDB.H>
 #include <AMReX_BLProfiler.H>
@@ -26,6 +28,7 @@
 
 #include <iostream>
 #include <memory>
+#include <string>
 
 
 namespace impactx {
@@ -118,6 +121,55 @@ namespace impactx {
             if (verbose > 0) {
                 std::cout << "\nGrids Summary:\n";
                 amr_data->printGridSummary(std::cout, 0, amr_data->finestLevel());
+            }
+        }
+
+        // warn on inefficient domain decompositions (number of boxes vs. parallel processes)
+        {
+            std::string const python_hint(
+                " In Python, the equivalent options are sim.max_grid_size and "
+                "sim.max_grid_size_x/_y/_z."
+            );
+            int const nprocs = amrex::ParallelDescriptor::NProcs();
+            for (int lev = 0; lev <= amr_data->finestLevel(); ++lev) {
+                amrex::Long const nboxes = amr_data->boxArray(lev).size();
+                if (nprocs == 1 && nboxes > 1) {
+                    ablastr::warn_manager::WMRecordWarning(
+                        "ImpactX::init_grids",
+                        "The mesh on level " + std::to_string(lev) + " is decomposed into " +
+                        std::to_string(nboxes) + " boxes, but this simulation runs on a "
+                        "single process. More than one box per process causes significant "
+                        "overhead (particle redistribution, communication in field solves, "
+                        "extra kernel launches) without any parallelization benefit. "
+                        "Set amr.max_grid_size at least as large as amr.n_cell "
+                        "(per direction: amr.max_grid_size_x/_y/_z) to create a single box, "
+                        "or run with more MPI processes." + python_hint,
+                        ablastr::warn_manager::WarnPriority::high
+                    );
+                } else if (nboxes > nprocs) {
+                    ablastr::warn_manager::WMRecordWarning(
+                        "ImpactX::init_grids",
+                        "The mesh on level " + std::to_string(lev) + " is decomposed into " +
+                        std::to_string(nboxes) + " boxes for only " + std::to_string(nprocs) +
+                        " MPI processes. More than one box per process (e.g., per GPU) "
+                        "causes significant overhead (particle redistribution, communication "
+                        "in field solves, extra kernel launches). Increase amr.max_grid_size "
+                        "(per direction: amr.max_grid_size_x/_y/_z) so that the number of "
+                        "boxes matches the number of processes." + python_hint,
+                        ablastr::warn_manager::WarnPriority::high
+                    );
+                } else if (lev == 0 && nboxes < nprocs) {
+                    ablastr::warn_manager::WMRecordWarning(
+                        "ImpactX::init_grids",
+                        "The mesh on level 0 is decomposed into " + std::to_string(nboxes) +
+                        " box(es) for " + std::to_string(nprocs) + " MPI processes. Processes "
+                        "without a box do not participate in field solves and hold no "
+                        "particles after redistribution. Decrease amr.max_grid_size "
+                        "(per direction: amr.max_grid_size_x/_y/_z) so that the number of "
+                        "boxes matches the number of processes." + python_hint,
+                        ablastr::warn_manager::WarnPriority::high
+                    );
+                }
             }
         }
 

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -130,7 +130,9 @@ void init_ImpactX (py::module& m)
                   },
                   "AMReX blocking factor for a direction, per MR level. "
                   "Also sets max_grid_size_x/_y/_z in this direction to the "
-                  "same value; assign that property afterwards to overwrite."
+                  "same value; assign that property afterwards to overwrite. "
+                  "The all-direction max_grid_size does not overwrite it, "
+                  "since per-direction values always take precedence."
             )
             .def_property(mgs_str.c_str(),
                   [mgs_str](ImpactX & /* ix */) {
@@ -149,7 +151,8 @@ void init_ImpactX (py::module& m)
                   },
                   "AMReX maximum box size for a direction, per MR level. "
                   "Boxes larger than this are chopped, aim for one box per "
-                  "parallel process."
+                  "parallel process. Takes precedence over the all-direction "
+                  "max_grid_size, no matter in which order they are assigned."
             );
     }
 
@@ -171,8 +174,10 @@ void init_ImpactX (py::module& m)
             },
             "AMReX maximum box size along all directions, per MR level. "
             "Boxes larger than this are chopped; aim for one box per "
-            "parallel process. Per-direction values (max_grid_size_x/_y/_z) "
-            "take precedence."
+            "parallel process. Per-direction values (max_grid_size_x/_y/_z, "
+            "also set by blocking_factor_x/_y/_z) take precedence, no matter "
+            "in which order they are assigned; assign those to change a "
+            "direction that is already set."
         );
 
     impactx

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -128,9 +128,52 @@ void init_ImpactX (py::module& m)
                       pp_amr.addarr(bf_str.c_str(), blocking_factor_dir);
                       pp_amr.addarr(mgs_str.c_str(), blocking_factor_dir);
                   },
-                  "AMReX blocking factor for a direction, per MR level."
+                  "AMReX blocking factor for a direction, per MR level. "
+                  "Also sets max_grid_size_x/_y/_z in this direction to the "
+                  "same value; assign that property afterwards to overwrite."
+            )
+            .def_property(mgs_str.c_str(),
+                  [mgs_str](ImpactX & /* ix */) {
+                      amrex::ParmParse pp_amr("amr");
+                      std::vector<int> max_grid_size_dir;
+                      pp_amr.queryarr(mgs_str.c_str(), max_grid_size_dir);
+
+                      return max_grid_size_dir;
+                  },
+                  [mgs_str](ImpactX &ix, std::vector<int> max_grid_size_dir) {
+                      if (ix.initialized())
+                          throw std::runtime_error("Read-only parameter after init_grids was called.");
+
+                      amrex::ParmParse pp_amr("amr");
+                      pp_amr.addarr(mgs_str.c_str(), max_grid_size_dir);
+                  },
+                  "AMReX maximum box size for a direction, per MR level. "
+                  "Boxes larger than this are chopped, aim for one box per "
+                  "parallel process."
             );
     }
+
+    impactx
+        .def_property("max_grid_size",
+            [](ImpactX & /* ix */) {
+                amrex::ParmParse pp_amr("amr");
+                std::vector<int> max_grid_size;
+                pp_amr.queryarr("max_grid_size", max_grid_size);
+
+                return max_grid_size;
+            },
+            [](ImpactX &ix, std::vector<int> max_grid_size) {
+                if (ix.initialized())
+                    throw std::runtime_error("Read-only parameter after init_grids was called.");
+
+                amrex::ParmParse pp_amr("amr");
+                pp_amr.addarr("max_grid_size", max_grid_size);
+            },
+            "AMReX maximum box size along all directions, per MR level. "
+            "Boxes larger than this are chopped; aim for one box per "
+            "parallel process. Per-direction values (max_grid_size_x/_y/_z) "
+            "take precedence."
+        );
 
     impactx
         // from amrex::AmrMesh

--- a/tests/python/test_space_charge_fields.py
+++ b/tests/python/test_space_charge_fields.py
@@ -32,6 +32,7 @@ def test_space_charge_phi_via_hook(save_png=True):
 
     # numerical parameters
     sim.n_cell = [48, 48, 40]
+    sim.max_grid_size = [48]  # one box per process: this test runs on a single process
     sim.tiny_profiler = False
     sim.particle_shape = 2
     sim.space_charge = "3D"


### PR DESCRIPTION
Creating too many boxes is a common way to tank AMReX performance, especially on single-rank simulations. Warns now about the most common problems that cause costly and unnecessary particle redistribution, extra communication in SC solves, and extra kernels on GPU.

We have a similar warning in WarpX for a while and I just this week fooled myself again in ImpactX by forgetting about this in benchmarks.

Reviewing by commit:
- C++ logic for warning b80f4f506cde212a8857990aff9fd3cf461a11ae
- Documentation 7e5f320280d5fbd184ea6d1b27eb9e791f53ec7b
- Large example change 36d90b1599026b2b6ae1e3e170d18b187c678d81

is the easiest for this PR.