### PR TITLE
`setup.py`: `IMPACTX_OPENPMD_*` Env Vars

### DIFF
--- a/docs/source/install/cmake.rst
+++ b/docs/source/install/cmake.rst
@@ -525,13 +525,18 @@ Environment Variable          Default & Values                             Descr
 ``IMPACTX_PYAMREX_REPO``      *None (uses cmake default)*                  Repository URI to pull and build pyAMReX from
 ``IMPACTX_PYAMREX_BRANCH``    *None (uses cmake default)*                  Repository branch for ``IMPACTX_PYAMREX_REPO``
 ``IMPACTX_PYAMREX_INTERNAL``  **ON**/OFF                                   Needs a pre-installed pyAMReX library if set to ``OFF``
+``IMPACTX_OPENPMD_SRC``       *None*                                       Absolute path to openPMD-api source directory (preferred if set)
+``IMPACTX_OPENPMD_REPO``      *None (uses cmake default)*                  Repository URI to pull and build openPMD-api from
+``IMPACTX_OPENPMD_BRANCH``    *None (uses cmake default)*                  Repository branch for ``IMPACTX_OPENPMD_REPO``
+``IMPACTX_OPENPMD_INTERNAL``  **ON**/OFF                                   Needs a pre-installed openPMD-api library if set to ``OFF``
 ``PYIMPACTX_LIBDIR``          *None*                                       If set, search for pre-built ImpactX C++ libraries (see below)
 ============================= ============================================ ================================================================
 
 Note that we currently change the ``IMPACTX_MPI`` default intentionally to ``OFF``, to simplify a first install from source.
 
 Additional CMake options can be passed through ``pip`` using variables of the form ``IMPACTX_CMAKE_<NAME>=<VALUE>``, which will be forwarded as ``-D<NAME>=<VALUE>`` to CMake.
-Use this to control, e.g., ABLASTR, openPMD-api, or pybind11 source/repo/branch selection when building via ``pip``.
+Use this to control, e.g., ABLASTR or pybind11 source/repo/branch selection when building via ``pip``.
+Note that Windows upper-cases environment variable names while CMake variables are case-sensitive, so mixed-case CMake options (e.g. ``ImpactX_openpmd_internal``) cannot be passed this way on Windows -- use the dedicated all-caps variables above.
 
 Some hints and workflows follow.
 Developers that want to test a change of the source code but did not change the ``impactx`` version number can force a reinstall via:

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ class CMakeBuild(build_ext):
             ## dependency control (developers & package managers)
             "-DImpactX_amrex_internal=" + ImpactX_amrex_internal,
             "-DImpactX_pyamrex_internal=" + ImpactX_pyamrex_internal,
+            "-DImpactX_openpmd_internal=" + ImpactX_openpmd_internal,
             # PEP-440 conformant version from package
             "-DpyImpactX_VERSION_INFO=" + self.distribution.get_version(),
             #        see PICSAR and openPMD below
@@ -143,6 +144,12 @@ class CMakeBuild(build_ext):
             cmake_args.append("-DImpactX_amrex_branch=" + ImpactX_amrex_branch)
         if ImpactX_pyamrex_branch:
             cmake_args.append("-DImpactX_pyamrex_branch=" + ImpactX_pyamrex_branch)
+        if ImpactX_openpmd_src:
+            cmake_args.append("-DImpactX_openpmd_src=" + ImpactX_openpmd_src)
+        if ImpactX_openpmd_repo:
+            cmake_args.append("-DImpactX_openpmd_repo=" + ImpactX_openpmd_repo)
+        if ImpactX_openpmd_branch:
+            cmake_args.append("-DImpactX_openpmd_branch=" + ImpactX_openpmd_branch)
 
         if CMAKE_INTERPROCEDURAL_OPTIMIZATION is not None:
             cmake_args.append(
@@ -222,6 +229,11 @@ ImpactX_pyamrex_src = os.environ.get("IMPACTX_PYAMREX_SRC")
 ImpactX_pyamrex_internal = os.environ.get("IMPACTX_PYAMREX_INTERNAL", "ON")
 ImpactX_pyamrex_repo = os.environ.get("IMPACTX_PYAMREX_REPO")
 ImpactX_pyamrex_branch = os.environ.get("IMPACTX_PYAMREX_BRANCH")
+
+ImpactX_openpmd_src = os.environ.get("IMPACTX_OPENPMD_SRC")
+ImpactX_openpmd_internal = os.environ.get("IMPACTX_OPENPMD_INTERNAL", "ON")
+ImpactX_openpmd_repo = os.environ.get("IMPACTX_OPENPMD_REPO")
+ImpactX_openpmd_branch = os.environ.get("IMPACTX_OPENPMD_BRANCH")
 
 # extra CMake arguments
 extra_cmake_args = []


### PR DESCRIPTION
AMReX and pyAMReX have first-class all-caps pip env vars, openPMD-api has none, so the docs point at the generic `IMPACTX_CMAKE_<NAME>` escape hatch — which cannot work on Windows: environment variables are upper-cased there and CMake variables are case-sensitive, so `IMPACTX_CMAKE_ImpactX_openpmd_internal=OFF` arrives as `-DIMPACTX_OPENPMD_INTERNAL=OFF` and is silently ignored.

Found in the 26.08 wheels: Windows still rebuilds openPMD-api once per CPython even though CI asks for an external one.
https://github.com/BLAST-ImpactX/impactx-wheels/pull/27

Same class as openPMD/openPMD-api#1896.

🤖 Generated with [Claude Code](https://claude.com/claude-code)