### PR TITLE
Final spin elements (bookkeeping)

### DIFF
--- a/src/elements/Marker.H
+++ b/src/elements/Marker.H
@@ -13,6 +13,7 @@
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/thin.H"
 #include "mixin/lineartransport.H"
+#include "mixin/spintransport.H"
 #include "mixin/named.H"
 #include "mixin/nofinalize.H"
 
@@ -26,6 +27,7 @@ namespace impactx::elements
     : public mixin::Named,
       public mixin::LinearTransport<Marker>,
       public mixin::Thin,
+      public mixin::SpinTransport,
       public mixin::NoFinalize,
       public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
     {
@@ -96,6 +98,46 @@ namespace impactx::elements
 
         /** This pushes the reference particle. */
         using Thin::operator();
+
+
+        /** This operator pushes the particle spin.
+         *
+         * An aperture is field-free, so the spin is unaffected.
+         *
+         * @param x particle position in x
+         * @param y particle position in y
+         * @param t particle position in t
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param sx particle spin x-component (unused)
+         * @param sy particle spin y-component (unused)
+         * @param sz particle spin z-component (unused)
+         * @param idcpu particle global index
+         * @param refpart reference particle (unused)
+         */
+        template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void spin_and_phasespace_push (
+            T_Real const & AMREX_RESTRICT x,
+            T_Real const & AMREX_RESTRICT y,
+            T_Real const & AMREX_RESTRICT t,
+            T_Real const & AMREX_RESTRICT px,
+            T_Real const & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sx,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sy,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT sz,
+            T_IdCpu & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
+            // spin is unaffected
+
+            // phase space push
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+        }
+
 
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();

--- a/src/elements/Marker.H
+++ b/src/elements/Marker.H
@@ -71,14 +71,14 @@ namespace impactx::elements
 
         /** Does nothing to a particle.
          *
-         * @param x particle position in x
-         * @param y particle position in y
-         * @param t particle position in t
-         * @param px particle momentum in x
-         * @param py particle momentum in y
-         * @param pt particle momentum in t
+         * @param x particle position in x (unused)
+         * @param y particle position in y (unused)
+         * @param t particle position in t (unused)
+         * @param px particle momentum in x (unused)
+         * @param py particle momentum in y (unused)
+         * @param pt particle momentum in t (unused)
          * @param idcpu particle global index (unused)
-         * @param refpart reference particle
+         * @param refpart reference particle (unused)
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -99,37 +99,36 @@ namespace impactx::elements
         /** This pushes the reference particle. */
         using Thin::operator();
 
-
         /** This operator pushes the particle spin.
          *
-         * An aperture is field-free, so the spin is unaffected.
+         * A marker does nothing, so the spin is unaffected.
          *
-         * @param x particle position in x
-         * @param y particle position in y
-         * @param t particle position in t
-         * @param px particle momentum in x
-         * @param py particle momentum in y
-         * @param pt particle momentum in t
+         * @param x particle position in x (unused)
+         * @param y particle position in y (unused)
+         * @param t particle position in t (unused)
+         * @param px particle momentum in x (unused)
+         * @param py particle momentum in y (unused)
+         * @param pt particle momentum in t (unused)
          * @param sx particle spin x-component (unused)
          * @param sy particle spin y-component (unused)
          * @param sz particle spin z-component (unused)
-         * @param idcpu particle global index
+         * @param idcpu particle global index (unused)
          * @param refpart reference particle (unused)
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void spin_and_phasespace_push (
-            T_Real const & AMREX_RESTRICT x,
-            T_Real const & AMREX_RESTRICT y,
-            T_Real const & AMREX_RESTRICT t,
-            T_Real const & AMREX_RESTRICT px,
-            T_Real const & AMREX_RESTRICT py,
-            T_Real const & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT x,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT y,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT t,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT px,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT py,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT pt,
             [[maybe_unused]] T_Real const & AMREX_RESTRICT sx,
             [[maybe_unused]] T_Real const & AMREX_RESTRICT sy,
             [[maybe_unused]] T_Real const & AMREX_RESTRICT sz,
-            T_IdCpu & AMREX_RESTRICT idcpu,
-            RefPart const & AMREX_RESTRICT refpart
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             // spin is unaffected
@@ -137,7 +136,6 @@ namespace impactx::elements
             // phase space push
             (*this)(x, y, t, px, py, pt, idcpu, refpart);
         }
-
 
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();

--- a/src/elements/PRot.H
+++ b/src/elements/PRot.H
@@ -15,6 +15,7 @@
 #include "mixin/beamoptic.H"
 #include "mixin/thin.H"
 #include "mixin/lineartransport.H"
+#include "mixin/spintransport.H"
 #include "mixin/named.H"
 #include "mixin/nofinalize.H"
 
@@ -35,6 +36,7 @@ namespace impactx::elements
       public mixin::BeamOptic<PRot>,
       public mixin::LinearTransport<PRot>,
       public mixin::Thin,
+      public mixin::SpinTransport,
       public mixin::NoFinalize,
       public amrex::simd::Vectorized<amrex::simd::native_simd_size_particlereal>
     {
@@ -160,6 +162,51 @@ namespace impactx::elements
 
         /** This pushes the reference particle. */
         using Thin::operator();
+
+        /** This operator pushes the particle spin.
+         *
+         * @param x particle position in x
+         * @param y particle position in y
+         * @param t particle position in t
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param sx particle spin x-component
+         * @param sy particle spin y-component
+         * @param sz particle spin z-component
+         * @param idcpu particle global index
+         * @param refpart reference particle (unused)
+         */
+        template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void spin_and_phasespace_push (
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            // A simple rotation about the y-axis (in the x-z plane).
+            T_Real const lambdax = 0_prt;
+            T_Real const lambday = m_phi_out - m_phi_in;
+            T_Real const lambdaz = 0_prt;
+
+            // push the spin vector using the generator just determined
+            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
+
+            // phase space push
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+        }
+
 
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();

--- a/src/elements/PRot.H
+++ b/src/elements/PRot.H
@@ -174,7 +174,7 @@ namespace impactx::elements
          * @param sx particle spin x-component
          * @param sy particle spin y-component
          * @param sz particle spin z-component
-         * @param idcpu particle global index
+         * @param idcpu particle global index (unused)
          * @param refpart reference particle (unused)
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
@@ -184,13 +184,13 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT y,
             T_Real & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
-            T_Real & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT py,
             T_Real const & AMREX_RESTRICT pt,
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            T_IdCpu const & AMREX_RESTRICT idcpu,
-            RefPart const & AMREX_RESTRICT refpart
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -206,7 +206,6 @@ namespace impactx::elements
             // phase space push
             (*this)(x, y, t, px, py, pt, idcpu, refpart);
         }
-
 
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();

--- a/src/elements/PlaneXYRot.H
+++ b/src/elements/PlaneXYRot.H
@@ -149,19 +149,18 @@ namespace impactx::elements
         /** This pushes the reference particle. */
         using Thin::operator();
 
-
         /** This operator pushes the particle spin.
          *
          * @param x particle position in x
          * @param y particle position in y
-         * @param t particle position in t
+         * @param t particle position in t (unused)
          * @param px particle momentum in x
          * @param py particle momentum in y
-         * @param pt particle momentum in t
+         * @param pt particle momentum in t (unused)
          * @param sx particle spin x-component
          * @param sy particle spin y-component
          * @param sz particle spin z-component
-         * @param idcpu particle global index
+         * @param idcpu particle global index (unused)
          * @param refpart reference particle (unused)
          */
         template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
@@ -169,15 +168,15 @@ namespace impactx::elements
         void spin_and_phasespace_push (
             T_Real & AMREX_RESTRICT x,
             T_Real & AMREX_RESTRICT y,
-            T_Real & AMREX_RESTRICT t,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT t,
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
-            T_Real const & AMREX_RESTRICT pt,
+            [[maybe_unused]] T_Real const & AMREX_RESTRICT pt,
             T_Real & AMREX_RESTRICT sx,
             T_Real & AMREX_RESTRICT sy,
             T_Real & AMREX_RESTRICT sz,
-            T_IdCpu const & AMREX_RESTRICT idcpu,
-            RefPart const & AMREX_RESTRICT refpart
+            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
+            [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
             using namespace amrex::literals; // for _rt and _prt
@@ -193,7 +192,6 @@ namespace impactx::elements
             // phase space push
             (*this)(x, y, t, px, py, pt, idcpu, refpart);
         }
-
 
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();

--- a/src/elements/PlaneXYRot.H
+++ b/src/elements/PlaneXYRot.H
@@ -15,6 +15,7 @@
 #include "mixin/beamoptic.H"
 #include "mixin/thin.H"
 #include "mixin/lineartransport.H"
+#include "mixin/spintransport.H"
 #include "mixin/named.H"
 #include "mixin/nofinalize.H"
 
@@ -36,6 +37,7 @@ namespace impactx::elements
       public mixin::LinearTransport<PlaneXYRot>,
       public mixin::Thin,
       public mixin::Alignment,
+      public mixin::SpinTransport,
       public mixin::NoFinalize
       // At least on Intel AVX512, there is a small overhead to vectorize this element, see
       // https://github.com/BLAST-ImpactX/impactx/pull/1002
@@ -146,6 +148,52 @@ namespace impactx::elements
 
         /** This pushes the reference particle. */
         using Thin::operator();
+
+
+        /** This operator pushes the particle spin.
+         *
+         * @param x particle position in x
+         * @param y particle position in y
+         * @param t particle position in t
+         * @param px particle momentum in x
+         * @param py particle momentum in y
+         * @param pt particle momentum in t
+         * @param sx particle spin x-component
+         * @param sy particle spin y-component
+         * @param sz particle spin z-component
+         * @param idcpu particle global index
+         * @param refpart reference particle (unused)
+         */
+        template<typename T_Real=amrex::ParticleReal, typename T_IdCpu=uint64_t>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void spin_and_phasespace_push (
+            T_Real & AMREX_RESTRICT x,
+            T_Real & AMREX_RESTRICT y,
+            T_Real & AMREX_RESTRICT t,
+            T_Real & AMREX_RESTRICT px,
+            T_Real & AMREX_RESTRICT py,
+            T_Real const & AMREX_RESTRICT pt,
+            T_Real & AMREX_RESTRICT sx,
+            T_Real & AMREX_RESTRICT sy,
+            T_Real & AMREX_RESTRICT sz,
+            T_IdCpu const & AMREX_RESTRICT idcpu,
+            RefPart const & AMREX_RESTRICT refpart
+        ) const
+        {
+            using namespace amrex::literals; // for _rt and _prt
+
+            // A simple rotation about the z-axis (in the x-y plane).
+            T_Real const lambdax = 0_prt;
+            T_Real const lambday = 0_prt;
+            T_Real const lambdaz = m_phi;
+
+            // push the spin vector using the generator just determined
+            rotate_spin(lambdax, lambday, lambdaz, sx, sy, sz);
+
+            // phase space push
+            (*this)(x, y, t, px, py, pt, idcpu, refpart);
+        }
+
 
         /** This pushes the covariance matrix. */
         using LinearTransport::operator();

--- a/src/elements/Source.H
+++ b/src/elements/Source.H
@@ -25,7 +25,6 @@ namespace impactx::elements
     : public mixin::Named,
       public mixin::LinearTransport<Source>,
       public mixin::Thin,
-      public mixin::SpinTransport,
       public mixin::NoFinalize
     {
         static constexpr auto type = "Source";

--- a/src/elements/Source.H
+++ b/src/elements/Source.H
@@ -75,7 +75,7 @@ namespace impactx::elements
          * the species metadata of the file before the particles are added.
          *
          * @param[in,out] pc particle container to push
-         * @param[in] step global step for diagnostics
+         * @param[in] step global step for diagnostics (unused)
          * @param[in] period for periodic lattices, this is the current period (turn or cycle)
          */
         void operator() (

--- a/src/elements/Source.H
+++ b/src/elements/Source.H
@@ -12,7 +12,6 @@
 
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/lineartransport.H"
-#include "mixin/spintransport.H"
 #include "mixin/named.H"
 #include "mixin/nofinalize.H"
 #include "mixin/thin.H"

--- a/src/elements/Source.H
+++ b/src/elements/Source.H
@@ -12,6 +12,7 @@
 
 #include "particles/ImpactXParticleContainer.H"
 #include "mixin/lineartransport.H"
+#include "mixin/spintransport.H"
 #include "mixin/named.H"
 #include "mixin/nofinalize.H"
 #include "mixin/thin.H"
@@ -25,6 +26,7 @@ namespace impactx::elements
     : public mixin::Named,
       public mixin::LinearTransport<Source>,
       public mixin::Thin,
+      public mixin::SpinTransport,
       public mixin::NoFinalize
     {
         static constexpr auto type = "Source";

--- a/tests/python/test_benchmark_elements.py
+++ b/tests/python/test_benchmark_elements.py
@@ -290,6 +290,7 @@ def test_NonlinearLens(benchmark, sim):
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)
 
 
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_PlaneXYRot(benchmark, sim):
     el = elements.PlaneXYRot(name="rotation1", angle=90.0)
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)
@@ -323,6 +324,7 @@ def test_PolygonAperture(benchmark, sim):
 #    benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)
 
 
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_PRot(benchmark, sim):
     el = elements.PRot(name="rotation1", phi_in=0.0, phi_out=-5.0)
     benchmark.pedantic(el.push, setup=partial(pc_setup, sim), rounds=rounds)

--- a/tests/python/test_reversibility_elements.py
+++ b/tests/python/test_reversibility_elements.py
@@ -615,12 +615,22 @@ def test_ThinDipole(sim):
 # =============================================================================
 
 
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_PlaneXYRot(sim):
-    roundtrip(elements.PlaneXYRot(angle=90.0, **ALIGNMENT_KWARGS), sim)
+    roundtrip(
+        elements.PlaneXYRot(angle=90.0, **ALIGNMENT_KWARGS),
+        sim,
+        spin=sim.spin,
+    )
 
 
+@pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_PRot(sim):
-    roundtrip(elements.PRot(phi_in=0.0, phi_out=-5.0), sim)
+    roundtrip(
+        elements.PRot(phi_in=0.0, phi_out=-5.0),
+        sim,
+        spin=sim.spin,
+    )
 
 
 # =============================================================================

--- a/tests/python/test_reversibility_elements.py
+++ b/tests/python/test_reversibility_elements.py
@@ -187,6 +187,40 @@ def check_roundtrip(
         )
 
 
+def check_spin_rotation(axis, angle_deg):
+    """Build a check that the forward push rotated every spin by ``angle_deg``
+    about ``axis``, in the convention of the C++ ``rotate_spin()`` helper.
+
+    The roundtrip alone cannot see this: a spin map that is the identity, or one
+    that uses the wrong axis or the wrong sign, is still cancelled exactly by its
+    own reverse. This pins down the forward map.
+    """
+
+    def check(beam, initial):
+        c = np.cos(np.radians(angle_deg))
+        s = np.sin(np.radians(angle_deg))
+        sx, sy, sz = (initial[col] for col in SPIN_COLS)
+        if axis == "y":
+            expected = (c * sx + s * sz, sy, -s * sx + c * sz)
+        elif axis == "z":
+            expected = (c * sx - s * sy, s * sx + c * sy, sz)
+        else:
+            raise ValueError(f"unsupported rotation axis: {axis}")
+
+        df = beam.to_df()
+        for col, exp in zip(SPIN_COLS, expected):
+            np.testing.assert_allclose(
+                df[col].to_numpy(),
+                exp,
+                atol=spin_atol,
+                rtol=0,
+                err_msg=f"Forward spin map is not a {angle_deg} deg rotation "
+                f"about {axis}: mismatch in {col}",
+            )
+
+    return check
+
+
 def roundtrip(
     el,
     sim,
@@ -194,8 +228,14 @@ def roundtrip(
     spin_atol=spin_atol,
     ref_atol=ref_atol,
     spin=False,
+    after_forward=None,
 ):
-    """Run forward + reverse + forward and verify roundtrip."""
+    """Run forward + reverse + forward and verify roundtrip.
+
+    ``after_forward`` is an optional ``check(beam, initial)`` callback applied to
+    the state after the forward push only, for element-specific assertions that
+    the reverse push would otherwise cancel (@see check_spin_rotation).
+    """
     beam = sim.beam
 
     initial = save_state(beam, spin=spin)
@@ -206,6 +246,10 @@ def roundtrip(
 
     # verify something changed
     check_changed(beam, initial, spin=spin)
+
+    # verify the forward map itself, before the reverse push cancels it
+    if spin and after_forward is not None:
+        after_forward(beam, initial)
 
     # reverse and push again
     el.reverse()
@@ -617,19 +661,28 @@ def test_ThinDipole(sim):
 
 @pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_PlaneXYRot(sim):
+    angle = 90.0
     roundtrip(
-        elements.PlaneXYRot(angle=90.0, **ALIGNMENT_KWARGS),
+        elements.PlaneXYRot(angle=angle, **ALIGNMENT_KWARGS),
         sim,
         spin=sim.spin,
+        # A rotation in the x-y plane rotates the spin about z by the same
+        # angle. The roll alignment error is a z-rotation as well, so it
+        # commutes with the element and cancels between entry and exit.
+        after_forward=check_spin_rotation("z", angle),
     )
 
 
 @pytest.mark.parametrize("sim", [True, False], indirect=True, ids=["spin", "nospin"])
 def test_PRot(sim):
+    phi_in, phi_out = 0.0, -5.0
     roundtrip(
-        elements.PRot(phi_in=0.0, phi_out=-5.0),
+        elements.PRot(phi_in=phi_in, phi_out=phi_out),
         sim,
         spin=sim.spin,
+        # A pole face rotation in the x-z plane rotates the spin about y by the
+        # net angle phi_out - phi_in.
+        after_forward=check_spin_rotation("y", phi_out - phi_in),
     )
 
 


### PR DESCRIPTION
This PR addresses the treatment of spin in the last remaining elements.  These are simple "bookkeeping" elements.

- [x] PlaneXYRot
- [x] PRot
- [x] Marker

## Follow-up PRs

- [ ] Source
- [ ] Programmable