### PR TITLE
Sphinx: Hide TOC Titles

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,13 +38,13 @@ There, you can find already answered questions, add your own, get help with inst
    /* front page: hide chapter titles
     * needed for consistent HTML-PDF-EPUB chapters
     */
-   div#installation.section,
-   div#usage.section,
-   div#theory.section,
-   div#data-analysis.section,
-   div#development.section,
-   div#maintenance.section,
-   div#epilogue.section {
+   section#installation,
+   section#usage,
+   section#data-analysis,
+   section#theory,
+   section#development,
+   section#maintenance,
+   section#epilogue {
        display:none;
    }
    </style>


### PR DESCRIPTION
Sphinx updated to more modern HTML and we like to hide the table-of-contents of included sections on the title page. This fixes this to the proper rendering.

## Old / New

<img width="350" alt="image" src="https://github.com/user-attachments/assets/a4b6c4ec-2650-44fd-b786-d97794e30b50" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/446b93fe-e4d7-4c86-82be-08dc13a70c8b" />

