### PR TITLE
Python: Improved `Config`

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -4,6 +4,7 @@
 #
 target_sources(pyImpactX
   PRIVATE
+    Config.cpp
     distribution.cpp
     elements.cpp
     flatten_rho.cpp

--- a/src/python/Config.cpp
+++ b/src/python/Config.cpp
@@ -5,6 +5,11 @@
  */
 #include "pyImpactX.H"
 
+#include <ImpactXVersion.H>
+
+#include <Utils/WarpXVersion.H>
+
+#include <AMReX.H>
 #include <AMReX_SIMD.H>
 
 #ifdef ImpactX_USE_OPENPMD
@@ -88,6 +93,8 @@ void init_Config (py::module& m)
 
     std::shared_ptr<ConfigMap const> const config = std::make_shared<ConfigMap>(
         ConfigMap{
+            {"ablastr_version", std::string{WARPX_GIT_VERSION}},
+            {"amrex_version", amrex::Version()},
             {"gpu_backend", gpu_backend},
             {"have_fft",
 #ifdef ImpactX_USE_FFT
@@ -131,6 +138,7 @@ void init_Config (py::module& m)
                 false
 #endif
             },
+            {"impactx_version", std::string{IMPACTX_GIT_VERSION}},
             {"openpmd_backends",
 #ifdef ImpactX_USE_OPENPMD
                 openPMD::getVariants()
@@ -157,6 +165,24 @@ void init_Config (py::module& m)
         }
     );
 
+    std::map<std::string, char const *> const doc = {
+        {"ablastr_version", "ABLASTR library version"},
+        {"amrex_version", "AMReX library version"},
+        {"gpu_backend", "GPU backend ('CUDA', 'HIP' or 'SYCL'), None without GPU support"},
+        {"have_fft", "Build supports FFT-based solvers"},
+        {"have_gpu", "Build supports GPUs"},
+        {"have_mpi", "Build supports MPI"},
+        {"have_omp", "Build supports OpenMP"},
+        {"have_openpmd", "Build supports openPMD I/O"},
+        {"have_simd", "Build supports explicit SIMD vectorization"},
+        {"impactx_version", "ImpactX library version"},
+        {"openpmd_backends", "openPMD I/O backends available in this build"},
+        {"precision", "Floating point precision of amrex::Real ('SINGLE' or 'DOUBLE')"},
+        {"precision_particles",
+            "Floating point precision of amrex::ParticleReal ('SINGLE' or 'DOUBLE')"},
+        {"simd_size", "Number of amrex::ParticleReal elements in a native SIMD vector"}
+    };
+
     py::dict config_metaclass_namespace;
     config_metaclass_namespace["__module__"] = m.attr("__name__");
     config_metaclass_namespace["__repr__"] = py::cpp_function(
@@ -181,7 +207,8 @@ void init_Config (py::module& m)
             entry.first.c_str(),
             [config, name = entry.first](py::object const &) {
                 return config->at(name);
-            }
+            },
+            doc.at(entry.first)
         );
     }
     pyImpactXConfig.def_static(

--- a/src/python/Config.cpp
+++ b/src/python/Config.cpp
@@ -39,7 +39,12 @@ namespace
         std::map<std::string, bool>,
         std::optional<std::string>
     >;
-    using ConfigMap = std::map<std::string, ConfigValue>;
+    struct ConfigEntry
+    {
+        ConfigValue value;
+        char const * doc;
+    };
+    using ConfigMap = std::map<std::string, ConfigEntry>;
 
     std::string config_repr (ConfigMap const & config)
     {
@@ -53,7 +58,7 @@ namespace
         }
 
         std::string repr = "impactx.Config:";
-        for (auto const & [name, value] : config)
+        for (auto const & [name, entry] : config)
         {
             repr += "\n    " + name;
             repr.append(name_width - name.size(), ' ');
@@ -61,7 +66,7 @@ namespace
             if (name == "openpmd_backends")
             {
                 py::list enabled_backends;
-                auto const & backends = std::get<std::map<std::string, bool>>(value);
+                auto const & backends = std::get<std::map<std::string, bool>>(entry.value);
                 for (auto const & [backend, enabled] : backends)
                 {
                     if (enabled)
@@ -73,7 +78,7 @@ namespace
             }
             else
             {
-                repr += py::repr(py::cast(value)).cast<std::string>();
+                repr += py::repr(py::cast(entry.value)).cast<std::string>();
             }
         }
         return repr;
@@ -93,95 +98,86 @@ void init_Config (py::module& m)
 
     std::shared_ptr<ConfigMap const> const config = std::make_shared<ConfigMap>(
         ConfigMap{
-            {"ablastr_version", std::string{WARPX_GIT_VERSION}},
-            {"amrex_version", amrex::Version()},
-            {"gpu_backend", gpu_backend},
-            {"have_fft",
+            {"ablastr_version", {
+                std::string{WARPX_GIT_VERSION},
+                "ABLASTR library version"}},
+            {"amrex_version", {
+                amrex::Version(),
+                "AMReX library version"}},
+            {"gpu_backend", {
+                gpu_backend,
+                "GPU backend ('CUDA', 'HIP' or 'SYCL'), None without GPU support"}},
+            {"have_fft", {
 #ifdef ImpactX_USE_FFT
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"have_gpu",
+                "Build supports FFT-based solvers"}},
+            {"have_gpu", {
 #ifdef AMREX_USE_GPU
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"have_mpi",
+                "Build supports GPUs"}},
+            {"have_mpi", {
 #ifdef AMREX_USE_MPI
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"have_omp",
+                "Build supports MPI"}},
+            {"have_omp", {
 #ifdef AMREX_USE_OMP
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"have_openpmd",
+                "Build supports OpenMP"}},
+            {"have_openpmd", {
 #ifdef ImpactX_USE_OPENPMD
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"have_simd",
+                "Build supports openPMD I/O"}},
+            {"have_simd", {
 #ifdef AMREX_USE_SIMD
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"impactx_version", std::string{IMPACTX_GIT_VERSION}},
-            {"openpmd_backends",
+                "Build supports explicit SIMD vectorization"}},
+            {"impactx_version", {
+                std::string{IMPACTX_GIT_VERSION},
+                "ImpactX library version"}},
+            {"openpmd_backends", {
 #ifdef ImpactX_USE_OPENPMD
-                openPMD::getVariants()
+                openPMD::getVariants(),
 #else
-                std::map<std::string, bool>{}
+                std::map<std::string, bool>{},
 #endif
-            },
-            {"precision",
+                "openPMD I/O backends available in this build"}},
+            {"precision", {
 #ifdef AMREX_USE_FLOAT
-                std::string{"SINGLE"}
+                std::string{"SINGLE"},
 #else
-                std::string{"DOUBLE"}
+                std::string{"DOUBLE"},
 #endif
-            },
-            {"precision_particles",
+                "Floating point precision of amrex::Real ('SINGLE' or 'DOUBLE')"}},
+            {"precision_particles", {
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-                std::string{"SINGLE"}
+                std::string{"SINGLE"},
 #else
-                std::string{"DOUBLE"}
+                std::string{"DOUBLE"},
 #endif
-            },
-            {"simd_size",
-                static_cast<int>(amrex::simd::native_simd_size_particlereal)}
+                "Floating point precision of amrex::ParticleReal ('SINGLE' or 'DOUBLE')"}},
+            {"simd_size", {
+                static_cast<int>(amrex::simd::native_simd_size_particlereal),
+                "Number of amrex::ParticleReal elements in a native SIMD vector"}}
         }
     );
-
-    std::map<std::string, char const *> const doc = {
-        {"ablastr_version", "ABLASTR library version"},
-        {"amrex_version", "AMReX library version"},
-        {"gpu_backend", "GPU backend ('CUDA', 'HIP' or 'SYCL'), None without GPU support"},
-        {"have_fft", "Build supports FFT-based solvers"},
-        {"have_gpu", "Build supports GPUs"},
-        {"have_mpi", "Build supports MPI"},
-        {"have_omp", "Build supports OpenMP"},
-        {"have_openpmd", "Build supports openPMD I/O"},
-        {"have_simd", "Build supports explicit SIMD vectorization"},
-        {"impactx_version", "ImpactX library version"},
-        {"openpmd_backends", "openPMD I/O backends available in this build"},
-        {"precision", "Floating point precision of amrex::Real ('SINGLE' or 'DOUBLE')"},
-        {"precision_particles",
-            "Floating point precision of amrex::ParticleReal ('SINGLE' or 'DOUBLE')"},
-        {"simd_size", "Number of amrex::ParticleReal elements in a native SIMD vector"}
-    };
 
     py::dict config_metaclass_namespace;
     config_metaclass_namespace["__module__"] = m.attr("__name__");
@@ -201,20 +197,25 @@ void init_Config (py::module& m)
     py::class_<Config> pyImpactXConfig(
         m, "Config", py::metaclass(config_metaclass)
     );
-    for (auto const & entry : *config)
+    for (auto const & [name, entry] : *config)
     {
         pyImpactXConfig.def_property_readonly_static(
-            entry.first.c_str(),
-            [config, name = entry.first](py::object const &) {
-                return config->at(name);
+            name.c_str(),
+            [config, name](py::object const &) {
+                return config->at(name).value;
             },
-            doc.at(entry.first)
+            entry.doc
         );
     }
     pyImpactXConfig.def_static(
         "to_dict",
         [config]() {
-            return *config;
+            py::dict d;
+            for (auto const & [name, entry] : *config)
+            {
+                d[name.c_str()] = entry.value;
+            }
+            return d;
         },
         "Return the ImpactX build configuration as a dictionary."
     );

--- a/src/python/Config.cpp
+++ b/src/python/Config.cpp
@@ -1,0 +1,194 @@
+/* Copyright 2026 The ImpactX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyImpactX.H"
+
+#include <AMReX_SIMD.H>
+
+#ifdef ImpactX_USE_OPENPMD
+#   include "openPMD/version.hpp"
+#endif
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+
+
+namespace py = pybind11;
+using namespace impactx;
+
+namespace impactx {
+    struct Config {};
+}
+
+namespace
+{
+    using ConfigValue = std::variant<
+        bool,
+        int,
+        std::string,
+        std::map<std::string, bool>,
+        std::optional<std::string>
+    >;
+    using ConfigMap = std::map<std::string, ConfigValue>;
+
+    std::string config_repr (ConfigMap const & config)
+    {
+        std::size_t name_width = 0;
+        for (auto const & entry : config)
+        {
+            if (entry.first.size() > name_width)
+            {
+                name_width = entry.first.size();
+            }
+        }
+
+        std::string repr = "impactx.Config:";
+        for (auto const & [name, value] : config)
+        {
+            repr += "\n    " + name;
+            repr.append(name_width - name.size(), ' ');
+            repr += " = ";
+            if (name == "openpmd_backends")
+            {
+                py::list enabled_backends;
+                auto const & backends = std::get<std::map<std::string, bool>>(value);
+                for (auto const & [backend, enabled] : backends)
+                {
+                    if (enabled)
+                    {
+                        enabled_backends.append(backend);
+                    }
+                }
+                repr += py::repr(enabled_backends).cast<std::string>();
+            }
+            else
+            {
+                repr += py::repr(py::cast(value)).cast<std::string>();
+            }
+        }
+        return repr;
+    }
+}
+
+void init_Config (py::module& m)
+{
+    std::optional<std::string> gpu_backend;
+#ifdef AMREX_USE_CUDA
+    gpu_backend = "CUDA";
+#elif defined(AMREX_USE_HIP)
+    gpu_backend = "HIP";
+#elif defined(AMREX_USE_DPCPP)
+    gpu_backend = "SYCL";
+#endif
+
+    std::shared_ptr<ConfigMap const> const config = std::make_shared<ConfigMap>(
+        ConfigMap{
+            {"gpu_backend", gpu_backend},
+            {"have_fft",
+#ifdef ImpactX_USE_FFT
+                true
+#else
+                false
+#endif
+            },
+            {"have_gpu",
+#ifdef AMREX_USE_GPU
+                true
+#else
+                false
+#endif
+            },
+            {"have_mpi",
+#ifdef AMREX_USE_MPI
+                true
+#else
+                false
+#endif
+            },
+            {"have_omp",
+#ifdef AMREX_USE_OMP
+                true
+#else
+                false
+#endif
+            },
+            {"have_openpmd",
+#ifdef ImpactX_USE_OPENPMD
+                true
+#else
+                false
+#endif
+            },
+            {"have_simd",
+#ifdef AMREX_USE_SIMD
+                true
+#else
+                false
+#endif
+            },
+            {"openpmd_backends",
+#ifdef ImpactX_USE_OPENPMD
+                openPMD::getVariants()
+#else
+                std::map<std::string, bool>{}
+#endif
+            },
+            {"precision",
+#ifdef AMREX_USE_FLOAT
+                std::string{"SINGLE"}
+#else
+                std::string{"DOUBLE"}
+#endif
+            },
+            {"precision_particles",
+#ifdef AMREX_SINGLE_PRECISION_PARTICLES
+                std::string{"SINGLE"}
+#else
+                std::string{"DOUBLE"}
+#endif
+            },
+            {"simd_size",
+                static_cast<int>(amrex::simd::native_simd_size_particlereal)}
+        }
+    );
+
+    py::dict config_metaclass_namespace;
+    config_metaclass_namespace["__module__"] = m.attr("__name__");
+    config_metaclass_namespace["__repr__"] = py::cpp_function(
+        [config]() {
+            return config_repr(*config);
+        }
+    );
+    py::object const impactx_class = m.attr("ImpactX");
+    py::object const pybind11_metaclass = py::type::of(impactx_class);
+    py::object const config_metaclass = py::type::of(pybind11_metaclass)(
+        "ConfigMeta",
+        py::make_tuple(pybind11_metaclass),
+        config_metaclass_namespace
+    );
+
+    py::class_<Config> pyImpactXConfig(
+        m, "Config", py::metaclass(config_metaclass)
+    );
+    for (auto const & entry : *config)
+    {
+        pyImpactXConfig.def_property_readonly_static(
+            entry.first.c_str(),
+            [config, name = entry.first](py::object const &) {
+                return config->at(name);
+            }
+        );
+    }
+    pyImpactXConfig.def_static(
+        "to_dict",
+        [config]() {
+            return *config;
+        },
+        "Return the ImpactX build configuration as a dictionary."
+    );
+}

--- a/src/python/Config.cpp
+++ b/src/python/Config.cpp
@@ -101,12 +101,15 @@ void init_Config (py::module& m)
             {"ablastr_version", {
                 std::string{WARPX_GIT_VERSION},
                 "ABLASTR library version"}},
+
             {"amrex_version", {
                 amrex::Version(),
                 "AMReX library version"}},
+
             {"gpu_backend", {
                 gpu_backend,
                 "GPU backend ('CUDA', 'HIP' or 'SYCL'), None without GPU support"}},
+
             {"have_fft", {
 #ifdef ImpactX_USE_FFT
                 true,
@@ -114,6 +117,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports FFT-based solvers"}},
+
             {"have_gpu", {
 #ifdef AMREX_USE_GPU
                 true,
@@ -121,6 +125,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports GPUs"}},
+
             {"have_mpi", {
 #ifdef AMREX_USE_MPI
                 true,
@@ -128,6 +133,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports MPI"}},
+
             {"have_omp", {
 #ifdef AMREX_USE_OMP
                 true,
@@ -135,6 +141,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports OpenMP"}},
+
             {"have_openpmd", {
 #ifdef ImpactX_USE_OPENPMD
                 true,
@@ -142,6 +149,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports openPMD I/O"}},
+
             {"have_simd", {
 #ifdef AMREX_USE_SIMD
                 true,
@@ -149,9 +157,11 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports explicit SIMD vectorization"}},
+
             {"impactx_version", {
                 std::string{IMPACTX_GIT_VERSION},
                 "ImpactX library version"}},
+
             {"openpmd_backends", {
 #ifdef ImpactX_USE_OPENPMD
                 openPMD::getVariants(),
@@ -159,6 +169,7 @@ void init_Config (py::module& m)
                 std::map<std::string, bool>{},
 #endif
                 "openPMD I/O backends available in this build"}},
+
             {"precision", {
 #ifdef AMREX_USE_FLOAT
                 std::string{"SINGLE"},
@@ -166,6 +177,7 @@ void init_Config (py::module& m)
                 std::string{"DOUBLE"},
 #endif
                 "Floating point precision of amrex::Real ('SINGLE' or 'DOUBLE')"}},
+
             {"precision_particles", {
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
                 std::string{"SINGLE"},
@@ -173,6 +185,7 @@ void init_Config (py::module& m)
                 std::string{"DOUBLE"},
 #endif
                 "Floating point precision of amrex::ParticleReal ('SINGLE' or 'DOUBLE')"}},
+
             {"simd_size", {
                 static_cast<int>(amrex::simd::native_simd_size_particlereal),
                 "Number of amrex::ParticleReal elements in a native SIMD vector"}}
@@ -197,8 +210,10 @@ void init_Config (py::module& m)
     py::class_<Config> pyImpactXConfig(
         m, "Config", py::metaclass(config_metaclass)
     );
-    for (auto const & [name, entry] : *config)
+    for (auto const & kv : *config)
     {
+        std::string const & name = kv.first;
+        ConfigEntry const & entry = kv.second;
         pyImpactXConfig.def_property_readonly_static(
             name.c_str(),
             [config, name](py::object const &) {

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -17,11 +17,6 @@
 #include <AMReX.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_ParallelDescriptor.H>
-#include <AMReX_SIMD.H>
-
-#ifdef ImpactX_USE_OPENPMD
-#   include "openPMD/version.hpp"
-#endif
 
 #if defined(AMREX_DEBUG) || defined(DEBUG)
 #   include <cstdio>
@@ -34,10 +29,6 @@
 
 namespace py = pybind11;
 using namespace impactx;
-
-namespace impactx {
-    struct Config {};
-}
 
 namespace detail
 {
@@ -874,112 +865,4 @@ void init_ImpactX (py::module& m)
             py::arg("lev")
         )
     ;
-
-    py::class_<Config> pyImpactXConfig(m, "Config");
-    pyImpactXConfig
-//        .def_property_readonly_static(
-//            "impactx_version",
-//            [](py::object) { return Version(); },
-//            "ImpactX version")
-        .def_property_readonly_static(
-            "have_mpi",
-            [](py::object const &){
-#ifdef AMREX_USE_MPI
-                return true;
-#else
-                return false;
-#endif
-            })
-        .def_property_readonly_static(
-            "have_gpu",
-            [](py::object const &){
-#ifdef AMREX_USE_GPU
-                return true;
-#else
-                return false;
-#endif
-            })
-        .def_property_readonly_static(
-            "have_omp",
-            [](py::object const &){
-#ifdef AMREX_USE_OMP
-                return true;
-#else
-                return false;
-#endif
-        })
-        .def_property_readonly_static(
-            "have_simd",
-            [](py::object const &){
-#ifdef AMREX_USE_SIMD
-                return true;
-#else
-                return false;
-#endif
-        })
-        .def_property_readonly_static(
-            "have_fft",
-            [](py::object const &){
-#ifdef ImpactX_USE_FFT
-                return true;
-#else
-                return false;
-#endif
-        })
-        .def_property_readonly_static(
-            "have_openpmd",
-            [](py::object const &){
-#ifdef ImpactX_USE_OPENPMD
-                return true;
-#else
-                return false;
-#endif
-        })
-    ;
-    pyImpactXConfig
-        .attr("openpmd_backends") =
-#ifdef ImpactX_USE_OPENPMD
-            openPMD::getVariants()
-#else
-            py::dict()
-#endif
-    ;
-    pyImpactXConfig
-        .def_property_readonly_static(
-            "simd_size",
-            [](py::object const &){
-                return amrex::simd::native_simd_size_particlereal;
-        })
-        .def_property_readonly_static(
-            "gpu_backend",
-            [](py::object const &){
-#ifdef AMREX_USE_CUDA
-                return "CUDA";
-#elif defined(AMREX_USE_HIP)
-                return "HIP";
-#elif defined(AMREX_USE_DPCPP)
-                return "SYCL";
-#else
-                return py::none();
-#endif
-        })
-        .def_property_readonly_static(
-            "precision",
-            [](py::object){
-#ifdef AMREX_USE_FLOAT
-                return "SINGLE";
-#else
-                return "DOUBLE";
-#endif
-        })
-        .def_property_readonly_static(
-            "precision_particles",
-            [](py::object const &){
-#ifdef AMREX_SINGLE_PRECISION_PARTICLES
-                return "SINGLE";
-#else
-                return "DOUBLE";
-#endif
-        })
-        ;
 }

--- a/src/python/pyImpactX.cpp
+++ b/src/python/pyImpactX.cpp
@@ -20,6 +20,7 @@ using namespace impactx;
 
 
 // forward declarations of exposed classes
+void init_Config(py::module&);
 void init_distribution(py::module&);
 void init_elements(py::module&);
 void init_flatten_rho(py::module& m);
@@ -53,6 +54,7 @@ PYBIND11_MODULE(impactx_pybind, m) {
     init_transformation(m);
     init_wakeconvolution(m);
     init_ImpactX(m);
+    init_Config(m);
     init_flatten_rho(m);
 
     // expose our amrex module


### PR DESCRIPTION
Improve and separate out the `impactx.Config` object. Make it exportable to Python dictionaries via `to_dict()` and ensure it prints nicely in interactive (IPython/Jupyter) usage:
```python
In [1]: import impactx

In [2]: impactx.Config
Out[2]:
impactx.Config:
    ablastr_version     = '26.06-5-g759c5cb11a41'
    amrex_version       = '26.06-30-g5fbc49bce6cc'
    gpu_backend         = None
    have_fft            = True
    have_gpu            = False
    have_mpi            = True
    have_omp            = True
    have_openpmd        = True
    have_simd           = True
    impactx_version     = '26.06-55-g1eeb36e33974-dirty'
    openpmd_backends    = ['adios2', 'hdf5', 'json', 'mpi', 'toml']
    precision           = 'DOUBLE'
    precision_particles = 'DOUBLE'
    simd_size           = 2

In [3]: impactx.Config.to_dict()
Out[3]: 
{'ablastr_version': '26.06-5-g759c5cb11a41',
 'amrex_version': '26.06-30-g5fbc49bce6cc',
 'gpu_backend': None,
 'have_fft': True,
 'have_gpu': False,
 'have_mpi': True,
 'have_omp': True,
 'have_openpmd': True,
 'have_simd': True,
 'impactx_version': '26.06-55-g1eeb36e33974-dirty',
 'openpmd_backends': {'adios1': False,
  'adios2': True,
  'hdf5': True,
  'json': True,
  'mpi': True,
  'toml': True},
 'precision': 'DOUBLE',
 'precision_particles': 'DOUBLE',
 'simd_size': 2}

```

Before this PR, the object just printed its class name.