### PR TITLE
Python: Fix Lattice Rebuild Corrupting Elements

### DIFF
--- a/src/python/impactx/extensions/KnownElementsList.py
+++ b/src/python/impactx/extensions/KnownElementsList.py
@@ -79,12 +79,38 @@ def _invalidate_all_registered_views(lattice) -> None:
         fel._invalidated = True
 
 
+# These report an angle in radians from ``to_dict()`` although their constructors
+# take degrees, so serializing them for round-trip needs ``in_degrees=True``.
+# See https://github.com/BLAST-ImpactX/impactx/issues/1367
+_DEGREE_ELEMENTS = (
+    "ExactSbend",
+    "PlaneXYRot",
+    "PRot",
+    "ThinDipole",
+)
+
+
+def _element_to_dict(element) -> dict:
+    """Serialize an element to a dict that its constructor can consume again.
+
+    Applies the radians/degrees work-around for the element types whose
+    ``to_dict()`` disagrees with their constructor.
+    """
+    if type(element).__name__ in _DEGREE_ELEMENTS:
+        return element.to_dict(in_degrees=True)
+    return element.to_dict()
+
+
 def _clone_element(template):
-    """Deep-clone a lattice element via ``to_dict`` (pybind elements are not copy.copy-able)."""
-    d = template.to_dict()
-    type_name = d.pop("type")
-    cls = getattr(elements, type_name)
-    return cls(**d)
+    """Deep-clone a lattice element via ``to_dict`` (pybind elements are not copy.copy-able).
+
+    Goes through ``_element_to_dict`` and ``_element_from_dict`` so that the dict is
+    one the constructor accepts: ``_filter_kwargs`` drops keys that ``to_dict``
+    reports but the constructor rejects (thin elements such as ``Marker`` report
+    ``ds=0.0`` yet take only a name), and angles are converted to the degrees the
+    constructor expects.
+    """
+    return _element_from_dict(_element_to_dict(template))
 
 
 def _make_drift_from_old(
@@ -822,19 +848,9 @@ def to_dicts(self) -> list[dict]:
     # simple implementation:
     # return [el.to_dict() for el in self]
 
-    # work-around for ExactSbend, PlaneXYRot, PRot, ThinDipole .to_dict() returning radians not degrees
-    results = []
-    for el in self:
-        if type(el) in [
-            elements.ExactSbend,
-            elements.PlaneXYRot,
-            elements.PRot,
-            elements.ThinDipole,
-        ]:
-            results.append(el.to_dict(in_degrees=True))
-        else:
-            results.append(el.to_dict())
-    return results
+    # work-around for ExactSbend, PlaneXYRot, PRot, ThinDipole .to_dict() returning
+    # radians not degrees; shared with _clone_element via _element_to_dict
+    return [_element_to_dict(el) for el in self]
 
 
 def _format_value(v):

--- a/tests/python/test_element_serialization.py
+++ b/tests/python/test_element_serialization.py
@@ -723,3 +723,47 @@ def test_to_py_roundtrip(all_elements):
             f"  Original: {d1}\n"
             f"  Reconstructed: {d2}"
         )
+
+
+def test_clone_element_covers_all_element_types(all_elements):
+    """Every element type must survive the clone used to rebuild a lattice.
+
+    ``delete()``, ``replace_each()`` and ``replace_with_drifts()`` rebuild the
+    lattice by cloning the elements they are not replacing. That clone goes
+    through ``to_dict()`` and back into the constructor, and the two are not
+    symmetric for thin elements: ``Marker.to_dict()`` reports ``ds=0.0`` while
+    ``Marker.__init__`` takes only a name. Cloning such an element used to raise
+    ``TypeError``, breaking all three operations on any lattice containing one.
+    """
+    from impactx.extensions.KnownElementsList import _clone_element
+
+    lattice, _ = all_elements
+
+    failures = []
+    for element in lattice:
+        type_name = type(element).__name__
+        if type_name in SKIP_ELEMENTS:
+            continue
+        try:
+            clone = _clone_element(element)
+        except Exception as e:  # noqa: BLE001 - report every offender at once
+            failures.append(f"{type_name}: {type(e).__name__}: {e}")
+            continue
+        assert type(clone) is type(element), type_name
+        assert dicts_equal(clone.to_dict(), element.to_dict()), (
+            f"clone of {type_name} does not match the original:\n"
+            f"  Original: {element.to_dict()}\n"
+            f"  Clone:    {clone.to_dict()}"
+        )
+
+    assert not failures, "elements that cannot be cloned:\n  " + "\n  ".join(failures)
+
+
+def test_lattice_rebuild_covers_all_element_types(all_elements):
+    """The same coverage through the public API that depends on cloning."""
+    lattice, _ = all_elements
+
+    n_before = len(lattice)
+    # delete a single element: every *other* element has to be cloned
+    lattice.select(kind="Marker").delete()
+    assert len(lattice) < n_before

--- a/tests/python/test_lattice_select.py
+++ b/tests/python/test_lattice_select.py
@@ -1134,3 +1134,38 @@ def test_replace_with_drifts_thin_element():
     assert lattice[0].ds == 0.0
     assert lattice[1].name == "d1"
     assert lattice[1].ds == 1.0
+
+
+def test_delete_with_thin_element_present():
+    """Cloning must not pass `ds` to thin elements that do not accept it.
+
+    `Marker.to_dict()` reports `ds=0.0` but `Marker.__init__` takes only a name,
+    so rebuilding the lattice used to raise TypeError whenever an unselected
+    thin element had to be cloned.
+    """
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Marker(name="m1"),
+            elements.Drift(name="d1", ds=1.0),
+            elements.ShortRF(name="rf1", V=1.0, freq=1.0e6, phase=0.0),
+        ]
+    )
+    lattice.select(kind="Drift").delete()
+    assert [type(e).__name__ for e in lattice] == ["Marker", "ShortRF"]
+    assert lattice[0].name == "m1"
+    assert lattice[1].name == "rf1"
+
+
+def test_replace_each_with_thin_element_present():
+    """Same cloning path, via replace_each."""
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Marker(name="m1"),
+            elements.Quad(name="q1", ds=0.5, k=1.0),
+        ]
+    )
+    lattice.select(kind="Quad").replace_each(elements.Drift(ds=0.5))
+    assert [type(e).__name__ for e in lattice] == ["Marker", "Drift"]
+    assert lattice[0].name == "m1"


### PR DESCRIPTION
`delete()`, `replace_each()` and `replace_with_drifts()` rebuild the lattice by cloning the elements they are *not* replacing. `_clone_element` fed `to_dict()` straight back into the constructor, but the two are not symmetric, in two independent ways.

## 1. Thin elements raise `TypeError`

`to_dict()` reports keys the constructor does not accept:

```python
>>> elements.Marker("m").to_dict()
{'ds': 0.0, 'name': 'm', 'type': 'Marker'}
>>> elements.Marker(ds=0.0, name="m")
TypeError: __init__(): incompatible constructor arguments
```

14 of 17 sampled element types are affected:

`Aperture`, `BeamMonitor`, `Buncher`, `DipEdge`, `Kicker`, `Marker`, `Multipole`, `NonlinearLens`, `PRot`, `PlaneXYRot`, `QuadEdge`, `ShortRF`, `TaperedPL`, `ThinDipole`

Only thick elements survive. So all three operations fail on any lattice containing a thin element — which is nearly every real lattice; a MAD-X import alone emits `Marker`, `Aperture`, `BeamMonitor` and `ShortRF`.

## 2. Angles are silently corrupted

`ExactSbend`, `PlaneXYRot`, `PRot` and `ThinDipole` report their angle in **radians** from `to_dict()` while their constructors take **degrees** (#1367). The radian value was fed back in as degrees:

```python
>>> b = elements.ExactSbend(ds=0.5, phi=15.0, B=0.5)
>>> clone_of(b).phi
0.004569261296800628      # 0.262 deg, was 15 deg
```

A 15° bend becomes 0.262° — off by exactly the 57.3× rad/deg factor, with no error raised. Any such element that happened to be *near* the one you deleted had its geometry quietly changed.

`to_dicts()` already worked around this by passing `in_degrees=True` for exactly these four types; `_clone_element` did not.

## Fix

Route cloning through a new `_element_to_dict` plus the existing `_element_from_dict`, so the dict handed to the constructor is one it accepts: `_filter_kwargs` drops `type` and a zero `ds`, and angles are emitted in degrees. `to_dicts()` had the degree work-around inline and now shares `_element_to_dict`, so the two cannot drift apart again.

`_element_from_dict` and `_filter_kwargs` already existed and were used by `from_dicts` — `_clone_element` simply predated them.

## Why the existing tests missed it

`test_replace_with_drifts_thin_element` does place a `Marker` in the lattice, but the `Marker` is the element being *replaced*, so it is constructed fresh rather than cloned. Every other test used thick-only lattices. The clone path only fires for an **unselected** element.

## Testing

Regression tests now cover every element type via the existing `all_elements` fixture rather than spot-checking, asserting both that each element can be cloned and that the clone round-trips equal — the second assertion is what caught the angle bug. Plus tests for the public rebuild path with thin elements present.

Python-only change. `pytest.ImpactX` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)