### PR TITLE
MAD-X/PALS Load File: `min_model=...`

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1015,7 +1015,7 @@ This module provides elements and methods for the accelerator lattice.
       starts out with at least the requested level of physical fidelity
       (see :ref:`theory-assumptions`):
 
-      * ``"linear"`` (default) reproduces the historic behavior
+      * ``"linear"`` (default) uses the linear model
       * ``"paraxial"`` requires at least the chromatic ``Chr*`` models
       * ``"exact"`` requires at least the exact-Hamiltonian ``Exact*`` models
 
@@ -1066,7 +1066,7 @@ This module provides elements and methods for the accelerator lattice.
       the same at every floor.
       Their *length*, however, is carried by drifts that the reader adds around
       that kick, and those follow ``min_model`` like any other drift.
-      A finite-length ``RFCAVITY``, for example, becomes
+      A finite-length ``RFCAVITY`` is a thin kick model, for example, becomes
       ``ExactDrift`` + ``ShortRF`` + ``ExactDrift`` at ``min_model="exact"``.
       The same applies to the drifts emitted for ``COLLIMATOR``, ``INSTRUMENT``,
       ``PLACEHOLDER`` and for a ``MONITOR`` with ``L > 0``.

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1005,9 +1005,64 @@ This module provides elements and methods for the accelerator lattice.
 
       Add a single element to the list.
 
-   .. py:method:: load_file(filename, nslice=1)
+   .. py:method:: load_file(filename, nslice=1, min_model="linear")
 
       Load and append a lattice file from MAD-X (.madx) or PALS (e.g., .pals.yaml) formats.
+
+      The reader picks the *cheapest* ImpactX element that represents each imported
+      element.
+      ``min_model`` raises the lower gate of that choice, so that an imported lattice
+      starts out with at least the requested level of physical fidelity
+      (see :ref:`theory-assumptions`):
+
+      * ``"linear"`` (default) reproduces the historic behavior
+      * ``"paraxial"`` requires at least the chromatic ``Chr*`` models
+      * ``"exact"`` requires at least the exact-Hamiltonian ``Exact*`` models
+
+      A floor never *lowers* a model.
+      An element that already requires a richer model, such as a skew quadrupole
+      that only exists as ``ExactMultipole``, keeps it.
+      Where a tier is not implemented for an element family, the next higher one is
+      used.
+      Where no model reaches the requested tier at all, the most faithful model
+      available is used and a warning is emitted:
+
+      .. list-table::
+         :header-rows: 1
+         :widths: 20 25 25 30
+
+         * - MAD-X element
+           - ``"linear"``
+           - ``"paraxial"``
+           - ``"exact"``
+         * - ``DRIFT``
+           - ``Drift``
+           - ``ChrDrift``
+           - ``ExactDrift``
+         * - ``QUADRUPOLE``
+           - ``Quad``
+           - ``ChrQuad``
+           - ``ExactQuad``
+         * - ``SBEND``, ``RBEND``
+           - ``Sbend`` / ``CFbend``
+           - ``ExactSbend`` / ``ExactCFbend``
+           - ``ExactSbend`` / ``ExactCFbend``
+         * - ``DIPEDGE`` (and bend edges)
+           - ``DipEdge(model="linear")``
+           - ``DipEdge(model="nonlinear")``
+           - ``DipEdge(model="nonlinear")``
+         * - ``SOLENOID``
+           - ``Sol``
+           - ``Sol`` (warns)
+           - ``Sol`` (warns)
+         * - ``SEXTUPOLE``, ``OCTUPOLE``, skew ``QUADRUPOLE``
+           - ``ExactMultipole``
+           - ``ExactMultipole``
+           - ``ExactMultipole``
+
+      Elements that MAD-X itself defines as thin (``MULTIPOLE``, ``KICKER``,
+      ``RFCAVITY``, ``NLLENS``) and structural elements (``MARKER``, apertures,
+      monitors) have no model tiers and are unaffected.
 
       .. warning::
 
@@ -1019,15 +1074,30 @@ This module provides elements and methods for the accelerator lattice.
 
          *synmadx*, our :ref:`alternative MAD-X parser <usage-python-synmadx>` ported from Synergia.
 
+         :py:meth:`impactx.elements.FilteredElementsList.replace_with_drifts` uses the
+         same ``"linear"``/``"paraxial"``/``"exact"`` vocabulary for its ``model``
+         parameter.
+
       :param filename: filename to file with beamline elements
       :param nslice: number of slices used for the application of collective effects
+      :param min_model: lowest element model to translate into, one of ``"linear"``
+         (default), ``"paraxial"`` or ``"exact"``
 
-   .. py:method:: from_pals(pals_line, nslice=1)
+      **Example:**
+
+      .. code-block:: python
+
+         # import a lattice with at least exact-Hamiltonian element models
+         sim.lattice.load_file("fodo.madx", nslice=25, min_model="exact")
+
+   .. py:method:: from_pals(pals_line, nslice=1, min_model="linear")
 
       Load and append a lattice from a Particle Accelerator Lattice Standard (PALS) Python Line.
 
       :param pals_line: PALS Python Line with beamline elements
       :param nslice: number of slices used for the application of collective effects
+      :param min_model: lowest element model to translate into, see
+         :py:meth:`~impactx.elements.KnownElementsList.load_file`
 
    .. py:method:: select(kind=None, name=None)
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1005,7 +1005,7 @@ This module provides elements and methods for the accelerator lattice.
 
       Add a single element to the list.
 
-   .. py:method:: load_file(filename, nslice=1, min_model="linear")
+   .. py:method:: load_file(filename, nslice=1, *, min_model="linear")
 
       Load and append a lattice file from MAD-X (.madx) or PALS (e.g., .pals.yaml) formats.
 
@@ -1062,7 +1062,14 @@ This module provides elements and methods for the accelerator lattice.
 
       Elements that MAD-X itself defines as thin (``MULTIPOLE``, ``KICKER``,
       ``RFCAVITY``, ``NLLENS``) and structural elements (``MARKER``, apertures,
-      monitors) have no model tiers and are unaffected.
+      monitors) have no model tiers, so the kick or map they translate into is
+      the same at every floor.
+      Their *length*, however, is carried by drifts that the reader adds around
+      that kick, and those follow ``min_model`` like any other drift.
+      A finite-length ``RFCAVITY``, for example, becomes
+      ``ExactDrift`` + ``ShortRF`` + ``ExactDrift`` at ``min_model="exact"``.
+      The same applies to the drifts emitted for ``COLLIMATOR``, ``INSTRUMENT``,
+      ``PLACEHOLDER`` and for a ``MONITOR`` with ``L > 0``.
 
       .. warning::
 
@@ -1090,7 +1097,7 @@ This module provides elements and methods for the accelerator lattice.
          # import a lattice with at least exact-Hamiltonian element models
          sim.lattice.load_file("fodo.madx", nslice=25, min_model="exact")
 
-   .. py:method:: from_pals(pals_line, nslice=1, min_model="linear")
+   .. py:method:: from_pals(pals_line, nslice=1, *, min_model="linear")
 
       Load and append a lattice from a Particle Accelerator Lattice Standard (PALS) Python Line.
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1053,8 +1053,8 @@ This module provides elements and methods for the accelerator lattice.
            - ``DipEdge(model="nonlinear")``
          * - ``SOLENOID``
            - ``Sol``
-           - ``Sol`` (warns)
-           - ``Sol`` (warns)
+           - ``ChrAcc(ez=0)``
+           - ``ChrAcc(ez=0)`` (warns)
          * - ``SEXTUPOLE``, ``OCTUPOLE``, skew ``QUADRUPOLE``
            - ``ExactMultipole``
            - ``ExactMultipole``
@@ -1064,6 +1064,18 @@ This module provides elements and methods for the accelerator lattice.
       reader translates a combined normal and skew quadrupole as one multipole,
       not because the cheaper tiers could not express it: a pure skew quadrupole
       is also a ``Quad`` or ``ChrQuad`` under a 45 degree ``rotation``.
+
+      The paraxial ``SOLENOID`` is ``ChrAcc`` with ``ez=0``, which is the same
+      hard-edge solenoid map for the reference particle and adds the chromatic
+      dependence.
+      ``Sol`` takes its strength per unit rigidity, as ``ks``, while ``ChrAcc``
+      takes ``bz = ks * beta_gamma``, so the paraxial solenoid is pinned to the
+      reference energy that the MAD-X ``BEAM`` command declares.
+      Changing the reference energy after the import does not rescale it, and the
+      reader warns when it applies this translation.
+      Only an ``ENERGY`` that the file actually states is used for this: MAD-X
+      defaults it to 1 GeV, so a lattice whose ``BEAM`` command omits it keeps
+      ``Sol`` at every floor rather than converting against an assumed energy.
 
       Elements that MAD-X itself defines as thin (``MULTIPOLE``, ``KICKER``,
       ``RFCAVITY``, ``NLLENS``) and structural elements (``MARKER``, apertures,

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1020,7 +1020,7 @@ This module provides elements and methods for the accelerator lattice.
       * ``"exact"`` requires at least the exact-Hamiltonian ``Exact*`` models
 
       A floor never *lowers* a model.
-      An element that already requires a richer model, such as a skew quadrupole
+      An element that already requires a richer model, such as a thick octupole
       that only exists as ``ExactMultipole``, keeps it.
       Where a tier is not implemented for an element family, the next higher one is
       used.
@@ -1059,6 +1059,11 @@ This module provides elements and methods for the accelerator lattice.
            - ``ExactMultipole``
            - ``ExactMultipole``
            - ``ExactMultipole``
+
+      A skew ``QUADRUPOLE`` reaches ``ExactMultipole`` at every floor because the
+      reader translates a combined normal and skew quadrupole as one multipole,
+      not because the cheaper tiers could not express it: a pure skew quadrupole
+      is also a ``Quad`` or ``ChrQuad`` under a 45 degree ``rotation``.
 
       Elements that MAD-X itself defines as thin (``MULTIPOLE``, ``KICKER``,
       ``RFCAVITY``, ``NLLENS``) and structural elements (``MARKER``, apertures,

--- a/src/python/impactx/MADXParser.py
+++ b/src/python/impactx/MADXParser.py
@@ -748,6 +748,10 @@ class Beam:
 
     particle: str = ""
     energy: float = 1.0  # GeV, MAD-X default
+    # Whether `energy` came from a BEAM command or is the MAD-X default above.
+    # Consumers that would silently produce wrong physics from an assumed
+    # energy, rather than a merely imprecise one, check this first.
+    energy_is_explicit: bool = False
     pc: float = 0.0  # momentum
     mass: float = 0.0
     charge: float = 0.0
@@ -826,6 +830,7 @@ class EvaluationContext:
             self.beams[sequence_name] = Beam(
                 particle=default.particle,
                 energy=default.energy,
+                energy_is_explicit=default.energy_is_explicit,
                 pc=default.pc,
                 mass=default.mass,
                 charge=default.charge,
@@ -2257,6 +2262,8 @@ class MADXParser:
         beam = self.context.get_beam_for_sequence(sequence_name)
         for attr, value in beam_attrs.items():
             setattr(beam, attr, value)
+        if "energy" in beam_attrs:
+            beam.energy_is_explicit = True
 
     def _parse_use_command(self):
         """Parse the USE command."""

--- a/src/python/impactx/element_models.py
+++ b/src/python/impactx/element_models.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 ImpactX contributors
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+"""Shared vocabulary for the ImpactX element model tiers.
+
+ImpactX implements most beamline elements at up to three levels of physical
+fidelity, documented in ``docs/source/theory/assumptions.rst``:
+
+============ =========================== ==========================
+tier         class name prefix           example
+============ =========================== ==========================
+``linear``   (none)                      ``Drift``, ``Quad``
+``paraxial`` ``Chr``                     ``ChrDrift``, ``ChrQuad``
+``exact``    ``Exact``                   ``ExactDrift``, ``ExactQuad``
+============ =========================== ==========================
+
+Cheaper tiers run faster, richer tiers model more physics. This module holds
+the one place of truth for that ordering, so that every user-facing knob that
+selects a model speaks the same language. Those knobs are
+``KnownElementsList.load_file(min_model=...)`` and
+``FilteredElementsList.replace_with_drifts(model=...)``.
+
+Not every element family implements every tier. There is no ``ChrSbend`` and no
+``ExactSol``, for instance. :func:`select_model` therefore takes a table of the
+tiers that a family *does* implement and rounds a requested minimum tier *up* to
+the cheapest implemented one that satisfies it.
+"""
+
+from functools import partial
+
+from impactx import elements
+
+#: The model tiers, ordered from cheapest/simplest to most faithful.
+MODEL_TIERS = ("linear", "paraxial", "exact")
+
+_MODEL_RANK = {tier: rank for rank, tier in enumerate(MODEL_TIERS)}
+
+
+def tier_rank(model: str) -> int:
+    """Return the ordering rank of a model tier (higher = more faithful)."""
+    return _MODEL_RANK[model]
+
+
+def validate_model(model: str, *, argument: str = "min_model", extra_values=()) -> str:
+    """Raise ``ValueError`` unless ``model`` names a known tier.
+
+    :param model: the value to check
+    :param argument: name of the user-facing argument, used in the error message
+    :param extra_values: additional accepted values beyond :data:`MODEL_TIERS`
+    :return: ``model``, unchanged
+    """
+    allowed = set(MODEL_TIERS) | set(extra_values)
+    if model not in allowed:
+        raise ValueError(f"{argument} must be one of {sorted(allowed)}, got {model!r}")
+    return model
+
+
+def tier_of_class(type_name: str) -> str:
+    """Return the model tier of an ImpactX element class name.
+
+    The class-name prefix *is* the tier. ``Exact*`` is exact, ``Chr*`` is
+    paraxial, everything else is linear.
+    """
+    if type_name.startswith("Exact"):
+        return "exact"
+    if type_name.startswith("Chr"):
+        return "paraxial"
+    return "linear"
+
+
+def select_model(builders: dict, min_model: str):
+    """Pick the cheapest implemented model tier that is at least ``min_model``.
+
+    :param builders: maps tier name to a callable creating the element. A family
+        registers only the tiers ImpactX actually implements. A feature-driven
+        requirement, such as skew multipoles needing the exact model, is
+        expressed by omitting the cheaper tiers.
+    :param min_model: the requested fidelity floor, one of :data:`MODEL_TIERS`
+    :return: ``(tier, builder)``. If no implemented tier reaches ``min_model``,
+        the highest implemented tier is returned instead. Callers detect that
+        case by comparing the returned tier against ``min_model`` and warn.
+    """
+    floor = _MODEL_RANK[min_model]
+    tiers = sorted(builders, key=_MODEL_RANK.__getitem__)
+    for tier in tiers:
+        if _MODEL_RANK[tier] >= floor:
+            return tier, builders[tier]
+    return tiers[-1], builders[tiers[-1]]
+
+
+#: Drift models per tier. All three share one constructor signature.
+DRIFT_MODEL_CLASSES = {
+    "linear": elements.Drift,
+    "paraxial": elements.ChrDrift,
+    "exact": elements.ExactDrift,
+}
+
+#: Quadrupole models per tier. ``unit=0`` is the MAD-X convention (``k`` in
+#: m^(-2)). Plain ``Quad`` is the only one without a ``unit`` argument and
+#: always assumes that convention.
+QUAD_MODEL_CLASSES = {
+    "linear": elements.Quad,
+    "paraxial": partial(elements.ChrQuad, unit=0),
+    "exact": partial(elements.ExactQuad, unit=0),
+}

--- a/src/python/impactx/element_models.py
+++ b/src/python/impactx/element_models.py
@@ -78,7 +78,7 @@ def select_model(builders: dict, min_model: str):
 
     :param builders: maps tier name to a callable creating the element. A family
         registers only the tiers ImpactX actually implements. A feature-driven
-        requirement, such as skew multipoles needing the exact model, is
+        requirement, such as a thick octupole needing the exact model, is
         expressed by omitting the cheaper tiers.
     :param min_model: the requested fidelity floor, one of :data:`MODEL_TIERS`
     :return: ``(tier, builder)``. If no implemented tier reaches ``min_model``,

--- a/src/python/impactx/extensions/KnownElementsList.py
+++ b/src/python/impactx/extensions/KnownElementsList.py
@@ -136,7 +136,7 @@ def load_file(self, filename, nslice=1, *, min_model="linear"):
     but never one below the requested tier (``"linear"``, ``"paraxial"`` or
     ``"exact"``). Where a tier is not implemented for an element family, the next
     higher one is used. Where no model reaches the requested tier at all, as for a
-    solenoid, which only has a linear model, a warning is emitted.
+    solenoid, which has no exact model, a warning is emitted.
 
     .. warning::
 

--- a/src/python/impactx/extensions/KnownElementsList.py
+++ b/src/python/impactx/extensions/KnownElementsList.py
@@ -12,6 +12,8 @@ import weakref
 
 from impactx import Config, elements
 
+from ..element_models import DRIFT_MODEL_CLASSES, tier_of_class, validate_model
+
 # All live FilteredElementsList views for a lattice (WeakKeyDictionary: key is KnownElementsList).
 _filtered_views_by_lattice: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 _filtered_views_by_lattice.__repr__ = lambda: (
@@ -23,35 +25,18 @@ FILTERED_ELEMENTS_LIST_INVALID_MSG = (
     "call select() again on the lattice."
 )
 
-# Drift implementation used by ``replace_with_drifts`` for ``model=`` (except ``"match"``).
-# ``model="match"`` picks the same key from the replaced element's class name (see
-# ``_model_key_from_element_typename``).
-_DRIFT_MODEL_CLASSES: dict[str, type] = {
-    "linear": elements.Drift,
-    "paraxial": elements.ChrDrift,
-    "exact": elements.ExactDrift,
-}
-
-
-def _model_key_from_element_typename(type_name: str) -> str:
-    """Return the drift-model key for an element class name (linear / paraxial / exact)."""
-    if type_name.startswith("Exact"):
-        return "exact"
-    if type_name.startswith("Chr"):
-        return "paraxial"
-    return "linear"
-
 
 def _drift_class_for_replace_with_drifts(model: str, old_el) -> type:
     """Map ``model`` and ``old_el`` to the Drift / ChrDrift / ExactDrift class to insert.
 
-    For ``model=="match"``, the class follows ``_model_key_from_element_typename``; otherwise
-    ``model`` must already be validated against ``_DRIFT_MODEL_CLASSES``."""
+    For ``model=="match"``, the class follows the replaced element's own tier (see
+    ``impactx.element_models.tier_of_class``). Otherwise ``model`` must already be
+    validated against :data:`impactx.element_models.MODEL_TIERS`."""
     if model == "match":
-        key = _model_key_from_element_typename(type(old_el).__name__)
+        key = tier_of_class(type(old_el).__name__)
     else:
         key = model
-    return _DRIFT_MODEL_CLASSES[key]
+    return DRIFT_MODEL_CLASSES[key]
 
 
 def _commit_lattice_rebuild(original, new_elements) -> None:
@@ -143,8 +128,15 @@ def _make_drift_from_old(
     )
 
 
-def load_file(self, filename, nslice=1):
+def load_file(self, filename, nslice=1, *, min_model="linear"):
     """Load and append a lattice file from MAD-X (.madx) or PALS (e.g., .pals.yaml) formats.
+
+    ``min_model`` raises the lower gate of the element model selection: the reader
+    still picks the cheapest ImpactX element that represents the imported element,
+    but never one below the requested tier (``"linear"``, ``"paraxial"`` or
+    ``"exact"``). Where a tier is not implemented for an element family, the next
+    higher one is used. Where no model reaches the requested tier at all, as for a
+    solenoid, which only has a linear model, a warning is emitted.
 
     .. warning::
 
@@ -177,13 +169,17 @@ def load_file(self, filename, nslice=1):
         # TODO: Expose explicit MAD-X line/sequence selection in this public API
         # once the user-facing interface is settled. The lower-level translator
         # already supports read_lattice(..., line=..., sequence=...).
-        self.extend(read_lattice(filename, nslice, line=None, sequence=None))
+        self.extend(
+            read_lattice(
+                filename, nslice, line=None, sequence=None, min_model=min_model
+            )
+        )
         return
 
     elif extension_inner == ".pals":
         from pals import load as load_pals_file
 
-        self.from_pals(load_pals_file(filename), nslice)
+        self.from_pals(load_pals_file(filename), nslice, min_model=min_model)
         return
 
     raise RuntimeError(
@@ -191,14 +187,16 @@ def load_file(self, filename, nslice=1):
     )
 
 
-def from_pals(self, pals_beamline, nslice=1):
+def from_pals(self, pals_beamline, nslice=1, *, min_model="linear"):
     """Load and append a lattice from a Particle Accelerator Lattice Standard (PALS) object.
+
+    ``min_model`` is the element model floor, see :py:func:`load_file`.
 
     https://github.com/campa-consortium/pals-python
     """
     from ..pals_to_impactx import read_lattice
 
-    self.extend(read_lattice(pals_beamline, nslice))
+    self.extend(read_lattice(pals_beamline, nslice, min_model=min_model))
 
 
 class FilteredElementsList:
@@ -379,10 +377,7 @@ class FilteredElementsList:
             _invalidate_all_registered_views(original)
             return FilteredElementsList(original, [])
 
-        if model != "match" and model not in _DRIFT_MODEL_CLASSES:
-            raise ValueError(
-                f"model must be 'match' or one of {sorted(_DRIFT_MODEL_CLASSES)}, got {model!r}"
-            )
+        validate_model(model, argument="model", extra_values=("match",))
 
         n = len(original)
         idx_set = set(indices)

--- a/src/python/impactx/madx_to_impactx.py
+++ b/src/python/impactx/madx_to_impactx.py
@@ -11,6 +11,13 @@ import warnings
 
 from impactx import Map6x6, RefPart, elements
 
+from .element_models import (
+    DRIFT_MODEL_CLASSES,
+    QUAD_MODEL_CLASSES,
+    select_model,
+    tier_rank,
+    validate_model,
+)
 from .MADXParser import MADXParser
 
 # Single-shape mapping from MAD-X APERTYPE to ImpactX Aperture.shape.
@@ -61,6 +68,7 @@ def lattice(
     options=None,
     ref_mass_MeV=None,
     bv=1.0,
+    min_model="linear",
 ):
     """
     Function that converts a list of elements in the MADXParser format into ImpactX format
@@ -72,14 +80,24 @@ def lattice(
         MAD-X exposes this as the per-node ``other_bv`` and multiplies it into
         bend angles, body multipole strengths, solenoid KS/KSI, kicker kicks,
         and RF cavity VOLT (twiss.f90:3856, 4547, 6852; trrun.f90:1610).
+    :param min_model: lowest ImpactX element model tier to translate into
+        ("linear", "paraxial" or "exact"). This raises the lower gate of the
+        model choice only. The translator still picks the cheapest model that
+        represents the MAD-X element, and a feature that already demands a
+        higher tier, such as skew multipoles, keeps it. See `build` below.
     :return: list of translated dictionaries
 
     Maintainer note (one-place-of-truth philosophy):
-    - Keep element-type mapping in one place (`madx_to_impactx_dict` below).
+    - Keep element-type mapping in one place (the `d["type"]` chain below).
+    - Keep the model-tier choice in one place per element family. Route every
+      construction of a tiered element through `build(...)` with a table of the
+      tiers ImpactX implements for it, so `min_model` applies uniformly.
     - Keep bend-body model choice in one place (`make_bend_body_element` below).
     - Prefer composition from existing ImpactX elements over silent drops.
     - Every physics fallback should `_warn(...)` and include a TODO comment.
     """
+
+    validate_model(min_model)
 
     supported_madx_elements = {
         "MARKER",
@@ -166,6 +184,71 @@ def lattice(
             _warn(message)
             warned_once.add(key)
 
+    def build(family, builders, **kwargs):
+        """Create an element at the cheapest model tier that satisfies `min_model`.
+
+        `builders` maps tier name ("linear"/"paraxial"/"exact") to the class or
+        factory for that tier, listing only the tiers ImpactX implements for this
+        family. Missing tiers are skipped upwards, so a paraxial floor on a
+        family that has only linear and exact models yields the exact one. A
+        floor that no implemented model reaches falls back to the most faithful
+        one available and warns once.
+        """
+        tier, builder = select_model(builders, min_model)
+        if tier_rank(tier) < tier_rank(min_model):
+            warn_once(
+                f"min_model:{family}",
+                f"{family} has no '{min_model}' (or higher) model in ImpactX; "
+                f"using the '{tier}' model instead.",
+            )
+        return builder(**kwargs)
+
+    def make_drift(*, name, ds):
+        """Drift of the requested model tier, with the lattice-wide `nslice`."""
+        return build("DRIFT", DRIFT_MODEL_CLASSES, name=name, ds=ds, nslice=nslice)
+
+    def make_quad(*, name, ds, k, tilt_degree):
+        """Quadrupole of the requested model tier (`k` in the MAD-X convention)."""
+        return build(
+            "QUADRUPOLE",
+            QUAD_MODEL_CLASSES,
+            name=name,
+            ds=ds,
+            k=k,
+            rotation=tilt_degree,
+            nslice=nslice,
+        )
+
+    def make_dipedge(*, name, psi, rc, g, K2, location, tilt_degree):
+        """Dipole edge of the requested model tier.
+
+        DipEdge selects its fringe-field model by argument rather than by class.
+        The 6th-order "nonlinear" map is its exact tier, the default "linear" map
+        its linear one. There is no separate paraxial fringe model, so a paraxial
+        floor rounds up to the nonlinear map. That is the same choice the synmadx
+        importer makes (`synmadx/syn2_to_impactx.py`, `cnv_dipedge`).
+        """
+
+        def dipedge(model):
+            return elements.DipEdge(
+                name=name,
+                psi=psi,
+                rc=rc,
+                g=g,
+                K2=K2,
+                model=model,
+                location=location,
+                rotation=tilt_degree,
+            )
+
+        return build(
+            "DIPEDGE",
+            {
+                "linear": lambda: dipedge("linear"),
+                "exact": lambda: dipedge("nonlinear"),
+            },
+        )
+
     def warn_unread_element_attributes(elem):
         """Warn if a MAD-X element attribute is present but not consumed."""
         ignored_meta = {"name", "type", "at", "from"}
@@ -190,15 +273,11 @@ def lattice(
             # TODO(audit): This is a paraxial length-preserving approximation.
             # Replace with dedicated thick elements when available.
             impactx_beamline.append(
-                elements.Drift(
-                    name=element_name + "_drift_in", ds=0.5 * length, nslice=nslice
-                )
+                make_drift(name=element_name + "_drift_in", ds=0.5 * length)
             )
             impactx_beamline.append(thin_element)
             impactx_beamline.append(
-                elements.Drift(
-                    name=element_name + "_drift_out", ds=0.5 * length, nslice=nslice
-                )
+                make_drift(name=element_name + "_drift_out", ds=0.5 * length)
             )
         else:
             impactx_beamline.append(thin_element)
@@ -351,10 +430,10 @@ def lattice(
         has_aperture = bool(aperture_params_list)
         if ds > 0.0 and has_aperture:
             _append_apertures("_aperture_entry")
-            impactx_beamline.append(elements.Drift(name=name, ds=ds, nslice=nslice))
+            impactx_beamline.append(make_drift(name=name, ds=ds))
             return "aperture_drift"
         if ds > 0.0:
-            impactx_beamline.append(elements.Drift(name=name, ds=ds, nslice=nslice))
+            impactx_beamline.append(make_drift(name=name, ds=ds))
             return "drift_only"
         if has_aperture:
             _append_apertures("_aperture")
@@ -376,9 +455,9 @@ def lattice(
         if ds > 0.0:
             if has_aperture:
                 _append_apertures("_aperture_entry")
-                impactx_beamline.append(elements.Drift(name=name, ds=ds, nslice=nslice))
+                impactx_beamline.append(make_drift(name=name, ds=ds))
                 return "aperture_drift"
-            impactx_beamline.append(elements.Drift(name=name, ds=ds, nslice=nslice))
+            impactx_beamline.append(make_drift(name=name, ds=ds))
             return "drift_only"
 
         impactx_beamline.append(elements.Marker(name=name))
@@ -415,10 +494,14 @@ def lattice(
         1) ExactCFbend when skew or higher body multipoles are present
         2) CFbend for pure dipole+quadrupole
         3) Sbend for pure dipole geometry
+
+        Each rung offers the model tiers ImpactX implements for it and lets
+        `min_model` raise the choice within that rung. There is no chromatic bend
+        model, so a paraxial floor rounds up to the exact one.
         """
-        use_exact_cfbend = any(abs(v) > 0.0 for v in (k1s, k2, k2s, k3, k3s))
-        if use_exact_cfbend:
-            curvature = 1.0 / rc if rc != 0.0 else 0.0
+        curvature = 1.0 / rc if rc != 0.0 else 0.0
+
+        def exact_cfbend():
             return elements.ExactCFbend(
                 name=name,
                 ds=ds,
@@ -428,21 +511,48 @@ def lattice(
                 rotation=tilt_degree,
                 nslice=nslice,
             )
+
+        use_exact_cfbend = any(abs(v) > 0.0 for v in (k1s, k2, k2s, k3, k3s))
+        if use_exact_cfbend:
+            # Skew or higher-order body multipoles have no linear ImpactX model.
+            # This rung is already at the exact tier, min_model cannot raise it.
+            return build("SBEND/RBEND body", {"exact": exact_cfbend})
         if abs(k1) > 0.0:
-            return elements.CFbend(
-                name=name,
-                ds=ds,
-                rc=rc,
-                k=k1,
-                rotation=tilt_degree,
-                nslice=nslice,
+            return build(
+                "SBEND/RBEND body",
+                {
+                    "linear": lambda: elements.CFbend(
+                        name=name,
+                        ds=ds,
+                        rc=rc,
+                        k=k1,
+                        rotation=tilt_degree,
+                        nslice=nslice,
+                    ),
+                    "exact": exact_cfbend,
+                },
             )
-        return elements.Sbend(
-            name=name,
-            ds=ds,
-            rc=rc,
-            rotation=tilt_degree,
-            nslice=nslice,
+        return build(
+            "SBEND/RBEND body",
+            {
+                "linear": lambda: elements.Sbend(
+                    name=name,
+                    ds=ds,
+                    rc=rc,
+                    rotation=tilt_degree,
+                    nslice=nslice,
+                ),
+                # ExactSbend takes the bend angle instead of the radius of
+                # curvature, in degrees. Both call sites derive rc as ds/angle,
+                # so ds/rc recovers the MAD-X ANGLE exactly.
+                "exact": lambda: elements.ExactSbend(
+                    name=name,
+                    ds=ds,
+                    phi=ds * curvature * rad_to_deg,
+                    rotation=tilt_degree,
+                    nslice=nslice,
+                ),
+            },
         )
 
     def make_thin_dipole_kick(*, name, angle, tilt_degree):
@@ -585,18 +695,14 @@ def lattice(
                 # MAD-X manual 11.20: INSTRUMENT is optically drift-like.
                 ds = d.get("l", 0.0)
                 if ds > 0.0:
-                    impactx_beamline.append(
-                        elements.Drift(name=d["name"], ds=ds, nslice=nslice)
-                    )
+                    impactx_beamline.append(make_drift(name=d["name"], ds=ds))
                 else:
                     impactx_beamline.append(elements.Marker(name=d["name"]))
                     _warn(f"INSTRUMENT '{d['name']}' has zero length; using Marker.")
             elif d["type"] == "drift":
                 ds = d.get("l", 0.0)
                 if ds > 0:
-                    impactx_beamline.append(
-                        elements.Drift(name=d["name"], ds=ds, nslice=nslice)
-                    )
+                    impactx_beamline.append(make_drift(name=d["name"], ds=ds))
             elif d["type"] == "quadrupole":
                 ds = d.get("l", 0.0)
                 k1 = d.get("k1", 0.0)
@@ -604,6 +710,9 @@ def lattice(
                 tilt_degree = d.get("tilt", 0.0) * rad_to_deg
                 if ds > 0:
                     if abs(k1s) > 0:
+                        # A skew quadrupole has no linear or paraxial ImpactX
+                        # model. It is already the exact tier, min_model cannot
+                        # raise it.
                         impactx_beamline.append(
                             elements.ExactMultipole(
                                 name=d["name"],
@@ -616,12 +725,8 @@ def lattice(
                         )
                     else:
                         impactx_beamline.append(
-                            elements.Quad(
-                                name=d["name"],
-                                ds=ds,
-                                k=k1,
-                                rotation=tilt_degree,
-                                nslice=nslice,
+                            make_quad(
+                                name=d["name"], ds=ds, k=k1, tilt_degree=tilt_degree
                             )
                         )
                 else:
@@ -663,14 +768,14 @@ def lattice(
 
                         if has_edges:
                             impactx_beamline.append(
-                                elements.DipEdge(
+                                make_dipedge(
                                     name=d["name"] + "_edge_entry",
                                     psi=e1,
                                     rc=rc,
                                     g=2.0 * hgap,
                                     K2=fint,
                                     location="entry",
-                                    rotation=tilt_degree,
+                                    tilt_degree=tilt_degree,
                                 )
                             )
 
@@ -691,14 +796,14 @@ def lattice(
 
                         if has_edges:
                             impactx_beamline.append(
-                                elements.DipEdge(
+                                make_dipedge(
                                     name=d["name"] + "_edge_exit",
                                     psi=e2,
                                     rc=rc,
                                     g=2.0 * hgap,
                                     K2=fintx,
                                     location="exit",
-                                    rotation=tilt_degree,
+                                    tilt_degree=tilt_degree,
                                 )
                             )
                     else:
@@ -723,18 +828,15 @@ def lattice(
                             )
                         elif abs(k1) > 0:
                             impactx_beamline.append(
-                                elements.Quad(
+                                make_quad(
                                     name=d["name"],
                                     ds=ds,
                                     k=k1,
-                                    rotation=tilt_degree,
-                                    nslice=nslice,
+                                    tilt_degree=tilt_degree,
                                 )
                             )
                         else:
-                            impactx_beamline.append(
-                                elements.Drift(name=d["name"], ds=ds, nslice=nslice)
-                            )
+                            impactx_beamline.append(make_drift(name=d["name"], ds=ds))
                         _warn(
                             f"SBEND '{d['name']}' has ANGLE=0; using straight-element fallback."
                         )
@@ -817,14 +919,14 @@ def lattice(
 
                         # Entry DipEdge
                         impactx_beamline.append(
-                            elements.DipEdge(
+                            make_dipedge(
                                 name=d["name"] + "_edge_entry",
                                 psi=e1,
                                 rc=rc,
                                 g=2.0 * hgap,
                                 K2=fint,
                                 location="entry",
-                                rotation=tilt_degree,
+                                tilt_degree=tilt_degree,
                             )
                         )
 
@@ -845,14 +947,14 @@ def lattice(
                         )
                         # Exit DipEdge
                         impactx_beamline.append(
-                            elements.DipEdge(
+                            make_dipedge(
                                 name=d["name"] + "_edge_exit",
                                 psi=e2,
                                 rc=rc,
                                 g=2.0 * hgap,
                                 K2=fintx,
                                 location="exit",
-                                rotation=tilt_degree,
+                                tilt_degree=tilt_degree,
                             )
                         )
                     else:
@@ -872,17 +974,16 @@ def lattice(
                             )
                         elif abs(k1) > 0:
                             impactx_beamline.append(
-                                elements.Quad(
+                                make_quad(
                                     name=d["name"],
                                     ds=l_arc,
                                     k=k1,
-                                    rotation=tilt_degree,
-                                    nslice=nslice,
+                                    tilt_degree=tilt_degree,
                                 )
                             )
                         else:
                             impactx_beamline.append(
-                                elements.Drift(name=d["name"], ds=l_arc, nslice=nslice)
+                                make_drift(name=d["name"], ds=l_arc)
                             )
                         _warn(
                             f"RBEND '{d['name']}' has ANGLE=0; using straight-element fallback."
@@ -940,8 +1041,12 @@ def lattice(
                     if abs(ks) == 0.0 and abs(ksi) > 0.0:
                         # MAD-X derives KS from KSI/L for thick solenoids.
                         ks = ksi / ds
+                    # ImpactX has only the ideal, hard-edge linear solenoid. A
+                    # higher min_model cannot be honored here and warns once.
                     impactx_beamline.append(
-                        elements.Sol(
+                        build(
+                            "SOLENOID",
+                            {"linear": elements.Sol},
                             name=d["name"],
                             ds=ds,
                             ks=ks,
@@ -1047,7 +1152,7 @@ def lattice(
                             f"DIPEDGE '{d['name']}' attribute 'he' is not translated; using simplified model."
                         )
                     impactx_beamline.append(
-                        elements.DipEdge(
+                        make_dipedge(
                             name=d["name"],
                             psi=d.get("e1", 0.0),
                             rc=1.0 / h,
@@ -1055,7 +1160,7 @@ def lattice(
                             g=2.0 * d.get("hgap", 0.0),
                             K2=d.get("fint", 0.0),
                             location=location,
-                            rotation=d.get("tilt", 0.0) * rad_to_deg,
+                            tilt_degree=d.get("tilt", 0.0) * rad_to_deg,
                         )
                     )
             elif d["type"] in ("kicker", "tkicker"):
@@ -1153,9 +1258,7 @@ def lattice(
                 # ignore them here.
                 if d.get("l", 0.0) > 0:
                     impactx_beamline.append(
-                        elements.Drift(
-                            name=d["name"] + "_drift", ds=d["l"], nslice=nslice
-                        )
+                        make_drift(name=d["name"] + "_drift", ds=d["l"])
                     )
                 impactx_beamline.append(
                     elements.BeamMonitor(name=d["name"], backend="h5")
@@ -1166,6 +1269,8 @@ def lattice(
                 k2s = d.get("k2s", 0.0)
                 tilt_degree = d.get("tilt", 0.0) * rad_to_deg
                 if ds > 0:
+                    # ImpactX has no thick linear or paraxial sextupole: already
+                    # the exact tier, min_model cannot raise it.
                     impactx_beamline.append(
                         elements.ExactMultipole(
                             name=d["name"],
@@ -1188,6 +1293,8 @@ def lattice(
                 k3s = d.get("k3s", 0.0)
                 tilt_degree = d.get("tilt", 0.0) * rad_to_deg
                 if ds > 0:
+                    # ImpactX has no thick linear or paraxial octupole: already
+                    # the exact tier, min_model cannot raise it.
                     impactx_beamline.append(
                         elements.ExactMultipole(
                             name=d["name"],
@@ -1245,19 +1352,13 @@ def lattice(
                     # lattice as a Drift (if L>0) or Marker rather than silently
                     # dropping it.
                     if ds > 0.0:
-                        impactx_beamline.append(
-                            elements.Drift(name=d["name"], ds=ds, nslice=nslice)
-                        )
+                        impactx_beamline.append(make_drift(name=d["name"], ds=ds))
                     else:
                         impactx_beamline.append(elements.Marker(name=d["name"]))
                 else:
                     if ds > 0.0:
                         impactx_beamline.append(
-                            elements.Drift(
-                                name=d["name"] + "_drift_in",
-                                ds=0.5 * ds,
-                                nslice=nslice,
-                            )
+                            make_drift(name=d["name"] + "_drift_in", ds=0.5 * ds)
                         )
                     for order, kn, ks in kick_components:
                         impactx_beamline.append(
@@ -1274,11 +1375,7 @@ def lattice(
                         )
                     if ds > 0.0:
                         impactx_beamline.append(
-                            elements.Drift(
-                                name=d["name"] + "_drift_out",
-                                ds=0.5 * ds,
-                                nslice=nslice,
-                            )
+                            make_drift(name=d["name"] + "_drift_out", ds=0.5 * ds)
                         )
             elif d["type"] == "nllens":
                 if abs(d.get("cnll", 0.0)) == 0.0:
@@ -1407,13 +1504,15 @@ def lattice(
     return impactx_beamline
 
 
-def read_lattice(madx_file, nslice=1, *, line=None, sequence=None):
+def read_lattice(madx_file, nslice=1, *, line=None, sequence=None, min_model="linear"):
     """
     Function that reads elements from a MAD-X file into a list of ImpactX.KnownElements
     :param madx_file: file name to MAD-X file with beamline elements
     :param nslice: number of ds slices per element
     :param line: explicit MAD-X LINE name to expand when no USE command is present
     :param sequence: explicit MAD-X SEQUENCE/PERIOD name to expand
+    :param min_model: lowest ImpactX element model tier to translate into
+        ("linear", "paraxial" or "exact"), see :py:func:`lattice`
     :return: list of ImpactX.KnownElements
     """
     madx = MADXParser()
@@ -1450,6 +1549,7 @@ def read_lattice(madx_file, nslice=1, *, line=None, sequence=None):
         options=options,
         ref_mass_MeV=ref_mass_MeV,
         bv=bv,
+        min_model=min_model,
     )
 
 

--- a/src/python/impactx/madx_to_impactx.py
+++ b/src/python/impactx/madx_to_impactx.py
@@ -84,7 +84,7 @@ def lattice(
         ("linear", "paraxial" or "exact"). This raises the lower gate of the
         model choice only. The translator still picks the cheapest model that
         represents the MAD-X element, and a feature that already demands a
-        higher tier, such as skew multipoles, keeps it. See `build` below.
+        higher tier, such as a thick octupole, keeps it. See `build` below.
     :return: list of translated dictionaries
 
     Maintainer note (one-place-of-truth philosophy):
@@ -514,7 +514,8 @@ def lattice(
 
         use_exact_cfbend = any(abs(v) > 0.0 for v in (k1s, k2, k2s, k3, k3s))
         if use_exact_cfbend:
-            # Skew or higher-order body multipoles have no linear ImpactX model.
+            # Skew or higher-order body multipoles have no linear or paraxial
+            # ImpactX bend-body model.
             # This rung is already at the exact tier, min_model cannot raise it.
             return build("SBEND/RBEND body", {"exact": exact_cfbend})
         if abs(k1) > 0.0:
@@ -710,9 +711,15 @@ def lattice(
                 tilt_degree = d.get("tilt", 0.0) * rad_to_deg
                 if ds > 0:
                     if abs(k1s) > 0:
-                        # A skew quadrupole has no linear or paraxial ImpactX
-                        # model. It is already the exact tier, min_model cannot
-                        # raise it.
+                        # Combined normal and skew quadrupole strengths are
+                        # translated as one multipole, which is already the exact
+                        # tier, so min_model cannot raise it.
+                        # TODO(models): a pure quadrupole field is also a single
+                        # quadrupole of strength hypot(k1, k1s) under a rotation
+                        # of half the (k1, k1s) phase angle, 45 degrees for a
+                        # purely skew one. The linear and paraxial tiers could
+                        # serve this via make_quad with that rotation folded into
+                        # tilt_degree; mind the MAD-X TILT sign convention.
                         impactx_beamline.append(
                             elements.ExactMultipole(
                                 name=d["name"],
@@ -809,8 +816,8 @@ def lattice(
                     else:
                         # MAD-X allows ANGLE=0 SBEND with extra attributes. Pick the
                         # narrowest ImpactX element that represents the remaining
-                        # straight-field content (skew or higher multipoles require
-                        # ExactMultipole).
+                        # straight-field content (skew or higher multipoles are
+                        # translated as ExactMultipole).
                         if abs(k0) > 0.0 or abs(k0s) > 0.0:
                             _warn(
                                 f"SBEND '{d['name']}' has ANGLE=0 but nonzero K0/K0S; these are dropped (MAD-X treats K0/K0S as obsolete)."

--- a/src/python/impactx/madx_to_impactx.py
+++ b/src/python/impactx/madx_to_impactx.py
@@ -69,6 +69,7 @@ def lattice(
     ref_mass_MeV=None,
     bv=1.0,
     min_model="linear",
+    ref_beta_gamma=None,
 ):
     """
     Function that converts a list of elements in the MADXParser format into ImpactX format
@@ -85,6 +86,10 @@ def lattice(
         model choice only. The translator still picks the cheapest model that
         represents the MAD-X element, and a feature that already demands a
         higher tier, such as a thick octupole, keeps it. See `build` below.
+    :param ref_beta_gamma: beta*gamma of the reference particle, from the MAD-X
+        BEAM total energy. Only needed for models whose strength is expressed
+        per unit rigidity rather than in the MAD-X k convention, currently the
+        paraxial solenoid. Those models are skipped when this is unknown.
     :return: list of translated dictionaries
 
     Maintainer note (one-place-of-truth philosophy):
@@ -184,23 +189,26 @@ def lattice(
             _warn(message)
             warned_once.add(key)
 
-    def build(family, builders, **kwargs):
+    def build(family, builders, *, note=None, **kwargs):
         """Create an element at the cheapest model tier that satisfies `min_model`.
 
         `builders` maps tier name ("linear"/"paraxial"/"exact") to the class or
-        factory for that tier, listing only the tiers ImpactX implements for this
-        family. Missing tiers are skipped upwards, so a paraxial floor on a
-        family that has only linear and exact models yields the exact one. A
-        floor that no implemented model reaches falls back to the most faithful
-        one available and warns once.
+        factory for that tier, listing only the tiers available for this family.
+        Missing tiers are skipped upwards, so a paraxial floor on a family that
+        has only linear and exact models yields the exact one. A floor that no
+        available model reaches falls back to the most faithful one available and
+        warns once, appending `note` when the family can explain why a tier is
+        missing here but present in ImpactX.
         """
         tier, builder = select_model(builders, min_model)
         if tier_rank(tier) < tier_rank(min_model):
-            warn_once(
-                f"min_model:{family}",
-                f"{family} has no '{min_model}' (or higher) model in ImpactX; "
-                f"using the '{tier}' model instead.",
+            message = (
+                f"{family} has no '{min_model}' (or higher) model available; "
+                f"using the '{tier}' model instead."
             )
+            if note is not None:
+                message += f" {note}"
+            warn_once(f"min_model:{family}", message)
         return builder(**kwargs)
 
     def make_drift(*, name, ds):
@@ -218,6 +226,57 @@ def lattice(
             rotation=tilt_degree,
             nslice=nslice,
         )
+
+    def make_solenoid(*, name, ds, ks, tilt_degree):
+        """Solenoid of the requested model tier.
+
+        The linear tier is the ideal hard-edge `Sol`. The paraxial tier is
+        `ChrAcc` with `ez=0`, which reduces to the same hard-edge solenoid map
+        for the reference particle while adding the chromatic dependence
+        (`tests/python/test_chracc_Ez0.py`). There is no exact tier yet.
+
+        The two elements express the field differently: `Sol.ks` is per unit
+        rigidity (`Bz/Brho`, the MAD-X convention) and so is momentum
+        independent, while `ChrAcc.bz` is `q*Bz/(m*c)`. They are related by
+        `bz = ks * beta_gamma`, which pins the paraxial solenoid to the beam
+        energy read from the MAD-X BEAM command. Without that energy the
+        paraxial tier is not offered at all.
+        """
+
+        def sol():
+            return elements.Sol(
+                name=name, ds=ds, ks=ks, rotation=tilt_degree, nslice=nslice
+            )
+
+        builders = {"linear": sol}
+        note = None
+        if ref_beta_gamma is not None and ref_beta_gamma > 0.0:
+            builders["paraxial"] = lambda: elements.ChrAcc(
+                name=name,
+                ds=ds,
+                ez=0.0,
+                bz=ks * ref_beta_gamma,
+                rotation=tilt_degree,
+                nslice=nslice,
+            )
+            if tier_rank(min_model) >= tier_rank("paraxial"):
+                # TODO(audit): ChrAcc.bz is fixed at translation time, so the
+                # promoted solenoid no longer follows a reference energy that is
+                # changed after import, unlike Sol.ks. Revisit once a paraxial
+                # solenoid takes ks directly.
+                warn_once(
+                    "solenoid_paraxial_energy",
+                    "SOLENOID is translated as ChrAcc(ez=0), whose field is "
+                    f"pinned to the MAD-X BEAM energy (beta*gamma={ref_beta_gamma:g}). "
+                    "Changing the reference energy after import will not rescale it.",
+                )
+        else:
+            note = (
+                "The paraxial ChrAcc(ez=0) model needs the reference energy, "
+                "which this lattice does not provide via the MAD-X BEAM command."
+            )
+
+        return build("SOLENOID", builders, note=note)
 
     def make_dipedge(*, name, psi, rc, g, K2, location, tilt_degree):
         """Dipole edge of the requested model tier.
@@ -1048,17 +1107,12 @@ def lattice(
                     if abs(ks) == 0.0 and abs(ksi) > 0.0:
                         # MAD-X derives KS from KSI/L for thick solenoids.
                         ks = ksi / ds
-                    # ImpactX has only the ideal, hard-edge linear solenoid. A
-                    # higher min_model cannot be honored here and warns once.
                     impactx_beamline.append(
-                        build(
-                            "SOLENOID",
-                            {"linear": elements.Sol},
+                        make_solenoid(
                             name=d["name"],
                             ds=ds,
                             ks=ks,
-                            rotation=tilt_degree,
-                            nslice=nslice,
+                            tilt_degree=tilt_degree,
                         )
                     )
                     if abs(ksi) > 0:
@@ -1549,6 +1603,24 @@ def read_lattice(madx_file, nslice=1, *, line=None, sequence=None, min_model="li
 
     bv = float(getattr(madx.context.beam, "bv", 1.0))
 
+    # beta*gamma of the reference particle, from the MAD-X BEAM total energy.
+    # Elements whose strength is expressed per unit rigidity rather than in the
+    # MAD-X k convention need it, see `ref_beta_gamma` in `lattice`.
+    #
+    # Only an ENERGY that the file actually states is used. MAD-X defaults it to
+    # 1 GeV, and translating a rigidity against an assumed energy would bake a
+    # wrong field strength into the lattice instead of merely approximating one.
+    ref_beta_gamma = None
+    if (
+        getattr(madx.context.beam, "energy_is_explicit", False)
+        and ref_mass_MeV is not None
+        and ref_mass_MeV > 0.0
+    ):
+        # MAD-X ENERGY is the total energy in GeV
+        gamma = float(madx.getEtot()) * 1.0e3 / ref_mass_MeV
+        if gamma > 1.0:
+            ref_beta_gamma = math.sqrt(gamma**2 - 1.0)
+
     return lattice(
         beamline,
         nslice,
@@ -1557,6 +1629,7 @@ def read_lattice(madx_file, nslice=1, *, line=None, sequence=None, min_model="li
         ref_mass_MeV=ref_mass_MeV,
         bv=bv,
         min_model=min_model,
+        ref_beta_gamma=ref_beta_gamma,
     )
 
 

--- a/src/python/impactx/pals_to_impactx.py
+++ b/src/python/impactx/pals_to_impactx.py
@@ -8,6 +8,19 @@ License: BSD-3-Clause-LBNL
 
 from impactx import elements
 
+from .element_models import DRIFT_MODEL_CLASSES, select_model, validate_model
+
+# Quadrupole models per tier for PALS input. PALS carries its own ``unit``
+# (0: MAD-X k, 1: T/m gradient), so the classes are listed bare here instead of
+# reusing ``element_models.QUAD_MODEL_CLASSES``, which pins ``unit=0``.
+# TODO: the linear ``Quad`` has no ``unit`` argument yet, so the cheapest tier
+# available here is the paraxial one. Add it once ImpactX issue #798 (dual unit
+# systems for all focusing elements) is resolved.
+_PALS_QUAD_MODEL_CLASSES = {
+    "paraxial": elements.ChrQuad,
+    "exact": elements.ExactQuad,
+}
+
 
 def flatten_pals(pals_data, registry=None):
     """Flatten a PALS root, lattice, or beamline to a list of PALS elements.
@@ -63,16 +76,21 @@ def flatten_pals(pals_data, registry=None):
     return [pals_data]
 
 
-def read_lattice(pals_beamline, nslice=1):
+def read_lattice(pals_beamline, nslice=1, *, min_model="linear"):
     """Translate a Particle Accelerator Lattice Standard (PALS) object into ImpactX elements.
 
     https://github.com/campa-consortium/pals-python
 
     :param pals_beamline: a PALS root, lattice, or beamline object
     :param nslice: number of ds slices per element
+    :param min_model: lowest element model tier to use ("linear", "paraxial" or
+        "exact"). A floor never lowers a tier, so quadrupoles stay paraxial
+        (``ChrQuad``) at the default, see ``_PALS_QUAD_MODEL_CLASSES`` above.
     :return: list of ImpactX.KnownElements
     """
     from pals import Drift, Quadrupole
+
+    validate_model(min_model)
 
     pals_elements = flatten_pals(pals_beamline)
 
@@ -80,10 +98,9 @@ def read_lattice(pals_beamline, nslice=1):
     ix_beamline = []
     for pals_element in pals_elements:
         if isinstance(pals_element, Drift):
+            _, drift_cls = select_model(DRIFT_MODEL_CLASSES, min_model)
             ix_beamline.append(
-                elements.Drift(
-                    name=pals_element.name, ds=pals_element.length, nslice=nslice
-                )
+                drift_cls(name=pals_element.name, ds=pals_element.length, nslice=nslice)
             )
         elif isinstance(pals_element, Quadrupole):
             magnetic_multipole = pals_element.MagneticMultipoleP
@@ -102,8 +119,9 @@ def read_lattice(pals_beamline, nslice=1):
                 raise RuntimeError(
                     f"from_pals: No gradient input provided for element of kind {type(pals_element)}."
                 )
+            _, quad_cls = select_model(_PALS_QUAD_MODEL_CLASSES, min_model)
             ix_beamline.append(
-                elements.ChrQuad(
+                quad_cls(
                     name=pals_element.name,
                     ds=pals_element.length,
                     k=k_quad,

--- a/tests/python/test_madx_min_model.py
+++ b/tests/python/test_madx_min_model.py
@@ -16,13 +16,13 @@ MAD-X input. ``min_model`` raises the *lower gate* of that choice without
 otherwise changing it. Three properties are asserted here:
 
 1. A floor never lowers a tier. An element that already needs a richer model,
-   such as a skew quadrupole that only exists as ``ExactMultipole``, keeps it at
+   such as a thick octupole that only exists as ``ExactMultipole``, keeps it at
    ``min_model="linear"``.
 2. Where a tier is not implemented, the floor rounds *up*. ImpactX has no
    ``ChrSbend``, so ``min_model="paraxial"`` on a plain SBEND yields the exact
    model rather than falling back to the linear one.
 3. Where no model reaches the floor at all, the translation still succeeds and
-   warns once. SOLENOID has only the ideal, hard-edge ``Sol``.
+   warns once. SOLENOID has no exact model.
 
 References:
     - https://impactx.readthedocs.io/en/latest/usage/python.html#impactx.elements.KnownElementsList.load_file
@@ -32,9 +32,10 @@ References:
 import math
 import warnings
 
+import numpy as np
 import pytest
 
-from impactx import elements
+from impactx import RefPart, elements
 from impactx.element_models import MODEL_TIERS, select_model
 from impactx.madx_to_impactx import (
     MADXImpactXTranslatorWarning,
@@ -259,7 +260,11 @@ def test_sextupole_stays_exact_at_linear_floor():
 
 
 def test_solenoid_warns_once_when_floor_is_unreachable():
-    """SOLENOID has only the linear Sol model: translate it anyway and warn once."""
+    """Without a reference energy only the linear Sol is available: warn once.
+
+    The paraxial ChrAcc(ez=0) model needs beta*gamma to convert ``ks``, so a
+    lattice translated without it keeps ``Sol`` at every floor.
+    """
     solenoids = [
         {"name": f"s{i}", "type": "solenoid", "l": 0.5, "ks": 1.0} for i in range(3)
     ]
@@ -286,6 +291,153 @@ def test_solenoid_does_not_warn_at_linear_floor():
 
     assert _types(beamline) == ["Sol"]
     assert not [w for w in caught if "no 'linear'" in str(w.message)]
+
+
+# ---------------------------------------------------------------------------
+# Solenoid promotion to the paraxial ChrAcc(ez=0) model
+# ---------------------------------------------------------------------------
+
+# beta*gamma of a 2 GeV kinetic-energy proton, the energy used below.
+_PROTON_MASS_MeV = 938.27208816
+_SOL_BETA_GAMMA = math.sqrt(((2000.0 + _PROTON_MASS_MeV) / _PROTON_MASS_MeV) ** 2 - 1.0)
+
+
+@pytest.mark.parametrize(
+    "min_model,expected",
+    [("linear", "Sol"), ("paraxial", "ChrAcc"), ("exact", "ChrAcc")],
+)
+def test_solenoid_promotes_to_chracc_with_reference_energy(min_model, expected):
+    """With beta*gamma known, the paraxial tier is ChrAcc(ez=0); exact rounds down."""
+    beamline = _translate(
+        {"name": "s1", "type": "solenoid", "l": 0.5, "ks": 1.0},
+        min_model=min_model,
+        ref_beta_gamma=_SOL_BETA_GAMMA,
+    )
+    assert _types(beamline) == [expected]
+
+
+def test_solenoid_chracc_field_follows_rigidity_conversion():
+    """Sol.ks is per unit rigidity, ChrAcc.bz is not: bz = ks * beta_gamma.
+
+    Both maps rotate by the same angle for the reference particle, Sol by
+    ks/2 * ds and ChrAcc by bz/2 * ds / beta_gamma.
+    """
+    ks = 1.7
+    beamline = _translate(
+        {"name": "s1", "type": "solenoid", "l": 0.5, "ks": ks},
+        min_model="paraxial",
+        ref_beta_gamma=_SOL_BETA_GAMMA,
+    )
+    sol = _only(beamline, elements.ChrAcc)
+    assert sol.ez == 0.0
+    assert sol.bz == pytest.approx(ks * _SOL_BETA_GAMMA)
+
+
+@pytest.mark.parametrize("ks", [1.7, -0.9])
+def test_solenoid_promotion_preserves_the_reference_map(ks):
+    """The promoted ChrAcc is the same transport map as the Sol it replaces.
+
+    ``ChrAcc`` adds the chromatic dependence on top, so the two agree exactly
+    only for the reference particle, which is what the 6x6 map describes.
+
+    ``ks=0`` is left out: ``Sol`` divides by its own strength when building the
+    map and returns NaN there, independent of this translation.
+    """
+    ref = RefPart()
+    ref.set_species("proton").set_kin_energy_MeV(2000.0)
+
+    common = {"name": "s1", "type": "solenoid", "l": 0.5, "ks": ks}
+    sol = _only(_translate(common, min_model="linear"), elements.Sol)
+    acc = _only(
+        _translate(common, min_model="paraxial", ref_beta_gamma=ref.beta_gamma),
+        elements.ChrAcc,
+    )
+
+    linear_map = np.array(sol.transfer_map(ref)).reshape(6, 6)
+    paraxial_map = np.array(acc.transfer_map(ref)).reshape(6, 6)
+    assert np.allclose(linear_map, paraxial_map, rtol=0.0, atol=1.0e-14)
+
+
+def test_solenoid_promotion_warns_about_energy_pinning():
+    """ChrAcc.bz is fixed at translation time, so the reader says so, once."""
+    solenoids = [
+        {"name": f"s{i}", "type": "solenoid", "l": 0.5, "ks": 1.0} for i in range(3)
+    ]
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        beamline = lattice(
+            solenoids, min_model="paraxial", ref_beta_gamma=_SOL_BETA_GAMMA
+        )
+
+    assert _types(beamline) == ["ChrAcc"] * 3
+    pinning = [w for w in caught if "pinned to the MAD-X BEAM energy" in str(w.message)]
+    assert len(pinning) == 1, [str(w.message) for w in caught]
+    # The paraxial floor is reachable now, so no "no model available" warning.
+    assert not [w for w in caught if "model available" in str(w.message)]
+
+
+def test_solenoid_exact_floor_warns_but_still_promotes():
+    """There is no ExactAcc yet, so an exact floor rounds down to ChrAcc and warns."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        beamline = lattice(
+            [{"name": "s1", "type": "solenoid", "l": 0.5, "ks": 1.0}],
+            min_model="exact",
+            ref_beta_gamma=_SOL_BETA_GAMMA,
+        )
+
+    assert _types(beamline) == ["ChrAcc"]
+    floor = [
+        w
+        for w in caught
+        if issubclass(w.category, MADXImpactXTranslatorWarning)
+        and "SOLENOID has no 'exact'" in str(w.message)
+        and "'paraxial' model instead" in str(w.message)
+    ]
+    assert len(floor) == 1, [str(w.message) for w in caught]
+
+
+def test_solenoid_promotion_end_to_end_from_madx_file(tmp_path):
+    """read_lattice derives beta*gamma from BEAM and promotes the solenoid."""
+    madx_file = tmp_path / "sol.madx"
+    madx_file.write_text(
+        "beam, particle=proton, energy=2.93827208816;\n"  # total energy in GeV
+        "s1: solenoid, l=0.5, ks=1.0;\n"
+        "cell: line=(s1);\n"
+        "use, sequence=cell;\n"
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        linear = read_lattice(str(madx_file), min_model="linear")
+        paraxial = read_lattice(str(madx_file), min_model="paraxial")
+
+    assert _types(linear) == ["Sol"]
+    assert _types(paraxial) == ["ChrAcc"]
+    assert _only(paraxial, elements.ChrAcc).bz == pytest.approx(
+        1.0 * _SOL_BETA_GAMMA, rel=1e-6
+    )
+
+
+def test_solenoid_not_promoted_without_a_stated_beam_energy(tmp_path):
+    """MAD-X defaults ENERGY to 1 GeV: do not translate a rigidity against it.
+
+    Promoting here would bake a wrong field strength into the lattice, so the
+    reader keeps the momentum-independent Sol and says why.
+    """
+    madx_file = tmp_path / "sol_no_energy.madx"
+    madx_file.write_text(
+        "beam, particle=proton;\n"  # no ENERGY: MAD-X assumes 1 GeV
+        "s1: solenoid, l=0.5, ks=1.0;\n"
+        "cell: line=(s1);\n"
+        "use, sequence=cell;\n"
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        beamline = read_lattice(str(madx_file), min_model="paraxial")
+
+    assert _types(beamline) == ["Sol"]
+    explained = [w for w in caught if "does not provide" in str(w.message)]
+    assert len(explained) == 1, [str(w.message) for w in caught]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/python/test_madx_min_model.py
+++ b/tests/python/test_madx_min_model.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 ImpactX contributors
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+"""
+Tests for the ``min_model`` fidelity floor of the MAD-X -> ImpactX translation.
+
+ImpactX implements most elements at up to three levels of fidelity: linear,
+paraxial (``Chr*``) and exact (``Exact*``), see ``docs/source/theory/assumptions.rst``.
+The MAD-X translator picks the cheapest ImpactX element that represents the
+MAD-X input. ``min_model`` raises the *lower gate* of that choice without
+otherwise changing it. Three properties are asserted here:
+
+1. A floor never lowers a tier. An element that already needs a richer model,
+   such as a skew quadrupole that only exists as ``ExactMultipole``, keeps it at
+   ``min_model="linear"``.
+2. Where a tier is not implemented, the floor rounds *up*. ImpactX has no
+   ``ChrSbend``, so ``min_model="paraxial"`` on a plain SBEND yields the exact
+   model rather than falling back to the linear one.
+3. Where no model reaches the floor at all, the translation still succeeds and
+   warns once. SOLENOID has only the ideal, hard-edge ``Sol``.
+
+References:
+    - https://impactx.readthedocs.io/en/latest/usage/python.html#impactx.elements.KnownElementsList.load_file
+    - MAD-X manual: https://madx.web.cern.ch/webguide/manual.html
+"""
+
+import math
+import warnings
+
+import pytest
+
+from impactx import elements
+from impactx.element_models import MODEL_TIERS, select_model
+from impactx.madx_to_impactx import (
+    MADXImpactXTranslatorWarning,
+    lattice,
+    read_lattice,
+)
+
+
+def _translate(elems, **kwargs):
+    """Translate parsed MAD-X element dicts through lattice(), muting warnings."""
+    if isinstance(elems, dict):
+        elems = [elems]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return lattice(elems, **kwargs)
+
+
+def _types(beamline):
+    """Element class names of a translated beamline."""
+    return [type(e).__name__ for e in beamline]
+
+
+def _only(beamline, cls):
+    """Return the single element of type ``cls`` in a translated beamline."""
+    matches = [e for e in beamline if isinstance(e, cls)]
+    assert len(matches) == 1, _types(beamline)
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# The tier picker itself
+# ---------------------------------------------------------------------------
+
+
+def test_select_model_picks_cheapest_at_or_above_floor():
+    """The cheapest implemented tier that satisfies the floor wins."""
+    full = {tier: tier for tier in MODEL_TIERS}
+    assert select_model(full, "linear") == ("linear", "linear")
+    assert select_model(full, "paraxial") == ("paraxial", "paraxial")
+    assert select_model(full, "exact") == ("exact", "exact")
+
+
+def test_select_model_rounds_up_through_a_missing_tier():
+    """A family without a paraxial model serves a paraxial floor from its exact one."""
+    holed = {"linear": "linear", "exact": "exact"}
+    assert select_model(holed, "linear") == ("linear", "linear")
+    assert select_model(holed, "paraxial") == ("exact", "exact")
+    assert select_model(holed, "exact") == ("exact", "exact")
+
+
+def test_select_model_falls_back_below_an_unreachable_floor():
+    """With nothing at or above the floor, the most faithful model available is used."""
+    linear_only = {"linear": "linear"}
+    assert select_model(linear_only, "exact") == ("linear", "linear")
+
+
+# ---------------------------------------------------------------------------
+# Element families with a full or partial tier ladder
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "min_model, expected",
+    [("linear", "Drift"), ("paraxial", "ChrDrift"), ("exact", "ExactDrift")],
+)
+def test_drift_tiers(min_model, expected):
+    """DRIFT has all three tiers, so the floor is met exactly."""
+    beamline = _translate(
+        {"name": "d1", "type": "drift", "l": 0.5}, min_model=min_model
+    )
+    assert _types(beamline) == [expected]
+    assert beamline[0].ds == pytest.approx(0.5)
+
+
+@pytest.mark.parametrize(
+    "min_model, expected",
+    [("linear", "Quad"), ("paraxial", "ChrQuad"), ("exact", "ExactQuad")],
+)
+def test_quadrupole_tiers(min_model, expected):
+    """QUADRUPOLE has all three tiers. Strength and rotation survive the promotion."""
+    beamline = _translate(
+        {"name": "q1", "type": "quadrupole", "l": 0.3, "k1": 2.0, "tilt": 0.25},
+        min_model=min_model,
+    )
+    assert _types(beamline) == [expected]
+    quad = beamline[0]
+    assert quad.ds == pytest.approx(0.3)
+    assert quad.k == pytest.approx(2.0)
+    assert quad.rotation == pytest.approx(0.25 * 180.0 / math.pi)
+    if min_model != "linear":
+        # MAD-X k convention: k in m^(-2), which plain Quad always assumes
+        assert quad.unit == 0
+
+
+@pytest.mark.parametrize(
+    "min_model, expected",
+    [("linear", "Sbend"), ("paraxial", "ExactSbend"), ("exact", "ExactSbend")],
+)
+def test_sbend_tiers_round_up(min_model, expected):
+    """There is no ChrSbend: a paraxial floor rounds up to the exact bend."""
+    ds, angle = 2.0, 0.1
+    beamline = _translate(
+        {"name": "b1", "type": "sbend", "l": ds, "angle": angle},
+        min_model=min_model,
+    )
+    assert _types(beamline) == [expected]
+    bend = beamline[0]
+    assert bend.ds == pytest.approx(ds)
+    if expected == "Sbend":
+        assert bend.to_dict()["rc"] == pytest.approx(ds / angle)
+    else:
+        # note: the ExactSbend constructor takes phi in degrees, but the
+        # property returns radians (ImpactX issue #1367)
+        assert bend.phi == pytest.approx(angle)
+
+
+@pytest.mark.parametrize(
+    "min_model, expected",
+    [("linear", "CFbend"), ("paraxial", "ExactCFbend"), ("exact", "ExactCFbend")],
+)
+def test_combined_function_bend_tiers_round_up(min_model, expected):
+    """A bend with K1 uses the combined-function rung of the ladder."""
+    ds, angle, k1 = 2.0, 0.1, 0.5
+    beamline = _translate(
+        {"name": "b1", "type": "sbend", "l": ds, "angle": angle, "k1": k1},
+        min_model=min_model,
+    )
+    assert _types(beamline) == [expected]
+    fields = beamline[0].to_dict()
+    if expected == "CFbend":
+        assert fields["rc"] == pytest.approx(ds / angle)
+        assert fields["k"] == pytest.approx(k1)
+    else:
+        assert fields["k_normal"][0] == pytest.approx(angle / ds)  # curvature 1/rc
+        assert fields["k_normal"][1] == pytest.approx(k1)
+
+
+@pytest.mark.parametrize(
+    "min_model, expected",
+    [("linear", "linear"), ("paraxial", "nonlinear"), ("exact", "nonlinear")],
+)
+def test_dipedge_fringe_model_follows_min_model(min_model, expected):
+    """DipEdge switches its fringe model by argument. "nonlinear" is its exact tier."""
+    beamline = _translate(
+        {
+            "name": "de",
+            "type": "dipedge",
+            "h": 0.0966,
+            "e1": 0.0483,
+            "hgap": 0.01,
+            "fint": 0.5,
+        },
+        min_model=min_model,
+    )
+    edge = _only(beamline, elements.DipEdge)
+    assert edge.model == expected
+    # physical parameters are untouched by the model choice
+    assert edge.psi == pytest.approx(0.0483)
+    assert edge.rc == pytest.approx(1.0 / 0.0966)
+
+
+def test_bend_edges_follow_min_model():
+    """The DipEdges a bend emits at its faces honor the floor, too."""
+    elem = {
+        "name": "b1",
+        "type": "sbend",
+        "l": 2.0,
+        "angle": 0.1,
+        "e1": 0.05,
+        "e2": 0.05,
+        "hgap": 0.01,
+        "fint": 0.5,
+    }
+    beamline = _translate(dict(elem), min_model="linear")
+    assert _types(beamline) == ["DipEdge", "Sbend", "DipEdge"]
+    assert [e.model for e in beamline if isinstance(e, elements.DipEdge)] == [
+        "linear",
+        "linear",
+    ]
+
+    beamline = _translate(dict(elem), min_model="exact")
+    assert _types(beamline) == ["DipEdge", "ExactSbend", "DipEdge"]
+    assert [e.model for e in beamline if isinstance(e, elements.DipEdge)] == [
+        "nonlinear",
+        "nonlinear",
+    ]
+
+
+def test_synthetic_drifts_follow_min_model():
+    """Drifts the translator adds itself (here: around a thin MONITOR) follow the floor."""
+    beamline = _translate(
+        {"name": "m1", "type": "monitor", "l": 0.4}, min_model="exact"
+    )
+    assert _types(beamline) == ["ExactDrift", "BeamMonitor"]
+
+
+# ---------------------------------------------------------------------------
+# A floor never lowers a tier
+# ---------------------------------------------------------------------------
+
+
+def test_skew_quadrupole_stays_exact_at_linear_floor():
+    """A skew quadrupole only exists as ExactMultipole. The floor must not downgrade it."""
+    beamline = _translate(
+        {"name": "q1", "type": "quadrupole", "l": 0.3, "k1": 2.0, "k1s": 0.4},
+        min_model="linear",
+    )
+    assert _types(beamline) == ["ExactMultipole"]
+
+
+def test_sextupole_stays_exact_at_linear_floor():
+    """ImpactX has no thick linear sextupole. SEXTUPOLE stays exact at any floor."""
+    beamline = _translate(
+        {"name": "s1", "type": "sextupole", "l": 0.2, "k2": 3.0}, min_model="linear"
+    )
+    assert _types(beamline) == ["ExactMultipole"]
+
+
+# ---------------------------------------------------------------------------
+# Unreachable floors warn, once
+# ---------------------------------------------------------------------------
+
+
+def test_solenoid_warns_once_when_floor_is_unreachable():
+    """SOLENOID has only the linear Sol model: translate it anyway and warn once."""
+    solenoids = [
+        {"name": f"s{i}", "type": "solenoid", "l": 0.5, "ks": 1.0} for i in range(3)
+    ]
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        beamline = lattice(solenoids, min_model="exact")
+
+    assert _types(beamline) == ["Sol", "Sol", "Sol"]
+    floor_warnings = [
+        w
+        for w in caught
+        if issubclass(w.category, MADXImpactXTranslatorWarning)
+        and "SOLENOID" in str(w.message)
+        and "exact" in str(w.message)
+    ]
+    assert len(floor_warnings) == 1, [str(w.message) for w in caught]
+
+
+def test_solenoid_does_not_warn_at_linear_floor():
+    """The default floor is reachable everywhere, so it never triggers the warning."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        beamline = lattice([{"name": "s1", "type": "solenoid", "l": 0.5, "ks": 1.0}])
+
+    assert _types(beamline) == ["Sol"]
+    assert not [w for w in caught if "no 'linear'" in str(w.message)]
+
+
+# ---------------------------------------------------------------------------
+# Validation and end-to-end plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_min_model_raises():
+    with pytest.raises(ValueError, match="min_model"):
+        lattice([{"name": "d1", "type": "drift", "l": 0.5}], min_model="quadratic")
+
+
+def test_read_lattice_forwards_min_model(tmp_path):
+    """min_model reaches the translator through the file-reading entry point."""
+    deck = tmp_path / "fodo.madx"
+    deck.write_text(
+        "BEAM, PARTICLE=ELECTRON, ENERGY=5.0;\n"
+        "D1: DRIFT, L=0.25;\n"
+        "Q1: QUADRUPOLE, L=0.5, K1=1.0;\n"
+        "MYLINE: LINE=(D1, Q1, D1);\n"
+        "USE, SEQUENCE=MYLINE;\n"
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        default = read_lattice(str(deck))
+        exact = read_lattice(str(deck), min_model="exact")
+
+    assert _types(default) == ["Drift", "Quad", "Drift"]
+    assert _types(exact) == ["ExactDrift", "ExactQuad", "ExactDrift"]
+
+
+def test_load_file_forwards_min_model(tmp_path):
+    """The public KnownElementsList.load_file entry point forwards min_model."""
+    deck = tmp_path / "fodo.madx"
+    deck.write_text(
+        "BEAM, PARTICLE=ELECTRON, ENERGY=5.0;\n"
+        "D1: DRIFT, L=0.25;\n"
+        "Q1: QUADRUPOLE, L=0.5, K1=1.0;\n"
+        "MYLINE: LINE=(D1, Q1, D1);\n"
+        "USE, SEQUENCE=MYLINE;\n"
+    )
+
+    lat = elements.KnownElementsList()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        lat.load_file(str(deck), nslice=2, min_model="paraxial")
+
+    assert _types(lat) == ["ChrDrift", "ChrQuad", "ChrDrift"]
+    assert lat[1].nslice == 2
+
+
+def test_load_file_rejects_invalid_min_model(tmp_path):
+    deck = tmp_path / "fodo.madx"
+    deck.write_text(
+        "BEAM, PARTICLE=ELECTRON, ENERGY=5.0;\n"
+        "D1: DRIFT, L=0.25;\n"
+        "MYLINE: LINE=(D1);\n"
+        "USE, SEQUENCE=MYLINE;\n"
+    )
+
+    lat = elements.KnownElementsList()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        with pytest.raises(ValueError, match="min_model"):
+            lat.load_file(str(deck), min_model="chromatic")
+
+
+# ---------------------------------------------------------------------------
+# PALS reader (same floor, same vocabulary)
+# ---------------------------------------------------------------------------
+
+
+def test_pals_min_model():
+    """The PALS reader shares the tier tables. Its default output is unchanged."""
+    pals = pytest.importorskip("pals")
+
+    beamline = pals.BeamLine(
+        name="fodo",
+        line=[
+            pals.Drift(name="d1", length=0.25),
+            pals.Quadrupole(
+                name="q1",
+                length=0.5,
+                MagneticMultipoleP=pals.MagneticMultipoleParameters(Kn1=1.0),
+            ),
+        ],
+    )
+
+    from impactx.pals_to_impactx import read_lattice as pals_read_lattice
+
+    # the linear `Quad` has no `unit` argument yet (ImpactX issue #798), so the
+    # cheapest quadrupole model available to PALS is the paraxial one
+    assert _types(pals_read_lattice(beamline)) == ["Drift", "ChrQuad"]
+    assert _types(pals_read_lattice(beamline, min_model="exact")) == [
+        "ExactDrift",
+        "ExactQuad",
+    ]


### PR DESCRIPTION
The MAD-X and PALS readers so far pick the cheapest ImpactX element that represents an imported element: `Drift`, `Quad`, `Sbend`, `CFbend`, `DipEdge(model="linear")`, escalating to `Exact*` only when a feature such as a skew or higher-order multipole leaves no alternative. Users who need chromatic or exact-Hamiltonian dynamics from the start had to post-process the imported lattice element by element.

Add a `min_model=` argument to `KnownElementsList.load_file()`, `from_pals()` and the underlying `read_lattice()`/`lattice()` translators. It raises the lower gate of that choice, using the same "linear"/"paraxial"/"exact" vocabulary as `FilteredElementsList.replace_with_drifts(model=...)`. The default "linear" reproduces the previous output exactly.

Docs: https://impactx--1593.org.readthedocs.build/en/1593/usage/python.html#impactx.elements.KnownElementsList.load_file

Related to #1435

## Details

The floor never lowers a tier: an element that already requires a richer model, such as a skew quadrupole that only exists as `ExactMultipole`, keeps it. Not every family implements every tier (there is no `ChrSbend`, `ChrCFbend`, `ChrSol` or `ExactSol`), so a missing tier is skipped upwards. A paraxial floor on a plain SBEND yields `ExactSbend` rather than falling back to the linear model. Where no implemented model reaches the floor, as for SOLENOID, the most faithful one available is used and a warning is emitted once per lattice.

<details>

New `impactx/element_models.py` holds the one place of truth for the tier ordering: `MODEL_TIERS`, `tier_rank`, `tier_of_class`, `validate_model`, `select_model` plus the `DRIFT_MODEL_CLASSES`/`QUAD_MODEL_CLASSES` tables. `KnownElementsList` now imports its tier helpers from there instead of keeping private copies, so both knobs share one vocabulary and one validation message.

In the MAD-X translator, a single `build(family, builders, **kwargs)` dispatcher plus the `make_drift`, `make_quad` and `make_dipedge` closures replace 14 `Drift`, 3 `Quad` and 5 `DipEdge` construction sites, so applying the floor is one table per family rather than a branch per call site. `make_bend_body_element` keeps its documented priority ladder, with each rung now declaring the tiers ImpactX implements for it.

`DipEdge` selects its fringe model by argument rather than by class, so its 6th-order "nonlinear" map is registered as the exact tier. This matches the choice the synmadx importer already makes in `cnv_dipedge`.

</details>

- [x] Design spec by @ax3l
- [x] Typed with help of Claude Opus 5 xHigh.
- [x] Auto-reviewed with help of Codex GPT 5.6-Sol xHigh.
- [x] Self-reviewed manually.