### PR TITLE
Elements: Argument Validation Raises `ValueError`

### DIFF
--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -96,17 +96,17 @@ namespace impactx::elements
             if (aperture_x > 0_prt) {
                 m_inv_aperture_x = 1_prt / aperture_x;
             } else {
-                throw std::runtime_error("Aperture: aperture_x must be > 0!");
+                throw std::invalid_argument("Aperture: aperture_x must be > 0!");
             }
 
             if (aperture_y > 0_prt) {
                 m_inv_aperture_y = 1_prt / aperture_y;
             } else {
-                throw std::runtime_error("Aperture: aperture_y must be > 0!");
+                throw std::invalid_argument("Aperture: aperture_y must be > 0!");
             }
 
             if (m_repeat_y == 0_prt && m_shift_odd_x) {
-                throw std::runtime_error("Aperture: shift_odd_x can only be used if repeat_y is set, too!");
+                throw std::invalid_argument("Aperture: shift_odd_x can only be used if repeat_y is set, too!");
             }
         }
 

--- a/src/elements/ConstF.H
+++ b/src/elements/ConstF.H
@@ -154,7 +154,7 @@ namespace impactx::elements
 
             if (m_kt < 0_prt)
             {
-                throw std::runtime_error(std::string(type) + ": must have kt >= 0!");
+                throw std::invalid_argument(std::string(type) + ": must have kt >= 0!");
             }
             auto const [sin_ktds, cos_ktds] = amrex::Math::sincos(m_kt * slice_ds);
             m_cos_ktds = cos_ktds;
@@ -357,7 +357,7 @@ namespace impactx::elements
             }
 
             if (m_kt < 0_prt) {
-                throw std::runtime_error(std::string(type) + ": must have kt >= 0!");
+                throw std::invalid_argument(std::string(type) + ": must have kt >= 0!");
             }
             auto const [sin_ktds, cos_ktds] = amrex::Math::sincos(m_kt * slice_ds);
             amrex::ParticleReal const_t = -m_kt * betgam2 * sin_ktds;

--- a/src/elements/ExactCFbend.H
+++ b/src/elements/ExactCFbend.H
@@ -115,11 +115,11 @@ namespace impactx::elements
           m_id(DynamicData::allocate_id())
         {
             if (m_int_order != 2 && m_int_order != 4 && m_int_order != 6)
-                throw std::runtime_error("ExactCFbend: The order used for symplectic integration must be 2, 4 or 6.");
+                throw std::invalid_argument("ExactCFbend: The order used for symplectic integration must be 2, 4 or 6.");
 
             m_ncoef = int(k_normal.size());
             if (m_ncoef != int(k_skew.size()))
-                throw std::runtime_error("ExactCFbend: normal and skew coefficient arrays must have same length!");
+                throw std::invalid_argument("ExactCFbend: normal and skew coefficient arrays must have same length!");
 
             auto& coef = DynamicData::emplace(
                 m_id,

--- a/src/elements/ExactMultipole.H
+++ b/src/elements/ExactMultipole.H
@@ -120,7 +120,7 @@ namespace impactx::elements
         {
             m_ncoef = int(k_normal.size());
             if (m_ncoef != int(k_skew.size()))
-                throw std::runtime_error("ExactMultipole: normal and skew coefficient arrays must have same length!");
+                throw std::invalid_argument("ExactMultipole: normal and skew coefficient arrays must have same length!");
 
             auto& coef = DynamicData::emplace(
                 m_id,

--- a/src/elements/PolygonAperture.H
+++ b/src/elements/PolygonAperture.H
@@ -115,17 +115,17 @@ namespace impactx::elements
             using namespace amrex::literals; // for _rt and _prt
 
             if (m_repeat_y == 0_prt && m_shift_odd_x) {
-                throw std::runtime_error("PolygonAperture: shift_odd_x can only be used if repeat_y is set, too!");
+                throw std::invalid_argument("PolygonAperture: shift_odd_x can only be used if repeat_y is set, too!");
             }
 
             m_nvert = vertices_x.size();
             if (m_nvert != vertices_y.size()) {
-                throw std::runtime_error("PolygonAperture: horizontal and vertical vertices arrays must have same length!");
+                throw std::invalid_argument("PolygonAperture: horizontal and vertical vertices arrays must have same length!");
             }
 
             if ((vertices_x[0] != vertices_x[m_nvert-1]) ||
                 (vertices_y[0] != vertices_y[m_nvert-1])) {
-                throw std::runtime_error("PolygonAperture: first and last vertex must be exactly equal!");
+                throw std::invalid_argument("PolygonAperture: first and last vertex must be exactly equal!");
             }
 
             auto& vert = DynamicData::emplace(

--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -158,7 +158,7 @@ namespace impactx::elements
         {
             m_ncoef = int(cos_coef.size());
             if (m_ncoef != int(sin_coef.size()))
-                throw std::runtime_error("RFCavity: cos and sin coefficients must have same length!");
+                throw std::invalid_argument("RFCavity: cos and sin coefficients must have same length!");
 
             auto& coef = DynamicData::emplace(
                 m_id,

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -163,7 +163,7 @@ namespace impactx::elements
         {
             m_ncoef = int(cos_coef.size());
             if (m_ncoef != int(sin_coef.size()))
-                throw std::runtime_error("SoftQuadrupole: cos and sin coefficients must have same length!");
+                throw std::invalid_argument("SoftQuadrupole: cos and sin coefficients must have same length!");
 
             auto& coef = DynamicData::emplace(
                 m_id,

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -174,7 +174,7 @@ namespace impactx::elements
         {
             m_ncoef = int(cos_coef.size());
             if (m_ncoef != int(sin_coef.size()))
-                throw std::runtime_error("SoftSolenoid: cos and sin coefficients must have same length!");
+                throw std::invalid_argument("SoftSolenoid: cos and sin coefficients must have same length!");
 
             auto& coef = DynamicData::emplace(
                 m_id,

--- a/src/elements/Source.H
+++ b/src/elements/Source.H
@@ -56,7 +56,7 @@ namespace impactx::elements
           m_load_ref_particle(load_ref_particle)
         {
             if (distribution != "openPMD") {
-                throw std::runtime_error("Only 'openPMD' distribution is supported if openpmd_path is provided!");
+                throw std::invalid_argument("Only 'openPMD' distribution is supported if openpmd_path is provided!");
             }
         }
 

--- a/src/elements/diagnostics/BeamMonitor.cpp
+++ b/src/elements/diagnostics/BeamMonitor.cpp
@@ -143,7 +143,7 @@ namespace detail {
         m_beam_moments(beam_moments)
     {
         if (period_sample_intervals < 1) {
-            throw std::runtime_error("BeamMonitor: period_sample_intervals must be >= 1");
+            throw std::invalid_argument("BeamMonitor: period_sample_intervals must be >= 1");
         }
     }
 

--- a/src/elements/mixin/accessors.H
+++ b/src/elements/mixin/accessors.H
@@ -100,7 +100,7 @@ namespace impactx::elements
         std::visit([nslice](auto & element) {
             if constexpr (mixin::has_settable_nslice_v<decltype(element)>) {
                 if (nslice <= 0) {
-                    throw std::runtime_error(
+                    throw std::invalid_argument(
                         "elements::nslice: nslice must be > 0.");
                 }
                 element.m_nslice = nslice;

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -15,6 +15,7 @@
 
 #include <map>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -965,7 +966,7 @@ void init_elements(py::module& m)
             )
             {
                  if (R <= 0.0)
-                     throw std::runtime_error(R"(DipEdge parameter R must be > 0.)");
+                     throw std::invalid_argument(R"(DipEdge parameter R must be > 0.)");
 
                 DipEdge::Model const fm = amrex::getEnum<DipEdge::Model>(model);
                 DipEdge::Location const fl = amrex::getEnum<DipEdge::Location>(location);
@@ -1010,7 +1011,7 @@ void init_elements(py::module& m)
             [](DipEdge & dip_edge) { return dip_edge.m_R; },
             [](DipEdge & dip_edge, amrex::ParticleReal R) {
                 if (R <= 0.0)
-                     throw std::runtime_error(R"(DipEdge parameter R must be > 0.)");
+                     throw std::invalid_argument(R"(DipEdge parameter R must be > 0.)");
                 dip_edge.m_R = R;
             },
             "Length scale for field integrals in m"
@@ -1334,7 +1335,7 @@ void init_elements(py::module& m)
             [](ExactCFbend & exact_cfbend) { return exact_cfbend.m_int_order; },
             [](ExactCFbend & exact_cfbend, int int_order) {
                 if (int_order != 2 && int_order != 4 && int_order != 6)
-                    throw std::runtime_error("ExactCFbend: The order used for symplectic integration must be 2, 4 or 6.");
+                    throw std::invalid_argument("ExactCFbend: The order used for symplectic integration must be 2, 4 or 6.");
                 exact_cfbend.m_int_order = int_order;
             },
             "order of symplectic integration used for particle push in applied fields"


### PR DESCRIPTION
Element checks that reject a bad user-supplied value threw `std::runtime_error`, which pybind11 surfaces as a Python `RuntimeError`. In Python a wrong argument is a `ValueError`, and today callers cannot distinguish one from a genuine runtime failure such as a missing openPMD attribute or an unsupported `reverse()`.

This converts argument and value validation on element construction and mutation to `std::invalid_argument`, which pybind11 maps to `ValueError`.

### Converted (20 sites)

| element | check |
|---|---|
| `Aperture` | `aperture_x` / `aperture_y` > 0; `shift_odd_x` requires `repeat_y` |
| `PolygonAperture` | same `shift_odd_x` rule; vertex array length; first and last vertex equality |
| `DipEdge` | `R` > 0 (both property setters) |
| `ExactCFbend` | `int_order` in {2,4,6} (constructor and setter); normal/skew array length |
| `ExactMultipole` | normal/skew array length |
| `RFCavity`, `SoftQuadrupole`, `SoftSolenoid` | cos/sin coefficient array length |
| `ConstF`, `Buncher` | `kt` >= 0 |
| `Source` | only the openPMD distribution is supported with `openpmd_path` |
| `BeamMonitor` | `period_sample_intervals` >= 1 |
| `elements::nslice` | `nslice` > 0 |

### Deliberately left as `runtime_error`

Errors that are not about an argument: `reverse()` and linear-transport-map "not supported", a non-symplectic `LinearMap`, an unset name, GPU registry failures, missing openPMD attributes, and the capability throws in `mixin/accessors.H` ("this element cannot be sliced"), which sit directly next to the value check they are deliberately distinguished from:

```cpp
if (nslice <= 0) {
    throw std::invalid_argument("elements::nslice: nslice must be > 0.");   // value
}
...
throw std::runtime_error("elements::nslice: this element cannot be sliced."); // capability
```

### Compatibility

`std::invalid_argument` derives from `std::logic_error`, **not** `std::runtime_error`, so a `catch (std::runtime_error&)` would no longer match these. Checked before converting:

- there are no `catch` sites at all in `src/`
- no test or example asserts on any of these 20 messages

Python code catching `RuntimeError` from these paths would need to catch `ValueError` instead. Nothing in-tree does.

Also adds the `<stdexcept>` include that `src/python/elements.cpp` had been getting transitively.

### Testing

Full build clean. `pytest.ImpactX` shows no new failures. Verified on representative constructor and setter paths that the converted checks now raise `ValueError` while a neighbouring not-implemented error still raises `RuntimeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)