### PR TITLE
Elements: Validate `nslice` > 0 and `int_order`

### DIFF
--- a/src/elements/ExactMultipole.H
+++ b/src/elements/ExactMultipole.H
@@ -118,6 +118,9 @@ namespace impactx::elements
           m_unit(unit), m_int_order(int_order), m_mapsteps(mapsteps),
           m_id(DynamicData::allocate_id())
         {
+            if (m_int_order != 2 && m_int_order != 4 && m_int_order != 6)
+                throw std::invalid_argument("ExactMultipole: The order used for symplectic integration must be 2, 4 or 6.");
+
             if (m_mapsteps <= 0)
                 throw std::invalid_argument("ExactMultipole: mapsteps must be > 0!");
 

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -95,6 +95,9 @@ namespace impactx::elements
           PipeAperture(aperture_x, aperture_y),
           m_k(k),m_unit(unit),m_int_order(int_order),m_mapsteps(mapsteps)
         {
+            if (m_int_order != 2 && m_int_order != 4 && m_int_order != 6)
+                throw std::invalid_argument("ExactQuad: The order used for symplectic integration must be 2, 4 or 6.");
+
             if (m_mapsteps <= 0)
                 throw std::invalid_argument("ExactQuad: mapsteps must be > 0!");
         }

--- a/src/elements/mixin/thick.H
+++ b/src/elements/mixin/thick.H
@@ -15,6 +15,8 @@
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
 
+#include <stdexcept>
+
 
 namespace impactx::elements::mixin
 {
@@ -27,7 +29,8 @@ namespace impactx::elements::mixin
         /** A finite-length element
          *
          * @param ds Segment length in m
-         * @param nslice number of slices used for the application of space charge
+         * @param nslice number of slices used for the application of space charge,
+         *               a positive integer
          */
         Thick (
             amrex::ParticleReal ds,
@@ -35,6 +38,8 @@ namespace impactx::elements::mixin
         )
         : m_ds(ds), m_nslice(nslice)
         {
+            if (m_nslice <= 0)
+                throw std::invalid_argument("Thick: nslice must be > 0!");
         }
 
         /** Number of slices used for the application of space charge

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -346,7 +346,11 @@ void init_elements(py::module& m)
         )
         .def_property("nslice",
             [](elements::mixin::Thick & th) { return th.m_nslice; },
-            [](elements::mixin::Thick & th, int nslice) { th.m_nslice = nslice; },
+            [](elements::mixin::Thick & th, int nslice) {
+                if (nslice <= 0)
+                    throw std::invalid_argument("Thick: nslice must be > 0!");
+                th.m_nslice = nslice;
+            },
             "number of slices used for the application of space charge"
         )
     ;
@@ -1262,7 +1266,11 @@ void init_elements(py::module& m)
         )
         .def_property("int_order",
             [](ExactMultipole & exact_multipole) { return exact_multipole.m_int_order; },
-            [](ExactMultipole & exact_multipole, int int_order) { exact_multipole.m_int_order = int_order; },
+            [](ExactMultipole & exact_multipole, int int_order) {
+                if (int_order != 2 && int_order != 4 && int_order != 6)
+                    throw std::invalid_argument("ExactMultipole: The order used for symplectic integration must be 2, 4 or 6.");
+                exact_multipole.m_int_order = int_order;
+            },
             "order of symplectic integration used for particle push in applied fields"
         )
         .def_property("mapsteps",
@@ -1419,7 +1427,11 @@ void init_elements(py::module& m)
         )
         .def_property("int_order",
             [](ExactQuad & exact_quad) { return exact_quad.m_int_order; },
-            [](ExactQuad & exact_quad, int int_order) { exact_quad.m_int_order = int_order; },
+            [](ExactQuad & exact_quad, int int_order) {
+                if (int_order != 2 && int_order != 4 && int_order != 6)
+                    throw std::invalid_argument("ExactQuad: The order used for symplectic integration must be 2, 4 or 6.");
+                exact_quad.m_int_order = int_order;
+            },
             "order of symplectic integration used for particle push in applied fields"
         )
         .def_property("mapsteps",
@@ -1921,7 +1933,11 @@ void init_elements(py::module& m)
         )
         .def_property("nslice",
             [](Programmable & p) { return p.nslice(); },
-            [](Programmable & p, int nslice) { p.m_nslice = nslice; }
+            [](Programmable & p, int nslice) {
+                if (nslice <= 0)
+                    throw std::invalid_argument("Programmable: nslice must be > 0!");
+                p.m_nslice = nslice;
+            }
         )
         .def_property("ds",
               [](Programmable & p) { return p.ds(); },


### PR DESCRIPTION
Follows #1595 (argument checks raise `ValueError`) and #1596 (`mapsteps > 0`), completing the numeric-knob validation. Two more knobs accepted values that are meaningless or that silently change the physics.

## `nslice`

The number of slices a thick element is divided into for the application of space charge. Zero and negative values were accepted by both the constructor and the setter:

```python
elements.Drift(ds=1.0, nslice=0)     # accepted
el.nslice = -3                       # accepted
```

Validated in the `mixin::Thick` constructor and in the property setter. `nslice` is bound **once** on `Thick` (`src/python/elements.cpp`), so the setter edit covers every thick element; `Programmable` carries its own binding and is fixed alongside.

This also closes a gap between the two ways of setting it: `elements::nslice(el, n)` in `mixin/accessors.H` already rejected `n <= 0`, but that guard is not reachable from Python, so the property setter bypassed it entirely.

## `int_order`

Selects the order of the symplectic integrator and must be 2, 4 or 6. `ExactCFbend` already rejected anything else, but `ExactQuad` and `ExactMultipole` accepted it — and then fell through to a silent default:

```cpp
// call integrator to advance through slice (int_order = 2 or 4, otherwise default 2)
if (m_int_order == 2) {
    integrators::symp2_integrate_particle(...);
} else if (m_int_order == 4) {
    integrators::symp4_integrate_particle(...);
} else if (m_int_order == 6) {
    integrators::symp6_integrate_particle(...);
} else {
    integrators::symp2_integrate_particle(...);   // <- int_order=3 lands here
}
```

So `int_order=3` quietly ran 2nd order and reported success. Validated in the constructors and setters of both, so all three exact elements now agree.

Raises `std::invalid_argument`, i.e. `ValueError` in Python, matching #1595.

## Testing

Full build clean. Verified that invalid values are rejected from both the constructor and the setter, and that valid values (`int_order=6`, `mapsteps=6`, `nslice=25`) still construct and assign.

The full `ctest` suite passes 524/526, with **every `.in`-file example green** — the relevant check here, since `mixin::Thick`'s constructor now throws and every thick element in every example is constructed through it. The two failures are unrelated to this change: pre-existing local WIP tests, and browser-driven dashboard tests that time out in this environment with no trace of the new validation in their output.

Nothing in-tree constructs an element with `nslice=0` or a bad `int_order`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)