### PR TITLE
`np.allclose` Defaults

### DIFF
--- a/examples/dogleg/analysis_dogleg_jitter.py
+++ b/examples/dogleg/analysis_dogleg_jitter.py
@@ -186,12 +186,13 @@ assert np.allclose(
     rtol=rtol,
     atol=atol,
 )
-atol = 1.0e-6  # ignored
+atol = 1.0e-6
 print(f"  atol={atol}")
 assert np.allclose(
     [px_mean],
     [
         px_mean_predicted,
     ],
+    rtol=0.0,
     atol=atol,
 )

--- a/examples/dogleg/run_dogleg_vertical.py
+++ b/examples/dogleg/run_dogleg_vertical.py
@@ -104,6 +104,7 @@ def assert_final_beam(moments):
             -2.666972e-01,
         ],
         rtol=2.0e-2,
+        atol=0.0,  # do not let the default atol swallow the emittance checks
     )
 
 

--- a/examples/rfcavity/analysis_rfcavity_ref_part.py
+++ b/examples/rfcavity/analysis_rfcavity_ref_part.py
@@ -63,7 +63,7 @@ print("")
 print("Initial Beam:")
 print(f"  s_ref={si:e} gamma_ref={gammai:e}")
 
-atol = 1.0e-4  # ignored
+atol = 1.0e-4
 print(f"  atol={atol}")
 
 assert np.allclose(
@@ -72,6 +72,7 @@ assert np.allclose(
         0.000000,
         451.09877160930125,
     ],
+    rtol=0.0,
     atol=atol,
 )
 
@@ -89,5 +90,6 @@ assert np.allclose(
         5.9391682799999987,
         585.11989430128892,
     ],
+    rtol=0.0,
     atol=atol,
 )

--- a/examples/rfcavity/analysis_rfcavity_ref_part_hook.py
+++ b/examples/rfcavity/analysis_rfcavity_ref_part_hook.py
@@ -63,7 +63,7 @@ print("")
 print("Initial Beam:")
 print(f"  s_ref={si:e} gamma_ref={gammai:e}")
 
-atol = 1.0e-4  # ignored
+atol = 1.0e-4
 print(f"  atol={atol}")
 
 assert np.allclose(
@@ -72,6 +72,7 @@ assert np.allclose(
         0.000000,
         451.09877160930125,
     ],
+    rtol=0.0,
     atol=atol,
 )
 
@@ -89,5 +90,6 @@ assert np.allclose(
         5.9391682799999987,
         585.11989430128892,
     ],
+    rtol=0.0,
     atol=atol,
 )

--- a/examples/rfcavity/analysis_rfcavity_ref_part_opt.py
+++ b/examples/rfcavity/analysis_rfcavity_ref_part_opt.py
@@ -63,7 +63,7 @@ print("")
 print("Initial Beam:")
 print(f"  s_ref={si:e} gamma_ref={gammai:e}")
 
-atol = 1.0e-4
+atol = 2.5e-4
 print(f"  atol={atol}")
 
 assert np.allclose(

--- a/examples/rfcavity/analysis_rfcavity_ref_part_opt.py
+++ b/examples/rfcavity/analysis_rfcavity_ref_part_opt.py
@@ -63,7 +63,7 @@ print("")
 print("Initial Beam:")
 print(f"  s_ref={si:e} gamma_ref={gammai:e}")
 
-atol = 2.5e-4
+atol = 1.0e-4
 print(f"  atol={atol}")
 
 assert np.allclose(
@@ -81,7 +81,7 @@ print("")
 print("Final Beam:")
 print(f"  s_ref={sf:e} gamma_ref={gammaf:e}")
 
-atol = 1.0e-4 if is_double else 2.0e-1
+atol = 5.0e-4 if is_double else 2.0e-1
 print(f"  atol={atol}")
 
 assert np.allclose(

--- a/examples/rfcavity/analysis_rfcavity_ref_part_opt.py
+++ b/examples/rfcavity/analysis_rfcavity_ref_part_opt.py
@@ -63,7 +63,7 @@ print("")
 print("Initial Beam:")
 print(f"  s_ref={si:e} gamma_ref={gammai:e}")
 
-atol = 1.0e-4  # ignored
+atol = 1.0e-4
 print(f"  atol={atol}")
 
 assert np.allclose(
@@ -72,6 +72,7 @@ assert np.allclose(
         0.000000,
         1.2451314527015738,
     ],
+    rtol=0.0,
     atol=atol,
 )
 
@@ -89,5 +90,6 @@ assert np.allclose(
         5.9391682799999987,
         39.858859594214152,
     ],
+    rtol=0.0,
     atol=atol,
 )

--- a/examples/spin_tracking/analysis_quad_spin_rbc.py
+++ b/examples/spin_tracking/analysis_quad_spin_rbc.py
@@ -127,6 +127,7 @@ print("")
 print(f"Spin moment consistency condition = {condition:e}")
 
 atol = 1.0e-12 if is_double else 1.0e-3
+rtol = 0.0
 print(f"  atol={atol}")
 
 assert np.allclose(
@@ -134,5 +135,6 @@ assert np.allclose(
     [
         1.0,
     ],
+    rtol=rtol,
     atol=atol,
 )


### PR DESCRIPTION
We just realized `np.allclose` has non-zero defaults for both `atol` and `rtol`. Fixing where we assumed they default to zero.