### PR TITLE
[WIP] CSR Surrogate Hook

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,14 +56,14 @@ jobs:
           cmake -S . -B build -DImpactX_FFT=ON -DImpactX_PYTHON=OFF
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v4.37.4
         with:
           config-file: ./.github/codeql/impactx-codeql.yml
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Build (py)
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@v4.37.4
         if: ${{ matrix.language == 'python' }}
         env:
           IMPACTX_FFT: ON
@@ -74,7 +74,7 @@ jobs:
           cmake --build build -j 4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v4.37.4
         with:
           category: "/language:${{ matrix.language }}"
           upload: False
@@ -96,6 +96,6 @@ jobs:
           output: sarif-results/${{ matrix.language }}.sarif
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@v4.37.4
         with:
           sarif_file: sarif-results/${{ matrix.language }}.sarif

--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -77,6 +77,7 @@ Coherent Synchrotron Radiation (CSR)
    :maxdepth: 1
 
    examples/chicane/README_csr.rst
+   examples/pytorch_csr_surrogate/README.rst
 
 
 Quantum Excitation

--- a/docs/source/usage/howto/python_extend.rst
+++ b/docs/source/usage/howto/python_extend.rst
@@ -14,6 +14,7 @@ This facilitates a wide range of workflows, including:
    - **Dynamic lattice manipulation**, e.g., changing element strengths between turns, ramping voltages, or feedback systems.
    - **Custom beam optics elements**, e.g., a non-linear kick or a tabulated map, plugged in via the :py:class:`impactx.elements.Programmable` element.
    - **AI/ML surrogate models** built with PyTorch or TensorFlow to emulate detailed transport in a single element.
+   - **Custom collective-effect models**, e.g., a pre-trained CSR surrogate replacing the built-in analytic CSR wake, plugged in via :py:attr:`~impactx.ImpactX.csr_kick_model`.
 
 Because ImpactX exposes particles and fields *without copies* through `pyAMReX <https://pyamrex.readthedocs.io/>`__,
 per-step Python callbacks have very low overhead and stay GPU-resident when ImpactX runs on GPUs
@@ -153,6 +154,44 @@ Typical usage (per-tile push) looks like this:
 
 A complete script is provided in this :ref:`FODO Cell example <examples-fodo-programmable>`.
 For a more complex example, see our :ref:`ML surrogate element example <examples-ml-surrogate>`.
+
+.. _usage-howto-python-extend-csr:
+
+Custom CSR Wake Models (ML Surrogates)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+While the surfaces above observe the beam between elements or replace an element entirely, the
+:py:attr:`~impactx.ImpactX.csr_kick_model` property plugs into the *collective-effect* slot of the
+tracking loop: it replaces the built-in analytic Coherent Synchrotron Radiation (CSR) wake model
+with a user-defined one, e.g., a neural network pre-trained on data from a high-fidelity CSR solver
+(`A. L. Edelen et al., in Proc. IPAC'22, WEPOMS013 <https://doi.org/10.18429/JACoW-IPAC2022-WEPOMS013>`__).
+
+ImpactX keeps the surrounding machinery (per-slice charge binning, MPI reduction, and the momentum
+kick) and calls the model once per tracking slice in CSR-active bend elements with the binned
+longitudinal beam profile (:py:class:`impactx.CSRProfile`) and the element context
+(:py:class:`impactx.CSRElementContext`). The model returns the per-bin kick forces in Newtons:
+
+.. code-block:: python
+
+   import numpy as np
+
+   def my_csr_model(profile, context):
+       """Predict the per-bin longitudinal CSR kick force [N]."""
+       lam = profile.charge.to_xp()  # lambda(t) [C/m], NumPy (CPU) or CuPy (GPU)
+
+       # example inputs, as in Edelen et al. (IPAC'22):
+       # the charge profile, the position in the bend, and the bend radius
+       kick = my_network(lam, context.s, context.rc)  # length profile.num_bins
+
+       return {"pt": kick}  # optional additional keys: "px", "py"
+
+   sim.csr = True  # still required
+   sim.csr_kick_model = my_csr_model  # None restores the built-in model
+
+Details of the units and the calling convention are documented in
+:py:attr:`~impactx.ImpactX.csr_kick_model`.
+A complete, self-contained script that trains and couples a PyTorch surrogate is provided in the
+:ref:`NN CSR surrogate example <examples-ml-csr-surrogate>`.
 
 .. _usage-howto-python-extend-data-access:
 

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -2532,6 +2532,14 @@ Currently, this is the 1D ultrarelativistic steady-state wakefield model (eq. 19
 
    CSR effects require the compilation flag ``-DImpactX_FFT=ON``.
 
+.. note::
+
+   Through the user-facing Python interface, the built-in analytic CSR wake model can be replaced with a user-defined kick model, e.g., a pre-trained machine-learning surrogate as in
+   `A. L. Edelen et al., in Proc. IPAC'22, WEPOMS013, DOI:10.18429/JACoW-IPAC2022-WEPOMS013 <https://doi.org/10.18429/JACoW-IPAC2022-WEPOMS013>`__
+   (`arXiv:2203.07542 <https://arxiv.org/abs/2203.07542>`__).
+   See ``csr_kick_model`` in the :ref:`Python interface documentation <usage-python>`. In that case, the FFT compilation requirement does not apply.
+   This is a Python-only feature and cannot be expressed in input files.
+
 .. _running-cpp-parameters-collective-isr:
 
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -183,11 +183,42 @@ Collective Effects & Overall Simulation Parameters
 
          CSR effects are only calculated for lattice elements that include bending, such as ``Sbend``, ``ExactSbend`` and ``CFbend``.
 
-         CSR effects require the compilation flag ``-DImpactX_FFT=ON``.
+         CSR effects require the compilation flag ``-DImpactX_FFT=ON``, unless a user-defined kick model is set via ``csr_kick_model``.
 
    .. py:property:: csr_bins
 
       The number of bins along the longitudinal direction used for the CSR calculations (default: ``150``).
+
+   .. py:property:: csr_kick_model
+
+      A user-defined CSR kick model (default: ``None``, which selects the built-in analytic model).
+
+      Use this to couple custom CSR models into the tracking loop, e.g., machine-learning surrogate models that were pre-trained on data from high-fidelity CSR solvers, as in
+      `A. L. Edelen et al., in Proc. IPAC'22, WEPOMS013, DOI:10.18429/JACoW-IPAC2022-WEPOMS013 <https://doi.org/10.18429/JACoW-IPAC2022-WEPOMS013>`__
+      (`arXiv:2203.07542 <https://arxiv.org/abs/2203.07542>`__).
+      See the :ref:`example <examples-ml-csr-surrogate>` and the :ref:`how-to guide <usage-howto-python-extend>`.
+
+      ``csr = True`` is still required for CSR to be applied. The model replaces only the wake/kick computation.
+      It is called once per tracking slice in CSR-active bend elements as ``model(profile, context)``, with an :py:class:`impactx.CSRProfile` and an :py:class:`impactx.CSRElementContext` argument.
+
+      The model must return the per-bin kick **forces in Newtons**, each an array of length ``profile.num_bins``, either as
+
+      * a dict with the required key ``"pt"`` (longitudinal force :math:`F_t`, applied as :math:`\Delta p_t = -F_t \Delta s / (c \, p_\mathrm{ref})`, where a positive value describes energy loss) and the optional keys ``"px"``/``"py"`` (transverse forces :math:`F_{x,y}`, applied as :math:`\Delta p_{x,y} = +F_{x,y} \Delta s / (\beta c \, p_\mathrm{ref})`), or
+      * a bare array, equivalent to ``{"pt": array}``.
+
+      Accepted array types: NumPy arrays and everything NumPy can convert (lists, detached CPU torch tensors, ...), pyAMReX ``PODVector``, and objects implementing the CUDA array interface (e.g., cupy arrays).
+
+      .. note::
+
+         The built-in analytic model corresponds to returning
+         :math:`F_t = \left(\mathrm{d}N/\mathrm{d}s \ast W_\mathrm{CSR}\right) \Delta`, the convolution of the number density derivative with the steady-state CSR wake function (:py:func:`impactx.wakeconvolution.w_l_csr`).
+
+      .. note::
+
+         This is a Python-only feature: it cannot be expressed in ParmParse input files and is not serialized.
+         Under MPI, set the model on every rank. It is invoked on the I/O rank only and the resulting kick is broadcast.
+         A model failure on the I/O rank is communicated to and raised on every rank, so parallel runs stop cleanly.
+         A kick model works in ImpactX builds without FFT support.
 
    .. py:property:: isr
 
@@ -531,6 +562,90 @@ Collective Effects & Overall Simulation Parameters
       :param ref: the reference particle (object from :py:class:`impactx.RefPart`)
       :return: a dictionary of beam moments
       :rtype: dict[str, float]
+
+
+.. py:class:: impactx.CSRProfile
+
+   The binned longitudinal beam profile passed to a user-defined CSR kick model, see :py:attr:`impactx.ImpactX.csr_kick_model`.
+
+   All arrays share the same binning: bin ``i`` spans ``[bin_min + i * bin_size, bin_min + (i+1) * bin_size)`` in the longitudinal coordinate :math:`t = ct` (in meters) and have ``num_bins + 1`` entries, where the last entry is a guard bin.
+   The arrays are pyAMReX ``PODVector`` objects in device memory on GPU builds. Use ``.to_xp()`` for zero-copy access (NumPy on CPU, cupy on GPU) or ``.to_numpy(copy=True)`` for a host copy.
+
+   .. warning::
+
+      The profile and its array views are only valid during the model call.
+      Copy any data you retain.
+
+   .. py:property:: charge
+
+      Line charge density :math:`\lambda(t)` in C/m from nearest-grid-point deposition. ``sum(charge) * bin_size`` approximates the bunch charge in C.
+
+   .. py:property:: mean_x
+
+      Charge-weighted mean of :math:`x` per bin, in meters (zero for empty bins).
+
+   .. py:property:: mean_y
+
+      Charge-weighted mean of :math:`y` per bin, in meters (zero for empty bins).
+
+   .. py:property:: bin_min
+
+      Lower edge of bin 0 in :math:`t = ct`, in meters.
+
+   .. py:property:: bin_size
+
+      Bin spacing in meters, ``(t_max - t_min) / (num_bins - 1)``.
+
+   .. py:property:: num_bins
+
+      Number of kick bins (= :py:attr:`impactx.ImpactX.csr_bins`). The profile arrays have ``num_bins + 1`` entries.
+
+
+.. py:class:: impactx.CSRElementContext
+
+   The per-element, per-slice context passed to a user-defined CSR kick model, see :py:attr:`impactx.ImpactX.csr_kick_model`.
+   Only valid during the model call. Copy any data you retain.
+
+   .. py:property:: element_name
+
+      User-given element name (empty if unnamed).
+
+   .. py:property:: element_type
+
+      Element type, e.g., ``"Sbend"``.
+
+   .. py:property:: rc
+
+      Radius-of-curvature magnitude :math:`|R|` in meters.
+
+   .. py:property:: signed_rc
+
+      Signed radius of curvature :math:`R` in meters, preserving the bend polarity for models
+      that return transverse kicks.
+
+   .. py:property:: ds
+
+      Element (arc) length in meters.
+
+   .. py:property:: nslice
+
+      Number of slices in the element.
+
+   .. py:property:: slice
+
+      Current slice index, 0-based, in forward orientation.
+
+   .. py:property:: s
+
+      Distance from the element entrance at kick time, in meters (``= slice * slice_ds``, also during back-tracking).
+
+   .. py:property:: slice_ds
+
+      Slice length in meters.
+
+   .. py:property:: ref
+
+      The reference particle (a :py:class:`impactx.RefPart` snapshot copy).
 
 
 .. py:class:: impactx.Config

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1401,6 +1401,17 @@ add_impactx_test(pytorch_surrogate_model
 label_impactx_test(pytorch_surrogate_model slow)
 
 
+# PyTorch CSR Surrogate: Chicane ##############################################
+#
+add_impactx_test(pytorch_csr_surrogate
+    examples/pytorch_csr_surrogate/run_chicane_csr_ml.py
+    OFF  # ImpactX MPI-parallel
+    examples/pytorch_csr_surrogate/analysis_chicane_csr_ml.py
+    OFF  # no plot script yet
+)
+label_impactx_test(pytorch_csr_surrogate slow)
+
+
 # IOTA s-dependent nonlinear lens with aperture ###############################
 #
 add_impactx_test(IOTA_nll_aperture

--- a/examples/pytorch_csr_surrogate/README.rst
+++ b/examples/pytorch_csr_surrogate/README.rst
@@ -1,0 +1,56 @@
+.. _examples-ml-csr-surrogate:
+
+Neural Network CSR Surrogate: Chicane
+=====================================
+
+This example runs the :ref:`Berlin-Zeuthen magnetic bunch compression chicane <examples-chicane>` with coherent synchrotron radiation (CSR), replacing the built-in analytic CSR wake model with a neural network surrogate that is coupled in through the user-facing Python interface ``sim.csr_kick_model``.
+The approach follows:
+
+- Edelen A L, Mayes C E, Emma C and Roussel R.
+  **Neural Network Solver for Coherent Synchrotron Radiation Wakefield Calculations in Accelerator-Based Charged Particle Beams**.
+  13th International Particle Accelerator Conference (IPAC'22), WEPOMS013, 2022.
+  `DOI:10.18429/JACoW-IPAC2022-WEPOMS013 <https://doi.org/10.18429/JACoW-IPAC2022-WEPOMS013>`__
+  (`arXiv:2203.07542 <https://arxiv.org/abs/2203.07542>`__)
+
+Per tracking slice inside each bend, ImpactX deposits the binned longitudinal charge profile :math:`\lambda(t)` and hands it, together with the element context (bend radius, position in the element, reference particle), to the user-defined kick model.
+The model returns the per-bin longitudinal CSR kick force, which ImpactX applies to the beam.
+
+In this self-contained example, the network is trained on the fly (a few seconds) against the steady-state CSR wake model: it learns the map from the *normalized* charge profile shape to the dimensionless per-bin kick shape :math:`G`.
+The physical kick then follows from the exact scaling of the steady-state model,
+
+.. math::
+
+   K = \frac{Q \, \kappa(R)}{q_e \, \Delta^{4/3}} \, G(\text{shape}),
+   \qquad
+   \kappa(R) = \frac{q_e^2}{2 \pi \varepsilon_0 \, 3^{1/3} R^{2/3}},
+
+with bunch charge :math:`Q`, bin size :math:`\Delta` and bend radius :math:`R`, so a single trained network generalizes over bunch charge, compression stage (bunch length), and bend radius.
+In production use, a pre-trained model (e.g., trained on data from a high-fidelity solver, including transient and 2D/3D CSR effects) would be loaded from disk instead.
+
+This example does not require ImpactX to be compiled with FFT support: the built-in analytic CSR model is fully replaced by the surrogate.
+
+In this test, the initial values of :math:`\sigma_x`, :math:`\sigma_y`, :math:`\sigma_t`, :math:`\epsilon_x`, :math:`\epsilon_y`, and :math:`\epsilon_t` must agree with nominal values, and the final values must agree with the built-in CSR model results within the surrogate approximation error, including the CSR-induced horizontal emittance growth.
+
+Run
+---
+
+This example can **only** be run with **Python**:
+
+* **Python** script: ``python3 run_chicane_csr_ml.py``
+
+For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
+
+.. literalinclude:: run_chicane_csr_ml.py
+   :language: python
+   :caption: You can copy this file from ``examples/pytorch_csr_surrogate/run_chicane_csr_ml.py``.
+
+Analyze
+-------
+
+We run the following script to analyze correctness:
+
+.. dropdown:: Script ``analysis_chicane_csr_ml.py``
+
+   .. literalinclude:: analysis_chicane_csr_ml.py
+      :language: python
+      :caption: You can copy this file from ``examples/pytorch_csr_surrogate/analysis_chicane_csr_ml.py``.

--- a/examples/pytorch_csr_surrogate/analysis_chicane_csr_ml.py
+++ b/examples/pytorch_csr_surrogate/analysis_chicane_csr_ml.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell, Auralee Edelen, Chris Mayes
+# License: BSD-3-Clause-LBNL
+#
+
+import numpy as np
+import openpmd_api as io
+from scipy.stats import moment
+
+
+def get_moments(beam):
+    """Calculate standard deviations of beam position & momenta
+    and emittance values
+
+    Returns
+    -------
+    sigx, sigy, sigt, emittance_x, emittance_y, emittance_t
+    """
+    sigx = moment(beam["position_x"], moment=2) ** 0.5  # variance -> std dev.
+    sigpx = moment(beam["momentum_x"], moment=2) ** 0.5
+    sigy = moment(beam["position_y"], moment=2) ** 0.5
+    sigpy = moment(beam["momentum_y"], moment=2) ** 0.5
+    sigt = moment(beam["position_t"], moment=2) ** 0.5
+    sigpt = moment(beam["momentum_t"], moment=2) ** 0.5
+
+    epstrms = beam.cov(ddof=0)
+
+    # Check for valid values before calculating emittance
+    if np.any(np.isnan([sigx, sigpx, sigy, sigpy, sigt, sigpt])) or np.any(
+        np.isnan(epstrms)
+    ):
+        raise ValueError(
+            "Invalid value detected in standard deviations or covariance matrix."
+        )
+
+    emittance_x = (sigx**2 * sigpx**2 - epstrms["position_x"]["momentum_x"] ** 2) ** 0.5
+    emittance_y = (sigy**2 * sigpy**2 - epstrms["position_y"]["momentum_y"] ** 2) ** 0.5
+    emittance_t = (sigt**2 * sigpt**2 - epstrms["position_t"]["momentum_t"] ** 2) ** 0.5
+
+    return (sigx, sigy, sigt, emittance_x, emittance_y, emittance_t)
+
+
+# initial/final beam
+series = io.Series("diags/openPMD/monitor.h5", io.Access.read_only)
+last_step = list(series.iterations)[-1]
+initial = series.iterations[1].particles["beam"].to_df()
+final = series.iterations[last_step].particles["beam"].to_df()
+
+# compare number of particles
+num_particles = len(initial)
+assert num_particles == len(initial)
+assert num_particles == len(final)
+
+print("Initial Beam:")
+sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(initial)
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
+print(
+    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
+)
+
+atol = 0.0  # ignored
+rtol = 3.5 * num_particles**-0.5  # from random sampling of a smooth distribution
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
+    [
+        6.4214719960819659e-005,
+        3.6603372435649773e-005,
+        1.9955175623579313e-004,
+        1.0198263116327677e-010,
+        1.0308359092878036e-010,
+        4.0035161705244885e-010,
+    ],
+    rtol=rtol,
+    atol=atol,
+)
+
+
+print("")
+print("Final Beam:")
+sigx, sigy, sigt, emittance_x, emittance_y, emittance_t = get_moments(final)
+print(f"  sigx={sigx:e} sigy={sigy:e} sigt={sigt:e}")
+print(
+    f"  emittance_x={emittance_x:e} emittance_y={emittance_y:e} emittance_t={emittance_t:e}"
+)
+
+# The reference values are the built-in analytic CSR model results (see
+# examples/chicane/analysis_chicane_csr.py). The tolerance combines the
+# statistical sampling error (8.1 / sqrt(N)) with the approximation error of
+# the on-the-fly trained NN CSR surrogate (a few percent on the kick).
+atol = 0.0  # ignored
+rtol = 0.15
+print(f"  rtol={rtol} (ignored: atol~={atol})")
+
+assert np.allclose(
+    [sigx, sigy, sigt, emittance_x, emittance_y, emittance_t],
+    [
+        2.3928429374387210e-005,
+        8.4424535301423173e-005,
+        1.9976426324802290e-005,
+        1.2135933108429935e-010,
+        1.0308356090529235e-010,
+        3.870603e-09,
+    ],
+    rtol=rtol,
+    atol=atol,
+)
+
+# The CSR-induced horizontal emittance growth signature must be present:
+# without CSR, the final emittance_x equals the initial ~1.02e-10 m; the
+# built-in CSR model grows it by ~19% (see examples/chicane/README_csr.rst).
+emittance_x_no_csr = 1.0198263116327677e-010
+assert emittance_x > 1.1 * emittance_x_no_csr, (
+    "The NN CSR surrogate did not reproduce the CSR-induced "
+    "horizontal emittance growth."
+)

--- a/examples/pytorch_csr_surrogate/run_chicane_csr_ml.py
+++ b/examples/pytorch_csr_surrogate/run_chicane_csr_ml.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 ImpactX contributors
+# Authors: Axel Huebl, Chad Mitchell, Auralee Edelen, Chris Mayes
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+#
+# Train a small neural network surrogate for the steady-state CSR kick on the
+# fly and couple it into the chicane example as a user-defined CSR kick model
+# (sim.csr_kick_model), following the approach of
+# A. L. Edelen et al., "Neural Network Solver for Coherent Synchrotron
+# Radiation Wakefield Calculations in Accelerator-Based Charged Particle
+# Beams", in Proc. IPAC'22, WEPOMS013 (https://arxiv.org/abs/2203.07542).
+#
+# The network maps the binned, normalized longitudinal charge profile to the
+# dimensionless per-bin CSR kick shape. The physical kick follows from the
+# exact scaling of the steady-state model,
+#     kick = Q * kappa(R) / (q_e * bin_size^(4/3)) * G(shape),
+# so one trained network generalizes over bunch charge, bunch length
+# (compression stage), and bend radius.
+
+import sys
+
+import numpy as np
+from scipy.constants import e as q_e
+from scipy.constants import epsilon_0
+
+from impactx import Config, ImpactX, distribution, elements
+
+try:
+    import torch
+    from torch import nn
+except ImportError:
+    print("Warning: Cannot import PyTorch. Skipping test.")
+    sys.exit(42)  # ImpactX special return code for skipped tests
+
+if not Config.have_openpmd:
+    print("Warning: ImpactX was built without openPMD support. Skipping test.")
+    sys.exit(42)
+
+# reproducible training
+torch.manual_seed(7)
+rng = np.random.default_rng(7)
+
+CSR_BINS = 150  # matches sim.csr_bins below
+
+
+def kappa(R):
+    """CSR wake strength kappa = q_e^2 / (2 pi epsilon_0 3^(1/3) R^(2/3)) [J m^(1/3)].
+
+    This is the prefactor of the bin-integrated steady-state CSR wake
+    function, see w_l_csr in ImpactX (Saldin et al., NIMA 398, 373 (1997)).
+    """
+    return q_e**2 / (2.0 * np.pi * epsilon_0 * 3.0 ** (1.0 / 3.0) * R ** (2.0 / 3.0))
+
+
+def normalized_csr_wake(n):
+    """The dimensionless CSR wake on 2n support in wrap-around order.
+
+    w_l_csr(s = j * bin_size, R, bin_size) = -kappa / bin_size^(1/3) * wn[j]
+    with wn independent of R and bin_size.
+    """
+    j = np.arange(2 * n)
+    s = np.where(j <= n, j, j - 2 * n).astype(np.float64)
+    wn = 1.5 * (
+        np.heaviside(s + 0.5, 1.0) * np.abs(s + 0.5) ** (2.0 / 3.0)
+        - np.heaviside(s - 0.5, 1.0) * np.abs(s - 0.5) ** (2.0 / 3.0)
+    )
+    wn[n] = 0.0
+    return wn
+
+
+def analytic_g(p, wn):
+    """Dimensionless per-bin kick shape G for a normalized profile p.
+
+    p has n + 1 entries (per-bin charge fractions, sum ~ 1); the result has
+    n entries. This replicates the built-in pipeline (charge derivative,
+    zero-padded FFT convolution with the wake) in normalized units:
+    kick = Q * kappa(R) / (q_e * bin_size^(4/3)) * G.
+    """
+    n = len(p) - 1
+    padded = np.zeros(2 * n)
+    padded[:n] = np.diff(p)
+    return -np.fft.irfft(np.fft.rfft(padded) * np.fft.rfft(wn), n=2 * n)[:n]
+
+
+def self_test_normalization():
+    """Verify the normalized pipeline against the physical one for one profile."""
+    n = CSR_BINS
+    R = 10.3462283686195526
+    sigma = 2.0e-5  # bunch length [m]
+    charge = 1.0e-9  # bunch charge [C]
+
+    z_min, z_max = -4.0 * sigma, 4.0 * sigma
+    bin_size = (z_max - z_min) / (n - 1)
+    z = z_min + np.arange(n + 1) * bin_size
+    lam = np.exp(-0.5 * (z / sigma) ** 2)
+    lam *= charge / (np.sum(lam) * bin_size)  # line density [C/m]
+
+    # physical pipeline, as in the built-in model
+    slopes = np.diff(lam) / bin_size / q_e
+    j = np.arange(2 * n)
+    s = np.where(j <= n, j, j - 2 * n).astype(np.float64) * bin_size
+    wake = (
+        -1.5
+        * kappa(R)
+        / bin_size
+        * (
+            np.heaviside(s + bin_size / 2, 1.0)
+            * np.abs(s + bin_size / 2) ** (2.0 / 3.0)
+            - np.heaviside(s - bin_size / 2, 1.0)
+            * np.abs(s - bin_size / 2) ** (2.0 / 3.0)
+        )
+    )
+    wake[n] = 0.0
+    padded = np.zeros(2 * n)
+    padded[:n] = slopes
+    kick_physical = (
+        np.fft.irfft(np.fft.rfft(padded) * np.fft.rfft(wake), n=2 * n)[:n] * bin_size
+    )
+
+    # normalized pipeline
+    p = lam * bin_size / charge
+    f_scale = charge * kappa(R) / (q_e * bin_size ** (4.0 / 3.0))
+    kick_normalized = f_scale * analytic_g(p, normalized_csr_wake(n))
+
+    assert np.allclose(
+        kick_physical,
+        kick_normalized,
+        rtol=1.0e-10,
+        atol=1.0e-12 * np.max(np.abs(kick_physical)),
+    ), "normalized CSR pipeline does not match the physical one"
+
+
+def sample_shapes(m, n):
+    """Sample m normalized profiles (n + 1 bins) as 1-2 Gaussian mixtures."""
+    shapes = np.zeros((m, n + 1))
+    xi = np.arange(n + 1) / (n - 1)  # normalized bin coordinate
+    for i in range(m):
+        n_peaks = rng.integers(1, 3)
+        weights = rng.uniform(0.3, 1.0, n_peaks)
+        p = np.zeros(n + 1)
+        for k in range(n_peaks):
+            mu = rng.uniform(0.3, 0.7)
+            sig = rng.uniform(0.08, 0.25)
+            p += weights[k] * np.exp(-0.5 * ((xi - mu) / sig) ** 2)
+        shapes[i] = p / np.sum(p)
+    return shapes
+
+
+def train_model():
+    """Train a small MLP mapping profile shape -> dimensionless kick shape."""
+    n = CSR_BINS
+    wn = normalized_csr_wake(n)
+
+    n_train, n_test = 800, 100
+    shapes = sample_shapes(n_train + n_test, n)
+    targets = np.array([analytic_g(p, wn) for p in shapes])
+    g_scale = targets.std()
+
+    X = torch.from_numpy(shapes)
+    Y = torch.from_numpy(targets / g_scale)
+    X_train, X_test = X[:n_train], X[n_train:]
+    Y_train, Y_test = Y[:n_train], Y[n_train:]
+
+    model = nn.Sequential(
+        nn.Linear(n + 1, 64),
+        nn.Tanh(),
+        nn.Linear(64, 64),
+        nn.Tanh(),
+        nn.Linear(64, n),
+    ).double()
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=2.0e-3)
+    loss_fn = nn.MSELoss()
+    for epoch in range(500):
+        optimizer.zero_grad()
+        loss = loss_fn(model(X_train), Y_train)
+        loss.backward()
+        optimizer.step()
+        if epoch % 100 == 0:
+            print(f"  epoch {epoch:4d}: loss={loss.item():.3e}")
+
+    with torch.no_grad():
+        pred = model(X_test)
+        rel_err = (pred - Y_test).norm(dim=1) / Y_test.norm(dim=1)
+    rel_err = rel_err.numpy()
+    print(
+        f"  test kick shape error: median={np.median(rel_err):.1%} "
+        f"max={np.max(rel_err):.1%}"
+    )
+    assert np.median(rel_err) < 0.1, "NN CSR surrogate did not train well enough"
+
+    return model, g_scale
+
+
+def make_csr_kick_nn(model, g_scale):
+    """Wrap the trained network as an ImpactX CSR kick model."""
+
+    def csr_kick_nn(profile, context):
+        lam = profile.charge.to_numpy(copy=True)
+        bin_size = profile.bin_size
+
+        charge = np.sum(lam) * bin_size  # bunch charge [C]
+        p = lam * bin_size / charge  # normalized profile (sum ~ 1)
+        f_scale = charge * kappa(context.rc) / (q_e * bin_size ** (4.0 / 3.0))
+
+        with torch.no_grad():
+            g = model(torch.from_numpy(p)).numpy()
+
+        return f_scale * g_scale * g  # per-bin longitudinal force [N]
+
+    return csr_kick_nn
+
+
+if __name__ == "__main__":
+    self_test_normalization()
+
+    # multi-threaded training, before AMReX/OpenMP starts
+    torch.set_num_threads(min(4, torch.get_num_threads()))
+    print("Training the NN CSR surrogate ...")
+    model, g_scale = train_model()
+
+    # PyTorch's threaded defaults interfere with AMReX OpenMP during
+    # tracking (see impactx#773, pyamrex#322)
+    torch.set_num_threads(1)
+
+    # the chicane example with the NN CSR kick model,
+    # following examples/chicane/run_chicane_csr.py
+    sim = ImpactX()
+
+    sim.particle_shape = 2  # B-spline order
+    sim.space_charge = False
+    sim.csr = True
+    sim.csr_bins = CSR_BINS
+    sim.csr_kick_model = make_csr_kick_nn(model, g_scale)
+    sim.slice_step_diagnostics = True
+
+    # domain decomposition & space charge mesh
+    sim.init_grids()
+
+    # load a 5 GeV electron beam with an initial
+    # normalized transverse rms emittance of 1 um
+    kin_energy_MeV = 5.0e3  # reference energy
+    bunch_charge_C = 1.0e-9  # used with space charge
+    npart = 10000  # number of macro particles
+
+    #   reference particle
+    ref = sim.beam.ref
+    ref.set_species("electron").set_kin_energy_MeV(kin_energy_MeV)
+
+    #   particle bunch
+    distr = distribution.Gaussian(
+        lambdaX=2.2951017632e-5,
+        lambdaY=1.3084093142e-5,
+        lambdaT=5.5555553e-8,
+        lambdaPx=1.598353425e-6,
+        lambdaPy=2.803697378e-6,
+        lambdaPt=2.000000000e-6,
+        muxpx=0.933345606203060,
+        muypy=0.933345606203060,
+        mutpt=0.999999961419755,
+    )
+    sim.add_particles(bunch_charge_C, distr, npart)
+
+    # add beam diagnostics
+    monitor = elements.BeamMonitor("monitor", backend="h5")
+
+    # design the accelerator lattice
+    ns = 25  # number of slices per ds in the element
+    rc = 10.3462283686195526  # bend radius (meters)
+    psi = 0.048345620280243  # pole face rotation angle (radians)
+    lb = 0.500194828041958  # bend arc length (meters)
+
+    # Drift elements
+    dr1 = elements.Drift(name="dr1", ds=5.0058489435, nslice=ns)
+    dr2 = elements.Drift(name="dr2", ds=1.0, nslice=ns)
+    dr3 = elements.Drift(name="dr3", ds=2.0, nslice=ns)
+
+    # Bend elements
+    sbend1 = elements.Sbend(name="sbend1", ds=lb, rc=-rc, nslice=ns)
+    sbend2 = elements.Sbend(name="sbend2", ds=lb, rc=rc, nslice=ns)
+
+    # Dipole Edge Focusing elements
+    dipedge1 = elements.DipEdge(name="dipedge1", psi=-psi, rc=-rc, g=0.0, K2=0.0)
+    dipedge2 = elements.DipEdge(name="dipedge2", psi=psi, rc=rc, g=0.0, K2=0.0)
+
+    lattice_half = [sbend1, dipedge1, dr1, dipedge2, sbend2]
+    # assign a segment with the first half of the lattice
+    sim.lattice.append(monitor)
+    sim.lattice.extend(lattice_half)
+    sim.lattice.append(dr2)
+    lattice_half.reverse()
+    # extend the lattice by a reversed half
+    sim.lattice.extend(lattice_half)
+    sim.lattice.append(dr3)
+    sim.lattice.append(monitor)
+
+    # run simulation
+    sim.track_particles()
+
+    # clean shutdown
+    sim.finalize()

--- a/src/ImpactX.H
+++ b/src/ImpactX.H
@@ -13,6 +13,7 @@
 #include "elements/All.H"
 #include "initialization/AmrCoreData.H"
 #include "particles/distribution/All.H"
+#include "particles/wakefields/CSRKickModel.H"
 #include "tracking/TrackingState.H"
 
 #include <AMReX_REAL.H>
@@ -170,6 +171,17 @@ namespace impactx
             std::string,
             std::function<void(ImpactX *)>
         > m_hook;  //! hooks that users can call
+
+        /** Optional user-provided CSR kick model (e.g., an ML surrogate).
+         *
+         * When set (non-empty), it replaces the built-in analytic CSR wake
+         * model: per tracking slice in CSR-active bend elements, it receives
+         * the binned longitudinal beam profile and the element context and
+         * returns per-bin kicks
+         * (\see particles::wakefields::CSRKickModel).
+         * algo.csr must additionally be enabled for CSR to be applied.
+         */
+        particles::wakefields::CSRKickModel m_csr_kick_model;
 
         /** A few states during tracking loops, useful to know in hooks (Python callback functions).
          */

--- a/src/particles/wakefields/CSRBendElement.H
+++ b/src/particles/wakefields/CSRBendElement.H
@@ -28,38 +28,43 @@ namespace impactx::particles::wakefields
      *
      * @param[in] element_variant the lattice element to check
      * @param[in] refpart reference particle
-     * @returns boolean flag indicating if the element has CSR, radius of curvature (or zero)
+     * @returns boolean flag indicating if the element has CSR, radius-of-curvature
+     *          magnitude, and signed radius of curvature (or zeroes)
      */
     template <typename VariantType>
-    std::tuple<bool, amrex::Real>
+    std::tuple<bool, amrex::Real, amrex::Real>
     CSRBendElement (
         VariantType const& element_variant,
         RefPart const & refpart
     )
     {
         amrex::Real R = 0;
+        amrex::Real signed_R = 0;
         bool element_has_csr = false;
 
         if (std::holds_alternative<elements::Sbend>(element_variant))
         {
             auto& element = std::get<elements::Sbend>(element_variant);
-            R = std::abs(element.m_rc);
+            signed_R = element.m_rc;
+            R = std::abs(signed_R);
             element_has_csr = true;
         }
         else if (std::holds_alternative<elements::CFbend>(element_variant))
         {
             auto& element = std::get<elements::CFbend>(element_variant);
-            R = std::abs(element.m_rc);
+            signed_R = element.m_rc;
+            R = std::abs(signed_R);
             element_has_csr = true;
         }
         else if (std::holds_alternative<elements::ExactSbend>(element_variant))
         {
             auto& element = std::get<elements::ExactSbend>(element_variant);
-            R = std::abs(element.rc(refpart));
+            signed_R = element.rc(refpart);
+            R = std::abs(signed_R);
             element_has_csr = true;
         }
 
-        return {element_has_csr, R};
+        return {element_has_csr, R, signed_R};
     }
 
 } // namespace impactx::particles::wakefields

--- a/src/particles/wakefields/CSRKickModel.H
+++ b/src/particles/wakefields/CSRKickModel.H
@@ -1,0 +1,97 @@
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl, Chad Mitchell
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_PARTICLES_WAKEFIELDS_CSRKICKMODEL_H_
+#define IMPACTX_PARTICLES_WAKEFIELDS_CSRKICKMODEL_H_
+
+#include "particles/ReferenceParticle.H"
+
+#include <AMReX_GpuContainers.H>
+#include <AMReX_REAL.H>
+
+#include <functional>
+#include <string>
+
+
+namespace impactx::particles::wakefields
+{
+    /** Binned longitudinal beam profile passed to a user-provided CSR kick model
+     *
+     * All arrays share the same binning: bin i spans
+     * [bin_min + i * bin_size, bin_min + (i+1) * bin_size) in the longitudinal
+     * coordinate t = ct [m]. The arrays have num_bins + 1 entries; the last
+     * entry is a guard bin that is usually (close to) zero.
+     *
+     * The arrays live in device memory (on GPU builds) and are only valid
+     * during the model call. Retained data must be copied.
+     */
+    struct CSRProfile
+    {
+        /** line charge density lambda(t) [C/m] from NGP deposition;
+         * sum(charge) * bin_size approximates the bunch charge [C] */
+        amrex::Gpu::DeviceVector<amrex::Real> charge;
+
+        /** charge-weighted mean of x per bin [m]; zero for empty bins */
+        amrex::Gpu::DeviceVector<amrex::Real> mean_x;
+
+        /** charge-weighted mean of y per bin [m]; zero for empty bins */
+        amrex::Gpu::DeviceVector<amrex::Real> mean_y;
+
+        amrex::Real bin_min = 0.0;   //!< lower edge of bin 0 in t = ct [m]
+        amrex::Real bin_size = 0.0;  //!< bin spacing [m]
+        int num_bins = 0;            //!< number of kick bins (= algo.csr_bins)
+    };
+
+    /** Per-element, per-slice context passed to a user-provided CSR kick model
+     */
+    struct CSRElementContext
+    {
+        std::string element_name;  //!< user-given element name (empty if unnamed)
+        std::string element_type;  //!< element type, e.g. "Sbend"
+
+        amrex::Real rc = 0.0;          //!< radius-of-curvature magnitude |R| [m]
+        amrex::Real signed_rc = 0.0;   //!< signed radius of curvature R [m]
+        amrex::ParticleReal ds = 0.0;  //!< element (arc) length [m]
+
+        int nslice = 1;  //!< number of slices in the element
+        int slice = 0;   //!< current slice index, 0-based, in forward orientation
+
+        /** distance from the element entrance at kick time [m]
+         * (= slice * slice_ds, also during back-tracking) */
+        amrex::ParticleReal s = 0.0;
+
+        amrex::ParticleReal slice_ds = 0.0;  //!< slice length [m]
+
+        RefPart ref;  //!< reference particle (snapshot copy)
+    };
+
+    /** Per-bin kick returned by a user-provided CSR kick model
+     *
+     * All entries are forces in Newtons on bins 0 .. num_bins-1.
+     * pt is required (size num_bins); px and py are optional (empty = not
+     * applied). \see WakePush for how the kicks are applied.
+     */
+    struct CSRKick
+    {
+        amrex::Gpu::DeviceVector<amrex::Real> pt;  //!< longitudinal force F_t [N]
+        amrex::Gpu::DeviceVector<amrex::Real> px;  //!< horizontal force F_x [N] (optional)
+        amrex::Gpu::DeviceVector<amrex::Real> py;  //!< vertical force F_y [N] (optional)
+    };
+
+    /** User-provided CSR kick model
+     *
+     * Maps the binned longitudinal beam profile and the element context to
+     * per-bin kicks, replacing the built-in analytic CSR wake model
+     * (e.g., with a pre-trained ML surrogate).
+     */
+    using CSRKickModel = std::function<CSRKick (CSRProfile const &, CSRElementContext const &)>;
+
+} // namespace impactx::particles::wakefields
+
+#endif // IMPACTX_PARTICLES_WAKEFIELDS_CSRKICKMODEL_H_

--- a/src/particles/wakefields/ChargeBinning.H
+++ b/src/particles/wakefields/ChargeBinning.H
@@ -46,6 +46,27 @@ namespace impactx::particles::wakefields
         bool GetNumberDensity = true
     );
 
+    /** Function to calculate the per-bin weighted transverse position sums along s
+     *
+     * The output is packed as [sum_w | sum_w*x | sum_w*y], each block of length
+     * num_bins = len(packed_sums) / 3, so that all three blocks can be
+     * MPI-reduced with a single reduction and normalized afterwards.
+     *
+     * @param[in] myspc the particle species to deposit along s
+     * @param[in,out] packed_sums zero-initialized output of size 3 * num_bins
+     * @param[in] bin_min lower end of the beam in s
+     * @param[in] bin_size size of the beam in s divided by num_bins
+     * @param[in] is_unity_particle_weight ignore the particle weighting per macro particle,
+     *                                     otherwise treat each particle as one physical particle
+     */
+    void WeightedTransverseSums (
+        impactx::ImpactXParticleContainer& myspc,
+        amrex::Gpu::DeviceVector<amrex::Real> & packed_sums,
+        amrex::Real bin_min,
+        amrex::Real bin_size,
+        bool is_unity_particle_weight = false
+    );
+
     /** Function to calculate the mean transverse positions (x and y) at each bin along s
      *
      * @param[in] myspc the particle species to deposit along s

--- a/src/particles/wakefields/ChargeBinning.cpp
+++ b/src/particles/wakefields/ChargeBinning.cpp
@@ -112,10 +112,9 @@ namespace impactx::particles::wakefields
         });
     }
 
-    void MeanTransversePosition (
+    void WeightedTransverseSums (
         impactx::ImpactXParticleContainer& myspc,
-        amrex::Gpu::DeviceVector<amrex::Real> & mean_x,
-        amrex::Gpu::DeviceVector<amrex::Real> & mean_y,
+        amrex::Gpu::DeviceVector<amrex::Real> & packed_sums,
         amrex::Real bin_min,
         amrex::Real bin_size,
         bool is_unity_particle_weight
@@ -123,18 +122,8 @@ namespace impactx::particles::wakefields
     {
         using namespace amrex::literals;
 
-        int const num_bins = mean_x.size();
-        amrex::Real* dptr_mean_x = mean_x.data();
-        amrex::Real* dptr_mean_y = mean_y.data();
-
-        // Declare arrays for sums of positions and weights
-        auto sum_x = amrex::Gpu::DeviceVector<amrex::Real>(num_bins, 0.0_rt);
-        auto sum_y = amrex::Gpu::DeviceVector<amrex::Real>(num_bins, 0.0_rt);
-        auto sum_w = amrex::Gpu::DeviceVector<amrex::Real>(num_bins, 0.0_rt);
-
-        amrex::Real* const sum_w_ptr = sum_w.data();
-        amrex::Real* const sum_x_ptr = sum_x.data();
-        amrex::Real* const sum_y_ptr = sum_y.data();
+        int const num_bins = packed_sums.size() / 3;
+        amrex::Real* const dptr_sums = packed_sums.data();
 
         int const nlevs = myspc.finestLevel();
         for (int lev = 0; lev <= nlevs; ++lev)
@@ -167,20 +156,40 @@ namespace impactx::particles::wakefields
 
                         amrex::Real const weight = is_unity_particle_weight ? 1.0_rt : w;  // Check is macroparticle made up of 1 or more particles
 
-                        amrex::HostDevice::Atomic::Add(&sum_w_ptr[bin], weight);      // Deposit the number of particles composing macroparticle
-                        amrex::HostDevice::Atomic::Add(&sum_x_ptr[bin], x * weight);  // Deposit x position multiplied by number of particles at this position
-                        amrex::HostDevice::Atomic::Add(&sum_y_ptr[bin], y * weight);
+                        amrex::HostDevice::Atomic::Add(&dptr_sums[bin], weight);                      // Deposit the number of particles composing macroparticle
+                        amrex::HostDevice::Atomic::Add(&dptr_sums[num_bins + bin], x * weight);       // Deposit x position multiplied by number of particles at this position
+                        amrex::HostDevice::Atomic::Add(&dptr_sums[2 * num_bins + bin], y * weight);
                     });
                 }
             }
         }
+    }
 
+    void MeanTransversePosition (
+        impactx::ImpactXParticleContainer& myspc,
+        amrex::Gpu::DeviceVector<amrex::Real> & mean_x,
+        amrex::Gpu::DeviceVector<amrex::Real> & mean_y,
+        amrex::Real bin_min,
+        amrex::Real bin_size,
+        bool is_unity_particle_weight
+    )
+    {
+        using namespace amrex::literals;
+
+        int const num_bins = mean_x.size();
+        amrex::Real* dptr_mean_x = mean_x.data();
+        amrex::Real* dptr_mean_y = mean_y.data();
+
+        auto packed_sums = amrex::Gpu::DeviceVector<amrex::Real>(3 * num_bins, 0.0_rt);
+        WeightedTransverseSums(myspc, packed_sums, bin_min, bin_size, is_unity_particle_weight);
+
+        amrex::Real const * const dptr_sums = packed_sums.data();
         amrex::ParallelFor(num_bins, [=] AMREX_GPU_DEVICE(int i)
         {
-            if (sum_w_ptr[i] > 0) // Ensure number of particles in a bin is >= 1 before taking the mean
+            if (dptr_sums[i] > 0) // Ensure number of particles in a bin is >= 1 before taking the mean
             {
-                dptr_mean_x[i] = sum_x_ptr[i] / sum_w_ptr[i];
-                dptr_mean_y[i] = sum_y_ptr[i] / sum_w_ptr[i];
+                dptr_mean_x[i] = dptr_sums[num_bins + i] / dptr_sums[i];
+                dptr_mean_y[i] = dptr_sums[2 * num_bins + i] / dptr_sums[i];
             }
             else
             {

--- a/src/particles/wakefields/HandleWakefield.H
+++ b/src/particles/wakefields/HandleWakefield.H
@@ -11,30 +11,44 @@
 #define HANDLE_WAKEFIELD_H
 
 #include "particles/ImpactXParticleContainer.H"
+#include "elements/mixin/named.H"
 #include "ChargeBinning.H"
 #include "CSRBendElement.H"
+#include "CSRKickModel.H"
 #include "WakeConvolution.H"
 #include "WakePush.H"
 
+#include <AMReX_BLassert.H>
 #include <AMReX_GpuContainers.H>
 #include <AMReX_GpuDevice.H>
 #include <AMReX_GpuParallelReduce.H>
+#include <AMReX_ParallelDescriptor.H>
 
 #include <cmath>
+#include <exception>
 #include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <variant>
 #include <vector>
 
 
 namespace impactx::particles::wakefields
 {
     /** Function to handle CSR bending process including charge deposition,
-     * mean transverse position calculation, wakefield generation, and convolution.
+     * wakefield generation (built-in analytic model or user-provided kick
+     * model), and the momentum kick.
      *
      * Returns immediately if slice_ds is zero.
      *
      * @param[in] particle_container the particle species container
      * @param[in] element_variant variant type of the lattice element
      * @param[in] slice_ds slice spacing along s
+     * @param[in] slice current slice index in the element (0-based, forward orientation)
+     * @param[in] nslice number of slices in the element
+     * @param[in] csr_kick_model optional user-provided CSR kick model;
+     *            empty selects the built-in analytic model
      * @param[in] print_wakefield for debugging: print the wakefield to convolved_wakefield.txt
      */
     template <typename T_Element>
@@ -42,6 +56,9 @@ namespace impactx::particles::wakefields
         impactx::ImpactXParticleContainer& particle_container,
         T_Element const& element_variant,
         amrex::Real slice_ds,
+        int slice,
+        int nslice,
+        CSRKickModel const & csr_kick_model = {},
         bool print_wakefield = false
     )
     {
@@ -54,13 +71,24 @@ namespace impactx::particles::wakefields
         pp_algo.queryAdd("csr", csr);
 
         // Call the CSR bend function
-        auto const [element_has_csr, R] = impactx::particles::wakefields::CSRBendElement(element_variant, particle_container.GetRefParticle());
+        auto const csr_bend = impactx::particles::wakefields::CSRBendElement(
+            element_variant, particle_container.GetRefParticle());
+        bool const element_has_csr = std::get<0>(csr_bend);
+        amrex::Real const R = std::get<1>(csr_bend);
+        amrex::Real const signed_R = std::get<2>(csr_bend);
 
         // Enter loop if lattice has bend element
         if (csr && element_has_csr)
         {
+            bool const use_kick_model = static_cast<bool>(csr_kick_model);
 #ifndef ImpactX_USE_FFT
-            throw std::runtime_error("algo.csr was requested but ImpactX was not compiled with FFT support. Recompile with ImpactX_FFT=ON.");
+            if (!use_kick_model) {
+                throw std::runtime_error(
+                    "algo.csr was requested but ImpactX was not compiled with FFT support. "
+                    "Recompile with ImpactX_FFT=ON or provide a user-defined CSR kick model "
+                    "(csr_kick_model)."
+                );
+            }
 #endif
 
             int csr_bins = 150;
@@ -100,28 +128,173 @@ namespace impactx::particles::wakefields
 
             // Allocate memory for the charge profile
             amrex::Gpu::DeviceVector<amrex::Real> charge_distribution(num_bins + 1, 0.0);
-            amrex::Gpu::DeviceVector<amrex::Real> mean_x(num_bins, 0.0);
-            amrex::Gpu::DeviceVector<amrex::Real> mean_y(num_bins, 0.0);
 
             // Call charge deposition function
             impactx::particles::wakefields::DepositCharge1D(particle_container, charge_distribution, bin_min, bin_size, is_unity_particle_weight);
 
             // Sum up all partial charge histograms to one MPI process to calculate the global wakefield.
-            // Once calculated, we will distribute convolved_wakefield back to every MPI process.
+            // Once calculated, we will distribute the kick per bin back to every MPI process.
             amrex::ParallelReduce::Sum(
                 charge_distribution,
                 amrex::ParallelDescriptor::IOProcessorNumber(),
                 amrex::ParallelDescriptor::Communicator()
             );
 
-            // Pre-size on every rank to the (global) wake length.  On the IO
-            // processor this is overwritten by the convolution result of the
-            // same length.
-            amrex::Gpu::DeviceVector<amrex::Real> convolved_wakefield(num_bins, 0.0);
-            if (amrex::ParallelDescriptor::IOProcessor()) {
-                // Call the mean transverse position function
-                impactx::particles::wakefields::MeanTransversePosition(particle_container, mean_x, mean_y, bin_min,
-                                                                       bin_size, is_unity_particle_weight);
+            // Per-bin kick forces [N]. wake_pt is pre-sized on every rank to
+            // the (global) wake length. On the IO processor it is overwritten
+            // by the built-in convolution result or the kick model output of
+            // the same length. The transverse components are optional and
+            // only allocated if a user-provided kick model returns them.
+            amrex::Gpu::DeviceVector<amrex::Real> wake_pt(num_bins, 0.0);
+            amrex::Gpu::DeviceVector<amrex::Real> wake_px;
+            amrex::Gpu::DeviceVector<amrex::Real> wake_py;
+
+            if (use_kick_model)
+            {
+                // Per-bin weighted transverse sums, packed as
+                // [sum_w | sum_w*x | sum_w*y] for a single MPI reduction.
+                amrex::Gpu::DeviceVector<amrex::Real> packed_sums(3 * (num_bins + 1), 0.0);
+                impactx::particles::wakefields::WeightedTransverseSums(
+                    particle_container, packed_sums, bin_min, bin_size, is_unity_particle_weight);
+                amrex::ParallelReduce::Sum(
+                    packed_sums,
+                    amrex::ParallelDescriptor::IOProcessorNumber(),
+                    amrex::ParallelDescriptor::Communicator()
+                );
+
+                int const io_rank = amrex::ParallelDescriptor::IOProcessorNumber();
+                int const nprocs = amrex::ParallelDescriptor::NProcs();
+                int has_transverse = 0;  // bit 0: px is present, bit 1: py is present
+                int model_succeeded = 1;
+                std::string model_error;
+                if (amrex::ParallelDescriptor::IOProcessor())
+                {
+                    auto invoke_model = [&] ()
+                    {
+                        // Assemble the binned beam profile
+                        CSRProfile profile;
+                        profile.charge = std::move(charge_distribution);
+                        profile.mean_x.resize(num_bins + 1);
+                        profile.mean_y.resize(num_bins + 1);
+                        profile.bin_min = bin_min;
+                        profile.bin_size = bin_size;
+                        profile.num_bins = num_bins;
+
+                        int const nb1 = num_bins + 1;
+                        amrex::Real const * const dptr_sums = packed_sums.data();
+                        amrex::Real * const dptr_mean_x = profile.mean_x.data();
+                        amrex::Real * const dptr_mean_y = profile.mean_y.data();
+                        amrex::ParallelFor(nb1, [=] AMREX_GPU_DEVICE (int i)
+                        {
+                            amrex::Real const sum_w = dptr_sums[i];
+                            dptr_mean_x[i] = sum_w > 0
+                                ? dptr_sums[nb1 + i] / sum_w
+                                : amrex::Real(0.0);
+                            dptr_mean_y[i] = sum_w > 0
+                                ? dptr_sums[2 * nb1 + i] / sum_w
+                                : amrex::Real(0.0);
+                        });
+
+                        // Assemble the element context
+                        CSRElementContext context;
+                        std::visit([&context] (auto const & element)
+                        {
+                            using T = std::decay_t<decltype(element)>;
+                            context.element_type = T::type;
+                            if constexpr (std::is_base_of_v<elements::mixin::Named, T>) {
+                                if (element.has_name()) {
+                                    context.element_name = element.name();
+                                }
+                            }
+                            context.ds = element.ds();
+                        }, element_variant);
+                        context.rc = R;
+                        context.signed_rc = signed_R;
+                        context.nslice = nslice;
+                        context.slice = slice;
+                        context.s = static_cast<amrex::ParticleReal>(slice) * slice_ds;
+                        context.slice_ds = slice_ds;
+                        context.ref = particle_container.GetRefParticle();
+
+                        // Ensure all deposition results are visible to the model
+                        amrex::Gpu::streamSynchronize();
+
+                        // Call the user-provided kick model
+                        CSRKick kick = csr_kick_model(profile, context);
+
+                        if (int(kick.pt.size()) != num_bins ||
+                            !(kick.px.empty() || int(kick.px.size()) == num_bins) ||
+                            !(kick.py.empty() || int(kick.py.size()) == num_bins))
+                        {
+                            throw std::runtime_error(
+                                "HandleWakefield: the user-provided CSR kick model returned "
+                                "arrays of wrong length for element type '" +
+                                context.element_type + "' (name: '" + context.element_name +
+                                "', slice " + std::to_string(slice) + "): expected " +
+                                std::to_string(num_bins) + " values per component."
+                            );
+                        }
+
+                        wake_pt = std::move(kick.pt);
+                        wake_px = std::move(kick.px);
+                        wake_py = std::move(kick.py);
+                        has_transverse =
+                            (wake_px.empty() ? 0 : 1) | (wake_py.empty() ? 0 : 2);
+                    };
+
+                    if (nprocs == 1)
+                    {
+                        // Preserve the original Python exception type and traceback in serial.
+                        invoke_model();
+                    }
+                    else
+                    {
+                        try
+                        {
+                            invoke_model();
+                        }
+                        catch (std::exception const & error)
+                        {
+                            model_succeeded = 0;
+                            model_error = error.what();
+                        }
+                        catch (...)
+                        {
+                            model_succeeded = 0;
+                            model_error = "The CSR kick model raised an unknown exception.";
+                        }
+                    }
+                }
+
+                if (nprocs > 1)
+                {
+                    amrex::ParallelDescriptor::Bcast(&model_succeeded, 1, io_rank);
+                    if (!model_succeeded)
+                    {
+                        int error_size = static_cast<int>(model_error.size());
+                        amrex::ParallelDescriptor::Bcast(&error_size, 1, io_rank);
+                        model_error.resize(error_size);
+                        if (error_size > 0) {
+                            amrex::ParallelDescriptor::Bcast(
+                                model_error.data(), error_size, io_rank);
+                        }
+                        throw std::runtime_error(model_error);
+                    }
+                }
+
+                // Broadcast which kick components are present and pre-size the
+                // receiving ranks accordingly (the vectors are broadcast below).
+                amrex::ParallelDescriptor::Bcast(&has_transverse, 1, io_rank);
+                if (!amrex::ParallelDescriptor::IOProcessor())
+                {
+                    if (has_transverse & 1) { wake_px.resize(num_bins, 0.0); }
+                    if (has_transverse & 2) { wake_py.resize(num_bins, 0.0); }
+                }
+            }
+            else if (amrex::ParallelDescriptor::IOProcessor())
+            {
+                // Built-in analytic CSR model:
+                // dN/ds convolved with the steady-state CSR wake function.
 
                 // Call charge density derivative function
                 amrex::Gpu::DeviceVector<amrex::Real> slopes(charge_distribution.size() - 1, 0.0);
@@ -144,25 +317,41 @@ namespace impactx::particles::wakefields
                 });
 
                 // Call convolution function
-                convolved_wakefield = impactx::particles::wakefields::convolve_fft(slopes, wake_function, bin_size);
+                wake_pt = impactx::particles::wakefields::convolve_fft(slopes, wake_function, bin_size);
             }
 
-            // Broadcast the global wakefield from the IO processor (which alone
-            // computed it) to every MPI rank. Receivers are pre-sized above.
+            // Broadcast the global kick per bin from the IO processor (which
+            // alone computed it) to every MPI rank. Receivers are pre-sized above.
             amrex::ParallelDescriptor::Bcast(
-                convolved_wakefield,
+                wake_pt,
                 amrex::ParallelDescriptor::IOProcessorNumber(),
                 amrex::ParallelDescriptor::Communicator()
             );
+            if (!wake_px.empty())
+            {
+                amrex::ParallelDescriptor::Bcast(
+                    wake_px,
+                    amrex::ParallelDescriptor::IOProcessorNumber(),
+                    amrex::ParallelDescriptor::Communicator()
+                );
+            }
+            if (!wake_py.empty())
+            {
+                amrex::ParallelDescriptor::Bcast(
+                    wake_py,
+                    amrex::ParallelDescriptor::IOProcessorNumber(),
+                    amrex::ParallelDescriptor::Communicator()
+                );
+            }
 
             // Check convolution output
             if (print_wakefield && amrex::ParallelDescriptor::IOProcessor())
             {
-                // convolved_wakefield is in (non-managed) device memory. Copy it
+                // wake_pt is in (non-managed) device memory. Copy it
                 // to the host before iterating it on the host for printing.
-                amrex::Gpu::HostVector<amrex::Real> h_wakefield(convolved_wakefield.size());
-                amrex::Gpu::dtoh_memcpy(h_wakefield.data(), convolved_wakefield.data(),
-                                        convolved_wakefield.size() * sizeof(amrex::Real));
+                amrex::Gpu::HostVector<amrex::Real> h_wakefield(wake_pt.size());
+                amrex::Gpu::dtoh_memcpy(h_wakefield.data(), wake_pt.data(),
+                                        wake_pt.size() * sizeof(amrex::Real));
                 std::cout << "Convolved wakefield: ";
                 std::ofstream outfile("convolved_wakefield.txt");
                 for (amrex::Real const val : h_wakefield) {
@@ -174,7 +363,7 @@ namespace impactx::particles::wakefields
             }
 
             // Call function to kick particles with wake
-            impactx::particles::wakefields::WakePush(particle_container, convolved_wakefield, slice_ds, bin_size, t_min);
+            impactx::particles::wakefields::WakePush(particle_container, wake_pt, wake_px, wake_py, slice_ds, bin_size, t_min);
         }
     }
 

--- a/src/particles/wakefields/WakeConvolution.H
+++ b/src/particles/wakefields/WakeConvolution.H
@@ -99,7 +99,7 @@ namespace impactx::particles::wakefields
      * @param[in] s value along s [m]
      * @param[in] R band radius [m]
      * @param[in] bin_size longitudinal bin size [m]
-     * @return wake functions in [V*pc/mm]
+     * @return bin-integrated wake function value in [J]
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     amrex::Real
@@ -120,10 +120,11 @@ namespace impactx::particles::wakefields
 
     /** Perform FFT-based convolution
      *
-     * @param[in] beam_profile_slope number density slope along s [1/m]
-     * @param[in] wake_func wake function along s [V*pc/mm]
+     * @param[in] beam_profile_slope number density slope along s [1/m^2]
+     * @param[in] wake_func wake function along s [J]
      * @param[in] delta_t size of a bin in wake_func [m]
-     * @return FFT convolution of beam_profile_slope & wake_func (N = len(beam_profile_slope) = len(wake_func)/2)
+     * @return FFT convolution of beam_profile_slope & wake_func, a per-bin
+     *         longitudinal force [N] (N = len(beam_profile_slope) = len(wake_func)/2)
      */
     amrex::Gpu::DeviceVector<amrex::Real>
     convolve_fft (

--- a/src/particles/wakefields/WakePush.H
+++ b/src/particles/wakefields/WakePush.H
@@ -18,17 +18,27 @@
 
 namespace impactx::particles::wakefields
 {
-    /** Function to update particle momentum using wake force kick
+    /** Function to update particle momentum using wake force kicks
+     *
+     * Gathers the per-bin forces along t (nearest grid point) and applies
+     * them as momentum kicks over the slice length.
      *
      * @param[inout] pc the particle species container
-     * @param[in] convolved_wakefield wake functions in [V*pc/mm]
+     * @param[in] wake_pt per-bin longitudinal force [N];
+     *            applied as pt -= slice_ds * F_t / (c * p_ref)
+     * @param[in] wake_px per-bin horizontal force [N] or empty (= no kick);
+     *            applied as px += slice_ds * F_x / (beta * c * p_ref)
+     * @param[in] wake_py per-bin vertical force [N] or empty (= no kick);
+     *            applied as py += slice_ds * F_y / (beta * c * p_ref)
      * @param[in] slice_ds slice spacing along s
      * @param[in] bin_size size of the beam in s divided by num_bins
      * @param[in] bin_min lower end of the beam in s
      */
     void WakePush (
         ImpactXParticleContainer & pc,
-        amrex::Gpu::DeviceVector<amrex::Real> const & convolved_wakefield,
+        amrex::Gpu::DeviceVector<amrex::Real> const & wake_pt,
+        amrex::Gpu::DeviceVector<amrex::Real> const & wake_px,
+        amrex::Gpu::DeviceVector<amrex::Real> const & wake_py,
         amrex::ParticleReal slice_ds,
         amrex::Real bin_size,
         amrex::Real bin_min

--- a/src/particles/wakefields/WakePush.cpp
+++ b/src/particles/wakefields/WakePush.cpp
@@ -11,7 +11,9 @@
 
 #include <ablastr/particles/NodalFieldGather.H>
 
+#include <AMReX_Algorithm.H>
 #include <AMReX_BLProfiler.H>
+#include <AMReX_BLassert.H>
 #include <AMReX_REAL.H>
 #include <AMReX_SPACE.H>
 
@@ -20,7 +22,9 @@ namespace impactx::particles::wakefields
 {
     void WakePush (
         ImpactXParticleContainer & pc,
-        amrex::Gpu::DeviceVector<amrex::Real> const & convolved_wakefield,
+        amrex::Gpu::DeviceVector<amrex::Real> const & wake_pt,
+        amrex::Gpu::DeviceVector<amrex::Real> const & wake_px,
+        amrex::Gpu::DeviceVector<amrex::Real> const & wake_py,
         amrex::ParticleReal slice_ds,
         amrex::Real bin_size,
         amrex::Real bin_min
@@ -30,9 +34,12 @@ namespace impactx::particles::wakefields
 
         using namespace amrex::literals;
 
-#if (defined(AMREX_DEBUG) || defined(DEBUG)) && !defined(AMREX_USE_GPU)
-        int const cw_size = convolved_wakefield.size(); // no padding anymore
-#endif
+        int const num_bins = int(wake_pt.size());
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            (wake_px.empty() || int(wake_px.size()) == num_bins) &&
+            (wake_py.empty() || int(wake_py.size()) == num_bins),
+            "WakePush: transverse wake arrays must be empty or match wake_pt in size."
+        );
 
         // Loop over refinement levels
         int const nLevel = pc.finestLevel();
@@ -51,48 +58,46 @@ namespace impactx::particles::wakefields
                 // Physical constants and reference quantities
                 amrex::ParticleReal const mc_SI = pc.GetRefParticle().mass * (ablastr::constant::SI::c);
                 amrex::ParticleReal const pz_ref_SI = pc.GetRefParticle().beta_gamma() * mc_SI;
+                amrex::ParticleReal const beta_ref = pc.GetRefParticle().beta();
 
                 // Access data from StructOfArrays (soa)
                 auto& soa_real = pti.GetStructOfArrays().GetRealData();
 
                 amrex::ParticleReal* const AMREX_RESTRICT part_t = soa_real[RealSoA::t].dataPtr();
                 amrex::ParticleReal* const AMREX_RESTRICT part_pt = soa_real[RealSoA::pt].dataPtr();
+                amrex::ParticleReal* const AMREX_RESTRICT part_px = soa_real[RealSoA::px].dataPtr();
+                amrex::ParticleReal* const AMREX_RESTRICT part_py = soa_real[RealSoA::py].dataPtr();
 
                 // Obtain constants for force normalization
-                amrex::ParticleReal const push_consts = 1_prt / ((ablastr::constant::SI::c) * pz_ref_SI);
+                amrex::ParticleReal const push_consts_t = 1_prt / ((ablastr::constant::SI::c) * pz_ref_SI);
+                amrex::ParticleReal const push_consts_xy = push_consts_t / beta_ref;
+
+                // Per-bin forces; the transverse arrays are optional (nullptr = no kick)
+                const amrex::Real* const wake_pt_ptr = wake_pt.data();
+                const amrex::Real* const wake_px_ptr = wake_px.empty() ? nullptr : wake_px.data();
+                const amrex::Real* const wake_py_ptr = wake_py.empty() ? nullptr : wake_py.data();
 
                 // Gather particles and push momentum
-                const amrex::Real* wakefield_ptr = convolved_wakefield.data();
                 amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE (int i)
                 {
                     // Access SoA Real data
                     amrex::ParticleReal const & AMREX_RESTRICT t = part_t[i];
-                    amrex::ParticleReal & AMREX_RESTRICT pt = part_pt[i];
 
-                    // Update longitudinal momentum with the convolved wakefield force
-                    int const idx = static_cast<int>((t - bin_min) / bin_size);  // Find index position along t
+                    // Find index position along t, clamped to the wake support
+                    // (guards against floating-point rounding at the beam edges)
+                    int idx = static_cast<int>((t - bin_min) / bin_size);
+                    idx = amrex::min(amrex::max(idx, 0), num_bins - 1);
 
-#if (defined(AMREX_DEBUG) || defined(DEBUG)) && !defined(AMREX_USE_GPU)
-                    if (idx < 0 || idx >= cw_size)
-                    {
-                        std::cerr << "Warning: Index out of range for wakefield: " << idx << std::endl;
+                    // Update longitudinal momentum with the longitudinal wake force
+                    part_pt[i] -= push_consts_t * slice_ds * wake_pt_ptr[idx];
+
+                    // Update transverse momenta, if transverse forces are provided
+                    if (wake_px_ptr != nullptr) {
+                        part_px[i] += push_consts_xy * slice_ds * wake_px_ptr[idx];
                     }
-#endif
-
-                    // Update longitudinal momentum
-                    amrex::ParticleReal const F_L = wakefield_ptr[idx];
-
-#if (defined(AMREX_DEBUG) || defined(DEBUG)) && !defined(AMREX_USE_GPU)
-                    // Check if the force (convolution) values are within a reasonable range
-                    if (!std::isfinite(F_L))
-                    {
-                        // Handle unexpected values: log warning and skip momentum update
-                        std::cerr << "Warning: Invalid or out-of-range values detected." << std::endl;
+                    if (wake_py_ptr != nullptr) {
+                        part_py[i] += push_consts_xy * slice_ds * wake_py_ptr[idx];
                     }
-#endif
-
-                    pt -= push_consts * slice_ds * F_L;
-                    // Other dimensions (x, y) remain unchanged
                 });
             } // End loop over all particle boxes
         } // End mesh-refinement level loop

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -5,6 +5,7 @@
 target_sources(pyImpactX
   PRIVATE
     Config.cpp
+    CSRKickModel.cpp
     distribution.cpp
     elements.cpp
     flatten_rho.cpp

--- a/src/python/CSRKickModel.cpp
+++ b/src/python/CSRKickModel.cpp
@@ -1,0 +1,134 @@
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl, Chad Mitchell
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyImpactX.H"
+
+#include <particles/wakefields/CSRKickModel.H>
+
+#include <AMReX_GpuContainers.H>
+#include <AMReX_REAL.H>
+
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace py = pybind11;
+using namespace impactx;
+using namespace impactx::particles::wakefields;
+
+
+impactx::particles::wakefields::CSRKickModel
+make_csr_kick_model (py::object callable)
+{
+    return [callable] (CSRProfile const & profile, CSRElementContext const & context) -> CSRKick
+    {
+        py::gil_scoped_acquire gil;
+
+        // borrowed views: only valid during the callable's execution
+        py::object const py_profile = py::cast(profile, py::return_value_policy::reference);
+        py::object const py_context = py::cast(context, py::return_value_policy::reference);
+
+        py::object result = callable(py_profile, py_context);
+
+        if (!py::isinstance<CSRKick>(result))
+        {
+            throw std::runtime_error(
+                "The CSR kick model wrapper must return an impactx.CSRKick "
+                "(install models via the csr_kick_model property) in element "
+                "type '" + context.element_type + "' (name: '" +
+                context.element_name + "')");
+        }
+
+        // take over the per-bin kick vectors from the temporary Python object
+        return std::move(result.cast<CSRKick &>());
+    };
+}
+
+void init_csr_kick_model (py::module & m)
+{
+    py::class_<CSRKick>(m, "CSRKick",
+        "Per-bin CSR kick forces in Newtons, handed to ImpactX by a wrapped "
+        "CSR kick model: the longitudinal component pt is required, the "
+        "transverse components px and py are optional. Constructed from "
+        "pyAMReX device vectors, which are moved in (the inputs are emptied)."
+    )
+        .def(py::init(
+            [](
+                amrex::Gpu::DeviceVector<amrex::Real> & pt,
+                py::object px,
+                py::object py_
+            ) {
+                CSRKick kick;
+                kick.pt = std::move(pt);
+                if (!px.is_none()) {
+                    kick.px = std::move(px.cast<amrex::Gpu::DeviceVector<amrex::Real> &>());
+                }
+                if (!py_.is_none()) {
+                    kick.py = std::move(py_.cast<amrex::Gpu::DeviceVector<amrex::Real> &>());
+                }
+                return kick;
+            }),
+            py::arg("pt"),
+            py::arg("px") = py::none(),
+            py::arg("py") = py::none()
+        )
+    ;
+
+    py::class_<CSRProfile>(m, "CSRProfile",
+        "Binned longitudinal beam profile passed to a user-provided CSR kick "
+        "model. All arrays share the same binning: bin i spans "
+        "[bin_min + i * bin_size, bin_min + (i+1) * bin_size) in the "
+        "longitudinal coordinate t = ct (in meters) and have num_bins + 1 "
+        "entries, where the last entry is a guard bin. The arrays live in "
+        "device memory on GPU builds (use .to_xp() for zero-copy access) and "
+        "are only valid during the model call: copy any data you retain."
+    )
+        .def_readonly("charge", &CSRProfile::charge,
+            "line charge density lambda(t) [C/m] from nearest-grid-point "
+            "deposition. sum(charge) * bin_size approximates the bunch charge [C]")
+        .def_readonly("mean_x", &CSRProfile::mean_x,
+            "charge-weighted mean of x per bin [m] (zero for empty bins)")
+        .def_readonly("mean_y", &CSRProfile::mean_y,
+            "charge-weighted mean of y per bin [m] (zero for empty bins)")
+        .def_readonly("bin_min", &CSRProfile::bin_min,
+            "lower edge of bin 0 in t = ct [m]")
+        .def_readonly("bin_size", &CSRProfile::bin_size,
+            "bin spacing [m]")
+        .def_readonly("num_bins", &CSRProfile::num_bins,
+            "number of kick bins (= csr_bins). The profile arrays have "
+            "num_bins + 1 entries")
+    ;
+
+    py::class_<CSRElementContext>(m, "CSRElementContext",
+        "Per-element, per-slice context passed to a user-provided CSR kick "
+        "model. Only valid during the model call: copy any data you retain."
+    )
+        .def_readonly("element_name", &CSRElementContext::element_name,
+            "user-given element name (empty if unnamed)")
+        .def_readonly("element_type", &CSRElementContext::element_type,
+            "element type, e.g. 'Sbend'")
+        .def_readonly("rc", &CSRElementContext::rc,
+            "radius-of-curvature magnitude |R| [m]")
+        .def_readonly("signed_rc", &CSRElementContext::signed_rc,
+            "signed radius of curvature R [m]")
+        .def_readonly("ds", &CSRElementContext::ds,
+            "element (arc) length [m]")
+        .def_readonly("nslice", &CSRElementContext::nslice,
+            "number of slices in the element")
+        .def_readonly("slice", &CSRElementContext::slice,
+            "current slice index, 0-based, in forward orientation")
+        .def_readonly("s", &CSRElementContext::s,
+            "distance from the element entrance at kick time [m] "
+            "(= slice * slice_ds, also during back-tracking)")
+        .def_readonly("slice_ds", &CSRElementContext::slice_ds,
+            "slice length [m]")
+        .def_readonly("ref", &CSRElementContext::ref,
+            "reference particle (snapshot copy)")
+    ;
+}

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -222,13 +222,26 @@ void init_ImpactX (py::module& m)
         )
         .def_property("csr_bins",
             [](ImpactX & /* ix */) {
-                return detail::get_or_throw<bool>("algo", "csr_bins");
+                return detail::get_or_throw<int>("algo", "csr_bins");
             },
             [](ImpactX & /* ix */, int csr_bins) {
                 amrex::ParmParse pp_algo("algo");
                 pp_algo.add("csr_bins", csr_bins);
             },
             "Number of longitudinal bins used for CSR calculations (default: 150)."
+        )
+        .def("_set_csr_kick_model",
+            [](ImpactX & ix, py::object callable) {
+                if (callable.is_none()) {
+                    ix.m_csr_kick_model = nullptr;
+                    return;
+                }
+                ix.m_csr_kick_model = make_csr_kick_model(callable);
+            },
+            py::arg("callable"),
+            "Internal: install a wrapped CSR kick model or None. Use the "
+            "csr_kick_model property instead, which validates user models "
+            "and converts their results via pyAMReX."
         )
         .def_property("isr",
             [](ImpactX & /* ix */) {
@@ -242,7 +255,7 @@ void init_ImpactX (py::module& m)
         )
         .def_property("isr_order",
             [](ImpactX & /* ix */) {
-                return detail::get_or_throw<bool>("algo", "isr_order");
+                return detail::get_or_throw<int>("algo", "isr_order");
             },
             [](ImpactX & /* ix */, int isr_order) {
                 amrex::ParmParse pp_algo("algo");

--- a/src/python/impactx/__init__.py
+++ b/src/python/impactx/__init__.py
@@ -32,6 +32,9 @@ from .extensions.KnownElementsList import (
     FilteredElementsList,
     register_KnownElementsList_extension,
 )
+from .extensions.ImpactX import (
+    register_ImpactX_extension,
+)
 from .extensions.ImpactXParticleContainer import (
     register_ImpactXParticleContainer_extension,
 )
@@ -62,6 +65,7 @@ FilteredElementsList.__module__ = impactx_pybind.elements.__name__
 RefPart.load_file = read_beam  # noqa
 
 # Pure Python extensions to ImpactX types
+register_ImpactX_extension(impactx_pybind.ImpactX)
 register_ImpactXParticleContainer_extension(impactx_pybind.ImpactXParticleContainer)
 
 # Alternative constructors from raw field data

--- a/src/python/impactx/extensions/ImpactX.py
+++ b/src/python/impactx/extensions/ImpactX.py
@@ -1,0 +1,158 @@
+"""
+This file is part of ImpactX
+
+Copyright 2026 ImpactX contributors
+Authors: Axel Huebl, Chad Mitchell
+License: BSD-3-Clause-LBNL
+"""
+
+
+def _as_kick_component(value, num_bins, key, context):
+    """Convert one CSR kick component into an AMReX real ``DeviceVector``.
+
+    Accepts NumPy arrays and array-likes (force-cast to the build precision),
+    any pyAMReX ``PODVector``, and objects implementing the CUDA array
+    interface (e.g., CuPy arrays), converted through the pyAMReX
+    ``DeviceVector`` helpers.
+
+    Returns the vector and whether the CUDA array interface was used.
+    """
+    import numpy as np
+
+    from ..impactx_pybind import Config
+    from .ImpactXParticleContainer import _as_real_device_vector
+
+    def error_context():
+        return (
+            f" for kick component '{key}' in element type "
+            f"'{context.element_type}' (name: '{context.element_name}', "
+            f"slice {context.slice}); expected {num_bins} values"
+        )
+
+    import amrex.space3d as amr
+
+    # pyAMReX PODVectors also export the CUDA array interface on GPU builds:
+    # only flag foreign device arrays (e.g., CuPy), which route through CuPy
+    is_podvector = type(value).__name__.startswith("PODVector_")
+    used_cuda_interface = not is_podvector and hasattr(
+        value, "__cuda_array_interface__"
+    )
+    if not used_cuda_interface and not is_podvector:
+        # host arrays and array-likes: force-cast to the build precision
+        dtype = np.float64 if Config.precision == "DOUBLE" else np.float32
+        try:
+            value = np.ascontiguousarray(np.asarray(value, dtype=dtype))
+        except (TypeError, ValueError) as e:
+            raise RuntimeError(
+                "The CSR kick model returned an object that cannot be "
+                "converted to a 1D array" + error_context()
+            ) from e
+        if value.ndim != 1:
+            raise RuntimeError(
+                "The CSR kick model returned an array that is not 1D" + error_context()
+            )
+
+    if isinstance(value, amr.DeviceVector_real):
+        # fresh copy: the CSRKick construction consumes (moves from) its
+        # inputs, which must not empty a vector owned by the user model
+        vec = amr.DeviceVector_real.from_xp(value.to_xp())
+    else:
+        vec = _as_real_device_vector(value)
+    if len(vec) != num_bins:
+        raise RuntimeError(
+            "The CSR kick model returned an array of wrong length" + error_context()
+        )
+    return vec, used_cuda_interface
+
+
+def _wrap_csr_kick_model(model):
+    """Wrap a user CSR kick model for the C++ side.
+
+    Validates the model result (a dict with the required key "pt" and the
+    optional keys "px" and "py", or a bare array meaning {"pt": array}),
+    converts every component into an AMReX real ``DeviceVector`` via pyAMReX,
+    and hands them to ImpactX as an ``impactx.CSRKick``.
+    """
+
+    def wrapped(profile, context):
+        result = model(profile, context)
+
+        if isinstance(result, dict) or hasattr(result, "keys"):
+            components = dict(result)
+            for key in components:
+                if key not in ("pt", "px", "py"):
+                    raise RuntimeError(
+                        f"The CSR kick model returned an unknown key '{key}' "
+                        "(allowed keys: 'pt', 'px', 'py') in element type "
+                        f"'{context.element_type}' "
+                        f"(name: '{context.element_name}')"
+                    )
+            if "pt" not in components:
+                raise RuntimeError(
+                    "The CSR kick model result is missing the required key "
+                    f"'pt' in element type '{context.element_type}' "
+                    f"(name: '{context.element_name}')"
+                )
+        else:
+            # a bare array is shorthand for {"pt": array}
+            components = {"pt": result}
+
+        used_cuda_interface = False
+        converted = {}
+        for key, value in components.items():
+            converted[key], used = _as_kick_component(
+                value, profile.num_bins, key, context
+            )
+            used_cuda_interface = used_cuda_interface or used
+
+        if used_cuda_interface:
+            # order device writes issued through CuPy before ImpactX reads
+            # the vectors on its own GPU stream
+            import cupy
+
+            cupy.cuda.get_current_stream().synchronize()
+
+        from ..impactx_pybind import CSRKick
+
+        return CSRKick(
+            pt=converted["pt"],
+            px=converted.get("px"),
+            py=converted.get("py"),
+        )
+
+    return wrapped
+
+
+def ix_csr_kick_model_get(self):
+    """The user-provided CSR kick model callable, or None."""
+    return getattr(self, "_csr_kick_model_callable", None)
+
+
+def ix_csr_kick_model_set(self, model):
+    """Install or clear the user-provided CSR kick model."""
+    if model is None:
+        self._csr_kick_model_callable = None
+        self._set_csr_kick_model(None)
+        return
+    if not callable(model):
+        raise TypeError("csr_kick_model must be callable or None")
+    # keep the original Python callable alive and introspectable
+    self._csr_kick_model_callable = model
+    self._set_csr_kick_model(_wrap_csr_kick_model(model))
+
+
+def register_ImpactX_extension(ix):
+    """ImpactX helper methods"""
+    ix.csr_kick_model = property(
+        ix_csr_kick_model_get,
+        ix_csr_kick_model_set,
+        doc="User-provided CSR kick model (e.g., an ML surrogate), replacing "
+        "the built-in analytic CSR wake model. Called per tracking slice in "
+        "CSR-active bend elements as model(profile: CSRProfile, context: "
+        "CSRElementContext) and must return per-bin kick forces in Newtons: "
+        "a dict with the required key 'pt' and the optional keys 'px'/'py', "
+        "or a bare array (= {'pt': array}), each of length profile.num_bins. "
+        "Requires csr = True to be applied. Set to None (default) to restore "
+        "the built-in analytic model. Under MPI, set it on every rank. It is "
+        "invoked on the I/O rank only.",
+    )

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -1102,7 +1102,7 @@ class Config:
     have_omp: typing.ClassVar[bool] = True
     have_openpmd: typing.ClassVar[bool] = True
     have_simd: typing.ClassVar[bool] = False
-    impactx_version: typing.ClassVar[str] = "f7f29aa4054f"
+    impactx_version: typing.ClassVar[str] = "387c6aed28b6"
     openpmd_backends: typing.ClassVar[dict] = {
         "adios1": False,
         "adios2": False,

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -1102,7 +1102,7 @@ class Config:
     have_omp: typing.ClassVar[bool] = True
     have_openpmd: typing.ClassVar[bool] = True
     have_simd: typing.ClassVar[bool] = False
-    impactx_version: typing.ClassVar[str] = "b1e9c55f8063"
+    impactx_version: typing.ClassVar[str] = "6271b3bb9ee2"
     openpmd_backends: typing.ClassVar[dict] = {
         "adios1": False,
         "adios2": False,

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -1102,7 +1102,7 @@ class Config:
     have_omp: typing.ClassVar[bool] = True
     have_openpmd: typing.ClassVar[bool] = True
     have_simd: typing.ClassVar[bool] = False
-    impactx_version: typing.ClassVar[str] = "48050cb25b4d"
+    impactx_version: typing.ClassVar[str] = "f7f29aa4054f"
     openpmd_backends: typing.ClassVar[dict] = {
         "adios1": False,
         "adios2": False,

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -1102,7 +1102,7 @@ class Config:
     have_omp: typing.ClassVar[bool] = True
     have_openpmd: typing.ClassVar[bool] = True
     have_simd: typing.ClassVar[bool] = False
-    impactx_version: typing.ClassVar[str] = "387c6aed28b6"
+    impactx_version: typing.ClassVar[str] = "ce977addfbcb"
     openpmd_backends: typing.ClassVar[dict] = {
         "adios1": False,
         "adios2": False,

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -1102,7 +1102,7 @@ class Config:
     have_omp: typing.ClassVar[bool] = True
     have_openpmd: typing.ClassVar[bool] = True
     have_simd: typing.ClassVar[bool] = False
-    impactx_version: typing.ClassVar[str] = "6271b3bb9ee2"
+    impactx_version: typing.ClassVar[str] = "55435ea5d132"
     openpmd_backends: typing.ClassVar[dict] = {
         "adios1": False,
         "adios2": False,

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -1093,6 +1093,8 @@ class UnorderedMap:
     def values(self) -> typing.ValuesView: ...
 
 class Config:
+    ablastr_version: typing.ClassVar[str] = "26.06-5-g759c5cb11a41"
+    amrex_version: typing.ClassVar[str] = "26.07-54-gaa5b8cc69640"
     gpu_backend = None
     have_fft: typing.ClassVar[bool] = True
     have_gpu: typing.ClassVar[bool] = False
@@ -1100,6 +1102,7 @@ class Config:
     have_omp: typing.ClassVar[bool] = True
     have_openpmd: typing.ClassVar[bool] = True
     have_simd: typing.ClassVar[bool] = False
+    impactx_version: typing.ClassVar[str] = "1be087abbf20"
     openpmd_backends: typing.ClassVar[dict] = {
         "adios1": False,
         "adios2": False,
@@ -1111,6 +1114,11 @@ class Config:
     precision: typing.ClassVar[str] = "DOUBLE"
     precision_particles: typing.ClassVar[str] = "DOUBLE"
     simd_size: typing.ClassVar[int] = 1
+    @staticmethod
+    def to_dict() -> dict:
+        """
+        Return the ImpactX build configuration as a dictionary.
+        """
 
 def coordinate_transformation(
     pc: ImpactXParticleContainer, direction: CoordSystem

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -1102,7 +1102,7 @@ class Config:
     have_omp: typing.ClassVar[bool] = True
     have_openpmd: typing.ClassVar[bool] = True
     have_simd: typing.ClassVar[bool] = False
-    impactx_version: typing.ClassVar[str] = "1be087abbf20"
+    impactx_version: typing.ClassVar[str] = "a929ebe5aef4"
     openpmd_backends: typing.ClassVar[dict] = {
         "adios1": False,
         "adios2": False,

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -1102,7 +1102,7 @@ class Config:
     have_omp: typing.ClassVar[bool] = True
     have_openpmd: typing.ClassVar[bool] = True
     have_simd: typing.ClassVar[bool] = False
-    impactx_version: typing.ClassVar[str] = "ce977addfbcb"
+    impactx_version: typing.ClassVar[str] = "00e6ae1c8af7"
     openpmd_backends: typing.ClassVar[dict] = {
         "adios1": False,
         "adios2": False,

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -1102,7 +1102,7 @@ class Config:
     have_omp: typing.ClassVar[bool] = True
     have_openpmd: typing.ClassVar[bool] = True
     have_simd: typing.ClassVar[bool] = False
-    impactx_version: typing.ClassVar[str] = "a929ebe5aef4"
+    impactx_version: typing.ClassVar[str] = "48050cb25b4d"
     openpmd_backends: typing.ClassVar[dict] = {
         "adios1": False,
         "adios2": False,

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -1102,7 +1102,7 @@ class Config:
     have_omp: typing.ClassVar[bool] = True
     have_openpmd: typing.ClassVar[bool] = True
     have_simd: typing.ClassVar[bool] = False
-    impactx_version: typing.ClassVar[str] = "a8e598cd2c53"
+    impactx_version: typing.ClassVar[str] = "b1e9c55f8063"
     openpmd_backends: typing.ClassVar[dict] = {
         "adios1": False,
         "adios2": False,

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -1102,7 +1102,7 @@ class Config:
     have_omp: typing.ClassVar[bool] = True
     have_openpmd: typing.ClassVar[bool] = True
     have_simd: typing.ClassVar[bool] = False
-    impactx_version: typing.ClassVar[str] = "00e6ae1c8af7"
+    impactx_version: typing.ClassVar[str] = "a8e598cd2c53"
     openpmd_backends: typing.ClassVar[dict] = {
         "adios1": False,
         "adios2": False,

--- a/src/python/pyImpactX.H
+++ b/src/python/pyImpactX.H
@@ -30,4 +30,19 @@ using namespace impactx;
 PYBIND11_MAKE_OPAQUE(std::list<elements::KnownElements>)
 PYBIND11_MAKE_OPAQUE(std::unordered_map<std::string, std::function<void(ImpactX *)> >)
 
+/** Wrap a Python callable into a C++ CSR kick model
+ *
+ * The returned wrapper acquires the GIL, passes borrowed views of the beam
+ * profile and the element context to the callable and converts its result
+ * (a dict with the required key "pt" and the optional keys "px"/"py", or a
+ * bare array meaning {"pt": array}) into per-bin kick device vectors.
+ *
+ * Implemented in CSRKickModel.cpp.
+ *
+ * @param callable a Python callable (CSRProfile, CSRElementContext) -> dict | array
+ * @return the C++ kick model wrapping the callable
+ */
+impactx::particles::wakefields::CSRKickModel
+make_csr_kick_model (pybind11::object callable);
+
 #endif // IMPACTX_PYIMPACTX_H

--- a/src/python/pyImpactX.cpp
+++ b/src/python/pyImpactX.cpp
@@ -21,6 +21,7 @@ using namespace impactx;
 
 // forward declarations of exposed classes
 void init_Config(py::module&);
+void init_csr_kick_model(py::module&);
 void init_distribution(py::module&);
 void init_elements(py::module&);
 void init_flatten_rho(py::module& m);
@@ -53,6 +54,7 @@ PYBIND11_MODULE(impactx_pybind, m) {
     init_elements(m);
     init_transformation(m);
     init_wakeconvolution(m);
+    init_csr_kick_model(m);
     init_ImpactX(m);
     init_Config(m);
     init_flatten_rho(m);

--- a/src/tracking/particles.H
+++ b/src/tracking/particles.H
@@ -50,7 +50,9 @@ namespace impactx
      *  so the caller is expected to reset it (to 0) before a forward run.
      *
      *  @tparam HookFn callable ``void (std::string const & name)`` invoking a named hook
-     *  @tparam CollectiveKicks callable, see @p ElementPush for the signature
+     *  @tparam CollectiveKicks callable
+     *    ``void (elements::KnownElements & element, amrex::ParticleReal slice_ds,
+     *            int slice_step, int nslice)``
      *  @tparam ElementPush callable
      *    ``void (elements::KnownElements & element, int element_index, int slice_step,
      *            int nslice, amrex::ParticleReal slice_ds, int step, int period)``
@@ -135,13 +137,13 @@ namespace impactx
                 // TODO: Strang-split here (#846 / #920)
                 if (forward)
                 {
-                    collective_kicks(element_variant, slice_ds);
+                    collective_kicks(element_variant, slice_ds, slice_step, nslice);
                     element_push(element_variant, step, period);
                 }
                 else
                 {
                     element_push(element_variant, step, period);
-                    collective_kicks(element_variant, slice_ds);
+                    collective_kicks(element_variant, slice_ds, slice_step, nslice);
                 }
             }
 

--- a/src/tracking/particles.cpp
+++ b/src/tracking/particles.cpp
@@ -20,6 +20,8 @@
 #include "particles/wakefields/HandleWakefield.H"
 #include "tracking/particles.H"
 
+#include <ablastr/warn_manager/WarnManager.H>
+
 #include <AMReX.H>
 #include <AMReX_AmrParGDB.H>
 #include <AMReX_BLProfiler.H>
@@ -104,8 +106,19 @@ namespace impactx
             );
         }
 
+        if (m_csr_kick_model && !csr) {
+            ablastr::warn_manager::WMRecordWarning(
+                "ImpactX::track_particles",
+                "A user-provided CSR kick model (csr_kick_model) is set, but "
+                "algo.csr is disabled. The CSR kick model will not be called. "
+                "Enable algo.csr to apply it.",
+                ablastr::warn_manager::WarnPriority::medium
+            );
+        }
+
         if (verbose > 0) {
-            amrex::Print() << " CSR effects: " << csr << "\n";
+            amrex::Print() << " CSR effects: " << csr
+                           << (csr && m_csr_kick_model ? " (user-provided kick model)" : "") << "\n";
             amrex::Print() << " ISR effects: " << isr << "\n";
             amrex::Print() << " Spin tracking: " << spin << "\n";
         }
@@ -114,11 +127,13 @@ namespace impactx
         // space charge, coherent and incoherent synchrotron radiation, etc.
         auto collective_kicks = [this, &pc] (
             elements::KnownElements & element_variant,
-            amrex::ParticleReal slice_ds
+            amrex::ParticleReal slice_ds,
+            int slice_step,
+            int nslice
         )
         {
             // Wakefield calculation: call wakefield function to apply wake effects
-            particles::wakefields::HandleWakefield(*pc, element_variant, slice_ds);
+            particles::wakefields::HandleWakefield(*pc, element_variant, slice_ds, slice_step, nslice, m_csr_kick_model);
 
             // ISR calculation: call ISR function to apply incoherent synchrotron radiation effects
             particles::wakefields::HandleISR(*pc, element_variant, slice_ds);

--- a/tests/python/test_csr_model.py
+++ b/tests/python/test_csr_model.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+import math
+
+import numpy as np
+import pytest
+from scipy.constants import c
+
+from impactx import Config, ImpactX, distribution, elements
+
+# beam parameters, following examples/chicane/run_chicane_csr.py
+KIN_ENERGY_MEV = 5.0e3
+BUNCH_CHARGE_C = 1.0e-9
+NPART = 2000
+
+BUILD_DTYPE = np.float64 if Config.precision == "DOUBLE" else np.float32
+CONTEXT_RTOL = 1.0e-14 if Config.precision == "DOUBLE" else 2.0e-6
+SLICE_POSITION_RTOL = 1.0e-13 if Config.precision == "DOUBLE" else 2.0e-6
+REFERENCE_RTOL = 1.0e-12 if Config.precision == "DOUBLE" else 2.0e-6
+CHARGE_RTOL = 1.0e-6 if Config.precision == "DOUBLE" else 2.0e-5
+KICK_RTOL = 1.0e-10 if Config.precision == "DOUBLE" else 2.0e-3
+ZERO_ATOL = 1.0e-14
+
+
+def force_for_precision():
+    """A force large enough to resolve its momentum change at build precision."""
+    return 1.0e-15 if Config.precision == "DOUBLE" else 1.0e-12
+
+
+def build_sim(
+    csr=True,
+    csr_bins=32,
+    ds=0.5,
+    rc=10.35,
+    nslice=6,
+    kick_model=None,
+    distr=None,
+):
+    """Build a one-bend simulation for CSR kick model tests."""
+    sim = ImpactX()
+
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.csr = csr
+    sim.csr_bins = csr_bins
+    sim.diagnostics = False
+    sim.slice_step_diagnostics = False
+    if kick_model is not None:
+        sim.csr_kick_model = kick_model
+
+    sim.init_grids()
+
+    ref = sim.beam.ref
+    ref.set_species("electron").set_kin_energy_MeV(KIN_ENERGY_MEV)
+
+    if distr is None:
+        distr = distribution.Gaussian(
+            lambdaX=2.2951017632e-5,
+            lambdaY=1.3084093142e-5,
+            lambdaT=5.5555553e-8,
+            lambdaPx=1.598353425e-6,
+            lambdaPy=2.803697378e-6,
+            lambdaPt=2.000000000e-6,
+            muxpx=0.933345606203060,
+            muypy=0.933345606203060,
+            mutpt=0.999999961419755,
+        )
+    sim.add_particles(BUNCH_CHARGE_C, distr, NPART)
+
+    sim.lattice.append(elements.Sbend(name="bend1", ds=ds, rc=rc, nslice=nslice))
+
+    return sim
+
+
+def ref_momentum_SI(ref):
+    """Reference momentum p_ref = beta * gamma * m * c in SI [kg m/s]."""
+    return ref.beta_gamma * ref.mass * c
+
+
+def mean_momenta(sim):
+    """Mean momenta (px, py, pt) of the beam (dimensionless, p/p_ref)."""
+    df = sim.beam.to_df()
+    return (
+        df["momentum_x"].mean(),
+        df["momentum_y"].mean(),
+        df["momentum_t"].mean(),
+    )
+
+
+def test_csr_kick_model_context_and_profile():
+    """A zero-kick model receives the correct context and profile and does
+    not alter the beam momentum."""
+    ds = 0.5
+    rc = -10.35
+    nslice = 6
+    csr_bins = 32
+    calls = []
+
+    def recorder(profile, context):
+        charge = profile.charge.to_numpy(copy=True)
+        mean_x = profile.mean_x.to_numpy(copy=True)
+        mean_y = profile.mean_y.to_numpy(copy=True)
+        calls.append(
+            {
+                "element_name": context.element_name,
+                "element_type": context.element_type,
+                "rc": context.rc,
+                "signed_rc": context.signed_rc,
+                "ds": context.ds,
+                "nslice": context.nslice,
+                "slice": context.slice,
+                "s": context.s,
+                "slice_ds": context.slice_ds,
+                "beta_gamma": context.ref.beta_gamma,
+                "num_bins": profile.num_bins,
+                "bin_min": profile.bin_min,
+                "bin_size": profile.bin_size,
+                "charge": charge,
+                "mean_x": mean_x,
+                "mean_y": mean_y,
+            }
+        )
+        return np.zeros(profile.num_bins)
+
+    sim = build_sim(csr_bins=csr_bins, ds=ds, rc=rc, nslice=nslice, kick_model=recorder)
+    try:
+        beta_gamma_ref = sim.beam.ref.beta_gamma
+        _, _, pt_mean_initial = mean_momenta(sim)
+
+        sim.track_particles()
+
+        # called once per slice, in order
+        assert len(calls) == nslice
+        assert [call["slice"] for call in calls] == list(range(nslice))
+
+        for call in calls:
+            # element context
+            assert call["element_name"] == "bend1"
+            assert call["element_type"] == "Sbend"
+            assert math.isclose(call["rc"], abs(rc), rel_tol=CONTEXT_RTOL)
+            assert math.isclose(call["signed_rc"], rc, rel_tol=CONTEXT_RTOL)
+            assert math.isclose(call["ds"], ds, rel_tol=CONTEXT_RTOL)
+            assert call["nslice"] == nslice
+            assert math.isclose(call["slice_ds"], ds / nslice, rel_tol=CONTEXT_RTOL)
+            assert math.isclose(
+                call["s"],
+                call["slice"] * call["slice_ds"],
+                rel_tol=SLICE_POSITION_RTOL,
+                abs_tol=0.0,
+            ) or (call["slice"] == 0 and call["s"] == 0.0)
+            assert math.isclose(
+                call["beta_gamma"], beta_gamma_ref, rel_tol=REFERENCE_RTOL
+            )
+
+            # binned profile
+            assert call["num_bins"] == csr_bins
+            assert len(call["charge"]) == csr_bins + 1
+            assert len(call["mean_x"]) == csr_bins + 1
+            assert len(call["mean_y"]) == csr_bins + 1
+            assert call["bin_size"] > 0.0
+            # the histogram integrates to the bunch charge
+            assert math.isclose(
+                np.sum(call["charge"]) * call["bin_size"],
+                BUNCH_CHARGE_C,
+                rel_tol=CHARGE_RTOL,
+            )
+            assert np.all(np.isfinite(call["mean_x"]))
+            assert np.all(np.isfinite(call["mean_y"]))
+
+        # a zero kick does not alter the mean longitudinal momentum
+        # (the bend map conserves pt)
+        _, _, pt_mean_final = mean_momenta(sim)
+        assert math.isclose(
+            pt_mean_final, pt_mean_initial, rel_tol=0.0, abs_tol=ZERO_ATOL
+        )
+    finally:
+        sim.finalize()
+
+
+def run_constant_kick(force, as_dict):
+    """Track through one bend with a constant longitudinal kick force [N]
+    and return (mean pt change, ds, reference momentum [kg m/s])."""
+    ds = 0.5
+
+    def constant_kick(profile, context):
+        kick = np.full(profile.num_bins, force)
+        return {"pt": kick} if as_dict else kick
+
+    sim = build_sim(ds=ds, kick_model=constant_kick)
+    try:
+        p_ref = ref_momentum_SI(sim.beam.ref)
+        _, _, pt_mean_initial = mean_momenta(sim)
+        sim.track_particles()
+        _, _, pt_mean_final = mean_momenta(sim)
+    finally:
+        sim.finalize()
+
+    return pt_mean_final - pt_mean_initial, ds, p_ref
+
+
+def test_csr_kick_model_longitudinal_kick():
+    """A constant longitudinal force F over a bend of length ds changes the
+    beam mean pt by exactly -ds * F / (c * p_ref)."""
+    force = force_for_precision()  # [N]
+    delta_pt, ds, p_ref = run_constant_kick(force, as_dict=True)
+
+    delta_pt_expected = -ds * force / (c * p_ref)
+    assert math.isclose(delta_pt, delta_pt_expected, rel_tol=KICK_RTOL)
+
+
+def test_csr_kick_model_bare_array_return():
+    """Returning a bare array is equivalent to returning {'pt': array}."""
+    force = force_for_precision()  # [N]
+    delta_pt_dict, _, _ = run_constant_kick(force, as_dict=True)
+    delta_pt_bare, _, _ = run_constant_kick(force, as_dict=False)
+
+    assert math.isclose(
+        delta_pt_dict,
+        delta_pt_bare,
+        rel_tol=KICK_RTOL,
+        abs_tol=0.0,
+    )
+
+
+def test_csr_kick_model_transverse_kick():
+    """A constant horizontal force F over a thin bend changes the beam mean
+    px by ds * F / (beta * c * p_ref)."""
+    ds = 1.0e-3
+    force = 1.0e-12 if Config.precision == "DOUBLE" else 1.0e-10  # [N]
+
+    def transverse_kick(profile, context):
+        return {
+            "pt": np.zeros(profile.num_bins),
+            "px": np.full(profile.num_bins, force),
+        }
+
+    # an unchirped beam with negligible momentum spread, so that the bend
+    # map's dispersion (px += -sin(theta) * pt) does not shift the mean px
+    # (the default chicane beam is strongly chirped: sample <pt> ~ 5e-4)
+    distr = distribution.Gaussian(
+        lambdaX=2.2951017632e-5,
+        lambdaY=1.3084093142e-5,
+        lambdaT=5.5555553e-8,
+        lambdaPx=1.598353425e-6,
+        lambdaPy=2.803697378e-6,
+        lambdaPt=1.0e-9,
+        muxpx=0.0,
+        muypy=0.0,
+        mutpt=0.0,
+    )
+    sim = build_sim(ds=ds, rc=10.0, nslice=1, kick_model=transverse_kick, distr=distr)
+    try:
+        ref = sim.beam.ref
+        p_ref = ref_momentum_SI(ref)
+        beta_ref = ref.beta
+        px_mean_initial, py_mean_initial, _ = mean_momenta(sim)
+        sim.track_particles()
+        px_mean_final, py_mean_final, _ = mean_momenta(sim)
+    finally:
+        sim.finalize()
+
+    delta_px_expected = ds * force / (beta_ref * c * p_ref)
+    # the bend map after the kick mixes phase space slightly (arc angle 1e-4)
+    assert math.isclose(
+        px_mean_final - px_mean_initial,
+        delta_px_expected,
+        rel_tol=1.0e-4 if Config.precision == "DOUBLE" else 2.0e-3,
+    )
+    # no vertical kick was applied
+    assert math.isclose(py_mean_final, py_mean_initial, rel_tol=0.0, abs_tol=ZERO_ATOL)
+
+
+def test_csr_kick_model_gpu_cupy_return():
+    """On GPU builds, cupy arrays work as zero-copy inputs and as returns
+    (via the CUDA array interface), including producer stream synchronization."""
+    if Config.gpu_backend not in {"CUDA", "HIP"}:
+        pytest.skip("CUDA/HIP-only test")
+    cp = pytest.importorskip("cupy")
+
+    ds = 0.5
+    force = force_for_precision()  # [N]
+
+    class ArrayWithStream:
+        """CUDA array-interface wrapper that records the producer stream."""
+
+        def __init__(self, array, stream):
+            self.array = array
+            self.stream = stream
+            self.__cuda_array_interface__ = dict(array.__cuda_array_interface__)
+            self.__cuda_array_interface__["stream"] = stream.ptr
+
+    def cupy_kick(profile, context):
+        lam = profile.charge.to_xp()  # zero-copy device view
+        assert isinstance(lam, cp.ndarray)
+        assert lam.shape == (profile.num_bins + 1,)
+        stream = cp.cuda.Stream(non_blocking=True)
+        with stream:
+            kick = cp.full(profile.num_bins, force, dtype=BUILD_DTYPE)
+        return {"pt": ArrayWithStream(kick, stream)}
+
+    sim = build_sim(ds=ds, kick_model=cupy_kick)
+    try:
+        p_ref = ref_momentum_SI(sim.beam.ref)
+        _, _, pt_mean_initial = mean_momenta(sim)
+        sim.track_particles()
+        _, _, pt_mean_final = mean_momenta(sim)
+    finally:
+        sim.finalize()
+
+    delta_pt_expected = -ds * force / (c * p_ref)
+    assert math.isclose(
+        pt_mean_final - pt_mean_initial, delta_pt_expected, rel_tol=KICK_RTOL
+    )
+
+
+def test_csr_kick_model_disabled_csr():
+    """With csr disabled, a set kick model is never called."""
+    calls = []
+
+    def recorder(profile, context):
+        calls.append(context.slice)
+        return np.zeros(profile.num_bins)
+
+    sim = build_sim(csr=False, kick_model=recorder)
+    try:
+        sim.track_particles()
+    finally:
+        sim.finalize()
+
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "bad_return, match",
+    [
+        (lambda n: np.zeros(n - 1), "wrong length"),
+        (lambda n: {"px": np.zeros(n)}, "missing the required key 'pt'"),
+        (lambda n: {"pt": np.zeros(n), "foo": np.zeros(n)}, "unknown key"),
+        (lambda n: object(), "cannot be converted"),
+    ],
+)
+def test_csr_kick_model_invalid_return(bad_return, match):
+    """Invalid model return values raise errors naming the element."""
+
+    def bad_model(profile, context):
+        return bad_return(profile.num_bins)
+
+    sim = build_sim(kick_model=bad_model)
+    try:
+        with pytest.raises(RuntimeError, match=match):
+            sim.track_particles()
+    finally:
+        sim.finalize()
+
+
+def test_csr_kick_model_property_validation():
+    """The csr_kick_model property accepts callables and None only."""
+    sim = ImpactX()
+    try:
+        assert sim.csr_kick_model is None
+
+        def model(profile, context):
+            return np.zeros(profile.num_bins)
+
+        sim.csr_kick_model = model
+        assert sim.csr_kick_model is model
+
+        sim.csr_kick_model = None
+        assert sim.csr_kick_model is None
+
+        with pytest.raises(TypeError, match="callable"):
+            sim.csr_kick_model = 5
+    finally:
+        sim.finalize()

--- a/tests/python/test_csr_model_equivalence.py
+++ b/tests/python/test_csr_model_equivalence.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+import math
+
+import numpy as np
+import pytest
+from scipy.constants import e as q_e
+
+from impactx import Config, ImpactX, amr, elements, wakeconvolution
+
+pytestmark = pytest.mark.skipif(
+    not Config.have_fft, reason="The built-in CSR model requires ImpactX_FFT=ON"
+)
+
+# a reduced version of examples/chicane/run_chicane_csr.py
+KIN_ENERGY_MEV = 5.0e3
+BUNCH_CHARGE_C = 1.0e-9
+NPART = 5000
+CSR_BINS = 100
+NSLICE = 10
+QM_EEV = -1.0 / 0.510998950 / 1e6  # electron charge/mass in e / eV
+
+
+def make_particles():
+    """A deterministic, chirped electron bunch in s-coordinates.
+
+    ImpactX distribution sampling is not reproducible across simulations in
+    one process (the RNG state advances), so both runs load this same array.
+    """
+    rng = np.random.default_rng(42)
+    x = rng.normal(0.0, 2.3e-5, NPART)
+    y = rng.normal(0.0, 1.3e-5, NPART)
+    t = rng.normal(0.0, 2.0e-4, NPART)
+    px = rng.normal(0.0, 1.6e-6, NPART)
+    py = rng.normal(0.0, 2.8e-6, NPART)
+    # a strong longitudinal chirp, as in the chicane compression example
+    pt = -36.0 * t + rng.normal(0.0, 1.0e-6, NPART)
+    return x, y, t, px, py, pt
+
+
+checked = {"convolution": False}
+
+
+def analytic_csr(profile, context):
+    """A Python CSR kick model replicating the built-in analytic model:
+    dN/ds convolved with the steady-state CSR wake function."""
+    lam = profile.charge.to_numpy(copy=True)
+    n = profile.num_bins
+    bin_size = profile.bin_size
+
+    # dN/ds, the number density slope per bin (\see DerivativeCharge1D)
+    slopes = np.diff(lam) / bin_size / q_e
+
+    # steady-state CSR wake function on 2N support, in wrap-around order
+    # (\see HandleWakefield.H)
+    idx = np.arange(2 * n)
+    s_wake = np.where(idx <= n, idx, idx - 2 * n) * bin_size
+    wake = np.array([wakeconvolution.w_l_csr(s, context.rc, bin_size) for s in s_wake])
+    wake[n] = 0.0
+
+    # zero-padded FFT convolution, cropped to the first N bins
+    # (\see convolve_fft)
+    padded = np.zeros(2 * n)
+    padded[:n] = slopes
+    kick = np.fft.irfft(np.fft.rfft(padded) * np.fft.rfft(wake), n=2 * n)[:n] * bin_size
+
+    if not checked["convolution"]:
+        # cross-check the numpy convolution against the compiled one, once
+        d_slopes = amr.PODVector_real_default.from_xp(slopes)
+        d_wake = amr.PODVector_real_default.from_xp(wake)
+        kick_ref = wakeconvolution.convolve_fft(d_slopes, d_wake, bin_size).to_numpy(
+            copy=True
+        )
+        assert np.allclose(
+            kick, kick_ref, rtol=1e-10, atol=1e-12 * np.max(np.abs(kick_ref))
+        )
+        checked["convolution"] = True
+
+    return kick
+
+
+def run_chicane(kick_model=None):
+    """Track the reduced CSR chicane and return the final beam moments."""
+    sim = ImpactX()
+
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.csr = True
+    sim.csr_bins = CSR_BINS
+    sim.diagnostics = False
+    sim.slice_step_diagnostics = False
+    if kick_model is not None:
+        sim.csr_kick_model = kick_model
+
+    sim.init_grids()
+
+    ref = sim.beam.ref
+    ref.set_species("electron").set_kin_energy_MeV(KIN_ENERGY_MEV)
+
+    x, y, t, px, py, pt = make_particles()
+    sim.beam.add_n_particles(x, y, t, px, py, pt, QM_EEV, bunch_charge=BUNCH_CHARGE_C)
+
+    ns = NSLICE
+    rc = 10.3462283686195526  # bend radius (meters)
+    psi = 0.048345620280243  # pole face rotation angle (radians)
+    lb = 0.500194828041958  # bend arc length (meters)
+
+    dr1 = elements.Drift(name="dr1", ds=5.0058489435, nslice=ns)
+    dr2 = elements.Drift(name="dr2", ds=1.0, nslice=ns)
+    dr3 = elements.Drift(name="dr3", ds=2.0, nslice=ns)
+    sbend1 = elements.Sbend(name="sbend1", ds=lb, rc=-rc, nslice=ns)
+    sbend2 = elements.Sbend(name="sbend2", ds=lb, rc=rc, nslice=ns)
+    dipedge1 = elements.DipEdge(name="dipedge1", psi=-psi, rc=-rc, g=0.0, K2=0.0)
+    dipedge2 = elements.DipEdge(name="dipedge2", psi=psi, rc=rc, g=0.0, K2=0.0)
+
+    lattice_half = [sbend1, dipedge1, dr1, dipedge2, sbend2]
+    sim.lattice.extend(lattice_half)
+    sim.lattice.append(dr2)
+    lattice_half.reverse()
+    sim.lattice.extend(lattice_half)
+    sim.lattice.append(dr3)
+
+    sim.track_particles()
+
+    moments = dict(sim.beam.beam_moments())
+    sim.finalize()
+    return moments
+
+
+def test_csr_kick_model_matches_builtin():
+    """An analytic Python kick model reproduces the built-in CSR model."""
+    moments_builtin = run_chicane()
+    moments_surrogate = run_chicane(kick_model=analytic_csr)
+
+    assert checked["convolution"]
+
+    rtol = 1.0e-8 if Config.precision == "DOUBLE" else 2.0e-4
+    for key in [
+        "sigma_x",
+        "sigma_y",
+        "sigma_t",
+        "sigma_px",
+        "sigma_py",
+        "sigma_pt",
+        "emittance_x",
+        "emittance_y",
+        "emittance_t",
+    ]:
+        assert math.isclose(
+            moments_builtin[key], moments_surrogate[key], rel_tol=rtol
+        ), (
+            f"{key}: built-in {moments_builtin[key]} "
+            f"vs surrogate {moments_surrogate[key]}"
+        )


### PR DESCRIPTION
Provide a Python hook to register custom CSR surrogate ML models, e.g., as in [A. L. Edelen et al., in Proc. IPAC'22, WEPOMS013, 2022](https://doi.org/10.18429/JACoW-IPAC2022-WEPOMS013).

Writes the bindings generic enough that we can later on also add transverse kicks.

Attn @lee-edelen @ChristopherMayes @jy-tang

- [Example](https://impactx--1588.org.readthedocs.build/en/1588/usage/examples/pytorch_csr_surrogate/README.html)
- [How-To](https://impactx--1588.org.readthedocs.build/en/1588/usage/howto/python_extend.html#custom-csr-wake-models-ml-surrogates)
- [API docs](https://impactx--1588.org.readthedocs.build/en/1588/usage/python.html#impactx.ImpactX.csr_kick_model)

Credits to Claude to help me with typing.