### PR TITLE
Python: Fix Element `unit` Bindings

### DIFF
--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -766,13 +766,13 @@ void init_elements(py::module& m)
              "An active Plasma Lens with chromatic effects included."
         )
         .def_property("k",
-            [](ChrQuad & cq) { return cq.m_k; },
-            [](ChrQuad & cq, amrex::ParticleReal k) { cq.m_k = k; },
+            [](ChrPlasmaLens & chr_pl_lens) { return chr_pl_lens.m_k; },
+            [](ChrPlasmaLens & chr_pl_lens, amrex::ParticleReal k) { chr_pl_lens.m_k = k; },
             "focusing strength in 1/m^2 (or T/m)"
         )
         .def_property("unit",
-            [](ChrQuad & cq) { return cq.m_unit; },
-            [](ChrQuad & cq, int unit) { cq.m_unit = unit; },
+            [](ChrPlasmaLens & chr_pl_lens) { return chr_pl_lens.m_unit; },
+            [](ChrPlasmaLens & chr_pl_lens, int unit) { chr_pl_lens.m_unit = unit; },
             "unit specification for focusing strength"
         )
     ;
@@ -2357,7 +2357,7 @@ void init_elements(py::module& m)
                  amrex::ParticleReal,
                  std::vector<amrex::ParticleReal>,
                  std::vector<amrex::ParticleReal>,
-                 amrex::ParticleReal,
+                 int,
                  amrex::ParticleReal,
                  amrex::ParticleReal,
                  amrex::ParticleReal,

--- a/tests/python/test_element_unit_argument.py
+++ b/tests/python/test_element_unit_argument.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 ImpactX contributors
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+"""The ``unit`` argument selects a convention and is an integer everywhere."""
+
+import pytest
+
+from impactx import elements
+
+# minimal constructor arguments per element that takes an integer ``unit``
+UNIT_ELEMENTS = {
+    "ChrPlasmaLens": dict(ds=0.3, k=1.0),
+    "ChrQuad": dict(ds=0.3, k=1.0),
+    "ExactCFbend": dict(ds=0.3, k_normal=[1.0], k_skew=[0.0]),
+    "ExactMultipole": dict(ds=0.3, k_normal=[1.0], k_skew=[0.0]),
+    "ExactQuad": dict(ds=0.3, k=1.0),
+    "QuadEdge": dict(k=1.0),
+    "SoftSolenoid": dict(
+        ds=1.0, bscale=1.0, cos_coefficients=[1.0], sin_coefficients=[0.0]
+    ),
+    "TaperedPL": dict(k=1.0, taper=0.0),
+}
+
+
+@pytest.mark.parametrize("name", sorted(UNIT_ELEMENTS))
+@pytest.mark.parametrize("unit", [0, 1])
+def test_unit_accepts_integers(name, unit):
+    """Both conventions can be selected, and the value is stored as given."""
+
+    element = getattr(elements, name)(unit=unit, **UNIT_ELEMENTS[name])
+
+    assert element.unit == unit
+
+
+@pytest.mark.parametrize("name", sorted(UNIT_ELEMENTS))
+def test_unit_rejects_floats(name):
+    """A float is not a convention: it is rejected rather than truncated."""
+
+    with pytest.raises(TypeError):
+        getattr(elements, name)(unit=1.7, **UNIT_ELEMENTS[name])


### PR DESCRIPTION
Two small bugs in the element bindings around the `unit` argument, which selects between the MAD-X (`0`) and SI (`1`) convention.

## `SoftSolenoid` silently truncated a float `unit`

`SoftSolenoid` declared `unit` as a floating-point argument, while its constructor takes an integer. A float was accepted and silently truncated:

```python
elements.SoftSolenoid(ds=1.0, bscale=1.0, cos_coefficients=[1.0], sin_coefficients=[0.0], unit=1.7).unit
# 1
```

Every other element with a `unit` rejects this:

```python
elements.ChrQuad(ds=0.3, k=1.0, unit=1.7)
# TypeError
```

`unit` is now declared as an integer, so an unintended value is reported rather than quietly reinterpreted. This also makes the generated stub read `unit: typing.SupportsInt | typing.SupportsIndex` like every other element, instead of `SupportsFloat`.

## `ChrPlasmaLens.k` and `.unit` were unreadable

Both properties were bound with lambdas taking a `ChrQuad`, so either access raised:

```python
elements.ChrPlasmaLens(ds=0.3, k=1.0).unit
# TypeError: (): incompatible function arguments. The following argument types are supported:
#     1. (arg0: impactx.impactx_pybind.elements.ChrQuad) -> int
```

They are now bound to `ChrPlasmaLens`. Its `k` and `unit` constructor arguments were always applied correctly; only reading and writing them afterwards was broken.

## Testing

`tests/python/test_element_unit_argument.py` covers every element that takes an integer `unit` — `ChrPlasmaLens`, `ChrQuad`, `ExactCFbend`, `ExactMultipole`, `ExactQuad`, `QuadEdge`, `SoftSolenoid`, `TaperedPL` — asserting both conventions round-trip and that a float is rejected. Against `development` it fails exactly the three cases fixed here (`ChrPlasmaLens` ×2, `SoftSolenoid` ×1) and passes the other 21.

I also swept `src/python/elements.cpp` for further binding lambdas whose parameter type does not match the class they are attached to; `ChrPlasmaLens` was the only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Au2ZAQ2jjQ74U4cXhjcaT
