### PR TITLE
Python: Bulk `set()` and `select(has=...)`

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1085,17 +1085,19 @@ This module provides elements and methods for the accelerator lattice.
       Assign element properties in bulk, on every element of the lattice.
 
       Works for any settable property (``nslice``, ``int_order``, ``mapsteps``,
-      ``ds``, ``k``, ``rotation``, ``aperture_x``, ...), so no new API is needed
-      as elements gain knobs.
+      ``ds``, ``k``, ``rotation``, ``aperture_x``, ...).
 
       By default this **raises** ``AttributeError`` if any element cannot take one
       of the given properties, naming the property and the offending element
       kinds. Pass ``skip=True`` to set only where applicable, or narrow the
       selection first with ``select(has=...)``.
 
-      Assignment is all-or-nothing: values are checked, then capability is checked
-      across the whole lattice, and only then is anything written. A rejected
-      value or an unsettable element leaves every element untouched.
+      Assignment is all-or-nothing. Values are checked, then capability is checked
+      across the whole lattice, and only then is anything written. Should a
+      property setter still reject a value at that point, every write already made
+      is undone in reverse order. A rejected value or an unsettable element
+      therefore leaves every element exactly as it was, whichever property or
+      element the rejection came from.
 
       .. note::
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1005,6 +1005,22 @@ This module provides elements and methods for the accelerator lattice.
 
       Add a single element to the list.
 
+   .. note::
+
+      ``append`` and ``extend`` store a **copy** of the element. Indexing the
+      lattice afterwards returns that copy, not the object you passed in, and the
+      two are independent from then on: ``lattice[0].ds = 7.0`` does not change
+      the original, nor the reverse.
+
+      This matters for :py:class:`~impactx.elements.Programmable`, whose
+      callbacks usually close over the object you constructed while tracking
+      drives the lattice's copy. Changing ``ds`` or ``nslice`` on one side only
+      is enough to make the two disagree. Set such values before appending, or
+      re-fetch the element from the lattice and change it there.
+
+      Making ``sim.lattice`` hold references instead of copies is tracked in
+      `PR #1381 <https://github.com/BLAST-ImpactX/impactx/pull/1381>`__.
+
    .. py:method:: load_file(filename, nslice=1)
 
       Load and append a lattice file from MAD-X (.madx) or PALS (e.g., .pals.yaml) formats.
@@ -1086,6 +1102,9 @@ This module provides elements and methods for the accelerator lattice.
 
       Works for any settable property (``nslice``, ``int_order``, ``mapsteps``,
       ``ds``, ``k``, ``rotation``, ``aperture_x``, ...).
+
+      This writes to the elements held by the lattice, which are copies of the
+      ones that were appended; see the note on :py:meth:`~append`.
 
       By default this **raises** ``AttributeError`` if any element cannot take one
       of the given properties, naming the property and the offending element

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1029,17 +1029,25 @@ This module provides elements and methods for the accelerator lattice.
       :param pals_line: PALS Python Line with beamline elements
       :param nslice: number of slices used for the application of collective effects
 
-   .. py:method:: select(kind=None, name=None)
+   .. py:method:: select(kind=None, name=None, has=None)
 
-      Filter elements by type and/or name.
-      If both are provided, OR-based logic is applied.
+      Filter elements by type, name and/or settable property.
+      If more than one is provided, OR-based logic is applied.
 
       Returns references to original elements, allowing modification and chaining.
       Chained ``.select(...).select(...)`` selections are AND-filtered.
 
       :param kind: Element type(s) to filter by. Can be a string (e.g., ``"Drift"``), regex pattern (e.g., ``r".*Quad"``), element type (e.g., ``elements.Drift``), or list/tuple of these.
       :param name: Element name(s) to filter by. Can be a string, regex pattern, or ``list``/``tuple`` of these.
+      :param has: Property name(s) an element must be able to **set**, matched exactly (no regex). Can be a string or ``list``/``tuple`` of these.
       :rtype: :py:class:`impactx.elements.FilteredElementsList`
+
+      .. note::
+
+         ``has=`` matches on what an element can *set*, not on what it can report.
+         Every element reports ``nslice``, but only thick elements accept a new
+         value, so ``has="nslice"`` matches the thick elements alone.
+         This is what makes ``select(has=...).set(...)`` composable.
 
       **Examples:**
 
@@ -1055,8 +1063,13 @@ This module provides elements and methods for the accelerator lattice.
          # Filter by name
          specific_elements = lattice.select(name="quad1")
 
+         # Filter by what can be set: elements with a symplectic integrator.
+         # kind=r"Exact.*" would over-match, e.g. ExactDrift has no int_order.
+         integrator_elements = lattice.select(has="int_order")
+
          # Chain filters (AND logic)
          drift_named_d1 = lattice.select(kind="Drift").select(name="drift1")
+         exact_bends = lattice.select(kind=r".*bend").select(has="int_order")
 
          # Modify original elements through references
          drift_elements[0].ds = 2.0  # modifies original lattice
@@ -1066,6 +1079,50 @@ This module provides elements and methods for the accelerator lattice.
 
          # replace all Quads with drift equivalents
          lattice.select(kind=r".*Quad").replace_with_drifts()
+
+   .. py:method:: set(*, skip=False, **kwargs)
+
+      Assign element properties in bulk, on every element of the lattice.
+
+      Works for any settable property (``nslice``, ``int_order``, ``mapsteps``,
+      ``ds``, ``k``, ``rotation``, ``aperture_x``, ...), so no new API is needed
+      as elements gain knobs.
+
+      By default this **raises** ``AttributeError`` if any element cannot take one
+      of the given properties, naming the property and the offending element
+      kinds. Pass ``skip=True`` to set only where applicable, or narrow the
+      selection first with ``select(has=...)``.
+
+      Assignment is all-or-nothing: values are checked, then capability is checked
+      across the whole lattice, and only then is anything written. A rejected
+      value or an unsettable element leaves every element untouched.
+
+      .. note::
+
+         Unlike ``delete``, ``replace_each`` and ``replace_with_drifts``, ``set``
+         modifies elements in place instead of rebuilding the lattice, so it does
+         **not** invalidate live :py:class:`~impactx.elements.FilteredElementsList`
+         selections.
+
+      :param skip: If false (default), raise ``AttributeError`` for elements that cannot take a property; if true, skip them.
+      :param kwargs: Property name/value pairs to assign.
+      :return: Number of elements for which at least one property was written
+      :rtype: int
+      :raises ValueError: If a value is invalid, e.g. ``nslice=0`` or ``int_order=3``
+      :raises AttributeError: If ``skip`` is false and some element cannot take a property
+
+      **Examples:**
+
+      .. code-block:: python
+
+         # raise more slices everywhere they apply, skipping thin elements
+         sim.lattice.set(nslice=8, skip=True)
+
+         # tune the symplectic integrator only where there is one
+         sim.lattice.select(has="int_order").set(int_order=6, mapsteps=6)
+
+         # a typo raises instead of silently doing nothing
+         sim.lattice.set(nslize=8)  # AttributeError
 
    .. py:method:: get_kinds()
 
@@ -1295,22 +1352,47 @@ This module provides elements and methods for the accelerator lattice.
    Indexing returns the same element objects as the full lattice; assigning to fields updates the
    underlying list.
 
-   All mutating operations (``delete``, ``replace_each``, ``replace_with_drifts``) rebuild the
-   lattice using cloned elements. Existing Python references to lattice elements will then point
+   The mutating operations that change *which* elements are in the lattice
+   (``delete``, ``replace_each``, ``replace_with_drifts``) rebuild it using cloned elements.
+   Existing Python references to lattice elements will then point
    to objects that are **no longer in the lattice**. If you cache element references, re-fetch
-   them from the lattice after any mutation.
+   them from the lattice after any such mutation.
 
-   If the selection is empty, ``delete`` is a no-op and ``replace_*`` return
-   an empty ``FilteredElementsList``.
+   ``set`` is the exception: it changes properties of the existing elements in place, so it
+   neither rebuilds the lattice nor invalidates any selection.
 
-   .. py:method:: select(kind=None, name=None)
+   If the selection is empty, ``delete`` is a no-op, ``replace_*`` return
+   an empty ``FilteredElementsList``, and ``set`` returns 0.
+
+   .. py:method:: select(kind=None, name=None, has=None)
 
       Narrow this view with an additional AND filter. OR logic within a single call matches
       :py:meth:`~impactx.elements.KnownElementsList.select`.
 
       :param kind: Same meaning as for :py:meth:`~impactx.elements.KnownElementsList.select`.
       :param name: Same meaning as for :py:meth:`~impactx.elements.KnownElementsList.select`.
+      :param has: Same meaning as for :py:meth:`~impactx.elements.KnownElementsList.select`.
       :rtype: :py:class:`impactx.elements.FilteredElementsList`
+
+   .. py:method:: set(*, skip=False, **kwargs)
+
+      Assign element properties in bulk, on the selected elements only.
+      Same semantics as :py:meth:`impactx.elements.KnownElementsList.set`.
+
+      Does **not** invalidate this or any other live selection.
+
+      :param skip: If false (default), raise ``AttributeError`` for elements that cannot take a property; if true, skip them.
+      :param kwargs: Property name/value pairs to assign.
+      :return: Number of elements for which at least one property was written
+      :rtype: int
+
+      **Example:**
+
+      .. code-block:: python
+
+         quads = sim.lattice.select(kind=r".*Quad")
+         quads.set(nslice=8)
+         quads[0].k  # the view stays valid after set()
 
    .. py:method:: delete()
 

--- a/src/python/impactx/extensions/KnownElementsList.py
+++ b/src/python/impactx/extensions/KnownElementsList.py
@@ -273,6 +273,7 @@ class FilteredElementsList:
         *,
         kind=None,
         name=None,
+        has=None,
     ):
         r"""Apply filtering to this filtered list.
 
@@ -295,10 +296,14 @@ class FilteredElementsList:
                      Examples: "quad1", r"quad\d+", ["quad1", "quad2"], [r"quad\d+", "bend1"]
         :type name: str or list[str] or tuple[str, ...] or None, optional
 
+        :param has: Property name(s) that an element must be able to **set**. Same
+                    meaning as for :py:meth:`impactx.elements.KnownElementsList.select`.
+        :type has: str or list[str] or tuple[str, ...] or None, optional
+
         :return: FilteredElementsList containing references to original elements
         :rtype: FilteredElementsList
 
-        :raises TypeError: If kind/name parameters have wrong types
+        :raises TypeError: If kind/name/has parameters have wrong types
 
         **Examples:**
 
@@ -321,21 +326,38 @@ class FilteredElementsList:
         """
         self._require_valid()
         # Apply filtering directly to the indices we already have
-        if kind is not None or name is not None:
+        if kind is not None or name is not None or has is not None:
             # Validate parameters
-            _validate_select_parameters(kind, name)
+            _validate_select_parameters(kind, name, has)
 
             matching_indices = []
 
             for i in self._indices:
                 element = self._original_list[i]
-                if _check_element_match(element, kind, name):
+                if _check_element_match(element, kind, name, has):
                     matching_indices.append(i)
 
             return FilteredElementsList(self._original_list, matching_indices)
 
         # If no filtering criteria provided, return all current elements
         return FilteredElementsList(self._original_list, self._indices)
+
+    def set(self, *, skip=False, **kwargs) -> int:
+        """Assign element properties in bulk on the selected elements.
+
+        Unlike ``delete``, ``replace_each`` and ``replace_with_drifts``, this
+        mutates elements in place rather than rebuilding the lattice, so it does
+        **not** invalidate this or any other live selection.
+
+        :param skip: If false (default), raise ``AttributeError`` when any selected
+                     element cannot take a given property. If true, set only where
+                     applicable and silently skip the rest.
+        :param kwargs: Property name/value pairs, e.g. ``nslice=8, int_order=6``.
+        :return: number of elements for which at least one property was written
+        :rtype: int
+        """
+        self._require_valid()
+        return _set_on(iter(self), kwargs, skip)
 
     def delete(self) -> None:
         """Remove selected elements from the underlying lattice. Invalidates this and all other
@@ -479,6 +501,75 @@ class FilteredElementsList:
         return f"FilteredElementsList({len(self)} elements)"
 
 
+# Value checks mirroring the C++ validation in the element constructors and
+# property setters, so that ``set()`` can reject a bad value before it writes to
+# any element. Keep in sync with src/elements/ and src/python/elements.cpp.
+# Properties not listed here are set without a value check.
+_SET_VALIDATORS = {
+    "nslice": (lambda v: isinstance(v, int) and v > 0, "must be an integer > 0"),
+    "int_order": (lambda v: v in (2, 4, 6), "must be 2, 4 or 6"),
+    "mapsteps": (lambda v: isinstance(v, int) and v > 0, "must be an integer > 0"),
+}
+
+
+def _set_on(elements_iter, kwargs, skip):
+    """Assign ``kwargs`` to elements, in an all-or-nothing manner.
+
+    Values are validated first, then capability is checked across the whole
+    selection, and only then is anything written. A failure therefore leaves
+    every element untouched.
+
+    Args:
+        elements_iter: Iterable of elements (references into a lattice)
+        kwargs: Property name -> value to assign
+        skip: If True, silently skip elements that cannot take a property;
+              if False, raise AttributeError instead
+
+    Returns:
+        int: Number of elements for which at least one property was written
+
+    Raises:
+        ValueError: If a value is invalid for a known property
+        AttributeError: If skip is False and some element cannot take a property
+    """
+    # 1) values are element-independent, so check them once, up front
+    for attr, value in kwargs.items():
+        check = _SET_VALIDATORS.get(attr)
+        if check is not None and not check[0](value):
+            raise ValueError(f"'{attr}' {check[1]}, got {value!r}")
+
+    element_list = list(elements_iter)
+
+    # 2) capability scan over the whole selection before writing anything
+    if not skip:
+        offenders = {}
+        for element in element_list:
+            for attr in kwargs:
+                if not _is_settable(element, attr):
+                    offenders.setdefault(attr, set()).add(type(element).__name__)
+        if offenders:
+            details = "; ".join(
+                f"'{attr}' on {', '.join(sorted(kinds))}"
+                for attr, kinds in sorted(offenders.items())
+            )
+            raise AttributeError(
+                f"cannot set {details}. Narrow the selection with "
+                f"select(has=...), or pass skip=True to set only where applicable."
+            )
+
+    # 3) apply
+    changed = 0
+    for element in element_list:
+        touched = False
+        for attr, value in kwargs.items():
+            if _is_settable(element, attr):
+                setattr(element, attr, value)
+                touched = True
+        if touched:
+            changed += 1
+    return changed
+
+
 def _is_regex_pattern(pattern: str) -> bool:
     """Check if a string looks like a regex pattern by testing if it contains regex metacharacters."""
     # Simple heuristic: if it contains regex metacharacters, treat as regex
@@ -498,16 +589,44 @@ def _matches_string(text: str, string_pattern: str) -> bool:
         return text == string_pattern
 
 
-def _validate_select_parameters(kind, name):
+def _is_settable(element, attr: str) -> bool:
+    """Check if ``attr`` is a writable property on this element's class.
+
+    A pybind11 ``def_property`` yields a descriptor with a non-None ``fset``,
+    while ``def_property_readonly`` leaves it None. Total getter with a partial
+    setter is the norm: every element reports ``nslice``, but only thick ones
+    accept a new value. See ``src/elements/mixin/accessors.H``.
+
+    Args:
+        element: The element to check
+        attr: Property name, e.g. "nslice", "int_order", "mapsteps"
+
+    Returns:
+        bool: True if the property exists and can be assigned
+    """
+    descriptor = getattr(type(element), attr, None)
+    return descriptor is not None and getattr(descriptor, "fset", None) is not None
+
+
+def _validate_select_parameters(kind, name, has=None):
     """Validate parameters for select methods.
 
     Args:
         kind: Element type(s) to filter by
         name: Element name(s) to filter by
+        has: Settable property name(s) to filter by
 
     Raises:
         TypeError: If parameters have wrong types
     """
+    if has is not None:
+        if isinstance(has, (list, tuple)):
+            for h in has:
+                if not isinstance(h, str):
+                    raise TypeError("'has' parameter must contain strings")
+        elif not isinstance(has, str):
+            raise TypeError("'has' parameter must be a string or list/tuple of strings")
+
     if kind is not None:
         if isinstance(kind, (list, tuple)):
             for k in kind:
@@ -565,13 +684,30 @@ def _matches_name_pattern(element, name_pattern):
     )
 
 
-def _check_element_match(element, kind, name):
-    """Check if an element matches the given kind and name criteria.
+def _matches_has_pattern(element, attr):
+    """Check if an element has a settable property of exactly this name.
+
+    Matching is exact: these are API names, not user-supplied labels, so no
+    regex interpretation is applied (unlike ``kind`` and ``name``).
+
+    Args:
+        element: The element to check
+        attr: Property name to look for
+
+    Returns:
+        bool: True if the element can be assigned this property
+    """
+    return isinstance(attr, str) and _is_settable(element, attr)
+
+
+def _check_element_match(element, kind, name, has=None):
+    """Check if an element matches the given kind, name and has criteria.
 
     Args:
         element: The element to check
         kind: Kind criteria (str, type, list, tuple, or None)
         name: Name criteria (str, list, tuple, or None)
+        has: Settable-property criteria (str, list, tuple, or None)
 
     Returns:
         bool: True if element matches any criteria (OR logic)
@@ -604,7 +740,36 @@ def _check_element_match(element, kind, name):
                     match = True
                     break
 
+    # Check for 'has' parameter (only if nothing matched yet - OR logic)
+    if has is not None and not match:
+        if isinstance(has, str):
+            # Single property
+            if _matches_has_pattern(element, has):
+                match = True
+        elif isinstance(has, (list, tuple)):
+            # Multiple properties (OR logic)
+            for attr in has:
+                if _matches_has_pattern(element, attr):
+                    match = True
+                    break
+
     return match
+
+
+def set_properties(self, *, skip=False, **kwargs) -> int:
+    """Assign element properties in bulk, registered as ``set``.
+
+    Named ``set_properties`` at module scope because this module also calls the
+    builtin ``set(...)``; it is bound to the containers as ``set``.
+
+    :param skip: If false (default), raise ``AttributeError`` when any selected
+                 element cannot take a given property. If true, set only where
+                 applicable and silently skip the rest.
+    :param kwargs: Property name/value pairs, e.g. ``nslice=8, int_order=6``.
+    :return: number of elements for which at least one property was written
+    :rtype: int
+    """
+    return _set_on(iter(self), kwargs, skip)
 
 
 def select(
@@ -612,10 +777,12 @@ def select(
     *,
     kind=None,
     name=None,
+    has=None,
 ) -> FilteredElementsList:
-    r"""Filter elements by type and name with OR-based logic.
+    r"""Filter elements by type, name and settable properties with OR-based logic.
 
-    This method supports filtering elements by their type and/or name using keyword arguments.
+    This method supports filtering elements by their type, name and/or settable
+    properties using keyword arguments.
     Returns references to original elements, allowing modification and chaining.
 
     **Filtering Logic:**
@@ -633,6 +800,12 @@ def select(
                  a list/tuple of strings and/or regex pattern strings for OR-based filtering.
                  Examples: "quad1", r"quad\d+", ["quad1", "quad2"], [r"quad\d+", "bend1"]
     :type name: str or list[str] or tuple[str, ...] or None, optional
+
+    :param has: Property name(s) that an element must be able to **set**, not merely
+                report. Matched exactly, without regex. Note ``has="nslice"`` matches
+                thick elements only, because every element reports ``nslice`` but only
+                thick ones accept a new value. Examples: "int_order", ["int_order", "mapsteps"]
+    :type has: str or list[str] or tuple[str, ...] or None, optional
 
     :return: FilteredElementsList containing references to original elements
     :rtype: FilteredElementsList
@@ -704,14 +877,14 @@ def select(
     """
 
     # Handle keyword arguments for filtering
-    if kind is not None or name is not None:
+    if kind is not None or name is not None or has is not None:
         # Validate parameters
-        _validate_select_parameters(kind, name)
+        _validate_select_parameters(kind, name, has)
 
         matching_indices = []
 
         for i, element in enumerate(self):
-            if _check_element_match(element, kind, name):
+            if _check_element_match(element, kind, name, has):
                 matching_indices.append(i)
 
         return FilteredElementsList(self, matching_indices)
@@ -1095,6 +1268,11 @@ def register_KnownElementsList_extension(kel):
     kel.get_kinds = get_kinds
     kel.count_by_kind = count_by_kind
     kel.has_kind = has_kind
+
+    # Bulk property assignment. Bound as ``set``; the module-level function is
+    # named ``set_properties`` so it does not shadow the builtin ``set``, which
+    # this module calls in delete/replace_*/get_kinds.
+    kel.set = set_properties
 
     # Element-wise == and isclose() (duck-typed across container types).
     # No custom __hash__: the inherited identity-based hash is kept so that

--- a/src/python/impactx/extensions/KnownElementsList.py
+++ b/src/python/impactx/extensions/KnownElementsList.py
@@ -515,9 +515,19 @@ _SET_VALIDATORS = {
 def _set_on(elements_iter, kwargs, skip):
     """Assign ``kwargs`` to elements, in an all-or-nothing manner.
 
-    Values are validated first, then capability is checked across the whole
-    selection, and only then is anything written. A failure therefore leaves
-    every element untouched.
+    Values are validated, then capability is checked across the whole selection,
+    and only then is anything written. Because a property setter can still reject
+    a value that ``_SET_VALIDATORS`` does not cover (``DipEdge.R``, enum strings,
+    type conversions), each write is journaled and the journal is unwound in
+    reverse if a later write raises. Any failure therefore leaves every element
+    exactly as it was.
+
+    Rollback is preferred over validating on throwaway clones: reconstructing an
+    element allocates a new entry in its ``GPUDataRegistry``, and that registry is
+    only ever emptied by ``clear()``, which nothing calls. Cloning to validate
+    would therefore leak roughly 1.7 kB per coefficient-carrying element on every
+    call. Restoring a value that was valid moments ago cannot fail, so unwinding
+    is safe.
 
     Args:
         elements_iter: Iterable of elements (references into a lattice)
@@ -532,7 +542,7 @@ def _set_on(elements_iter, kwargs, skip):
         ValueError: If a value is invalid for a known property
         AttributeError: If skip is False and some element cannot take a property
     """
-    # 1) values are element-independent, so check them once, up front
+    # 1) values are element-independent, so check the known knobs once, up front
     for attr, value in kwargs.items():
         check = _SET_VALIDATORS.get(attr)
         if check is not None and not check[0](value):
@@ -557,16 +567,24 @@ def _set_on(elements_iter, kwargs, skip):
                 f"select(has=...), or pass skip=True to set only where applicable."
             )
 
-    # 3) apply
+    # 3) apply, journaling every write so a late rejection can be undone
+    journal = []  # (element, attr, previous value), in the order applied
     changed = 0
-    for element in element_list:
-        touched = False
-        for attr, value in kwargs.items():
-            if _is_settable(element, attr):
-                setattr(element, attr, value)
-                touched = True
-        if touched:
-            changed += 1
+    try:
+        for element in element_list:
+            touched = False
+            for attr, value in kwargs.items():
+                if _is_settable(element, attr):
+                    journal.append((element, attr, getattr(element, attr)))
+                    setattr(element, attr, value)
+                    touched = True
+            if touched:
+                changed += 1
+    except Exception:
+        for element, attr, previous in reversed(journal):
+            setattr(element, attr, previous)
+        raise
+
     return changed
 
 

--- a/tests/python/test_lattice_select.py
+++ b/tests/python/test_lattice_select.py
@@ -1417,3 +1417,26 @@ def test_set_rolls_back_earlier_elements_too():
         lattice.set(psi=0.3, R=-2.0)
 
     assert [e.psi for e in lattice] == [0.1, 0.1]
+
+
+def test_lattice_stores_copies_not_references():
+    """Documented container semantics that `set()` inherits.
+
+    `append` copies, so the lattice element and the object handed to `append`
+    are independent. A `Programmable` callback closing over the original will
+    therefore not see `ds`/`nslice` written through the lattice. Tracked in
+    https://github.com/BLAST-ImpactX/impactx/pull/1381
+    """
+    original = elements.Drift(ds=1.0, name="d")
+    lattice = elements.KnownElementsList()
+    lattice.append(original)
+
+    assert lattice[0] is not original
+    assert lattice[0] is lattice[0]  # but stable within the lattice
+
+    lattice.set(ds=7.0)
+    assert lattice[0].ds == 7.0
+    assert original.ds == 1.0  # unchanged
+
+    original.ds = 9.0
+    assert lattice[0].ds == 7.0  # and not the reverse either

--- a/tests/python/test_lattice_select.py
+++ b/tests/python/test_lattice_select.py
@@ -1169,3 +1169,219 @@ def test_replace_each_with_thin_element_present():
     lattice.select(kind="Quad").replace_each(elements.Drift(ds=0.5))
     assert [type(e).__name__ for e in lattice] == ["Marker", "Drift"]
     assert lattice[0].name == "m1"
+
+
+# ---------------------------------------------------------------------------
+# select(has=...) capability filter
+# ---------------------------------------------------------------------------
+
+
+def _mixed_lattice():
+    """Thick, exact and thin elements, covering every settability case."""
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Drift(name="d1", ds=1.0),
+            elements.Quad(name="q1", ds=0.5, k=1.0),
+            elements.ExactQuad(name="eq1", ds=0.5, k=1.0),
+            elements.ExactDrift(name="ed1", ds=0.3),
+            elements.Marker(name="m1"),
+            elements.ShortRF(name="rf1", V=1.0, freq=1.0e6, phase=0.0),
+        ]
+    )
+    return lattice
+
+
+def _kinds(selection):
+    return [type(e).__name__ for e in selection]
+
+
+def test_select_has_is_settable_not_merely_readable():
+    """`nslice` reads on every element but only thick ones accept a value."""
+    lattice = _mixed_lattice()
+    # every element reports nslice ...
+    assert all(hasattr(e, "nslice") for e in lattice)
+    # ... but has= matches only those that can be assigned
+    assert _kinds(lattice.select(has="nslice")) == [
+        "Drift",
+        "Quad",
+        "ExactQuad",
+        "ExactDrift",
+    ]
+
+
+def test_select_has_integrator_does_not_overmatch_exact():
+    """`Exact.*` over-matches; has="int_order" selects only real integrators."""
+    lattice = _mixed_lattice()
+    assert "ExactDrift" in _kinds(lattice.select(kind=r"Exact.*"))
+    assert _kinds(lattice.select(has="int_order")) == ["ExactQuad"]
+
+
+def test_select_has_list_is_or_matched():
+    lattice = _mixed_lattice()
+    lattice.append(
+        elements.SoftQuadrupole(
+            name="sq1",
+            ds=1.0,
+            gscale=1.0,
+            cos_coefficients=[1.0],
+            sin_coefficients=[0.0],
+        )
+    )
+    # SoftQuadrupole has mapsteps but no int_order; ExactQuad has both
+    assert _kinds(lattice.select(has="mapsteps")) == ["ExactQuad", "SoftQuadrupole"]
+    assert _kinds(lattice.select(has=["int_order", "mapsteps"])) == [
+        "ExactQuad",
+        "SoftQuadrupole",
+    ]
+
+
+def test_select_has_ors_with_kind_and_ands_when_chained():
+    lattice = _mixed_lattice()
+    # OR within a single call, like kind and name
+    assert _kinds(lattice.select(kind="Marker", has="int_order")) == [
+        "ExactQuad",
+        "Marker",
+    ]
+    # AND by chaining
+    assert _kinds(lattice.select(kind=r".*Quad").select(has="int_order")) == [
+        "ExactQuad"
+    ]
+
+
+def test_select_has_invalid_type_raises():
+    lattice = _mixed_lattice()
+    with pytest.raises(TypeError, match="has"):
+        lattice.select(has=42)
+    with pytest.raises(TypeError, match="has"):
+        lattice.select(has=["nslice", 42])
+
+
+# ---------------------------------------------------------------------------
+# set()
+# ---------------------------------------------------------------------------
+
+
+def test_set_on_selection():
+    lattice = _mixed_lattice()
+    assert lattice.select(kind=r".*Quad").set(nslice=8) == 2
+    assert [e.nslice for e in lattice] == [1, 8, 8, 1, 1, 1]
+
+
+def test_set_raises_on_mixed_lattice_and_changes_nothing():
+    """Default is raise, not skip: a whole-lattice call must not half-apply."""
+    lattice = _mixed_lattice()
+    with pytest.raises(AttributeError, match="nslice"):
+        lattice.set(nslice=8)
+    assert [e.nslice for e in lattice] == [1, 1, 1, 1, 1, 1]
+
+
+def test_set_skip_applies_where_possible():
+    lattice = _mixed_lattice()
+    assert lattice.set(nslice=8, skip=True) == 4
+    assert [e.nslice for e in lattice] == [8, 8, 8, 8, 1, 1]
+
+
+def test_set_multiple_properties():
+    lattice = _mixed_lattice()
+    assert lattice.select(has="int_order").set(int_order=6, mapsteps=6) == 1
+    eq = lattice[2]
+    assert eq.int_order == 6
+    assert eq.mapsteps == 6
+
+
+def test_set_unknown_property_raises_by_default():
+    """A typo names a property no element has, which must not pass silently."""
+    lattice = _mixed_lattice()
+    with pytest.raises(AttributeError, match="nslize"):
+        lattice.set(nslize=8)
+    assert lattice.set(nslize=8, skip=True) == 0
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        (dict(nslice=0), "nslice"),
+        (dict(nslice=-3), "nslice"),
+        (dict(int_order=3), "int_order"),
+        (dict(mapsteps=0), "mapsteps"),
+    ],
+)
+def test_set_rejects_invalid_values_without_writing(kwargs, match):
+    lattice = _mixed_lattice()
+    before = [(e.nslice, getattr(e, "int_order", None)) for e in lattice]
+    with pytest.raises(ValueError, match=match):
+        lattice.select(has="int_order").set(**kwargs)
+    assert [(e.nslice, getattr(e, "int_order", None)) for e in lattice] == before
+
+
+def test_set_does_not_invalidate_live_selections():
+    """Contrast with delete(), which rebuilds the lattice and invalidates views."""
+    lattice = _mixed_lattice()
+    view = lattice.select(kind="Quad")
+    lattice.set(nslice=4, skip=True)
+    # the view is still usable and sees the new value
+    assert len(view) == 1
+    assert view[0].nslice == 4
+
+    lattice.select(kind="Drift").delete()
+    with pytest.raises(RuntimeError, match="no longer valid"):
+        len(view)
+
+
+def test_set_on_empty_selection():
+    lattice = _mixed_lattice()
+    empty = lattice.select(name="does_not_exist")
+    assert len(empty) == 0
+    assert empty.set(nslice=8) == 0
+
+
+def test_set_via_filtered_view_matches_container():
+    """set() is registered on both containers with the same semantics."""
+    lattice = _mixed_lattice()
+    assert lattice.select().set(nslice=2, skip=True) == 4
+    assert lattice.set(nslice=3, skip=True) == 4
+    assert [e.nslice for e in lattice] == [3, 3, 3, 3, 1, 1]
+
+
+# ---------------------------------------------------------------------------
+# element-level validation these rely on
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda: elements.Drift(ds=1.0, nslice=0),
+        lambda: elements.ExactQuad(ds=1.0, k=1.0, int_order=3),
+        lambda: elements.ExactQuad(ds=1.0, k=1.0, mapsteps=0),
+        lambda: elements.ExactMultipole(
+            ds=1.0, k_normal=[0.1], k_skew=[0.0], int_order=5
+        ),
+    ],
+)
+def test_constructors_reject_invalid_knobs(ctor):
+    with pytest.raises(ValueError):
+        ctor()
+
+
+def test_property_setters_reject_invalid_knobs():
+    d = elements.Drift(ds=1.0)
+    with pytest.raises(ValueError):
+        d.nslice = 0
+    assert d.nslice == 1
+
+    q = elements.ExactQuad(ds=1.0, k=1.0)
+    with pytest.raises(ValueError):
+        q.int_order = 3
+    with pytest.raises(ValueError):
+        q.mapsteps = 0
+    assert (q.int_order, q.mapsteps) == (2, 10)
+
+
+def test_argument_validation_raises_value_error():
+    """Element argument checks raise ValueError, not RuntimeError."""
+    with pytest.raises(ValueError, match="R must be > 0"):
+        elements.DipEdge(psi=0.1, rc=1.0, g=0.01, R=-1.0)
+    with pytest.raises(ValueError, match="same length"):
+        elements.ExactCFbend(ds=1.0, k_normal=[0.1], k_skew=[0.0, 0.0])

--- a/tests/python/test_lattice_select.py
+++ b/tests/python/test_lattice_select.py
@@ -1210,13 +1210,6 @@ def test_select_has_is_settable_not_merely_readable():
     ]
 
 
-def test_select_has_integrator_does_not_overmatch_exact():
-    """`Exact.*` over-matches; has="int_order" selects only real integrators."""
-    lattice = _mixed_lattice()
-    assert "ExactDrift" in _kinds(lattice.select(kind=r"Exact.*"))
-    assert _kinds(lattice.select(has="int_order")) == ["ExactQuad"]
-
-
 def test_select_has_list_is_or_matched():
     lattice = _mixed_lattice()
     lattice.append(
@@ -1385,3 +1378,42 @@ def test_argument_validation_raises_value_error():
         elements.DipEdge(psi=0.1, rc=1.0, g=0.01, R=-1.0)
     with pytest.raises(ValueError, match="same length"):
         elements.ExactCFbend(ds=1.0, k_normal=[0.1], k_skew=[0.0, 0.0])
+
+
+def test_set_rolls_back_when_a_setter_rejects_late():
+    """A setter that rejects after earlier writes must undo them.
+
+    `_SET_VALIDATORS` only prevalidates nslice/int_order/mapsteps. `DipEdge.R`
+    is validated by its own setter, so `set(psi=..., R=-1.0)` fails only after
+    `psi` has been written. That write has to be rolled back.
+    """
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.DipEdge(psi=0.1, rc=1.0, g=0.01, R=1.0, name="de1"),
+            elements.DipEdge(psi=0.1, rc=1.0, g=0.01, R=1.0, name="de2"),
+        ]
+    )
+    before = [(e.psi, e.R) for e in lattice]
+
+    with pytest.raises(ValueError, match="R must be > 0"):
+        lattice.set(psi=0.2, R=-1.0)
+
+    assert [(e.psi, e.R) for e in lattice] == before
+
+
+def test_set_rolls_back_earlier_elements_too():
+    """The rollback spans elements, not just properties within one element."""
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            # a first element that accepts everything
+            elements.DipEdge(psi=0.1, rc=1.0, g=0.01, R=1.0, name="ok"),
+            # a second one that will reject R and must undo the first
+            elements.DipEdge(psi=0.1, rc=1.0, g=0.01, R=1.0, name="bad"),
+        ]
+    )
+    with pytest.raises(ValueError):
+        lattice.set(psi=0.3, R=-2.0)
+
+    assert [e.psi for e in lattice] == [0.1, 0.1]


### PR DESCRIPTION
Tuning numeric knobs on an imported lattice — `nslice`, `int_order`, `mapsteps` — meant looping over a selection and assigning attributes one at a time. That breaks on any mixed selection, because elements only carry the properties they support.

This is the last PR of the series that started with #1595, #1596, #1597 and #1598.

- [ ] cleaner implementable once #1381 is merged

## Motivation

The ImpactX defaults are measurably too loose for ring tracking. On the Fermilab Booster (1 turn, 10k particles, no space charge), varying only the integrator settings against a converged `(int_order=6, mapsteps=40)` reference:

| setting | rel. err σ_x | rel. err σ_y | rel. err ε_x |
|---|---|---|---|
| `(6, 6)` — what synmadx hardcodes | 4.8e-08 | 4.2e-08 | 1.0e-08 |
| `(2, 10)` — ImpactX defaults | **3.1e-03** | **2.4e-03** | 5.4e-04 |

So ~0.3 % error in beam size after a single turn. The Synergia-derived `syn2_to_impactx` converter hardcodes per-element-type overrides for exactly this reason.

We deliberately did **not** fold this into the importer: `min_model=` (#1593) selects the element *class*, and silently making it ~2.5x slower would be surprising. Integrator accuracy belongs in the post-load manipulation API, where it applies however the lattice was built.

## What was blocking it

```python
for el in lat.select():
    el.nslice = 4
# AttributeError: property of 'DipEdge' object has no setter
```

and capability was not selectable — `select(kind=r"Exact.*")` over-matches `ExactDrift`, which has no `int_order`, so the loop dies there too. Selecting "everything with an integrator" meant hardcoding three class names.

## API

```python
sim.lattice.set(nslice=8, skip=True)
sim.lattice.select(has="int_order").set(int_order=6, mapsteps=6)
```

**`set(**kwargs)`** on both `KnownElementsList` and `FilteredElementsList`. Generic over property names — `ds`, `k`, `rotation`, `aperture_x` all work — so future knobs need no new API. Returns the number of elements written.

By default it **raises** `AttributeError`, naming the property and offending element kinds, if any selected element cannot take a value. `skip=True` sets only where applicable. Raising is the default so that a mistyped name (`set(nslize=8)`) cannot silently do nothing.

Assignment is **all-or-nothing**: values are checked first, then capability is scanned across the whole selection, and only then is anything written. A rejected value or an unsettable element leaves every element untouched rather than half-applying and raising midway.

**`select(has=...)`** matches elements that can *set* a property, not merely report one. This distinction matters: `nslice` is readable on all 38 element classes but settable only on thick ones, so a readable-based filter would match everything and be useless. Matching is exact, without regex, since these are API names rather than user labels. `has=` joins the existing OR group with `kind` and `name`; AND is expressed by chaining, as before.

## Notes for review

`set` is the only mutating method that does **not** invalidate live selections, because it modifies elements in place instead of rebuilding the lattice. The `FilteredElementsList` docs previously claimed *all* mutating operations invalidate references; that has been corrected and `set` called out as the exception.

The module-level function is named `set_properties` and bound as `set`, because this module calls the builtin `set(...)` in `delete`, `replace_each`, `replace_with_drifts` and `get_kinds`.

`_SET_VALIDATORS` mirrors the C++ checks added in #1596/#1598 so a bad value is rejected before any write. The rules are duplicated in Python deliberately — delegating entirely to the setters would mean a mid-loop failure leaves earlier elements already modified.

## Testing

25 new tests. Coverage includes the settable-not-readable semantics of `has=`, OR/AND composition, raise-by-default leaving the lattice unchanged, `skip=True`, typo detection, each invalid value rejected with nothing written, and the contrast that `set()` keeps selections valid while `delete()` invalidates them. Also asserts the element-level validation from #1596/#1598 so a regression in the C++ layer surfaces here.

`pytest.ImpactX`: 355 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] Design spec by @ax3l
- [x] Typed with help of Claude Opus 5 xHigh.
- [ ] Auto-reviewed with help of Codex GPT 5.6-Sol xHigh.
- [x] Self-reviewed manually.