### PR TITLE
Elements: Validate `mapsteps` > 0

### DIFF
--- a/src/elements/ExactCFbend.H
+++ b/src/elements/ExactCFbend.H
@@ -117,6 +117,9 @@ namespace impactx::elements
             if (m_int_order != 2 && m_int_order != 4 && m_int_order != 6)
                 throw std::runtime_error("ExactCFbend: The order used for symplectic integration must be 2, 4 or 6.");
 
+            if (m_mapsteps <= 0)
+                throw std::invalid_argument("ExactCFbend: mapsteps must be > 0!");
+
             m_ncoef = int(k_normal.size());
             if (m_ncoef != int(k_skew.size()))
                 throw std::runtime_error("ExactCFbend: normal and skew coefficient arrays must have same length!");

--- a/src/elements/ExactMultipole.H
+++ b/src/elements/ExactMultipole.H
@@ -118,6 +118,9 @@ namespace impactx::elements
           m_unit(unit), m_int_order(int_order), m_mapsteps(mapsteps),
           m_id(DynamicData::allocate_id())
         {
+            if (m_mapsteps <= 0)
+                throw std::invalid_argument("ExactMultipole: mapsteps must be > 0!");
+
             m_ncoef = int(k_normal.size());
             if (m_ncoef != int(k_skew.size()))
                 throw std::runtime_error("ExactMultipole: normal and skew coefficient arrays must have same length!");

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -95,6 +95,8 @@ namespace impactx::elements
           PipeAperture(aperture_x, aperture_y),
           m_k(k),m_unit(unit),m_int_order(int_order),m_mapsteps(mapsteps)
         {
+            if (m_mapsteps <= 0)
+                throw std::invalid_argument("ExactQuad: mapsteps must be > 0!");
         }
 
         /** Reverse the element (negate ds) */

--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -156,6 +156,9 @@ namespace impactx::elements
             m_escale(escale), m_freq(freq), m_phase(phase), m_mapsteps(mapsteps),
             m_id(DynamicData::allocate_id())
         {
+            if (m_mapsteps <= 0)
+                throw std::invalid_argument("RFCavity: mapsteps must be > 0!");
+
             m_ncoef = int(cos_coef.size());
             if (m_ncoef != int(sin_coef.size()))
                 throw std::runtime_error("RFCavity: cos and sin coefficients must have same length!");

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -161,6 +161,9 @@ namespace impactx::elements
             m_gscale(gscale), m_mapsteps(mapsteps),
             m_id(DynamicData::allocate_id())
         {
+            if (m_mapsteps <= 0)
+                throw std::invalid_argument("SoftQuadrupole: mapsteps must be > 0!");
+
             m_ncoef = int(cos_coef.size());
             if (m_ncoef != int(sin_coef.size()))
                 throw std::runtime_error("SoftQuadrupole: cos and sin coefficients must have same length!");

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -172,6 +172,9 @@ namespace impactx::elements
             m_bscale(bscale), m_unit(unit), m_mapsteps(mapsteps),
             m_id(DynamicData::allocate_id())
         {
+            if (m_mapsteps <= 0)
+                throw std::invalid_argument("SoftSolenoid: mapsteps must be > 0!");
+
             m_ncoef = int(cos_coef.size());
             if (m_ncoef != int(sin_coef.size()))
                 throw std::runtime_error("SoftSolenoid: cos and sin coefficients must have same length!");

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -1266,7 +1266,11 @@ void init_elements(py::module& m)
         )
         .def_property("mapsteps",
             [](ExactMultipole & exact_multipole) { return exact_multipole.m_mapsteps; },
-            [](ExactMultipole & exact_multipole, int mapsteps) { exact_multipole.m_mapsteps = mapsteps; },
+            [](ExactMultipole & exact_multipole, int mapsteps) {
+                if (mapsteps <= 0)
+                    throw std::invalid_argument("ExactMultipole: mapsteps must be > 0!");
+                exact_multipole.m_mapsteps = mapsteps;
+            },
             "number of integration steps per slice used for particle push in the applied fields"
         )
     ;
@@ -1341,7 +1345,11 @@ void init_elements(py::module& m)
         )
         .def_property("mapsteps",
             [](ExactCFbend & exact_cfbend) { return exact_cfbend.m_mapsteps; },
-            [](ExactCFbend & exact_cfbend, int mapsteps) { exact_cfbend.m_mapsteps = mapsteps; },
+            [](ExactCFbend & exact_cfbend, int mapsteps) {
+                if (mapsteps <= 0)
+                    throw std::invalid_argument("ExactCFbend: mapsteps must be > 0!");
+                exact_cfbend.m_mapsteps = mapsteps;
+            },
             "number of integration steps per slice used for particle push in the applied fields"
         )
     ;
@@ -1415,7 +1423,11 @@ void init_elements(py::module& m)
         )
         .def_property("mapsteps",
             [](ExactQuad & exact_quad) { return exact_quad.m_mapsteps; },
-            [](ExactQuad & exact_quad, int mapsteps) { exact_quad.m_mapsteps = mapsteps; },
+            [](ExactQuad & exact_quad, int mapsteps) {
+                if (mapsteps <= 0)
+                    throw std::invalid_argument("ExactQuad: mapsteps must be > 0!");
+                exact_quad.m_mapsteps = mapsteps;
+            },
             "number of integration steps per slice used for particle push in the applied fields"
         )
     ;
@@ -2067,7 +2079,11 @@ void init_elements(py::module& m)
         // TODO sin_coefficients
         .def_property("mapsteps",
             [](RFCavity & rfc) { return rfc.m_mapsteps; },
-            [](RFCavity & rfc, int mapsteps) { rfc.m_mapsteps = mapsteps; },
+            [](RFCavity & rfc, int mapsteps) {
+                if (mapsteps <= 0)
+                    throw std::invalid_argument("RFCavity: mapsteps must be > 0!");
+                rfc.m_mapsteps = mapsteps;
+            },
             "number of integration steps per slice used for map and reference particle push in applied fields"
         )
         .def_property_readonly("map",
@@ -2391,7 +2407,11 @@ void init_elements(py::module& m)
         )
         .def_property("mapsteps",
             [](SoftSolenoid & soft_sol) { return soft_sol.m_mapsteps; },
-            [](SoftSolenoid & soft_sol, int mapsteps) { soft_sol.m_mapsteps = mapsteps; },
+            [](SoftSolenoid & soft_sol, int mapsteps) {
+                if (mapsteps <= 0)
+                    throw std::invalid_argument("SoftSolenoid: mapsteps must be > 0!");
+                soft_sol.m_mapsteps = mapsteps;
+            },
             "number of integration steps per slice used for map and reference particle push in applied fields"
         )
         .def_property_readonly("map",
@@ -2653,7 +2673,11 @@ void init_elements(py::module& m)
         // TODO sin_coefficients
         .def_property("mapsteps",
             [](SoftQuadrupole & soft_quad) { return soft_quad.m_mapsteps; },
-            [](SoftQuadrupole & soft_quad, int mapsteps) { soft_quad.m_mapsteps = mapsteps; },
+            [](SoftQuadrupole & soft_quad, int mapsteps) {
+                if (mapsteps <= 0)
+                    throw std::invalid_argument("SoftQuadrupole: mapsteps must be > 0!");
+                soft_quad.m_mapsteps = mapsteps;
+            },
             "number of integration steps per slice used for map and reference particle push in applied fields"
         )
         .def_property_readonly("map",


### PR DESCRIPTION
`mapsteps` is the number of integration steps per slice used to push particles through the applied fields. Nothing validated it: `mapsteps=0` or a negative value was accepted by every constructor and every property setter, and then used as the step count of a symplectic integrator.

Reject it in both places, following the existing `ExactCFbend` `int_order` pattern of validating in the constructor *and* in the setter, for all six elements that expose the knob:

`ExactQuad`, `ExactCFbend`, `ExactMultipole`, `RFCavity`, `SoftSolenoid`, `SoftQuadrupole`

```python
elements.ExactQuad(ds=1.0, k=1.0, mapsteps=0)
# ValueError: ExactQuad: mapsteps must be > 0!

q = elements.ExactQuad(ds=1.0, k=1.0)
q.mapsteps = -1
# ValueError: ExactQuad: mapsteps must be > 0!
```

Raises `std::invalid_argument`, i.e. `ValueError` in Python.

### Note for review: temporary mixed exception types

This is intentionally independent of #1595, which converts the *existing* element argument checks from `std::runtime_error` to `std::invalid_argument`. Until that merges, a constructor can contain two adjacent argument checks that raise different Python types:

```cpp
if (m_mapsteps <= 0)
    throw std::invalid_argument("SoftQuadrupole: mapsteps must be > 0!");    // this PR -> ValueError

m_ncoef = int(cos_coef.size());
if (m_ncoef != int(sin_coef.size()))
    throw std::runtime_error("SoftQuadrupole: cos and sin coefficients ..."); // -> RuntimeError until #1595
```

Both PRs are mergeable in either order; the inconsistency resolves once #1595 lands. `ValueError` is the intended end state for both, so this PR does not need to be held for it.

`src/python/elements.cpp` uses `std::invalid_argument` without an explicit `#include <stdexcept>`; it resolves through the same transitive include that already served `std::runtime_error` in that file, and a full build confirms it. The explicit include is added by #1595 rather than duplicated here, to avoid a conflict between the two branches.

### Testing

Full build clean. Verified that invalid values are rejected from both the constructor and the setter on all six classes, and that valid values (e.g. `mapsteps=6`) still construct and assign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)