### PR TITLE
Tests: ChrAcc Ez=0 SP tolerance

### DIFF
--- a/tests/python/test_chracc_Ez0.py
+++ b/tests/python/test_chracc_Ez0.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 import amrex.space3d as amr
-from impactx import ImpactX, elements
+from impactx import Config, ImpactX, elements
 
 
 def expected_ez0_transport_map(ds, bz, beta_gamma):
@@ -58,6 +58,13 @@ def test_element_push(bz_scale):
     """
     This tests using ImpactX without a lattice.
     """
+    # In single precision (float32, eps ~1.2e-7) the double-precision tolerance
+    # is unreachable: over one full period the ChrAcc + inverse ChrDrift
+    # roundtrip accumulates ~1.5e-6 in position_t (~13 eps), and single
+    # precision builds commonly enable -ffast-math on top. This is ordinary
+    # float32 accumulation, not a loss of significance in the maps.
+    atol = 1.0e-12 if Config.precision != "SINGLE" else 1.0e-5
+
     sim = ImpactX()
 
     # set numerical parameters and IO control
@@ -132,7 +139,7 @@ def test_element_push(bz_scale):
     np.testing.assert_allclose(
         sol_chr.transfer_map(initial_ref).to_numpy(),
         expected_ez0_transport_map(ds=ds_value, bz=bz_value, beta_gamma=ref.beta_gamma),
-        atol=1.0e-12,
+        atol=atol,
         rtol=0.0,
     )
 
@@ -163,7 +170,7 @@ def test_element_push(bz_scale):
         np.testing.assert_allclose(
             df_final[c].to_numpy(),
             df_initial[c].to_numpy(),
-            atol=1.0e-12,
+            atol=atol,
             rtol=0,
             err_msg=f"Roundtrip mismatch in {c}",
         )
@@ -171,7 +178,7 @@ def test_element_push(bz_scale):
         np.testing.assert_allclose(
             getattr(sim.beam.ref, c),
             getattr(initial_ref, c),
-            atol=1.0e-12,
+            atol=atol,
             rtol=0,
             err_msg=f"Reference-particle roundtrip mismatch in {c}",
         )


### PR DESCRIPTION
## Problem

`tests/python/test_chracc_Ez0.py`, added in #1577, hard-codes `atol=1.0e-12, rtol=0` on all three of its comparisons and has no precision guard. It can never pass in single precision: float32 eps is ~1.2e-7, five orders of magnitude above that tolerance.

Both parametrizations fail, and because the first assertion fires *before* `sim.finalize()` is reached, the un-finalized `ImpactX` instance then makes the `amrex_init` fixture teardown segfault:

```
tests/python/test_chracc_Ez0.py::test_element_push[no-bz] FAILED
tests/python/test_chracc_Ez0.py::test_element_push[bz] FAILED
Fatal Python error: Segmentation fault
  File ".../tests/python/conftest.py", line 62 in amrex_init
```

That aborts pytest at test 28 of 339 and takes the rest of the single-precision suite with it.

## Measurements

On a 26.08 `ImpactX_PRECISION=SINGLE` build (gcc 15, `-ffast-math`, SIMD, LTO, `-march=x86-64-v3`):

| quantity | no-bz | bz |
| --- | --- | --- |
| `transfer_map` max abs dev | 2.09e-08 | 1.30e-07 |
| `position_t` roundtrip | 1.55e-06 | 1.52e-06 |
| ref-particle `t` | 3.35e-07 | 3.35e-07 |
| ref-particle `pz` | 2.38e-07 | 2.38e-07 |

Worst overall: **1.55e-06**.

## Fix

The 1.5e-6 in `position_t` is ~13 eps accumulated over one full period of the ChrAcc + inverse ChrDrift roundtrip — ordinary float32 accumulation, not a loss of significance in the maps — so this relaxes the tolerance rather than skipping the test:

```python
atol = 1.0e-12 if Config.precision != "SINGLE" else 1.0e-5
```

`1.0e-5` leaves ~6.5x headroom over the worst observed deviation for compiler and platform variation. Double precision keeps `1.0e-12` unchanged. This follows the existing pattern in e.g. `test_dipedge_ref.py`, which uses the same `1.0e-12` / relaxed-SP shape.

## Verification

Against the SP build described above:

- `test_chracc_Ez0.py` — 2 failed + segfault before, **2 passed** after.
- Full 26.08 single-precision suite with the CI filter (`not (spacecharge or expanding or nC_ or transformation or element_insert)`): **334 passed, 2 skipped, 3 deselected**. Nothing else was hiding behind the segfault.

Found via the conda-forge 26.08 build (conda-forge/impactx-feedstock#71), where every SP job that runs tests fails this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XnHqQQmgzuEyEcWZwkkgw