### PR TITLE
Multipole: 2nd-Order Accurate Spin Push

### DIFF
--- a/src/elements/Multipole.H
+++ b/src/elements/Multipole.H
@@ -191,10 +191,8 @@ namespace impactx::elements
 
         /** This operator pushes the particle spin.
          *
-         * The push is s-symmetric: half spin kick, phase space kick, half
-         * spin kick, with the second half evaluated at the updated momenta.
-         * The map is second-order accurate in the kick strength and an exact
-         * inverse of the reversed element.
+         * The push is s-symmetric: the map is second-order accurate in the
+         * kick strength and an exact inverse of the reversed element.
          *
          * @param x particle position in x
          * @param y particle position in y
@@ -243,26 +241,40 @@ namespace impactx::elements
             // assign complex position and complex multipole strength
             Complex const zeta(x, y);
 
-            // compute multipole magnetic field normalized by q/mc (half-step):
+            // compute multipole magnetic field normalized by q/mc:
             int const m = m_multipole - 1;
             Complex const kick = amrex::pow(zeta, m) * m_alpha;
-            T_Real const Bx = 0.5_prt * kick.m_imag * m_inv_factorial * m_beta * gamma_ref;
-            T_Real const By = 0.5_prt * kick.m_real * m_inv_factorial * m_beta * gamma_ref;
+            T_Real const Bx = kick.m_imag * m_inv_factorial * m_beta * gamma_ref;
+            T_Real const By = kick.m_real * m_inv_factorial * m_beta * gamma_ref;
             T_Real const Bz = 0_prt;
 
-            // Electric field normalized by q/mc^2 (half-step):
+            // Electric field normalized by q/mc^2:
             T_Real const Ex = 0.0_prt;
             T_Real const Ey = 0.0_prt;
             T_Real const Ez = 0.0_prt;
 
-            // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
+            // The Thomas-BMT generator is evaluated at the transverse momentum
+            // halfway through the kick, so that reversing the element (negating
+            // the strengths) produces the exact inverse rotation.
+            T_Real const px_in = px;
+            T_Real const py_in = py;
+
+            // phase space push
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+
+            // transverse momenta at the kick midpoint
+            T_Real const px_mid = 0.5_prt * (px_in + px);
+            T_Real const py_mid = 0.5_prt * (py_in + py);
+
+            // Quantities required to evaluate the full Thomas-BMT precession
+            // vector, at the midpoint transverse momentum.
             T_Real const Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
             T_Real const iPnorm = 1_prt/Pnorm;
+            T_Real const Ps = sqrt(Pnorm*Pnorm - px_mid*px_mid - py_mid*py_mid);
             T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
-            T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
-            T_Real ux = px * iPnorm;
-            T_Real uy = py * iPnorm;
-            T_Real uz = Ps * iPnorm;
+            T_Real const ux = px_mid * iPnorm;
+            T_Real const uy = py_mid * iPnorm;
+            T_Real const uz = Ps * iPnorm;
 
             // Zero curvature in a multipole
             amrex::ParticleReal const h = 0.0_prt;
@@ -270,24 +282,7 @@ namespace impactx::elements
             // Evaluation of the full Thomas-BMT precession vector.
             tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
 
-            // push the spin vector using the generator just determined (half spin-kick)
-            rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);
-
-            // phase space push
-            (*this)(x, y, t, px, py, pt, idcpu, refpart);
-
-            // Quantities required to evaluate the full Thomas-BMT precession vector (after phase space kick).
-            // The fields depend only on (x,y) and pt is unchanged, so only the
-            // velocity direction needs to be refreshed.
-            Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
-            ux = px * iPnorm;
-            uy = py * iPnorm;
-            uz = Ps * iPnorm;
-
-            // Evaluation of the full Thomas-BMT precession vector.
-            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
-
-            // push the spin vector using the generator just determined (half spin-kick)
+            // push the spin vector using the generator just determined
             rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);
         }
 

--- a/src/elements/Multipole.H
+++ b/src/elements/Multipole.H
@@ -191,6 +191,11 @@ namespace impactx::elements
 
         /** This operator pushes the particle spin.
          *
+         * The push is s-symmetric: half spin kick, phase space kick, half
+         * spin kick, with the second half evaluated at the updated momenta.
+         * The map is second-order accurate in the kick strength and an exact
+         * inverse of the reversed element.
+         *
          * @param x particle position in x
          * @param y particle position in y
          * @param t particle position in t
@@ -238,39 +243,52 @@ namespace impactx::elements
             // assign complex position and complex multipole strength
             Complex const zeta(x, y);
 
-            // compute multipole magnetic field normalized by q/mc:
+            // compute multipole magnetic field normalized by q/mc (half-step):
             int const m = m_multipole - 1;
             Complex const kick = amrex::pow(zeta, m) * m_alpha;
-            T_Real const Bx = kick.m_imag * m_inv_factorial * m_beta * gamma_ref;
-            T_Real const By = kick.m_real * m_inv_factorial * m_beta * gamma_ref;
+            T_Real const Bx = 0.5_prt * kick.m_imag * m_inv_factorial * m_beta * gamma_ref;
+            T_Real const By = 0.5_prt * kick.m_real * m_inv_factorial * m_beta * gamma_ref;
             T_Real const Bz = 0_prt;
 
-            // Electric field normalized by q/mc^2:
+            // Electric field normalized by q/mc^2 (half-step):
             T_Real const Ex = 0.0_prt;
             T_Real const Ey = 0.0_prt;
             T_Real const Ez = 0.0_prt;
 
-            // Quantities required to evaluate the full Thomas-BMT precession vector.
+            // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
             T_Real const Pnorm = sqrt(1_prt - 2_prt * pt * m_ibeta + pt*pt);
             T_Real const iPnorm = 1_prt/Pnorm;
-            T_Real const Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
             T_Real const gamma = gamma_ref * (1_prt - pt*m_beta);
-            T_Real const ux = px * iPnorm;
-            T_Real const uy = py * iPnorm;
-            T_Real const uz = Ps * iPnorm;
+            T_Real Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
+            T_Real ux = px * iPnorm;
+            T_Real uy = py * iPnorm;
+            T_Real uz = Ps * iPnorm;
 
-            // Zero curvature in a quadrupole
+            // Zero curvature in a multipole
             amrex::ParticleReal const h = 0.0_prt;
 
             // Evaluation of the full Thomas-BMT precession vector.
             tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
 
-            // push the spin vector using the generator just determined
+            // push the spin vector using the generator just determined (half spin-kick)
             rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);
 
             // phase space push
             (*this)(x, y, t, px, py, pt, idcpu, refpart);
 
+            // Quantities required to evaluate the full Thomas-BMT precession vector (after phase space kick).
+            // The fields depend only on (x,y) and pt is unchanged, so only the
+            // velocity direction needs to be refreshed.
+            Ps = sqrt(Pnorm*Pnorm - px*px - py*py);
+            ux = px * iPnorm;
+            uy = py * iPnorm;
+            uz = Ps * iPnorm;
+
+            // Evaluation of the full Thomas-BMT precession vector.
+            tbmt_precession_vector(x,ux,uy,uz,gamma,h,gyro_anomaly,Bx,By,Bz,Ex,Ey,Ez,lambdax,lambday,lambdaz);
+
+            // push the spin vector using the generator just determined (half spin-kick)
+            rotate_spin(lambdax,lambday,lambdaz,sx,sy,sz);
         }
 
         /** This pushes the covariance matrix. */

--- a/tests/python/test_reversibility_elements.py
+++ b/tests/python/test_reversibility_elements.py
@@ -551,9 +551,24 @@ def test_Kicker(sim, unit, xkick, ykick):
 
 
 @pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
-def test_Multipole(sim):
+@pytest.mark.parametrize(
+    ("multipole", "K_normal", "K_skew"),
+    [
+        # deflects by only ~1e-13 at this beam size: the small-angle limit
+        (4, 65.0, 6.0),
+        # a strong low-order kick, rotating the spin by a large angle
+        (2, 300.0, 100.0),
+    ],
+    ids=["octupole", "strong_quadrupole"],
+)
+def test_Multipole(sim, multipole, K_normal, K_skew):
     roundtrip(
-        elements.Multipole(multipole=4, K_normal=65.0, K_skew=6.0, **ALIGNMENT_KWARGS),
+        elements.Multipole(
+            multipole=multipole,
+            K_normal=K_normal,
+            K_skew=K_skew,
+            **ALIGNMENT_KWARGS,
+        ),
         sim,
         spin=sim.spin,
     )


### PR DESCRIPTION
## Fix s-Symmetric Spin Push for Thin Multipole

Apply the spin rotation once, with the Thomas-BMT generator evaluated at the transverse momentum halfway through the kick. This makes the map second-order accurate in the kick strength and an exact inverse of the reversed element, matching the structure used by `TaperedPL`.

The fields depend only on `(x,y)`, which the kick leaves unchanged, and `pt` is unchanged over the kick, so only the transverse momenta need to be averaged across it.

Measured on a single particle at `x = 1e-3` through a thin quadrupole multipole, forward + `reverse()` + forward:

```
kick             spin rotation    before      after
K=1   (dpx=1e-3)  -5.54e-3 rad    2.770e-09   2.301e-21
K=100 (dpx=0.1)   -0.555 rad      2.791e-03   1.116e-16
```

The residual of the previous one-sided kick scaled as `lambda * dpx^2`, confirmed (locally) across six orders of magnitude and matching the analytic estimate of `2.78e-3` at `K=100`.

## Test

Parametrize `test_Multipole` over the existing octupole and a _strong_ low-order kick (multipole=2, K_normal=300, K_skew=100).

The octupole deflects by only ~1e-13 at this beam size, so it exercises the spin roundtrip in the small-angle limit only. The strong quadrupole rotates the spin by a large angle, where the structure of the spin push decides whether forward + reverse closes.

Against a one-sided spin kick, `[strong_quadrupole-spin]` fails with `||delta spin||` up to `0.73` on a unit vector, while `[strong_quadrupole-nospin]` passes: the phase space map is unaffected.
