### PR TITLE
Element Accessors: Traits and KnownElements Getters/Setters

### DIFF
--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -10,6 +10,7 @@
 #include "ImpactX.H"
 #include "diagnostics/DiagnosticOutput.H"
 #include "diagnostics/FilePrefix.H"
+#include "elements/mixin/accessors.H"
 #include "elements/mixin/dynamicdata.H"
 #include "initialization/InitAmrCore.H"
 #include "particles/ImpactXParticleContainer.H"
@@ -66,9 +67,7 @@ namespace impactx {
         // loop over all beamline elements & finalize them
         for (auto & element_variant : m_lattice)
         {
-            std::visit([](auto&& element){
-                element.finalize();
-            }, element_variant);
+            elements::finalize(element_variant);
         }
     }
 

--- a/src/elements/mixin/accessors.H
+++ b/src/elements/mixin/accessors.H
@@ -14,7 +14,6 @@
 
 #include "elements/All.H"
 
-#include <AMReX_BLassert.H>
 #include <AMReX_REAL.H>
 
 #include <stdexcept>
@@ -38,9 +37,9 @@ namespace impactx::elements
      * these unqualified; the explicit ``elements::`` spelling is preferred for clarity.
      *
      * Getters are total: every lattice element provides ``ds()``, ``nslice()``, ``name()``,
-     * ``has_name()`` and a static ``type``. Setters are partial and assert on elements that
-     * do not support them, @see mixin::has_settable_ds_v, mixin::has_settable_nslice_v and
-     * mixin::is_named_v for the exact sets.
+     * ``has_name()`` and a static ``type``. Setters are partial and throw ``std::runtime_error``
+     * on elements that do not support them, @see mixin::has_settable_ds_v,
+     * mixin::has_settable_nslice_v and mixin::is_named_v for the exact sets.
      *
      * @note This header includes ``elements/All.H`` and therefore sits *above* the element
      *       definitions. Do not include it from an element header or from another header in
@@ -70,7 +69,7 @@ namespace impactx::elements
             if constexpr (mixin::has_settable_ds_v<decltype(element)>) {
                 element.m_ds = ds;
             } else {
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+                throw std::runtime_error(
                     "elements::ds: this element has no settable segment length.");
             }
         }, element_variant);
@@ -100,9 +99,13 @@ namespace impactx::elements
     {
         std::visit([nslice](auto & element) {
             if constexpr (mixin::has_settable_nslice_v<decltype(element)>) {
+                if (nslice <= 0) {
+                    throw std::runtime_error(
+                        "elements::nslice: nslice must be > 0.");
+                }
                 element.m_nslice = nslice;
             } else {
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+                throw std::runtime_error(
                     "elements::nslice: this element cannot be sliced.");
             }
         }, element_variant);
@@ -146,7 +149,7 @@ namespace impactx::elements
             if constexpr (mixin::is_named_v<decltype(element)>) {
                 element.set_name(name);
             } else {
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+                throw std::runtime_error(
                     "elements::name: this element has no settable name.");
             }
         }, element_variant);

--- a/src/elements/mixin/accessors.H
+++ b/src/elements/mixin/accessors.H
@@ -128,7 +128,9 @@ namespace impactx::elements
     inline std::string
     name (KnownElements const & element_variant)
     {
-        return std::visit([](auto const & element) { return element.name(); }, element_variant);
+        return std::visit([](auto const & element) {
+            return element.has_name() ? element.name() : std::string{};
+        }, element_variant);
     }
 
     /** Set the name of an element

--- a/src/elements/mixin/accessors.H
+++ b/src/elements/mixin/accessors.H
@@ -1,0 +1,284 @@
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_ELEMENTS_MIXIN_ACCESSORS_H
+#define IMPACTX_ELEMENTS_MIXIN_ACCESSORS_H
+
+#include "traits.H"
+
+#include "elements/All.H"
+
+#include <AMReX_BLassert.H>
+#include <AMReX_REAL.H>
+
+#include <string>
+#include <type_traits>
+#include <variant>
+
+
+namespace impactx::elements
+{
+    /** @file
+     *
+     * Property access on the ``KnownElements`` variant.
+     *
+     * These free functions wrap the ``std::visit`` dispatch that would otherwise be spelled
+     * out at every call site that only wants to read or write one element property. Getters
+     * and setters are overloaded on arity and named after the property itself, mirroring the
+     * element member functions: ``ds(element)`` reads, ``ds(element, 0.1)`` writes.
+     *
+     * Since ``KnownElements`` is a ``std::variant`` over types in this namespace, ADL finds
+     * these unqualified; the explicit ``elements::`` spelling is preferred for clarity.
+     *
+     * Getters are total: every lattice element provides ``ds()``, ``nslice()``, ``name()``,
+     * ``has_name()`` and a static ``type``. Setters are partial and assert on elements that
+     * do not support them, @see mixin::has_settable_ds_v, mixin::has_settable_nslice_v and
+     * mixin::is_named_v for the exact sets.
+     *
+     * @note This header includes ``elements/All.H`` and therefore sits *above* the element
+     *       definitions. Do not include it from an element header or from another header in
+     *       ``mixin/``. Those need the type-level traits instead, @see traits.H.
+     */
+
+    /** Return the segment length of an element
+     *
+     * @param element_variant the element to query
+     * @return value in meters, zero for zero-length elements
+     */
+    inline amrex::ParticleReal
+    ds (KnownElements const & element_variant)
+    {
+        return std::visit([](auto const & element) { return element.ds(); }, element_variant);
+    }
+
+    /** Set the segment length of an element
+     *
+     * @param[in,out] element_variant the element to modify
+     * @param ds segment length in meters
+     */
+    inline void
+    ds (KnownElements & element_variant, amrex::ParticleReal ds)
+    {
+        std::visit([ds](auto & element) {
+            if constexpr (mixin::has_settable_ds_v<decltype(element)>) {
+                element.m_ds = ds;
+            } else {
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+                    "elements::ds: this element has no settable segment length.");
+            }
+        }, element_variant);
+    }
+
+    /** Return the number of slices used for the application of collective effects
+     *
+     * @param element_variant the element to query
+     * @return positive integer, one for elements that cannot be sliced
+     */
+    inline int
+    nslice (KnownElements const & element_variant)
+    {
+        return std::visit([](auto const & element) { return element.nslice(); }, element_variant);
+    }
+
+    /** Set the number of slices used for the application of collective effects
+     *
+     * This subdivides the element's transport: the element then applies ``ds/nslice`` per
+     * push. @see ScopedNslice to do this temporarily.
+     *
+     * @param[in,out] element_variant the element to modify
+     * @param nslice number of slices, a positive integer
+     */
+    inline void
+    nslice (KnownElements & element_variant, int nslice)
+    {
+        std::visit([nslice](auto & element) {
+            if constexpr (mixin::has_settable_nslice_v<decltype(element)>) {
+                element.m_nslice = nslice;
+            } else {
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+                    "elements::nslice: this element cannot be sliced.");
+            }
+        }, element_variant);
+    }
+
+    /** Return the length of a single slice of an element
+     *
+     * @param element_variant the element to query
+     * @return ``ds/nslice`` in meters, zero for zero-length elements
+     */
+    inline amrex::ParticleReal
+    slice_ds (KnownElements const & element_variant)
+    {
+        return std::visit([](auto const & element) {
+            return element.ds() / element.nslice();
+        }, element_variant);
+    }
+
+    /** Return the name of an element
+     *
+     * @param element_variant the element to query
+     * @return the element name, or an empty string if it has none
+     */
+    inline std::string
+    name (KnownElements const & element_variant)
+    {
+        return std::visit([](auto const & element) { return element.name(); }, element_variant);
+    }
+
+    /** Set the name of an element
+     *
+     * @param[in,out] element_variant the element to modify
+     * @param name the new element name
+     */
+    inline void
+    name (KnownElements & element_variant, std::string const & name)
+    {
+        std::visit([&name](auto & element) {
+            if constexpr (mixin::is_named_v<decltype(element)>) {
+                element.set_name(name);
+            } else {
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+                    "elements::name: this element has no settable name.");
+            }
+        }, element_variant);
+    }
+
+    /** Does this element carry a name?
+     *
+     * @param element_variant the element to query
+     * @return true if the element has a name
+     */
+    inline bool
+    has_name (KnownElements const & element_variant)
+    {
+        return std::visit([](auto const & element) { return element.has_name(); }, element_variant);
+    }
+
+    /** Return the element type, e.g. "quad"
+     *
+     * @param element_variant the element to query
+     * @return the element's static type name
+     */
+    inline std::string
+    type (KnownElements const & element_variant)
+    {
+        return std::visit([](auto const & element) {
+            return std::string(std::decay_t<decltype(element)>::type);
+        }, element_variant);
+    }
+
+    /** Does this element have a finite length? (@see mixin::Thick)
+     *
+     * @param element_variant the element to query
+     * @return true for finite-length elements
+     */
+    inline bool
+    is_thick (KnownElements const & element_variant)
+    {
+        return std::visit([](auto const & element) {
+            return mixin::is_thick_v<decltype(element)>;
+        }, element_variant);
+    }
+
+    /** Does this element have zero length? (@see mixin::Thin)
+     *
+     * @param element_variant the element to query
+     * @return true for zero-length elements
+     */
+    inline bool
+    is_thin (KnownElements const & element_variant)
+    {
+        return std::visit([](auto const & element) {
+            return mixin::is_thin_v<decltype(element)>;
+        }, element_variant);
+    }
+
+    /** Can this element be subdivided by overriding its slice count?
+     *
+     * True for the elements that derive their per-push transport length from their own
+     * ``nslice()``, so that raising the slice count shortens one push. Note that this is
+     * narrower than "has a slice count": @see mixin::can_slice_v for which elements are
+     * excluded and why.
+     *
+     * @param element_variant the element to query
+     * @return true if the element can be subdivided, @see ScopedNslice
+     */
+    inline bool
+    can_slice (KnownElements const & element_variant)
+    {
+        return std::visit([](auto const & element) {
+            return mixin::can_slice_v<decltype(element)>;
+        }, element_variant);
+    }
+
+    /** Reverse an element in place
+     *
+     * After this call, pushing particles through the element reverses the effect of the
+     * original element. This is an involution.
+     *
+     * @param[in,out] element_variant the element to reverse
+     */
+    inline void
+    reverse (KnownElements & element_variant)
+    {
+        std::visit([](auto & element) { element.reverse(); }, element_variant);
+    }
+
+    /** Close and deallocate all data and handles of an element
+     *
+     * @param[in,out] element_variant the element to finalize
+     */
+    inline void
+    finalize (KnownElements & element_variant)
+    {
+        std::visit([](auto & element) { element.finalize(); }, element_variant);
+    }
+
+    /** Temporarily override an element's slice count, restoring it on scope exit
+     *
+     * Subdividing an element is how a caller shortens its transport: with the slice count
+     * temporarily doubled, each push advances ``ds/(2*nslice)`` instead of ``ds/nslice``.
+     * Restoring on scope exit keeps the lattice consistent even if the pushes in between
+     * throw, e.g. from a Programmable element's Python callback.
+     *
+     * The element must be sliceable, @see can_slice.
+     */
+    class ScopedNslice
+    {
+    public:
+        /** Override an element's slice count for the lifetime of this object
+         *
+         * @param[in,out] element_variant the element to subdivide
+         * @param nslice the temporary number of slices, a positive integer
+         */
+        ScopedNslice (KnownElements & element_variant, int nslice)
+        : m_element_variant(element_variant),
+          m_nslice_original(elements::nslice(element_variant))
+        {
+            elements::nslice(m_element_variant, nslice);
+        }
+
+        ~ScopedNslice ()
+        {
+            elements::nslice(m_element_variant, m_nslice_original);
+        }
+
+        ScopedNslice (ScopedNslice const &) = delete;
+        ScopedNslice & operator= (ScopedNslice const &) = delete;
+        ScopedNslice (ScopedNslice &&) = delete;
+        ScopedNslice & operator= (ScopedNslice &&) = delete;
+
+    private:
+        KnownElements & m_element_variant; //! the subdivided element
+        int m_nslice_original; //! slice count to restore on scope exit
+    };
+
+} // namespace impactx::elements
+
+#endif // IMPACTX_ELEMENTS_MIXIN_ACCESSORS_H

--- a/src/elements/mixin/accessors.H
+++ b/src/elements/mixin/accessors.H
@@ -4,7 +4,7 @@
  *
  * This file is part of ImpactX.
  *
- * Authors: Axel Huebl
+ * Authors: Axel Huebl, Edoardo Zoni, Chad Mitchell
  * License: BSD-3-Clause-LBNL
  */
 #ifndef IMPACTX_ELEMENTS_MIXIN_ACCESSORS_H

--- a/src/elements/mixin/accessors.H
+++ b/src/elements/mixin/accessors.H
@@ -17,6 +17,7 @@
 #include <AMReX_BLassert.H>
 #include <AMReX_REAL.H>
 
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <variant>
@@ -247,7 +248,7 @@ namespace impactx::elements
      * Subdividing an element is how a caller shortens its transport: with the slice count
      * temporarily doubled, each push advances ``ds/(2*nslice)`` instead of ``ds/nslice``.
      * Restoring on scope exit keeps the lattice consistent even if the pushes in between
-     * throw, e.g. from a Programmable element's Python callback.
+     * throw.
      *
      * The element must be sliceable, @see can_slice.
      */
@@ -263,6 +264,10 @@ namespace impactx::elements
         : m_element_variant(element_variant),
           m_nslice_original(elements::nslice(element_variant))
         {
+            if (!elements::can_slice(m_element_variant)) {
+                throw std::runtime_error(
+                    "elements::ScopedNslice: this element cannot be sliced.");
+            }
             elements::nslice(m_element_variant, nslice);
         }
 

--- a/src/elements/mixin/beamoptic.H
+++ b/src/elements/mixin/beamoptic.H
@@ -13,6 +13,7 @@
 #include "alignment.H"
 #include "pipeaperture.H"
 #include "spintransport.H"
+#include "traits.H"
 
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/PushAll.H"
@@ -272,8 +273,8 @@ namespace detail
 #endif
 
             // pre/post-push functionality declared by mixin classes
-            constexpr bool has_alignment = std::is_base_of_v<mixin::Alignment, T_Element> && T_DoAlignment;
-            constexpr bool has_aperture = std::is_base_of_v<mixin::PipeAperture, T_Element>;
+            constexpr bool has_alignment = mixin::has_alignment_v<T_Element> && T_DoAlignment;
+            constexpr bool has_aperture = mixin::has_pipe_aperture_v<T_Element>;
 
             // shift into the alignment-error frame (compile-time gated)
             if constexpr (has_alignment) {
@@ -423,8 +424,8 @@ namespace detail
 #endif
 
             // pre/post-push functionality declared by mixin classes
-            constexpr bool has_alignment = std::is_base_of_v<mixin::Alignment, T_Element> && T_DoAlignment;
-            constexpr bool has_aperture = std::is_base_of_v<mixin::PipeAperture, T_Element>;
+            constexpr bool has_alignment = mixin::has_alignment_v<T_Element> && T_DoAlignment;
+            constexpr bool has_aperture = mixin::has_pipe_aperture_v<T_Element>;
 
             // shift into the alignment-error frame (compile-time gated)
             if constexpr (has_alignment) {
@@ -494,7 +495,7 @@ namespace detail
     template< typename T_Element, typename F >
     void dispatch_misalignment ([[maybe_unused]] T_Element & element, F && f)
     {
-        if constexpr (std::is_base_of_v<mixin::Alignment, std::decay_t<T_Element>>) {
+        if constexpr (mixin::has_alignment_v<T_Element>) {
 #ifdef ImpactX_OPTIMIZE_ALIGNMENT
             if (element.misaligned()) { f(std::true_type{}); }
             else                      { f(std::false_type{}); }
@@ -531,7 +532,7 @@ namespace detail
         uint64_t* const AMREX_RESTRICT part_idcpu = soa.GetIdCPUData().dataPtr();
 
         if (spin) {
-            if constexpr (std::is_base_of_v<mixin::SpinTransport, std::decay_t<T_Element>>) {
+            if constexpr (mixin::has_spin_transport_v<T_Element>) {
                 amrex::ParticleReal* const AMREX_RESTRICT part_sx = soa_real[RealSoA::sx].dataPtr();
                 amrex::ParticleReal* const AMREX_RESTRICT part_sy = soa_real[RealSoA::sy].dataPtr();
                 amrex::ParticleReal* const AMREX_RESTRICT part_sz = soa_real[RealSoA::sz].dataPtr();

--- a/src/elements/mixin/traits.H
+++ b/src/elements/mixin/traits.H
@@ -1,0 +1,142 @@
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
+ *           Berkeley National Laboratory (subject to receipt of any required
+ *           approvals from the U.S. Dept. of Energy). All rights reserved.
+ *
+ * This file is part of ImpactX.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef IMPACTX_ELEMENTS_MIXIN_TRAITS_H
+#define IMPACTX_ELEMENTS_MIXIN_TRAITS_H
+
+#include "alignment.H"
+#include "named.H"
+#include "pipeaperture.H"
+#include "spintransport.H"
+#include "thick.H"
+#include "thin.H"
+
+#include <AMReX_REAL.H>
+
+#include <type_traits>
+#include <utility>
+
+
+namespace impactx::elements::mixin
+{
+    /** @file
+     *
+     * Compile-time traits over a *concrete* lattice element type.
+     *
+     * These replace the hand-spelled
+     * ``std::is_base_of_v<mixin::X, std::remove_cv_t<std::remove_reference_t<decltype(el)>>>``
+     * at the call sites: the decay is applied inside the trait, so a trait can be used
+     * directly on the deduced type of a ``std::visit`` or ``BeamOptic`` lambda parameter.
+     *
+     * This header deliberately does not include ``elements/All.H``, so it can be used from
+     * element headers, from other mixins (e.g. @see beamoptic.H) and from the Python
+     * bindings. For dispatch over the ``KnownElements`` variant @see accessors.H.
+     */
+
+    /** Does this element have a finite length (@see Thick)? */
+    template<typename T_Element>
+    inline constexpr bool is_thick_v = std::is_base_of_v<Thick, std::decay_t<T_Element>>;
+
+    /** Does this element have zero length (@see Thin)? */
+    template<typename T_Element>
+    inline constexpr bool is_thin_v = std::is_base_of_v<Thin, std::decay_t<T_Element>>;
+
+    /** Does this element carry a user-settable name (@see Named)? */
+    template<typename T_Element>
+    inline constexpr bool is_named_v = std::is_base_of_v<Named, std::decay_t<T_Element>>;
+
+    /** Does this element support alignment errors (@see Alignment)? */
+    template<typename T_Element>
+    inline constexpr bool has_alignment_v = std::is_base_of_v<Alignment, std::decay_t<T_Element>>;
+
+    /** Does this element support a transverse beam pipe aperture (@see PipeAperture)? */
+    template<typename T_Element>
+    inline constexpr bool has_pipe_aperture_v = std::is_base_of_v<PipeAperture, std::decay_t<T_Element>>;
+
+    /** Does this element support spin transport (@see SpinTransport)? */
+    template<typename T_Element>
+    inline constexpr bool has_spin_transport_v = std::is_base_of_v<SpinTransport, std::decay_t<T_Element>>;
+
+    namespace detail
+    {
+        /** Does this element have a publicly writable ``m_ds`` member?
+         *
+         * std::void_t detection idiom. Note that presence alone does not imply that ``m_ds``
+         * is the element's segment length, @see has_settable_ds_v.
+         */
+        template<typename T_Element, typename = void>
+        struct has_m_ds : std::false_type {};
+
+        template<typename T_Element>
+        struct has_m_ds<
+            T_Element,
+            std::void_t<decltype(std::declval<std::decay_t<T_Element> &>().m_ds = amrex::ParticleReal(0))>
+        > : std::true_type {};
+
+        /** Does this element have a publicly writable ``m_nslice`` member? */
+        template<typename T_Element, typename = void>
+        struct has_m_nslice : std::false_type {};
+
+        template<typename T_Element>
+        struct has_m_nslice<
+            T_Element,
+            std::void_t<decltype(std::declval<std::decay_t<T_Element> &>().m_nslice = 1)>
+        > : std::true_type {};
+
+    } // namespace detail
+
+    /** Can this element's segment length be set?
+     *
+     * True for all finite-length elements: everything deriving from @see Thick, plus
+     * Programmable, LinearMap and SpinMap, which carry their own ``m_ds``.
+     *
+     * The ``!is_thin_v`` term is load-bearing and *not* redundant with the member detection:
+     * ThinDipole is a zero-length element (@see Thin, so ``ds()`` returns 0) that nevertheless
+     * owns an ``m_ds`` member holding its *effective (equivalent) arc length* ``theta * rc``.
+     * Detection alone would let a setter silently overwrite that with a segment length.
+     */
+    template<typename T_Element>
+    inline constexpr bool has_settable_ds_v = std::conjunction_v<
+        std::bool_constant<!is_thin_v<T_Element>>,
+        detail::has_m_ds<T_Element>
+    >;
+
+    /** Can this element's slice count be set?
+     *
+     * True for everything deriving from @see Thick, plus Programmable, which carries its own
+     * ``m_nslice``. False for LinearMap and SpinMap: those have a finite ``ds`` but their
+     * ``nslice()`` returns a literal 1.
+     */
+    template<typename T_Element>
+    inline constexpr bool has_settable_nslice_v = std::conjunction_v<
+        std::bool_constant<!is_thin_v<T_Element>>,
+        detail::has_m_nslice<T_Element>
+    >;
+
+    /** Can this element be subdivided by overriding its slice count?
+     *
+     * True exactly for the elements that derive their per-push transport length from their
+     * own ``nslice()`` at push time, i.e. everything deriving from @see Thick. Only for those
+     * does temporarily raising the slice count actually shorten the transport of one push,
+     * @see ScopedNslice in accessors.H.
+     *
+     * This is deliberately narrower than @see has_settable_nslice_v:
+     * - Programmable *stores* a slice count, but its push is an opaque user callback. The
+     *   callback reads ``ds`` and ``nslice`` from the user's own Python object, while the
+     *   lattice holds a copy — a temporary override is invisible to it, and the callback
+     *   would transport a full slice on each of the two half-maps.
+     * - LinearMap and SpinMap have a finite ``ds`` but no slice count to raise: their
+     *   ``nslice()`` returns a literal 1.
+     */
+    template<typename T_Element>
+    inline constexpr bool can_slice_v = is_thick_v<T_Element>;
+
+} // namespace impactx::elements::mixin
+
+#endif // IMPACTX_ELEMENTS_MIXIN_TRAITS_H

--- a/src/elements/mixin/traits.H
+++ b/src/elements/mixin/traits.H
@@ -4,7 +4,7 @@
  *
  * This file is part of ImpactX.
  *
- * Authors: Axel Huebl
+ * Authors: Axel Huebl, Edoardo Zoni, Chad Mitchell
  * License: BSD-3-Clause-LBNL
  */
 #ifndef IMPACTX_ELEMENTS_MIXIN_TRAITS_H

--- a/src/elements/transformation/Insert.cpp
+++ b/src/elements/transformation/Insert.cpp
@@ -9,9 +9,9 @@
  */
 #include "elements/transformation/Insert.H"
 
+#include "elements/mixin/accessors.H"
+
 #include <stdexcept>
-#include <type_traits>
-#include <variant>
 
 
 namespace impactx::elements::transformation
@@ -24,11 +24,7 @@ namespace impactx::elements::transformation
     )
     {
         // algorithm below is so far only implemented for thin elements to insert
-        double new_element_ds = 0.0;  // in meters
-        std::visit([&new_element_ds](auto &&new_element)
-        {
-            new_element_ds = new_element.ds();
-        }, element);
+        double const new_element_ds = elements::ds(element);  // in meters
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             new_element_ds == 0,
             "insert_element_ever_s: Only thin elements are supported."
@@ -46,40 +42,26 @@ namespace impactx::elements::transformation
             list.pop_front();
 
             // check where the current element ends
-            double cur_s_out;  // in meters
-            std::visit([&s, &cur_s_out](auto &&cur_element)
-            {
-                cur_s_out = s + cur_element.ds();
-            }, cur_element_variant);
+            double const cur_s_out = s + elements::ds(cur_element_variant);  // in meters
 
             // case 1: current element is thick and ends after next insert
             if (s_next_insert < cur_s_out)
             {
                 double const s_rel_insert = s_next_insert - s;
 
+                if (elements::is_thin(cur_element_variant))
+                {
+                    throw std::runtime_error("insert_element_ever_s: Thin element cannot be split.");
+                }
+
                 // split element and shorten each part
                 elements::KnownElements cur_element_leftover = cur_element_variant;
-                std::visit([&s_rel_insert](auto &&cur_element)
-                {
-                    if constexpr(std::is_base_of_v<elements::mixin::Thin, std::decay_t<decltype(cur_element)>>)
-                    {
-                        throw std::runtime_error("insert_element_ever_s: Thin element cannot be split.");
-                    }
-                    else {
-                        cur_element.m_ds = static_cast<amrex::ParticleReal>(s_rel_insert);
-                    }
-                }, cur_element_variant);
-                std::visit([&s_rel_insert](auto &&cur_element_left)
-                {
-                    if constexpr(std::is_base_of_v<elements::mixin::Thin, std::decay_t<decltype(cur_element_left)>>)
-                    {
-                        throw std::runtime_error("insert_element_ever_s: Thin element cannot be split.");
-                    }
-                    else {
-                        cur_element_left.m_ds -= static_cast<amrex::ParticleReal>(s_rel_insert);
-                        cur_element_left.set_name(cur_element_left.name() + "_leftover");
-                    }
-                }, cur_element_leftover);
+                elements::ds(cur_element_variant, static_cast<amrex::ParticleReal>(s_rel_insert));
+                elements::ds(
+                    cur_element_leftover,
+                    elements::ds(cur_element_leftover) - static_cast<amrex::ParticleReal>(s_rel_insert)
+                );
+                elements::name(cur_element_leftover, elements::name(cur_element_leftover) + "_leftover");
 
                 // insert element in between
                 new_list.push_back(cur_element_variant);

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -7,6 +7,7 @@
 
 #include <particles/Push.H>
 #include <elements/All.H>
+#include <elements/mixin/accessors.H>
 #include <particles/CovarianceMatrix.H>
 
 #include <AMReX_Enum.H>
@@ -214,7 +215,7 @@ namespace
         std::string extra_args;
 
         // properties of mixin classes
-        if constexpr (std::is_base_of_v<elements::mixin::Thick, std::decay_t<T_Element>>) {
+        if constexpr (elements::mixin::is_thick_v<T_Element>) {
             extra_args.append(format_extra(std::make_pair("ds", el.ds())));
         }
 
@@ -285,12 +286,12 @@ namespace
             // for thin elements, nslice is 1 by definition and not a constructor argument
             ret.insert(std::make_pair("nslice", el.nslice()));
         }
-        if constexpr (std::is_base_of_v<elements::mixin::Alignment, std::decay_t<T_Element>>) {
+        if constexpr (elements::mixin::has_alignment_v<T_Element>) {
             ret.insert(std::make_pair("dx", el.dx()));
             ret.insert(std::make_pair("dy", el.dy()));
             ret.insert(std::make_pair("rotation", el.rotation()));
         }
-        if constexpr (std::is_base_of_v<elements::mixin::PipeAperture, std::decay_t<T_Element>>) {
+        if constexpr (elements::mixin::has_pipe_aperture_v<T_Element>) {
             ret.insert(std::make_pair("aperture_x", el.aperture_x()));
             ret.insert(std::make_pair("aperture_y", el.aperture_y()));
         }
@@ -2934,7 +2935,7 @@ void init_elements(py::module& m)
     );
 
     m.def("reverse", [](elements::KnownElements & el) {
-            std::visit([](auto && e) { e.reverse(); }, el);
+            elements::reverse(el);
         },
         py::arg("element"),
         "Reverse an element in-place so that pushing particles through\n"

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -9,6 +9,7 @@
  */
 #include "ImpactX.H"
 #include "diagnostics/DiagnosticOutput.H"
+#include "elements/mixin/accessors.H"
 #include "envelope/spacecharge/EnvelopeSpaceChargePush.H"
 #include "initialization/Algorithms.H"
 #include "initialization/InitAmrCore.H"
@@ -147,13 +148,8 @@ namespace impactx
                 call_hook("before_element");
 
                 // number of slices used for the application of space charge
-                int nslice = 1;
-                amrex::ParticleReal slice_ds; // in meters
-                std::visit([&nslice, &slice_ds](auto &&element)
-                {
-                    nslice = element.nslice();
-                    slice_ds = element.ds() / nslice;
-                }, element_variant);
+                int const nslice = elements::nslice(element_variant);
+                amrex::ParticleReal const slice_ds = elements::slice_ds(element_variant); // in meters
 
                 // sub-steps for space charge within the element
                 for (int slice_step = 0; slice_step < nslice; ++slice_step)

--- a/src/tracking/particles.H
+++ b/src/tracking/particles.H
@@ -11,6 +11,7 @@
 #define IMPACTX_TRACKING_PARTICLES_H
 
 #include "elements/All.H"
+#include "elements/mixin/accessors.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "tracking/TrackingDirection.H"
 #include "tracking/TrackingState.H"
@@ -22,7 +23,6 @@
 
 #include <list>
 #include <string>
-#include <variant>
 
 
 namespace impactx
@@ -103,16 +103,12 @@ namespace impactx
             {
                 // back-tracking: invert this element's map in place so the element
                 // transport below applies the inverse map.
-                std::visit([](auto && element){ element.reverse(); }, element_variant);
+                elements::reverse(element_variant);
             }
 
             // number of slices used for the application of space charge
-            int nslice = 1;
-            amrex::ParticleReal slice_ds = 0; // in meters
-            std::visit([&nslice, &slice_ds](auto && element) {
-                nslice = element.nslice();
-                slice_ds = element.ds() / nslice;
-            }, element_variant);
+            int const nslice = elements::nslice(element_variant);
+            amrex::ParticleReal const slice_ds = elements::slice_ds(element_variant); // in meters
 
             // sub-steps for space charge within the element
             for (int s = 0; s < nslice; ++s)
@@ -153,7 +149,7 @@ namespace impactx
             else
             {
                 // restore the forward element map (reverse() is an involution)
-                std::visit([](auto && element){ element.reverse(); }, element_variant);
+                elements::reverse(element_variant);
             }
         };
 

--- a/src/tracking/reference.cpp
+++ b/src/tracking/reference.cpp
@@ -9,6 +9,7 @@
  */
 #include "ImpactX.H"
 #include "diagnostics/DiagnosticOutput.H"
+#include "elements/mixin/accessors.H"
 #include "initialization/Algorithms.H"
 #include "initialization/InitAmrCore.H"
 #include "particles/ImpactXParticleContainer.H"
@@ -105,13 +106,7 @@ namespace impactx
                 call_hook("before_element");
 
                 // number of slices through the element
-                int nslice = 1;
-                amrex::ParticleReal slice_ds; // in meters
-                std::visit([&nslice, &slice_ds](auto &&element)
-                {
-                    nslice = element.nslice();
-                    slice_ds = element.ds() / nslice;
-                }, element_variant);
+                int const nslice = elements::nslice(element_variant);
 
                 // sub-steps within the element
                 for (int slice_step = 0; slice_step < nslice; ++slice_step)

--- a/tests/python/test_lattice_insert.py
+++ b/tests/python/test_lattice_insert.py
@@ -41,3 +41,21 @@ def test_element_insert():
 
     # clean shutdown
     monitor.finalize()
+
+
+def test_element_insert_unnamed():
+    """Splitting an unnamed element gives its leftover segments generated names."""
+    lattice = elements.transformation.insert_element_every_ds(
+        elements.KnownElementsList([elements.Drift(ds=0.25)]),
+        ds=0.1,
+        element=elements.Empty(),
+    )
+
+    drifts = [el for el in lattice if el.to_dict()["type"] == "Drift"]
+
+    assert len(lattice) == 5
+    assert [drift.name for drift in drifts] == [
+        None,
+        "_leftover",
+        "_leftover_leftover",
+    ]


### PR DESCRIPTION
Dispatching over the `KnownElements` variant to read or write a single element property is spelled out with `std::visit` at 15 places across tracking, diagnostics, lattice transformations and the Python bindings. Each one
re-derives the element type with `std::remove_cv_t<std::remove_reference_t<decltype(element)>>` or `std::is_base_of_v<mixin::X, std::decay_t<T>>`.

Add two headers for this:

- `elements/mixin/traits.H`: compile-time traits over a concrete element type
  (`is_thick_v`, `is_thin_v`, `is_named_v`, `has_alignment_v`, `has_pipe_aperture_v`,
  `has_spin_transport_v`, `can_slice_v`, `has_settable_ds_v`/`nslice_v`). The decay is
  applied inside the trait, so they work directly on the deduced type of a
  visit or `BeamOptic` lambda parameter. This header does not include `All.H`, so
  element headers, other mixins and the Python bindings can use it.

- `elements/mixin/accessors.H`: free functions over the `KnownElements` variant,
  overloaded on arity and named after the property, mirroring the element
  member functions: `ds(element)` reads, `ds(element, 0.1)` writes. Also `nslice`,
  `slice_ds`, `name`, `has_name`, `type`, `is_thick`, `is_thin`, `can_slice`, `reverse`,
  `finalize`, and a `ScopedNslice` guard that restores an element's slice count on
  scope exit.

Setters are partial and assert on unsupported elements.

Used in #1530