### PR TITLE
Spin push for thin kick elements

### DIFF
--- a/src/elements/Buncher.H
+++ b/src/elements/Buncher.H
@@ -181,6 +181,7 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
+            using namespace std; // for cmath(float)
 
             // reference particle relativistic factors
             amrex::ParticleReal const gamma_ref = refpart.gamma();
@@ -236,7 +237,6 @@ namespace impactx::elements
 
             // push the spin vector using the generator just determined (half spin-kick)
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
-
         }
 
 

--- a/src/elements/Buncher.H
+++ b/src/elements/Buncher.H
@@ -190,24 +190,42 @@ namespace impactx::elements
             T_Real lambday = 0_prt;
             T_Real lambdaz = 0_prt;
 
-            // Integrated magnetic field normalized by q/mc (half-step):
-            T_Real const Bx = 0.5_prt * m_kV_r2bg2 * y * m_beta * gamma_ref;
-            T_Real const By = -0.5_prt * m_kV_r2bg2 * x * m_beta * gamma_ref;
+            // Integrated magnetic field normalized by q/mc:
+            T_Real const Bx = m_kV_r2bg2 * y * m_beta * gamma_ref;
+            T_Real const By = -m_kV_r2bg2 * x * m_beta * gamma_ref;
             T_Real const Bz = 0_prt;
 
-            // Integrated electric field normalized by q/mc^2 (half-step):
+            // Integrated electric field normalized by q/mc^2:
             T_Real const Ex = 0.0_prt;
             T_Real const Ey = 0.0_prt;
-            T_Real const Ez = -0.5_prt * m_neg_kV * t * m_beta * gamma_ref;
+            T_Real const Ez = -m_neg_kV * t * m_beta * gamma_ref;
 
-            // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
-            T_Real Pnorm = sqrt(1_prt - 2_prt * pt / m_beta + pt*pt);
-            T_Real iPnorm = 1_prt/Pnorm;
-            T_Real gamma = gamma_ref * (1_prt - pt*m_beta);
-            T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
-            T_Real ux = px * iPnorm;
-            T_Real uy = py * iPnorm;
-            T_Real uz = Ps * iPnorm;
+            // The Thomas-BMT generator is evaluated at the momentum halfway
+            // through the kick, so that reversing the element (negating V)
+            // produces the exact inverse rotation. The buncher also changes the
+            // energy deviation, so pt is averaged along with the transverse
+            // momenta.
+            T_Real const px_in = px;
+            T_Real const py_in = py;
+            T_Real const pt_in = pt;
+
+            // phase space push
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+
+            // momenta at the kick midpoint
+            T_Real const px_mid = 0.5_prt * (px_in + px);
+            T_Real const py_mid = 0.5_prt * (py_in + py);
+            T_Real const pt_mid = 0.5_prt * (pt_in + pt);
+
+            // Quantities required to evaluate the full Thomas-BMT precession
+            // vector, at the midpoint momentum.
+            T_Real const Pnorm = sqrt(1_prt - 2_prt * pt_mid / m_beta + pt_mid*pt_mid);
+            T_Real const iPnorm = 1_prt/Pnorm;
+            T_Real const gamma = gamma_ref * (1_prt - pt_mid*m_beta);
+            T_Real const Ps = sqrt(Pnorm*Pnorm - px_mid*px_mid - py_mid*py_mid);
+            T_Real const ux = px_mid * iPnorm;
+            T_Real const uy = py_mid * iPnorm;
+            T_Real const uz = Ps * iPnorm;
 
             // Zero curvature in a buncher
             amrex::ParticleReal const h = 0.0_prt;
@@ -215,25 +233,7 @@ namespace impactx::elements
             // Evaluation of the full Thomas-BMT precession vector.
             tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
 
-            // push the spin vector using the generator just determined (half spin-kick)
-            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
-
-            // phase space push
-            (*this)(x, y, t, px, py, pt, idcpu, refpart);
-
-            // Quantities required to evaluate the full Thomas-BMT precession vector (after phase space kick).
-            Pnorm = sqrt(1_prt - 2_prt * pt / m_beta + pt*pt);
-            iPnorm = 1_prt/Pnorm;
-            gamma = gamma_ref * (1_prt - pt*m_beta);
-            Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
-            ux = px * iPnorm;
-            uy = py * iPnorm;
-            uz = Ps * iPnorm;
-
-            // Evaluation of the full Thomas-BMT precession vector.
-            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
-
-            // push the spin vector using the generator just determined (half spin-kick)
+            // push the spin vector using the generator just determined
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
         }
 

--- a/src/elements/Buncher.H
+++ b/src/elements/Buncher.H
@@ -15,6 +15,7 @@
 #include "mixin/beamoptic.H"
 #include "mixin/thin.H"
 #include "mixin/lineartransport.H"
+#include "mixin/spintransport.H"
 #include "mixin/named.H"
 #include "mixin/nofinalize.H"
 
@@ -34,6 +35,7 @@ namespace impactx::elements
       public mixin::LinearTransport<Buncher>,
       public mixin::Thin,
       public mixin::Alignment,
+      public mixin::SpinTransport,
       public mixin::NoFinalize
       // At least on Intel AVX512, there is a small overhead to vectorize this element, see
       // https://github.com/BLAST-ImpactX/impactx/pull/1002
@@ -90,6 +92,9 @@ namespace impactx::elements
 
             m_neg_kV = -m_k * m_V;
             m_kV_r2bg2 = -m_neg_kV / (2.0_prt * betgam2);
+
+            m_beta = refpart.beta();
+            m_ibeta = 1.0_prt / m_beta;
         }
 
         /** This is a buncher functor, so that a variable of this type can be used like a
@@ -143,6 +148,98 @@ namespace impactx::elements
         /** This pushes the reference particle. */
         using Thin::operator();
 
+
+        /** This operator pushes the particle spin.
+         *
+         * @param x particle position in x
+         * @param y particle position in y
+         * @param t particle position in t
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param sx particle spin x-component
+         * @param sy particle spin y-component
+         * @param sz particle spin z-component
+         * @param idcpu particle global index
+         * @param refpart reference particle (unused)
+         */
+        template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void spin_and_phasespace_push (
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
+            T_Real const & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
+            using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
+
+            // reference particle relativistic factors
+            amrex::ParticleReal const gamma_ref = refpart.gamma();
+            amrex::ParticleReal const gyro_anomaly = refpart.gyromagnetic_anomaly;
+
+            // initialize the three components of the axis-angle vector
+            T_Real lambdax = 0_prt;
+            T_Real lambday = 0_prt;
+            T_Real lambdaz = 0_prt;
+
+            // Integrated magnetic field normalized by q/mc (half-step):
+            T_Real const Bx = 0.5_prt * m_kV_r2bg2 * y * m_beta * gamma_ref;
+            T_Real const By = -0.5_prt * m_kV_r2bg2 * x * m_beta * gamma_ref;
+            T_Real const Bz = 0_prt;
+
+            // Integrated electric field normalized by q/mc^2 (half-step):
+            T_Real const Ex = 0.0_prt;
+            T_Real const Ey = 0.0_prt;
+            T_Real const Ez = -0.5_prt * m_neg_kV * t * m_beta * gamma_ref;
+
+            // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
+            T_Real Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
+            T_Real iPnorm = 1_prt/Pnorm;
+            T_Real gamma = gamma_ref * (1_prt - pt*m_beta);
+            T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
+            T_Real ux = px * iPnorm;
+            T_Real uy = py * iPnorm;
+            T_Real uz = Ps * iPnorm;
+
+            // Zero curvature in a quadrupole
+            amrex::ParticleReal const h = 0.0_prt;
+
+            // Evaluation of the full Thomas-BMT precession vector.
+            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+
+            // push the spin vector using the generator just determined (half spin-kick)
+            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
+
+            // phase space push
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+
+            // Quantities required to evaluate the full Thomas-BMT precession vector (after phase space kick).
+            Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
+            iPnorm = 1_prt/Pnorm;
+            gamma = gamma_ref * (1_prt - pt*m_beta);
+            Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
+            ux = px * iPnorm;
+            uy = py * iPnorm;
+            uz = Ps * iPnorm;
+
+            // Evaluation of the full Thomas-BMT precession vector.
+            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+
+            // push the spin vector using the generator just determined (half spin-kick)
+            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
+
+        }
+
+
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();
 
@@ -184,6 +281,7 @@ namespace impactx::elements
         // see: compute_constants() to refresh
         amrex::ParticleReal m_neg_kV;    //! -m_k*m_V
         amrex::ParticleReal m_kV_r2bg2;  //! m_k*m_V/(2.0_prt*betgam2)
+        amrex::ParticleReal m_beta, m_ibeta;  // relativistic factors
     };
 
 } // namespace impactx

--- a/src/elements/Buncher.H
+++ b/src/elements/Buncher.H
@@ -161,7 +161,7 @@ namespace impactx::elements
          * @param sy particle spin y-component
          * @param sz particle spin z-component
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -175,12 +175,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-            using amrex::Math::powi;
             using namespace std; // for cmath(float)
 
             // reference particle relativistic factors
@@ -211,7 +210,7 @@ namespace impactx::elements
             T_Real uy = py * iPnorm;
             T_Real uz = Ps * iPnorm;
 
-            // Zero curvature in a quadrupole
+            // Zero curvature in a buncher
             amrex::ParticleReal const h = 0.0_prt;
 
             // Evaluation of the full Thomas-BMT precession vector.

--- a/src/elements/Buncher.H
+++ b/src/elements/Buncher.H
@@ -94,7 +94,6 @@ namespace impactx::elements
             m_kV_r2bg2 = -m_neg_kV / (2.0_prt * betgam2);
 
             m_beta = refpart.beta();
-            m_ibeta = 1.0_prt / m_beta;
         }
 
         /** This is a buncher functor, so that a variable of this type can be used like a
@@ -202,7 +201,7 @@ namespace impactx::elements
             T_Real const Ez = -0.5_prt * m_neg_kV * t * m_beta * gamma_ref;
 
             // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
-            T_Real Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
+            T_Real Pnorm = sqrt(1_prt - 2_prt * pt / m_beta + pt*pt);
             T_Real iPnorm = 1_prt/Pnorm;
             T_Real gamma = gamma_ref * (1_prt - pt*m_beta);
             T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
@@ -223,7 +222,7 @@ namespace impactx::elements
             (*this)(x, y, t, px, py, pt, idcpu, refpart);
 
             // Quantities required to evaluate the full Thomas-BMT precession vector (after phase space kick).
-            Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
+            Pnorm = sqrt(1_prt - 2_prt * pt / m_beta + pt*pt);
             iPnorm = 1_prt/Pnorm;
             gamma = gamma_ref * (1_prt - pt*m_beta);
             Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
@@ -280,7 +279,7 @@ namespace impactx::elements
         // see: compute_constants() to refresh
         amrex::ParticleReal m_neg_kV;    //! -m_k*m_V
         amrex::ParticleReal m_kV_r2bg2;  //! m_k*m_V/(2.0_prt*betgam2)
-        amrex::ParticleReal m_beta, m_ibeta;  // relativistic factors
+        amrex::ParticleReal m_beta;  // relativistic factor
     };
 
 } // namespace impactx

--- a/src/elements/Kicker.H
+++ b/src/elements/Kicker.H
@@ -196,9 +196,9 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            T_Real & AMREX_RESTRICT x,
-            T_Real & AMREX_RESTRICT y,
-            T_Real & AMREX_RESTRICT t,
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
+            T_Real const & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real const & AMREX_RESTRICT pt,

--- a/src/elements/Kicker.H
+++ b/src/elements/Kicker.H
@@ -191,7 +191,7 @@ namespace impactx::elements
          * @param sy particle spin y-component
          * @param sz particle spin z-component
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -210,7 +210,6 @@ namespace impactx::elements
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-            using amrex::Math::powi;
             using namespace std; // for cmath(float)
 
             // reference particle relativistic factors
@@ -241,7 +240,7 @@ namespace impactx::elements
             T_Real uy = py * iPnorm;
             T_Real uz = Ps * iPnorm;
 
-            // Zero curvature in a quadrupole
+            // Zero curvature in a kicker
             amrex::ParticleReal const h = 0.0_prt;
 
             // Evaluation of the full Thomas-BMT precession vector.

--- a/src/elements/Kicker.H
+++ b/src/elements/Kicker.H
@@ -15,6 +15,7 @@
 #include "mixin/beamoptic.H"
 #include "mixin/thin.H"
 #include "mixin/lineartransport.H"
+#include "mixin/spintransport.H"
 #include "mixin/named.H"
 #include "mixin/nofinalize.H"
 
@@ -35,6 +36,7 @@ namespace impactx::elements
       public mixin::LinearTransport<Kicker>,
       public mixin::Thin,
       public mixin::Alignment,
+      public mixin::SpinTransport,
       public mixin::NoFinalize
       // At least on Intel AVX512, there is a small overhead to vectorize this element, see
       // https://github.com/BLAST-ImpactX/impactx/pull/1002
@@ -109,6 +111,9 @@ namespace impactx::elements
 
             // normalize quad units to MAD-X convention if needed
             m_p_scale = m_unit == UnitSystem::Tm ? 1.0_prt / refpart.rigidity_Tm() : 1.0_prt;
+
+            m_beta = refpart.beta();
+            m_ibeta = 1.0_prt / m_beta;
         }
 
         /** This is a transverse kicker functor, so that a variable of this type can be
@@ -173,6 +178,95 @@ namespace impactx::elements
         /** This pushes the reference particle. */
         using Thin::operator();
 
+
+        /** This operator pushes the particle spin.
+         *
+         * @param x particle position in x
+         * @param y particle position in y
+         * @param t particle position in t
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param sx particle spin x-component
+         * @param sy particle spin y-component
+         * @param sz particle spin z-component
+         * @param idcpu particle global index
+         * @param refpart reference particle (unused)
+         */
+        template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void spin_and_phasespace_push (
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
+            using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
+
+            // reference particle relativistic factors
+            amrex::ParticleReal const gamma_ref = refpart.gamma();
+            amrex::ParticleReal const gyro_anomaly = refpart.gyromagnetic_anomaly;
+
+            // initialize the three components of the axis-angle vector
+            T_Real lambdax = 0_prt;
+            T_Real lambday = 0_prt;
+            T_Real lambdaz = 0_prt;
+
+            // Integrated magnetic field normalized by q/mc (half-step):
+            T_Real const Bx = 0.5_prt * m_ykick * m_p_scale * m_beta * gamma_ref;
+            T_Real const By = -0.5_prt * m_xkick * m_p_scale * m_beta * gamma_ref;
+            T_Real const Bz = 0_prt;
+
+            // Integrated electric field normalized by q/mc^2 (half-step):
+            T_Real const Ex = 0.0_prt;
+            T_Real const Ey = 0.0_prt;
+            T_Real const Ez = 0.0_prt;
+
+            // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
+            T_Real const Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
+            T_Real const iPnorm = 1_prt/Pnorm;
+            T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
+            T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
+            T_Real ux = px * iPnorm;
+            T_Real uy = py * iPnorm;
+            T_Real uz = Ps * iPnorm;
+
+            // Zero curvature in a quadrupole
+            amrex::ParticleReal const h = 0.0_prt;
+
+            // Evaluation of the full Thomas-BMT precession vector.
+            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+
+            // push the spin vector using the generator just determined (half spin-kick)
+            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
+
+            // phase space push
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+
+            // Quantities required to evaluate the full Thomas-BMT precession vector (after phase space kick).
+            Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
+            ux = px * iPnorm;
+            uy = py * iPnorm;
+            uz = Ps * iPnorm;
+
+            // Evaluation of the full Thomas-BMT precession vector.
+            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+
+            // push the spin vector using the generator just determined (half spin-kick)
+            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
+
+        }
+
+
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();
 
@@ -200,6 +294,7 @@ namespace impactx::elements
         // constants that are independent of the individually tracked particle,
         // see: compute_constants() to refresh
         amrex::ParticleReal m_p_scale;  // either 1 or the inverse rigidity
+        amrex::ParticleReal m_beta, m_ibeta;
     };
 
 } // namespace impactx

--- a/src/elements/Kicker.H
+++ b/src/elements/Kicker.H
@@ -220,24 +220,38 @@ namespace impactx::elements
             T_Real lambday = 0_prt;
             T_Real lambdaz = 0_prt;
 
-            // Integrated magnetic field normalized by q/mc (half-step):
-            T_Real const Bx = 0.5_prt * m_ykick * m_p_scale * m_beta * gamma_ref;
-            T_Real const By = -0.5_prt * m_xkick * m_p_scale * m_beta * gamma_ref;
+            // Integrated magnetic field normalized by q/mc:
+            T_Real const Bx = m_ykick * m_p_scale * m_beta * gamma_ref;
+            T_Real const By = -m_xkick * m_p_scale * m_beta * gamma_ref;
             T_Real const Bz = 0_prt;
 
-            // Integrated electric field normalized by q/mc^2 (half-step):
+            // Integrated electric field normalized by q/mc^2:
             T_Real const Ex = 0.0_prt;
             T_Real const Ey = 0.0_prt;
             T_Real const Ez = 0.0_prt;
 
-            // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
+            // The Thomas-BMT generator is evaluated at the transverse momentum
+            // halfway through the kick, so that reversing the element (negating
+            // the kicks) produces the exact inverse rotation.
+            T_Real const px_in = px;
+            T_Real const py_in = py;
+
+            // phase space push
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+
+            // transverse momenta at the kick midpoint
+            T_Real const px_mid = 0.5_prt * (px_in + px);
+            T_Real const py_mid = 0.5_prt * (py_in + py);
+
+            // Quantities required to evaluate the full Thomas-BMT precession
+            // vector, at the midpoint transverse momentum.
             T_Real const Pnorm = sqrt(1_prt - 2_prt * pt / m_beta + pt*pt);
             T_Real const iPnorm = 1_prt/Pnorm;
             T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
-            T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
-            T_Real ux = px * iPnorm;
-            T_Real uy = py * iPnorm;
-            T_Real uz = Ps * iPnorm;
+            T_Real const Ps = sqrt(Pnorm*Pnorm - px_mid*px_mid - py_mid*py_mid);
+            T_Real const ux = px_mid * iPnorm;
+            T_Real const uy = py_mid * iPnorm;
+            T_Real const uz = Ps * iPnorm;
 
             // Zero curvature in a kicker
             amrex::ParticleReal const h = 0.0_prt;
@@ -245,22 +259,7 @@ namespace impactx::elements
             // Evaluation of the full Thomas-BMT precession vector.
             tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
 
-            // push the spin vector using the generator just determined (half spin-kick)
-            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
-
-            // phase space push
-            (*this)(x, y, t, px, py, pt, idcpu, refpart);
-
-            // Quantities required to evaluate the full Thomas-BMT precession vector (after phase space kick).
-            Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
-            ux = px * iPnorm;
-            uy = py * iPnorm;
-            uz = Ps * iPnorm;
-
-            // Evaluation of the full Thomas-BMT precession vector.
-            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
-
-            // push the spin vector using the generator just determined (half spin-kick)
+            // push the spin vector using the generator just determined
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
         }
 

--- a/src/elements/Kicker.H
+++ b/src/elements/Kicker.H
@@ -211,6 +211,7 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
+            using namespace std; // for cmath(float)
 
             // reference particle relativistic factors
             amrex::ParticleReal const gamma_ref = refpart.gamma();
@@ -263,7 +264,6 @@ namespace impactx::elements
 
             // push the spin vector using the generator just determined (half spin-kick)
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
-
         }
 
 

--- a/src/elements/Kicker.H
+++ b/src/elements/Kicker.H
@@ -113,7 +113,6 @@ namespace impactx::elements
             m_p_scale = m_unit == UnitSystem::Tm ? 1.0_prt / refpart.rigidity_Tm() : 1.0_prt;
 
             m_beta = refpart.beta();
-            m_ibeta = 1.0_prt / m_beta;
         }
 
         /** This is a transverse kicker functor, so that a variable of this type can be
@@ -232,7 +231,7 @@ namespace impactx::elements
             T_Real const Ez = 0.0_prt;
 
             // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
-            T_Real const Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
+            T_Real const Pnorm = sqrt(1_prt - 2_prt * pt / m_beta + pt*pt);
             T_Real const iPnorm = 1_prt/Pnorm;
             T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
             T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
@@ -293,7 +292,7 @@ namespace impactx::elements
         // constants that are independent of the individually tracked particle,
         // see: compute_constants() to refresh
         amrex::ParticleReal m_p_scale;  // either 1 or the inverse rigidity
-        amrex::ParticleReal m_beta, m_ibeta;
+        amrex::ParticleReal m_beta;
     };
 
 } // namespace impactx

--- a/src/elements/NonlinearLens.H
+++ b/src/elements/NonlinearLens.H
@@ -248,24 +248,38 @@ namespace impactx::elements
             // which does not change over the kick: evaluate it only once
             amrex::GpuComplex<T_Real> const dF = dF_dzeta(x, y);
 
-            // Integrated magnetic field normalized by q/mc (half-step):
-            T_Real const Bx = -0.5_prt * m_kick * dF.m_imag * m_beta * gamma_ref;
-            T_Real const By = -0.5_prt * m_kick * dF.m_real * m_beta * gamma_ref;
+            // Integrated magnetic field normalized by q/mc:
+            T_Real const Bx = -m_kick * dF.m_imag * m_beta * gamma_ref;
+            T_Real const By = -m_kick * dF.m_real * m_beta * gamma_ref;
             T_Real const Bz = 0_prt;
 
-            // Integrated electric field normalized by q/mc^2 (half-step):
+            // Integrated electric field normalized by q/mc^2:
             T_Real const Ex = 0.0_prt;
             T_Real const Ey = 0.0_prt;
             T_Real const Ez = 0.0_prt;
 
-            // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
+            // The Thomas-BMT generator is evaluated at the transverse momentum
+            // halfway through the kick, so that reversing the element (negating
+            // knll) produces the exact inverse rotation.
+            T_Real const px_in = px;
+            T_Real const py_in = py;
+
+            // phase space push, reusing F'(zeta) from above
+            apply_kick(dF, px, py);
+
+            // transverse momenta at the kick midpoint
+            T_Real const px_mid = 0.5_prt * (px_in + px);
+            T_Real const py_mid = 0.5_prt * (py_in + py);
+
+            // Quantities required to evaluate the full Thomas-BMT precession
+            // vector, at the midpoint transverse momentum.
             T_Real const Pnorm = sqrt(1_prt - 2_prt * pt / m_beta + pt*pt);
             T_Real const iPnorm = 1_prt/Pnorm;
             T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
-            T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
-            T_Real ux = px * iPnorm;
-            T_Real uy = py * iPnorm;
-            T_Real uz = Ps * iPnorm;
+            T_Real const Ps = sqrt(Pnorm*Pnorm - px_mid*px_mid - py_mid*py_mid);
+            T_Real const ux = px_mid * iPnorm;
+            T_Real const uy = py_mid * iPnorm;
+            T_Real const uz = Ps * iPnorm;
 
             // Zero curvature in a nonlinear lens
             amrex::ParticleReal const h = 0.0_prt;
@@ -273,22 +287,7 @@ namespace impactx::elements
             // Evaluation of the full Thomas-BMT precession vector.
             tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
 
-            // push the spin vector using the generator just determined (half spin-kick)
-            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
-
-            // phase space push, reusing F'(zeta) from above
-            apply_kick(dF, px, py);
-
-            // Quantities required to evaluate the full Thomas-BMT precession vector (after phase space kick).
-            Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
-            ux = px * iPnorm;
-            uy = py * iPnorm;
-            uz = Ps * iPnorm;
-
-            // Evaluation of the full Thomas-BMT precession vector.
-            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
-
-            // push the spin vector using the generator just determined (half spin-kick)
+            // push the spin vector using the generator just determined
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
         }
 

--- a/src/elements/NonlinearLens.H
+++ b/src/elements/NonlinearLens.H
@@ -222,6 +222,7 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
+            using namespace std; // for cmath(float)
 
             // reference particle relativistic factors
             amrex::ParticleReal const gamma_ref = refpart.gamma();
@@ -296,7 +297,6 @@ namespace impactx::elements
 
             // push the spin vector using the generator just determined (half spin-kick)
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
-
         }
 
 

--- a/src/elements/NonlinearLens.H
+++ b/src/elements/NonlinearLens.H
@@ -96,7 +96,6 @@ namespace impactx::elements
             m_kick = -m_knll * m_inv_cnll;
 
             m_beta = refpart.beta();
-            m_ibeta = 1_prt / m_beta;
         }
 
         /** Evaluate the complex function F'(zeta) of the nonlinear lens.
@@ -260,7 +259,7 @@ namespace impactx::elements
             T_Real const Ez = 0.0_prt;
 
             // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
-            T_Real const Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
+            T_Real const Pnorm = sqrt(1_prt - 2_prt * pt / m_beta + pt*pt);
             T_Real const iPnorm = 1_prt/Pnorm;
             T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
             T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
@@ -350,7 +349,7 @@ namespace impactx::elements
         // see: compute_constants() to refresh
         amrex::ParticleReal m_inv_cnll;  //! 1 / m_cnll
         amrex::ParticleReal m_kick;
-        amrex::ParticleReal m_beta, m_ibeta;
+        amrex::ParticleReal m_beta;
     };
 
 } // namespace impactx

--- a/src/elements/NonlinearLens.H
+++ b/src/elements/NonlinearLens.H
@@ -99,6 +99,76 @@ namespace impactx::elements
             m_ibeta = 1_prt / m_beta;
         }
 
+        /** Evaluate the complex function F'(zeta) of the nonlinear lens.
+         *
+         * With zeta = (x + i*y)/cnll and croot = sqrt(1 - zeta^2),
+         *   F'(zeta) = zeta/croot^2 + arcsin(zeta)/croot^3 .
+         *
+         * This is by far the most expensive part of the element (a complex
+         * square root and logarithm), and both the phase space kick and the
+         * spin push are expressed through it, so it is evaluated only once
+         * per particle.
+         *
+         * The @see compute_constants method must be called before this is used.
+         *
+         * @param x particle position in x
+         * @param y particle position in y
+         * @returns the value of F'(zeta)
+         */
+        template<typename T_Real=amrex::ParticleReal>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        amrex::GpuComplex<T_Real> dF_dzeta (
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y
+        ) const
+        {
+            using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
+
+            // a complex type with two T_Real
+            using Complex = amrex::GpuComplex<T_Real>;
+
+            // assign complex position zeta = (x + iy)/cnll
+            Complex zeta(x, y);
+            zeta = zeta * m_inv_cnll;
+            Complex const re1(1.0_prt, 0.0_prt);
+            Complex const im1(0.0_prt, 1.0_prt);
+
+            // compute croot = sqrt(1-zeta**2)
+            Complex croot = powi<2>(zeta);
+            croot = re1 - croot;
+            croot = amrex::sqrt(croot);
+
+            // compute carcsin = arcsin(zeta)
+            Complex carcsin = im1 * zeta + croot;
+            carcsin = -im1 * amrex::log(carcsin);
+
+            // compute complex function F'(zeta)
+            Complex dF = zeta / powi<2>(croot);
+            dF = dF + carcsin / powi<3>(croot);
+
+            return dF;
+        }
+
+        /** Apply the thin momentum kick of the nonlinear lens.
+         *
+         * @param dF the value of F'(zeta), @see dF_dzeta
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         */
+        template<typename T_Real=amrex::ParticleReal>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void apply_kick (
+            amrex::GpuComplex<T_Real> const & AMREX_RESTRICT dF,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py
+        ) const
+        {
+            // the position and the energy deviation are unchanged
+            px = px + m_kick * dF.m_real;
+            py = py - m_kick * dF.m_imag;
+        }
+
         /** This is a nonlinear lens functor, so that a variable of this type
          *  can be used like a nonlinear lens function.
          *
@@ -126,64 +196,7 @@ namespace impactx::elements
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
-            using namespace amrex::literals; // for _rt and _prt
-            using amrex::Math::powi;
-
-            // a complex type with two T_Real
-            using Complex = amrex::GpuComplex<T_Real>;
-
-            // access reference particle values to find (beta*gamma)^2
-            //amrex::ParticleReal const pt_ref = refpart.pt;
-            //amrex::ParticleReal const betgam2 = powi<2>(pt_ref) - 1.0_prt;
-
-            // initialize output values
-            // T_Real xout = x;
-            // T_Real yout = y;
-            // T_Real tout = t;
-            T_Real pxout = px;
-            T_Real pyout = py;
-            // T_Real ptout = pt;
-
-            // assign complex position zeta = (x + iy)/cnll
-            Complex zeta(x, y);
-            zeta = zeta * m_inv_cnll;
-            Complex const re1(1.0_prt, 0.0_prt);
-            Complex const im1(0.0_prt, 1.0_prt);
-
-            // compute croot = sqrt(1-zeta**2)
-            Complex croot = powi<2>(zeta);
-            croot = re1 - croot;
-            croot = amrex::sqrt(croot);
-
-            // compute carcsin = arcsin(zeta)
-            Complex carcsin = im1 * zeta + croot;
-            carcsin = -im1 * amrex::log(carcsin);
-
-            // compute complex function F'(zeta)
-            Complex dF = zeta / powi<2>(croot);
-            dF = dF + carcsin / powi<3>(croot);
-
-            // compute momentum kick
-            T_Real const dpx = +m_kick * dF.m_real;
-            T_Real const dpy = -m_kick * dF.m_imag;
-
-            // advance position and momentum
-            // xout = x;
-            pxout = px + dpx;
-
-            // yout = y;
-            pyout = py + dpy;
-
-            // tout = t;
-            // ptout = pt;
-
-            // assign updated values
-            // x = xout;
-            // y = yout;
-            // t = tout;
-            px = pxout;
-            py = pyout;
-            // pt = ptout;
+            apply_kick(dF_dzeta(x, y), px, py);
         }
 
         /** This pushes the reference particle. */
@@ -209,19 +222,18 @@ namespace impactx::elements
         void spin_and_phasespace_push (
             T_Real const & AMREX_RESTRICT x,
             T_Real const & AMREX_RESTRICT y,
-            T_Real const & AMREX_RESTRICT t,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real const & AMREX_RESTRICT pt,
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            T_IdCpu const & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-            using amrex::Math::powi;
             using namespace std; // for cmath(float)
 
             // reference particle relativistic factors
@@ -233,27 +245,9 @@ namespace impactx::elements
             T_Real lambday = 0_prt;
             T_Real lambdaz = 0_prt;
 
-            // a complex type with two T_Real
-            using Complex = amrex::GpuComplex<T_Real>;
-
-            // assign complex position zeta = (x + iy)/cnll
-            Complex zeta(x, y);
-            zeta = zeta * m_inv_cnll;
-            Complex const re1(1.0_prt, 0.0_prt);
-            Complex const im1(0.0_prt, 1.0_prt);
-
-            // compute croot = sqrt(1-zeta**2)
-            Complex croot = powi<2>(zeta);
-            croot = re1 - croot;
-            croot = amrex::sqrt(croot);
-
-            // compute carcsin = arcsin(zeta)
-            Complex carcsin = im1 * zeta + croot;
-            carcsin = -im1 * amrex::log(carcsin);
-
-            // compute complex function F'(zeta)
-            Complex dF = zeta / powi<2>(croot);
-            dF = dF + carcsin / powi<3>(croot);
+            // the field and the phase space kick share this expensive term,
+            // which does not change over the kick: evaluate it only once
+            amrex::GpuComplex<T_Real> const dF = dF_dzeta(x, y);
 
             // Integrated magnetic field normalized by q/mc (half-step):
             T_Real const Bx = -0.5_prt * m_kick * dF.m_imag * m_beta * gamma_ref;
@@ -283,8 +277,8 @@ namespace impactx::elements
             // push the spin vector using the generator just determined (half spin-kick)
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
 
-            // phase space push
-            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+            // phase space push, reusing F'(zeta) from above
+            apply_kick(dF, px, py);
 
             // Quantities required to evaluate the full Thomas-BMT precession vector (after phase space kick).
             Ps = sqrt(Pnorm*Pnorm - px*px - py*py);

--- a/src/elements/NonlinearLens.H
+++ b/src/elements/NonlinearLens.H
@@ -15,6 +15,7 @@
 #include "mixin/beamoptic.H"
 #include "mixin/thin.H"
 #include "mixin/lineartransport.H"
+#include "mixin/spintransport.H"
 #include "mixin/named.H"
 #include "mixin/nofinalize.H"
 
@@ -37,6 +38,7 @@ namespace impactx::elements
       public mixin::LinearTransport<NonlinearLens>,
       public mixin::Thin,
       public mixin::Alignment,
+      public mixin::SpinTransport,
       public mixin::NoFinalize
       // TODO: public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
     {
@@ -92,6 +94,9 @@ namespace impactx::elements
 
             m_inv_cnll = 1.0_prt / m_cnll;
             m_kick = -m_knll * m_inv_cnll;
+
+            m_beta = refpart.beta();
+            m_ibeta = 1_prt / m_beta;
         }
 
         /** This is a nonlinear lens functor, so that a variable of this type
@@ -184,6 +189,117 @@ namespace impactx::elements
         /** This pushes the reference particle. */
         using Thin::operator();
 
+
+        /** This operator pushes the particle spin.
+         *
+         * @param x particle position in x
+         * @param y particle position in y
+         * @param t particle position in t
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param sx particle spin x-component
+         * @param sy particle spin y-component
+         * @param sz particle spin z-component
+         * @param idcpu particle global index
+         * @param refpart reference particle (unused)
+         */
+        template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void spin_and_phasespace_push (
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
+            using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
+
+            // reference particle relativistic factors
+            amrex::ParticleReal const gamma_ref = refpart.gamma();
+            amrex::ParticleReal const gyro_anomaly = refpart.gyromagnetic_anomaly;
+
+            // initialize the three components of the axis-angle vector
+            T_Real lambdax = 0_prt;
+            T_Real lambday = 0_prt;
+            T_Real lambdaz = 0_prt;
+
+            // a complex type with two T_Real
+            using Complex = amrex::GpuComplex<T_Real>;
+
+            // assign complex position zeta = (x + iy)/cnll
+            Complex zeta(x, y);
+            zeta = zeta * m_inv_cnll;
+            Complex const re1(1.0_prt, 0.0_prt);
+            Complex const im1(0.0_prt, 1.0_prt);
+
+            // compute croot = sqrt(1-zeta**2)
+            Complex croot = powi<2>(zeta);
+            croot = re1 - croot;
+            croot = amrex::sqrt(croot);
+
+            // compute carcsin = arcsin(zeta)
+            Complex carcsin = im1 * zeta + croot;
+            carcsin = -im1 * amrex::log(carcsin);
+
+            // compute complex function F'(zeta)
+            Complex dF = zeta / powi<2>(croot);
+            dF = dF + carcsin / powi<3>(croot);
+
+            // Integrated magnetic field normalized by q/mc (half-step):
+            T_Real const Bx = -0.5_prt * m_kick * dF.m_imag * m_beta * gamma_ref;
+            T_Real const By = -0.5_prt * m_kick * dF.m_real * m_beta * gamma_ref;
+            T_Real const Bz = 0_prt;
+
+            // Integrated electric field normalized by q/mc^2 (half-step):
+            T_Real const Ex = 0.0_prt;
+            T_Real const Ey = 0.0_prt;
+            T_Real const Ez = 0.0_prt;
+
+            // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
+            T_Real const Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
+            T_Real const iPnorm = 1_prt/Pnorm;
+            T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
+            T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
+            T_Real ux = px * iPnorm;
+            T_Real uy = py * iPnorm;
+            T_Real uz = Ps * iPnorm;
+
+            // Zero curvature in a quadrupole
+            amrex::ParticleReal const h = 0.0_prt;
+
+            // Evaluation of the full Thomas-BMT precession vector.
+            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+
+            // push the spin vector using the generator just determined (half spin-kick)
+            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
+
+            // phase space push
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+
+            // Quantities required to evaluate the full Thomas-BMT precession vector (after phase space kick).
+            Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
+            ux = px * iPnorm;
+            uy = py * iPnorm;
+            uz = Ps * iPnorm;
+
+            // Evaluation of the full Thomas-BMT precession vector.
+            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+
+            // push the spin vector using the generator just determined (half spin-kick)
+            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
+
+        }
+
+
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();
 
@@ -240,6 +356,7 @@ namespace impactx::elements
         // see: compute_constants() to refresh
         amrex::ParticleReal m_inv_cnll;  //! 1 / m_cnll
         amrex::ParticleReal m_kick;
+        amrex::ParticleReal m_beta, m_ibeta;
     };
 
 } // namespace impactx

--- a/src/elements/NonlinearLens.H
+++ b/src/elements/NonlinearLens.H
@@ -202,22 +202,22 @@ namespace impactx::elements
          * @param sy particle spin y-component
          * @param sz particle spin z-component
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
             T_Real const & AMREX_RESTRICT x,
             T_Real const & AMREX_RESTRICT y,
-            [[maybe_unused]] T_Real const & AMREX_RESTRICT t,
+            T_Real const & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            [[maybe_unused]] T_Real const & AMREX_RESTRICT pt,
+            T_Real const & AMREX_RESTRICT pt,
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -274,7 +274,7 @@ namespace impactx::elements
             T_Real uy = py * iPnorm;
             T_Real uz = Ps * iPnorm;
 
-            // Zero curvature in a quadrupole
+            // Zero curvature in a nonlinear lens
             amrex::ParticleReal const h = 0.0_prt;
 
             // Evaluation of the full Thomas-BMT precession vector.

--- a/src/elements/ShortRF.H
+++ b/src/elements/ShortRF.H
@@ -103,8 +103,6 @@ namespace impactx::elements
             amrex::ParticleReal const pti_ref = ptf_ref + m_V_cos_phi;
             m_bgf = std::sqrt(powi<2>(ptf_ref) - 1.0_prt);
             m_bgi = std::sqrt(powi<2>(pti_ref) - 1.0_prt);
-            m_gamf = -ptf_ref;
-            m_gami = -pti_ref;
         }
 
         /** This is a shortrf functor, so that a variable of this type can be used like a
@@ -259,8 +257,12 @@ namespace impactx::elements
             using namespace amrex::literals; // for _rt and _prt
             using namespace std; // for cmath(float)
 
-            // reference particle relativistic factors
+            // reference particle relativistic factors, before and after the
+            // cavity: the reference particle carries pt = -gamma of the final
+            // state, and gained m_V_cos_phi passing through
             amrex::ParticleReal const gyro_anomaly = refpart.gyromagnetic_anomaly;
+            amrex::ParticleReal const gamf = -refpart.pt;
+            amrex::ParticleReal const gami = gamf - m_V_cos_phi;
 
             // initialize the three components of the axis-angle vector
             T_Real lambdax = 0_prt;
@@ -282,11 +284,11 @@ namespace impactx::elements
             T_Real const Ez = 0.5_prt * m_V * cos(m_k * t + m_phi);
 
             // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
-            amrex::ParticleReal beta = m_bgi / m_gami;
-            amrex::ParticleReal ibeta = m_gami / m_bgi;
+            amrex::ParticleReal beta = m_bgi / gami;
+            amrex::ParticleReal ibeta = gami / m_bgi;
             T_Real Pnorm = sqrt(1_prt - 2_prt * pt * ibeta + pt*pt);
             T_Real iPnorm = 1_prt/Pnorm;
-            T_Real gamma = m_gami * (1_prt - pt*beta);
+            T_Real gamma = gami * (1_prt - pt*beta);
             T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
             T_Real ux = px * iPnorm;
             T_Real uy = py * iPnorm;
@@ -305,11 +307,11 @@ namespace impactx::elements
             (*this)(x, y, t, px, py, pt, idcpu, refpart);
 
             // Quantities required to evaluate the full Thomas-BMT precession vector (after phase space kick).
-            beta = m_bgf / m_gamf;
-            ibeta = m_gamf / m_bgf;
+            beta = m_bgf / gamf;
+            ibeta = gamf / m_bgf;
             Pnorm = sqrt(1_prt - 2_prt * pt * ibeta + pt*pt);
             iPnorm = 1_prt/Pnorm;
-            gamma = m_gamf * (1_prt - pt*beta);
+            gamma = gamf * (1_prt - pt*beta);
             Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
             ux = px * iPnorm;
             uy = py * iPnorm;
@@ -371,7 +373,7 @@ namespace impactx::elements
       private:
         // constants that are independent of the individually tracked particle,
         // see: compute_constants() to refresh
-        amrex::ParticleReal m_k, m_phi, m_V_cos_phi, m_bgi, m_bgf, m_gamf, m_gami;
+        amrex::ParticleReal m_k, m_phi, m_V_cos_phi, m_bgi, m_bgf;
     };
 
 } // namespace impactx

--- a/src/elements/ShortRF.H
+++ b/src/elements/ShortRF.H
@@ -243,8 +243,8 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
-            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
             T_Real const & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,

--- a/src/elements/ShortRF.H
+++ b/src/elements/ShortRF.H
@@ -17,6 +17,7 @@
 #include "mixin/named.H"
 #include "mixin/nofinalize.H"
 #include "mixin/lineartransport.H"
+#include "mixin/spintransport.H"
 
 #include <AMReX_Extension.H>
 #include <AMReX_Math.H>
@@ -33,6 +34,7 @@ namespace impactx::elements
       public mixin::LinearTransport<ShortRF>,
       public mixin::Thin,
       public mixin::Alignment,
+      public mixin::SpinTransport,
       public mixin::NoFinalize,
       public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
     {
@@ -220,6 +222,102 @@ namespace impactx::elements
             refpart.pz = pz*bgf/bgi;
 
         }
+
+
+        /** This operator pushes the particle spin.
+         *
+         * @param x particle position in x
+         * @param y particle position in y
+         * @param t particle position in t
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param sx particle spin x-component
+         * @param sy particle spin y-component
+         * @param sz particle spin z-component
+         * @param idcpu particle global index
+         * @param refpart reference particle (unused)
+         */
+        template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void spin_and_phasespace_push (
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
+            using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
+
+            // reference particle relativistic factors
+            amrex::ParticleReal const gamma_ref = refpart.gamma();
+            amrex::ParticleReal const gyro_anomaly = refpart.gyromagnetic_anomaly;
+
+            // initialize the three components of the axis-angle vector
+            T_Real lambdax = 0_prt;
+            T_Real lambday = 0_prt;
+            T_Real lambdaz = 0_prt;
+
+            // The ShortRF model is based on the impulse associated with the
+            // on-axis longitudinal electric field Ez.  As a result, only this
+            // contribution is considered below.
+
+            // Integrated magnetic field normalized by q/mc (half-step):
+            T_Real const Bx = 0_prt;
+            T_Real const By = 0_prt;
+            T_Real const Bz = 0_prt;
+
+            // Integrated electric field normalized by q/mc^2 (half-step):
+            T_Real const Ex = 0.0_prt;
+            T_Real const Ey = 0.0_prt;
+            T_Real const Ez = 0.5_prt * m_V * cos(m_k * t + m_phi);
+
+            // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
+            T_Real Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
+            T_Real iPnorm = 1_prt/Pnorm;
+            T_Real gamma = gamma_ref * (1_prt - pt*m_beta);
+            T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
+            T_Real ux = px * iPnorm;
+            T_Real uy = py * iPnorm;
+            T_Real uz = Ps * iPnorm;
+
+            // Zero curvature
+            amrex::ParticleReal const h = 0.0_prt;
+
+            // Evaluation of the full Thomas-BMT precession vector.
+            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+
+            // push the spin vector using the generator just determined (half spin-kick)
+            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
+
+            // phase space push
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+
+            // Quantities required to evaluate the full Thomas-BMT precession vector (after phase space kick).
+            Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
+            iPnorm = 1_prt/Pnorm;
+            gamma = gamma_ref * (1_prt - pt*m_beta);
+            Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
+            ux = px * iPnorm;
+            uy = py * iPnorm;
+            uz = Ps * iPnorm;
+
+            // Evaluation of the full Thomas-BMT precession vector.
+            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+
+            // push the spin vector using the generator just determined (half spin-kick)
+            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
+
+        }
+
 
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();

--- a/src/elements/ShortRF.H
+++ b/src/elements/ShortRF.H
@@ -238,7 +238,7 @@ namespace impactx::elements
          * @param sy particle spin y-component
          * @param sz particle spin z-component
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -252,12 +252,11 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
-            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-            using amrex::Math::powi;
             using namespace std; // for cmath(float)
 
             // reference particle relativistic factors

--- a/src/elements/ShortRF.H
+++ b/src/elements/ShortRF.H
@@ -103,6 +103,8 @@ namespace impactx::elements
             amrex::ParticleReal const pti_ref = ptf_ref + m_V_cos_phi;
             m_bgf = std::sqrt(powi<2>(ptf_ref) - 1.0_prt);
             m_bgi = std::sqrt(powi<2>(pti_ref) - 1.0_prt);
+            m_gamf = -ptf_ref;
+            m_gami = -pti_ref;
         }
 
         /** This is a shortrf functor, so that a variable of this type can be used like a
@@ -241,24 +243,23 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            T_Real & AMREX_RESTRICT x,
-            T_Real & AMREX_RESTRICT y,
-            T_Real & AMREX_RESTRICT t,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT x,
+            [[maybe_unused]] T_Real & AMREX_RESTRICT y,
+            T_Real const & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT pt,
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            T_IdCpu const & AMREX_RESTRICT idcpu,
-            RefPart const & AMREX_RESTRICT refpart
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
 
             // reference particle relativistic factors
-            amrex::ParticleReal const gamma_ref = refpart.gamma();
             amrex::ParticleReal const gyro_anomaly = refpart.gyromagnetic_anomaly;
 
             // initialize the three components of the axis-angle vector
@@ -281,9 +282,11 @@ namespace impactx::elements
             T_Real const Ez = 0.5_prt * m_V * cos(m_k * t + m_phi);
 
             // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
-            T_Real Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
+            amrex::ParticleReal beta = m_bgi / m_gami;
+            amrex::ParticleReal ibeta = m_gami / m_bgi;
+            T_Real Pnorm = sqrt(1_prt - 2_prt * pt * ibeta + pt*pt);
             T_Real iPnorm = 1_prt/Pnorm;
-            T_Real gamma = gamma_ref * (1_prt - pt*m_beta);
+            T_Real gamma = m_gami * (1_prt - pt*beta);
             T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
             T_Real ux = px * iPnorm;
             T_Real uy = py * iPnorm;
@@ -302,9 +305,11 @@ namespace impactx::elements
             (*this)(x, y, t, px, py, pt, idcpu, refpart);
 
             // Quantities required to evaluate the full Thomas-BMT precession vector (after phase space kick).
-            Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
+            beta = m_bgf / m_gamf;
+            ibeta = m_gamf / m_bgf;
+            Pnorm = sqrt(1_prt - 2_prt * pt * ibeta + pt*pt);
             iPnorm = 1_prt/Pnorm;
-            gamma = gamma_ref * (1_prt - pt*m_beta);
+            gamma = m_gamf * (1_prt - pt*beta);
             Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
             ux = px * iPnorm;
             uy = py * iPnorm;
@@ -367,7 +372,7 @@ namespace impactx::elements
       private:
         // constants that are independent of the individually tracked particle,
         // see: compute_constants() to refresh
-        amrex::ParticleReal m_k, m_phi, m_V_cos_phi, m_bgi, m_bgf;
+        amrex::ParticleReal m_k, m_phi, m_V_cos_phi, m_bgi, m_bgf, m_gamf, m_gami;
     };
 
 } // namespace impactx

--- a/src/elements/ShortRF.H
+++ b/src/elements/ShortRF.H
@@ -258,6 +258,7 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
+            using namespace std; // for cmath(float)
 
             // reference particle relativistic factors
             amrex::ParticleReal const gyro_anomaly = refpart.gyromagnetic_anomaly;
@@ -320,7 +321,6 @@ namespace impactx::elements
 
             // push the spin vector using the generator just determined (half spin-kick)
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
-
         }
 
 

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -200,11 +200,11 @@ namespace impactx::elements
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            T_Real & AMREX_RESTRICT x,
-            T_Real & AMREX_RESTRICT y,
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
             T_Real & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
-            T_Real & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT py,
             T_Real const & AMREX_RESTRICT pt,
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -245,10 +245,13 @@ namespace impactx::elements
             T_Real uz = Ps * iPnorm;
 
             // Integrated curvature = bend angle in rad (half-step):
-            amrex::ParticleReal const h = 0.5_prt * m_theta;
+            amrex::ParticleReal const h = 0.5_prt * m_kx;
 
             // Evaluation of the full Thomas-BMT precession vector.
             tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+            lambdax *= m_ds;
+            lambday *= m_ds;
+            lambdaz *= m_ds;
 
             // push the spin vector using the generator just determined (half spin-kick)
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
@@ -264,6 +267,9 @@ namespace impactx::elements
 
             // Evaluation of the full Thomas-BMT precession vector.
             tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+            lambdax *= m_ds;
+            lambday *= m_ds;
+            lambdaz *= m_ds;
 
             // push the spin vector using the generator just determined (half spin-kick)
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -195,7 +195,7 @@ namespace impactx::elements
          * @param sy particle spin y-component
          * @param sz particle spin z-component
          * @param idcpu particle global index
-         * @param refpart reference particle (unused)
+         * @param refpart reference particle
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -214,7 +214,6 @@ namespace impactx::elements
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
-            using amrex::Math::powi;
             using namespace std; // for cmath(float)
 
             // reference particle relativistic factors

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -234,46 +234,39 @@ namespace impactx::elements
             T_Real const Ey = 0.0_prt;
             T_Real const Ez = 0.0_prt;
 
-            // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
-            T_Real const Pnorm = sqrt(1_prt - 2_prt * pt / m_beta + pt*pt);
-            T_Real const iPnorm = 1_prt/Pnorm;
-            T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
-            T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
-            T_Real ux = px * iPnorm;
-            T_Real uy = py * iPnorm;
-            T_Real uz = Ps * iPnorm;
-
-            // Design-orbit curvature [1/m]
-            amrex::ParticleReal const h = m_kx;
-
-            // generator over half of the effective (equivalent) arc length
-            amrex::ParticleReal const half_ds = 0.5_prt * m_ds;
-
-            // Evaluation of the full Thomas-BMT precession vector.
-            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
-            lambdax *= half_ds;
-            lambday *= half_ds;
-            lambdaz *= half_ds;
-
-            // push the spin vector using the generator just determined (half spin-kick)
-            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
+            // The Thomas-BMT generator is evaluated at the horizontal momentum
+            // halfway through the kick, so that reversing the element (negating
+            // the bend angle) produces the exact inverse rotation.
+            T_Real const px_in = px;
 
             // phase space push
             (*this)(x, y, t, px, py, pt, idcpu, refpart);
 
-            // Quantities required to evaluate the full Thomas-BMT precession vector (after phase space kick).
-            Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
-            ux = px * iPnorm;
-            uy = py * iPnorm;
-            uz = Ps * iPnorm;
+            // horizontal momentum at the kick midpoint
+            T_Real const px_mid = 0.5_prt * (px_in + px);
+
+            // Quantities required to evaluate the full Thomas-BMT precession
+            // vector, at the midpoint horizontal momentum.
+            T_Real const Pnorm = sqrt(1_prt - 2_prt * pt / m_beta + pt*pt);
+            T_Real const iPnorm = 1_prt/Pnorm;
+            T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
+            T_Real const Ps = sqrt(Pnorm*Pnorm - px_mid*px_mid - py*py);
+            T_Real const ux = px_mid * iPnorm;
+            T_Real const uy = py * iPnorm;
+            T_Real const uz = Ps * iPnorm;
+
+            // Design-orbit curvature [1/m]
+            amrex::ParticleReal const h = m_kx;
 
             // Evaluation of the full Thomas-BMT precession vector.
             tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
-            lambdax *= half_ds;
-            lambday *= half_ds;
-            lambdaz *= half_ds;
 
-            // push the spin vector using the generator just determined (half spin-kick)
+            // generator over the effective (equivalent) arc length
+            lambdax *= m_ds;
+            lambday *= m_ds;
+            lambdaz *= m_ds;
+
+            // push the spin vector using the generator just determined
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
         }
 

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -92,7 +92,6 @@ namespace impactx::elements
 
             // access reference particle to find relativistic beta
             m_beta = refpart.beta();
-            m_ibeta = 1_prt / m_beta;
 
             // compute the effective (equivalent) arc length and curvature
             m_ds = m_theta * m_rc;
@@ -236,7 +235,7 @@ namespace impactx::elements
             T_Real const Ez = 0.0_prt;
 
             // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
-            T_Real const Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
+            T_Real const Pnorm = sqrt(1_prt - 2_prt * pt / m_beta + pt*pt);
             T_Real const iPnorm = 1_prt/Pnorm;
             T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
             T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
@@ -330,7 +329,7 @@ namespace impactx::elements
       private:
         // constants that are independent of the individually tracked particle,
         // see: compute_constants() to refresh
-        amrex::ParticleReal m_beta, m_ibeta;  //! beta of the reference particle
+        amrex::ParticleReal m_beta;  //! beta of the reference particle
         amrex::ParticleReal m_ds;    //! effective (equivalent) arc length
         amrex::ParticleReal m_kx;    //! effective (equivalent) curvature
     };

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -15,6 +15,7 @@
 #include "mixin/beamoptic.H"
 #include "mixin/thin.H"
 #include "mixin/lineartransport.H"
+#include "mixin/spintransport.H"
 #include "mixin/named.H"
 #include "mixin/nofinalize.H"
 
@@ -34,6 +35,7 @@ namespace impactx::elements
       public mixin::LinearTransport<ThinDipole>,
       public mixin::Thin,
       public mixin::Alignment,
+      public mixin::SpinTransport,
       public mixin::NoFinalize,
       public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
     {
@@ -90,6 +92,7 @@ namespace impactx::elements
 
             // access reference particle to find relativistic beta
             m_beta = refpart.beta();
+            m_ibeta = 1_prt / m_beta;
 
             // compute the effective (equivalent) arc length and curvature
             m_ds = m_theta * m_rc;
@@ -179,6 +182,95 @@ namespace impactx::elements
             refpart.pz = pz*cos_theta + px*sin_theta;
         }
 
+
+        /** This operator pushes the particle spin.
+         *
+         * @param x particle position in x
+         * @param y particle position in y
+         * @param t particle position in t
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param sx particle spin x-component
+         * @param sy particle spin y-component
+         * @param sz particle spin z-component
+         * @param idcpu particle global index
+         * @param refpart reference particle (unused)
+         */
+        template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void spin_and_phasespace_push (
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
+            using namespace amrex::literals; // for _rt and _prt
+            using amrex::Math::powi;
+
+            // reference particle relativistic factors
+            amrex::ParticleReal const gamma_ref = refpart.gamma();
+            amrex::ParticleReal const gyro_anomaly = refpart.gyromagnetic_anomaly;
+
+            // initialize the three components of the axis-angle vector
+            T_Real lambdax = 0_prt;
+            T_Real lambday = 0_prt;
+            T_Real lambdaz = 0_prt;
+
+            // Integrated magnetic field normalized by q/mc (half-step):
+            T_Real const Bx = 0_prt;
+            T_Real const By = 0.5_prt * m_kx * m_beta * gamma_ref;
+            T_Real const Bz = 0_prt;
+
+            // Integrated electric field normalized by q/mc^2 (half-step):
+            T_Real const Ex = 0.0_prt;
+            T_Real const Ey = 0.0_prt;
+            T_Real const Ez = 0.0_prt;
+
+            // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
+            T_Real const Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
+            T_Real const iPnorm = 1_prt/Pnorm;
+            T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
+            T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
+            T_Real ux = px * iPnorm;
+            T_Real uy = py * iPnorm;
+            T_Real uz = Ps * iPnorm;
+
+            // Integrated curvature = bend angle in rad (half-step):
+            amrex::ParticleReal const h = 0.5_prt * m_theta;
+
+            // Evaluation of the full Thomas-BMT precession vector.
+            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+
+            // push the spin vector using the generator just determined (half spin-kick)
+            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
+
+            // phase space push
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+
+            // Quantities required to evaluate the full Thomas-BMT precession vector (after phase space kick).
+            Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
+            ux = px * iPnorm;
+            uy = py * iPnorm;
+            uz = Ps * iPnorm;
+
+            // Evaluation of the full Thomas-BMT precession vector.
+            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+
+            // push the spin vector using the generator just determined (half spin-kick)
+            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
+
+        }
+
+
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();
 
@@ -230,7 +322,7 @@ namespace impactx::elements
       private:
         // constants that are independent of the individually tracked particle,
         // see: compute_constants() to refresh
-        amrex::ParticleReal m_beta;  //! beta of the reference particle
+        amrex::ParticleReal m_beta, m_ibeta;  //! beta of the reference particle
         amrex::ParticleReal m_ds;    //! effective (equivalent) arc length
         amrex::ParticleReal m_kx;    //! effective (equivalent) curvature
     };

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -215,6 +215,7 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
             using amrex::Math::powi;
+            using namespace std; // for cmath(float)
 
             // reference particle relativistic factors
             amrex::ParticleReal const gamma_ref = refpart.gamma();
@@ -273,7 +274,6 @@ namespace impactx::elements
 
             // push the spin vector using the generator just determined (half spin-kick)
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
-
         }
 
 

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -225,12 +225,12 @@ namespace impactx::elements
             T_Real lambday = 0_prt;
             T_Real lambdaz = 0_prt;
 
-            // Integrated magnetic field normalized by q/mc (half-step):
+            // Magnetic field normalized by q/mc [1/m]:
             T_Real const Bx = 0_prt;
-            T_Real const By = 0.5_prt * m_kx * m_beta * gamma_ref;
+            T_Real const By = m_kx * m_beta * gamma_ref;
             T_Real const Bz = 0_prt;
 
-            // Integrated electric field normalized by q/mc^2 (half-step):
+            // Electric field normalized by q/mc^2 [1/m]:
             T_Real const Ex = 0.0_prt;
             T_Real const Ey = 0.0_prt;
             T_Real const Ez = 0.0_prt;
@@ -244,14 +244,17 @@ namespace impactx::elements
             T_Real uy = py * iPnorm;
             T_Real uz = Ps * iPnorm;
 
-            // Integrated curvature = bend angle in rad (half-step):
-            amrex::ParticleReal const h = 0.5_prt * m_kx;
+            // Design-orbit curvature [1/m]
+            amrex::ParticleReal const h = m_kx;
+
+            // generator over half of the effective (equivalent) arc length
+            amrex::ParticleReal const half_ds = 0.5_prt * m_ds;
 
             // Evaluation of the full Thomas-BMT precession vector.
             tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
-            lambdax *= m_ds;
-            lambday *= m_ds;
-            lambdaz *= m_ds;
+            lambdax *= half_ds;
+            lambday *= half_ds;
+            lambdaz *= half_ds;
 
             // push the spin vector using the generator just determined (half spin-kick)
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
@@ -267,9 +270,9 @@ namespace impactx::elements
 
             // Evaluation of the full Thomas-BMT precession vector.
             tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
-            lambdax *= m_ds;
-            lambday *= m_ds;
-            lambdaz *= m_ds;
+            lambdax *= half_ds;
+            lambday *= half_ds;
+            lambdaz *= half_ds;
 
             // push the spin vector using the generator just determined (half spin-kick)
             rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);

--- a/tests/python/test_benchmark_elements.py
+++ b/tests/python/test_benchmark_elements.py
@@ -134,6 +134,7 @@ def test_Aperture(benchmark, sim):
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)
 
 
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_Buncher(benchmark, sim):
     el = elements.Buncher(name="shortrf1", V=0.01, k=15.0)
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)
@@ -251,6 +252,7 @@ def test_ExactSbend(benchmark, sim):
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)
 
 
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_Kicker(benchmark, sim):
     el = elements.Kicker(name="kick1", xkick=2.0e-3, ykick=0.0, unit="dimensionless")
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)
@@ -281,6 +283,7 @@ def test_Multipole(benchmark, sim):
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)
 
 
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_NonlinearLens(benchmark, sim):
     el = elements.NonlinearLens(name="nllens", knll=4.0e-6, cnll=0.01)
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)
@@ -412,6 +415,7 @@ def test_Sbend(benchmark, sim):
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)
 
 
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_ShortRF(benchmark, sim):
     el = elements.ShortRF(name="shortrf1", V=1000.0, freq=1.3e9, phase=-89.5)
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)
@@ -539,6 +543,7 @@ def test_TaperedPL(benchmark, sim):
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)
 
 
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_ThinDipole(benchmark, sim):
     el = elements.ThinDipole(name="kick", theta=0.45, rc=1.0)
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)

--- a/tests/python/test_reversibility_elements.py
+++ b/tests/python/test_reversibility_elements.py
@@ -612,10 +612,13 @@ def test_PRot(sim):
 # RF / energy-changing elements
 # =============================================================================
 
+
 @pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_ShortRF(sim):
     roundtrip(
-        elements.ShortRF(V=1000.0, freq=1.3e9, phase=-89.5, **ALIGNMENT_KWARGS), sim, spin=sim.spin
+        elements.ShortRF(V=1000.0, freq=1.3e9, phase=-89.5, **ALIGNMENT_KWARGS),
+        sim,
+        spin=sim.spin,
     )
 
 

--- a/tests/python/test_reversibility_elements.py
+++ b/tests/python/test_reversibility_elements.py
@@ -531,10 +531,12 @@ def test_Sol(sim):
 # =============================================================================
 
 
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_Buncher(sim):
-    roundtrip(elements.Buncher(V=0.01, k=15.0, **ALIGNMENT_KWARGS), sim)
+    roundtrip(elements.Buncher(V=0.01, k=15.0, **ALIGNMENT_KWARGS), sim, spin=sim.spin)
 
 
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 @pytest.mark.parametrize(
     ("unit", "xkick", "ykick"),
     [
@@ -560,8 +562,13 @@ def test_Multipole(sim):
     )
 
 
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_NonlinearLens(sim):
-    roundtrip(elements.NonlinearLens(knll=4.0e-6, cnll=0.01, **ALIGNMENT_KWARGS), sim)
+    roundtrip(
+        elements.NonlinearLens(knll=4.0e-6, cnll=0.01, **ALIGNMENT_KWARGS),
+        sim,
+        spin=sim.spin,
+    )
 
 
 @pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
@@ -579,8 +586,13 @@ def test_TaperedPL(sim, unit, k):
     )
 
 
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_ThinDipole(sim):
-    roundtrip(elements.ThinDipole(theta=0.45, rc=1.0, **ALIGNMENT_KWARGS), sim)
+    roundtrip(
+        elements.ThinDipole(theta=0.45, rc=1.0, **ALIGNMENT_KWARGS),
+        sim,
+        spin=sim.spin,
+    )
 
 
 # =============================================================================
@@ -600,10 +612,10 @@ def test_PRot(sim):
 # RF / energy-changing elements
 # =============================================================================
 
-
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_ShortRF(sim):
     roundtrip(
-        elements.ShortRF(V=1000.0, freq=1.3e9, phase=-89.5, **ALIGNMENT_KWARGS), sim
+        elements.ShortRF(V=1000.0, freq=1.3e9, phase=-89.5, **ALIGNMENT_KWARGS), sim, spin=sim.spin
     )
 
 

--- a/tests/python/test_reversibility_elements.py
+++ b/tests/python/test_reversibility_elements.py
@@ -547,6 +547,7 @@ def test_Kicker(sim, unit, xkick, ykick):
     roundtrip(
         elements.Kicker(xkick=xkick, ykick=ykick, unit=unit, **ALIGNMENT_KWARGS),
         sim,
+        spin=sim.spin,   
     )
 
 

--- a/tests/python/test_reversibility_elements.py
+++ b/tests/python/test_reversibility_elements.py
@@ -547,7 +547,7 @@ def test_Kicker(sim, unit, xkick, ykick):
     roundtrip(
         elements.Kicker(xkick=xkick, ykick=ykick, unit=unit, **ALIGNMENT_KWARGS),
         sim,
-        spin=sim.spin,   
+        spin=sim.spin,
     )
 
 


### PR DESCRIPTION
This PR adds the spin push through those `Thin` elements _not_ associated with fringe fields.  The logic for all of these elements uses the same pattern, and only the evaluation of the magnetic or electric fields should differ.

The implementation here is $s$-symmetric.  A reversibility test will be included.

- [x] Kicker
- [x] ShortRF
- [x] NonlinearLens
- [x] ThinDipole
- [x] Buncher
- [x] finalize reversibility tests
- [x] change all but `ShortRF` to midpush scheme? https://github.com/cemitch99/impactx/pull/4

This closes Issue #1322 
