### PR TITLE
CI: Actions Cache Hygiene

### DIFF
--- a/.github/workflows/cleanup-cache-postpr.yml
+++ b/.github/workflows/cleanup-cache-postpr.yml
@@ -1,0 +1,50 @@
+# Copyright 2022-2026 The ImpactX Community
+#
+# This file is part of ImpactX.
+#
+# License: BSD-3-Clause-LBNL
+# Authors: Axel Huebl
+
+name: CleanUpCachePostPR
+
+on:
+  workflow_run:
+    workflows: [PostPR]
+    types:
+      - completed
+
+jobs:
+  CleanUpCcacheCachePostPR:
+    name: Clean Up Ccache Cache Post PR
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Clean up ccache
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+
+          # For debugging cat ${GITHUB_EVENT_PATH} to see the payload.
+
+          pr_head_sha=${{ github.event.workflow_run.head_sha }}
+          pr_number=$(gh pr list --state all --search $pr_head_sha --json number --jq '.[0].number')
+          echo "Post-PR cache cleanup for PR ${pr_number}"
+          BRANCH=refs/pull/${pr_number}/merge
+
+          # Setting this to not fail the workflow while deleting cache keys.
+          set +e
+
+          keys=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH | cut -f 1)
+          # $keys might contain spaces. Thus we set IFS to \n.
+          IFS=$'\n'
+          for k in $keys
+          do
+            gh actions-cache delete "$k" -R $REPO -B $BRANCH --confirm
+          done
+          unset IFS

--- a/.github/workflows/cleanup-cache-postpr.yml
+++ b/.github/workflows/cleanup-cache-postpr.yml
@@ -3,7 +3,7 @@
 # This file is part of ImpactX.
 #
 # License: BSD-3-Clause-LBNL
-# Authors: Axel Huebl
+# Authors: Axel Huebl, Weiqun Zhang
 
 name: CleanUpCachePostPR
 
@@ -16,7 +16,7 @@ on:
 jobs:
   CleanUpCcacheCachePostPR:
     name: Clean Up Ccache Cache Post PR
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -1,0 +1,96 @@
+# Copyright 2022-2026 The ImpactX Community
+#
+# This file is part of ImpactX.
+#
+# License: BSD-3-Clause-LBNL
+# Authors: Axel Huebl
+
+name: CleanUpCache
+
+on:
+  workflow_run:
+    # All workflows that store Actions caches. Keep this list in sync when
+    # adding a workflow that sets up a ccache cache. 🔍 CodeQL does not use
+    # ccache, but github/codeql-action stores its own TRAP database caches.
+    workflows: [🔍 CodeQL, 🐧 CUDA, 🐧 HIP, 🍏 macOS, 🐧 OpenMP, 🔄 Update Stub Files, 🐧 Tooling, 🪟 Windows]
+    types:
+      - completed
+
+jobs:
+  CleanUpCcacheCache:
+    name: Clean Up Ccache Cache for ${{ github.event.workflow_run.name }}
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Clean up ccache
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+
+          # push or pull_request or schedule or ...
+          EVENT=${{ github.event.workflow_run.event }}
+
+          # Triggering workflow run name (e.g., 🐧 OpenMP)
+          WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
+
+          # For debugging, cat ${GITHUB_EVENT_PATH} to see the payload.
+
+          if [[ $EVENT == "pull_request" ]]; then
+            pr_head_sha=${{ github.event.workflow_run.head_sha }}
+            pr_number=$(gh pr list --search $pr_head_sha --json number --jq '.[0].number')
+            echo "Clean up cache for PR ${pr_number}"
+            BRANCH=refs/pull/${pr_number}/merge
+          else
+            BRANCH=refs/heads/${{ github.event.workflow_run.head_branch }}
+          fi
+
+          # Setting this to not fail the workflow while deleting cache keys.
+          set +e
+
+          # In our cache keys, substring after `-git-` is git hash, substring
+          # before that is a unique id for jobs (e.g., `ccache-🐧 OpenMP-build_gcc`).
+          # The goal is to keep the last used key of each job and delete all others.
+
+          # something like ccache-🐧 OpenMP-
+          keyprefix="ccache-${WORKFLOW_NAME}-"
+
+          cached_jobs=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key "$keyprefix" | awk -F '-git-' '{print $1}' | sort | uniq)
+
+          # cached_jobs is something like "ccache-🐧 OpenMP-build_gcc ccache-🐧 OpenMP-build_gcc_python".
+          # It might also contain spaces. Thus we set IFS to \n.
+          IFS=$'\n'
+          for j in $cached_jobs
+          do
+            # Delete all entries except the last used one
+            old_keys=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key "${j}-git-" --sort last-used | cut -f 1 | tail -n +2)
+            for k in $old_keys
+            do
+              gh actions-cache delete "$k" -R $REPO -B $BRANCH --confirm
+            done
+          done
+          unset IFS
+
+          # github/codeql-action stores its own TRAP database caches, which are
+          # the single largest entries we keep (~1 GB each). They do not carry
+          # the `ccache-` prefix and look like
+          #   codeql-trap-<n>-<codeql-version>-<language>-<git-hash>
+          # Strip the trailing git hash to group them per language and version,
+          # then keep only the last used entry of each group.
+          codeql_jobs=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key "codeql-trap-" | cut -f 1 | sed -E 's/-[0-9a-f]{40}$//' | sort | uniq)
+
+          IFS=$'\n'
+          for j in $codeql_jobs
+          do
+            old_keys=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key "${j}-" --sort last-used | cut -f 1 | tail -n +2)
+            for k in $old_keys
+            do
+              gh actions-cache delete "$k" -R $REPO -B $BRANCH --confirm
+            done
+          done
+          unset IFS

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -3,7 +3,7 @@
 # This file is part of ImpactX.
 #
 # License: BSD-3-Clause-LBNL
-# Authors: Axel Huebl
+# Authors: Axel Huebl, Weiqun Zhang
 
 name: CleanUpCache
 
@@ -19,7 +19,7 @@ on:
 jobs:
   CleanUpCcacheCache:
     name: Clean Up Ccache Cache for ${{ github.event.workflow_run.name }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -1,6 +1,9 @@
 name: 🐧 CUDA
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [development]
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-cuda

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -1,6 +1,9 @@
 name: 🐧 HIP
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [development]
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-hip

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,9 @@
 name: 🍏 macOS
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [development]
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-macos

--- a/.github/workflows/post-pr.yml
+++ b/.github/workflows/post-pr.yml
@@ -1,0 +1,24 @@
+# Copyright 2022-2026 The ImpactX Community
+#
+# This file is part of ImpactX.
+#
+# License: BSD-3-Clause-LBNL
+# Authors: Axel Huebl
+
+name: PostPR
+
+on:
+  pull_request:
+    types:
+      - closed
+
+# This workflow does not have the permission to clean up cache for PRs
+# originated from a fork. The purpose here is to trigger a workflow_run
+# cleanup-cache-postpr.yml that has the right permission.
+
+jobs:
+  noop:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: No OP
+        run: echo "This workflow is going to trigger CleanUpCachePostPR."

--- a/.github/workflows/post-pr.yml
+++ b/.github/workflows/post-pr.yml
@@ -3,7 +3,7 @@
 # This file is part of ImpactX.
 #
 # License: BSD-3-Clause-LBNL
-# Authors: Axel Huebl
+# Authors: Axel Huebl, Weiqun Zhang
 
 name: PostPR
 
@@ -18,7 +18,7 @@ on:
 
 jobs:
   noop:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: No OP
         run: echo "This workflow is going to trigger CleanUpCachePostPR."

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -7,7 +7,10 @@
 
 name: 📜 Source
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [development]
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-source

--- a/.github/workflows/stubs.yml
+++ b/.github/workflows/stubs.yml
@@ -1,6 +1,9 @@
 name: 🔄 Update Stub Files
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [development]
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-subs

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -1,6 +1,9 @@
 name: 🐧 Tooling
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [development]
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-tooling

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,6 +1,9 @@
 name: 🐧 OpenMP
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [development]
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-ubuntu

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,9 @@
 name: 🪟 Windows
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [development]
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-windows


### PR DESCRIPTION
## Problem

The repository sits at the **10 GB GitHub Actions cache quota** — 10.01 GB across 44 caches when measured — so GitHub LRU-evicts entries and jobs silently lose their ccache.

Unlike WarpX and pyAMReX, this repository has no cache cleanup at all, so nothing ever prunes stale generations. When measured, `development` alone held six generations of `ccache-🐧 HIP-build_hip-*` (109 MB each) and three of `ccache-🔄 Update Stub Files-stubs-*` (~180 MB each). The `codeql-trap-*` caches that `github/codeql-action` stores were also accumulating unmanaged at ~900 MB per generation (1.79 GB when measured).

## Changes

Adopt the cache handling WarpX uses:

- **Add `CleanUpCache`, `PostPR` and `CleanUpCachePostPR`.** The first keeps only the last used cache of each job per branch; the latter two drop all caches of a pull request once it is closed. `CleanUpCache` additionally prunes the CodeQL TRAP database caches, which carry neither the `ccache-` prefix nor a `-git-` separator and so need their own pass.

- **Only run on pushes to `development`.** Developers work from forks, whose pushes never trigger this repository; the only branches pushed here directly are mainline and the pre-commit.ci / dependabot update branches, which open PRs anyway. Running on those pushes as well only stored a second, redundant cache set under `refs/heads/<branch>` next to the `refs/pull/<n>/merge` one. A branch filter also excludes tag pushes, which would cache under the never-restorable `refs/heads/refs/tags/<tag>`. `codeql.yml` already did this, so it is unchanged.

## Notes

- The `workflows:` list in `cleanup-cache.yml` must stay in sync with the workflows that set up a cache — a name that does not match an existing workflow silently disables the cleanup for it. All eight names were verified against the `name:` fields in this branch.
- `🔍 CodeQL` is in the list even though it uses no ccache, because it produces the TRAP caches.
- `🪟 Windows` is in the list for its `build_win_msvc` job. The `build_win_clang` caches use `hashFiles()` keys instead of `-git-<sha>` ones and are intentionally left untouched by the pruning loop.