### PR TITLE
synmadx: Fix ExactCFbend/ExactMultipole Conversion Crashes

### DIFF
--- a/src/python/impactx/synmadx/syn2_to_impactx.py
+++ b/src/python/impactx/synmadx/syn2_to_impactx.py
@@ -175,8 +175,6 @@ def cnv_sbend(elem, order):
             )
         else:
             # CF bend
-            # ExactCFbend requires k_normal and k_skew to have the same length,
-            # so both arrays are truncated at the same order (see cnv_rbend).
             if k2 == 0.0:
                 knormal = [1 / radius_of_curvature, k1]
                 kskew = [0.0, k1s]
@@ -554,7 +552,6 @@ def cnv_octupole(elem, order):
             ds=L,
             k_normal=knorm,
             k_skew=kskew,
-            # the ExactMultipole argument is int_order, matching cnv_sextupole
             int_order=4,
             nslice=nslice_by_elem_type["octupole"],
             name=nm,

--- a/src/python/impactx/synmadx/syn2_to_impactx.py
+++ b/src/python/impactx/synmadx/syn2_to_impactx.py
@@ -175,9 +175,11 @@ def cnv_sbend(elem, order):
             )
         else:
             # CF bend
+            # ExactCFbend requires k_normal and k_skew to have the same length,
+            # so both arrays are truncated at the same order (see cnv_rbend).
             if k2 == 0.0:
                 knormal = [1 / radius_of_curvature, k1]
-                kskew = [0.0, k1s, 0.0]
+                kskew = [0.0, k1s]
             else:
                 knormal = [1 / radius_of_curvature, k1, k2]
                 kskew = [0.0, k1s, 0.0]
@@ -552,7 +554,8 @@ def cnv_octupole(elem, order):
             ds=L,
             k_normal=knorm,
             k_skew=kskew,
-            order=4,
+            # the ExactMultipole argument is int_order, matching cnv_sextupole
+            int_order=4,
             nslice=nslice_by_elem_type["octupole"],
             name=nm,
         )


### PR DESCRIPTION
Two element conversions in `impactx.synmadx.syn2_to_impactx` raise instead of returning an element. Neither is reachable from the Fermilab Booster deck that the `simple_booster_synmadx` example and its test use, so nothing catches them today.

### `cnv_sbend`: mismatched multipole array lengths

For a combined-function `SBEND` with `K2=0`, the skew array kept a third entry while the normal array had only two:

```python
if k2 == 0.0:
    knormal = [1 / radius_of_curvature, k1]
    kskew = [0.0, k1s, 0.0]     # <- three entries
```

`ExactCFbend` requires both arrays to have the same length:

```
RuntimeError: ExactCFbend: normal and skew coefficient arrays must have same length!
```

`cnv_rbend` already truncates both arrays at the same order in its own `K2=0` branch, so this matches that.

The Booster's F/D magnets all carry `K2 != 0`, which is why the working branch is the one that gets exercised.

### `cnv_octupole`: wrong keyword name

The `ExactMultipole` integration-order argument is `int_order`, not `order`, so every MAD-X `OCTUPOLE` converted at `Order.chr` or `Order.exact` raised:

```
TypeError: __init__(): incompatible constructor arguments.
```

`cnv_sextupole` spells the same argument correctly. The Booster deck has 6 sextupoles and no octupoles, so this path has never run.

### Reproducer

```madx
beam, particle=proton, energy=1.738272;
b1: sbend, l=1.0, angle=0.05, k1=0.1;   ! combined-function, K2=0
o1: octupole, l=0.2, k3=1.5;
d1: drift, l=0.5;
testline: line=(d1, b1, d1, o1, d1);
```

Before this change, `cnv_sbend` and `cnv_octupole` both raise at `Order.chr` and `Order.exact`. After it, both convert at all three orders (`CFbend`/`ExactCFbend` and `Drift`/`ExactMultipole` respectively).

Found while comparing the synmadx conversion against the primary MAD-X importer, `KnownElementsList.load_file()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)