### PR TITLE
Diagnostics: Guard Degenerate Beam Moments

### DIFF
--- a/docs/source/dataanalysis/dataanalysis.rst
+++ b/docs/source/dataanalysis/dataanalysis.rst
@@ -135,6 +135,9 @@ The code writes out the values in an ASCII file prefixed ``reduced_beam_characte
 * ``sigma_sx``, ``sigma_sy``, ``sigma_sz``
     Standard deviation of the three spin components (unit: dimensionless).  This diagnostic is written only if spin tracking is on (algo.spin = True).
 
+Quantities that a beam does not define are written as ``nan``.
+The Courant-Snyder (Twiss) ``alpha`` and ``beta`` of a plane are ratios to its rms emittance, and are undefined wherever that emittance vanishes: for a single particle, for a cold plane, or longitudinally for a beam without energy spread.
+
 
 .. _dataanalysis-plot:
 

--- a/src/diagnostics/ReducedBeamCharacteristics.cpp
+++ b/src/diagnostics/ReducedBeamCharacteristics.cpp
@@ -29,6 +29,7 @@
 #include <AMReX_TypeList.H>             // for TypeMultiplier
 
 #include <array>
+#include <cmath>
 #include <limits>
 #include <vector>
 
@@ -37,6 +38,29 @@ namespace impactx::diagnostics
 {
 namespace
 {
+    /** Square root of a quantity that is mathematically non-negative
+     *
+     * Variances and squared emittances are non-negative by construction, but the
+     * finite-precision moment sums they are recovered from can put them marginally
+     * below zero. std::sqrt of such a value raises FE_INVALID, which aborts the run
+     * under amrex.fpe_trap_invalid, so clamp the (rounding-level) negative case to
+     * zero instead.
+     *
+     * A NaN input is passed through rather than clamped: it means the beam moments
+     * are already poisoned, which should stay visible in the output.
+     *
+     * @param x a quantity that is non-negative up to rounding
+     * @returns sqrt(x), or zero if x is negative
+     */
+    AMREX_FORCE_INLINE
+    amrex::ParticleReal
+    sqrt_clamped (amrex::ParticleReal x)
+    {
+        using namespace amrex::literals; // for _prt
+
+        return (x < 0.0_prt) ? 0.0_prt : std::sqrt(x);
+    }
+
     //! constant coordinate shifts subtracted before forming the beam moments
     struct Shifts
     {
@@ -119,6 +143,8 @@ namespace
         BL_PROFILE("impactx::diagnostics::reduced_beam_characteristics(pc)");
 
         using namespace amrex::literals; // for _prt
+
+        auto const nan = std::numeric_limits<amrex::ParticleReal>::quiet_NaN();
 
         // preparing to access reference particle data: RefPart
         RefPart const ref_part = pc.GetRefParticle();
@@ -308,17 +334,17 @@ namespace
         // beam charge
         amrex::ParticleReal const charge = q_C * w_sum;
         // standard deviations of positions
-        amrex::ParticleReal const sigma_x = std::sqrt(x_ms);
-        amrex::ParticleReal const sigma_y = std::sqrt(y_ms);
-        amrex::ParticleReal const sigma_t = std::sqrt(t_ms);
+        amrex::ParticleReal const sigma_x = sqrt_clamped(x_ms);
+        amrex::ParticleReal const sigma_y = sqrt_clamped(y_ms);
+        amrex::ParticleReal const sigma_t = sqrt_clamped(t_ms);
         // standard deviations of momenta
-        amrex::ParticleReal const sigma_px = std::sqrt(px_ms);
-        amrex::ParticleReal const sigma_py = std::sqrt(py_ms);
-        amrex::ParticleReal const sigma_pt = std::sqrt(pt_ms);
+        amrex::ParticleReal const sigma_px = sqrt_clamped(px_ms);
+        amrex::ParticleReal const sigma_py = sqrt_clamped(py_ms);
+        amrex::ParticleReal const sigma_pt = sqrt_clamped(pt_ms);
         // standard deviations of spin
-        amrex::ParticleReal const sigma_sx = std::sqrt(sx_ms);
-        amrex::ParticleReal const sigma_sy = std::sqrt(sy_ms);
-        amrex::ParticleReal const sigma_sz = std::sqrt(sz_ms);
+        amrex::ParticleReal const sigma_sx = sqrt_clamped(sx_ms);
+        amrex::ParticleReal const sigma_sy = sqrt_clamped(sy_ms);
+        amrex::ParticleReal const sigma_sz = sqrt_clamped(sz_ms);
         // RMS emittances
         amrex::ParticleReal const e2_x = x_ms*px_ms-xpx*xpx;
         amrex::ParticleReal const e2_y = y_ms*py_ms-ypy*ypy;
@@ -334,19 +360,24 @@ namespace
         amrex::ParticleReal const x_msd = x_ms - pt_ms*dispersion_x*dispersion_x;
         amrex::ParticleReal const px_msd = px_ms - pt_ms*dispersion_px*dispersion_px;
         amrex::ParticleReal const xpx_d = xpx - pt_ms*dispersion_x*dispersion_px;
-        amrex::ParticleReal const emittance_xd = std::sqrt(x_msd*px_msd-xpx_d*xpx_d);
+        amrex::ParticleReal const emittance_xd = sqrt_clamped(x_msd*px_msd-xpx_d*xpx_d);
         amrex::ParticleReal const y_msd = y_ms - pt_ms*dispersion_y*dispersion_y;
         amrex::ParticleReal const py_msd = py_ms - pt_ms*dispersion_py*dispersion_py;
         amrex::ParticleReal const ypy_d = ypy - pt_ms*dispersion_y*dispersion_py;
-        amrex::ParticleReal const emittance_yd = std::sqrt(y_msd*py_msd-ypy_d*ypy_d);
-        // Courant-Snyder (Twiss) beta-function
-        amrex::ParticleReal const beta_x = x_msd / emittance_xd;
-        amrex::ParticleReal const beta_y = y_msd / emittance_yd;
-        amrex::ParticleReal const beta_t = t_ms / emittance_t;
-        // Courant-Snyder (Twiss) alpha
-        amrex::ParticleReal const alpha_x = - xpx_d / emittance_xd;
-        amrex::ParticleReal const alpha_y = - ypy_d / emittance_yd;
-        amrex::ParticleReal const alpha_t = - tpt / emittance_t;
+        amrex::ParticleReal const emittance_yd = sqrt_clamped(y_msd*py_msd-ypy_d*ypy_d);
+        /* Courant-Snyder (Twiss) beta-function and alpha
+         *
+         * Both are ratios to an rms emittance, and are undefined where that emittance
+         * vanishes: a single particle, a cold plane, or a longitudinal plane without
+         * energy spread. Report NaN there rather than dividing by zero, which raises
+         * FE_DIVBYZERO (or FE_INVALID, for 0/0) under amrex.fpe_trap_zero/_invalid.
+         */
+        amrex::ParticleReal const beta_x = (emittance_xd > 0.0) ? x_msd / emittance_xd : nan;
+        amrex::ParticleReal const beta_y = (emittance_yd > 0.0) ? y_msd / emittance_yd : nan;
+        amrex::ParticleReal const beta_t = (emittance_t > 0.0) ? t_ms / emittance_t : nan;
+        amrex::ParticleReal const alpha_x = (emittance_xd > 0.0) ? - xpx_d / emittance_xd : nan;
+        amrex::ParticleReal const alpha_y = (emittance_yd > 0.0) ? - ypy_d / emittance_yd : nan;
+        amrex::ParticleReal const alpha_t = (emittance_t > 0.0) ? - tpt / emittance_t : nan;
 
         // Calculate normalized emittances
         amrex::ParticleReal emittance_xn = emittance_x * bg;
@@ -497,6 +528,8 @@ namespace
 
         using namespace amrex::literals; // for _prt
 
+        auto const nan = std::numeric_limits<amrex::ParticleReal>::quiet_NaN();
+
         // reference particle relativistic beta*gamma
         amrex::ParticleReal const bg = ref_part.beta_gamma();
         amrex::ParticleReal const bg2 = bg*bg;
@@ -524,13 +557,13 @@ namespace
         amrex::ParticleReal const yt     = cm(3,5);
         amrex::ParticleReal const pyt    = cm(4,5);
         // standard deviations of positions
-        amrex::ParticleReal const sig_x = std::sqrt(x_ms);
-        amrex::ParticleReal const sig_y = std::sqrt(y_ms);
-        amrex::ParticleReal const sig_t = std::sqrt(t_ms);
+        amrex::ParticleReal const sig_x = sqrt_clamped(x_ms);
+        amrex::ParticleReal const sig_y = sqrt_clamped(y_ms);
+        amrex::ParticleReal const sig_t = sqrt_clamped(t_ms);
         // standard deviations of momenta
-        amrex::ParticleReal const sig_px = std::sqrt(px_ms);
-        amrex::ParticleReal const sig_py = std::sqrt(py_ms);
-        amrex::ParticleReal const sig_pt = std::sqrt(pt_ms);
+        amrex::ParticleReal const sig_px = sqrt_clamped(px_ms);
+        amrex::ParticleReal const sig_py = sqrt_clamped(py_ms);
+        amrex::ParticleReal const sig_pt = sqrt_clamped(pt_ms);
         // RMS emittances
         amrex::ParticleReal const e2_x = x_ms*px_ms-xpx*xpx;
         amrex::ParticleReal const e2_y = y_ms*py_ms-ypy*ypy;
@@ -546,19 +579,24 @@ namespace
         amrex::ParticleReal const x_msd = x_ms - pt_ms*dispersion_x*dispersion_x;
         amrex::ParticleReal const px_msd = px_ms - pt_ms*dispersion_px*dispersion_px;
         amrex::ParticleReal const xpx_d = xpx - pt_ms*dispersion_x*dispersion_px;
-        amrex::ParticleReal const emittance_xd = std::sqrt(x_msd*px_msd-xpx_d*xpx_d);
+        amrex::ParticleReal const emittance_xd = sqrt_clamped(x_msd*px_msd-xpx_d*xpx_d);
         amrex::ParticleReal const y_msd = y_ms - pt_ms*dispersion_y*dispersion_y;
         amrex::ParticleReal const py_msd = py_ms - pt_ms*dispersion_py*dispersion_py;
         amrex::ParticleReal const ypy_d = ypy - pt_ms*dispersion_y*dispersion_py;
-        amrex::ParticleReal const emittance_yd = std::sqrt(y_msd*py_msd-ypy_d*ypy_d);
-        // Courant-Snyder (Twiss) beta-function
-        amrex::ParticleReal const beta_x = x_msd / emittance_xd;
-        amrex::ParticleReal const beta_y = y_msd / emittance_yd;
-        amrex::ParticleReal const beta_t = t_ms / emittance_t;
-        // Courant-Snyder (Twiss) alpha
-        amrex::ParticleReal const alpha_x = - xpx_d / emittance_xd;
-        amrex::ParticleReal const alpha_y = - ypy_d / emittance_yd;
-        amrex::ParticleReal const alpha_t = - tpt / emittance_t;
+        amrex::ParticleReal const emittance_yd = sqrt_clamped(y_msd*py_msd-ypy_d*ypy_d);
+        /* Courant-Snyder (Twiss) beta-function and alpha
+         *
+         * Both are ratios to an rms emittance, and are undefined where that emittance
+         * vanishes: a single particle, a cold plane, or a longitudinal plane without
+         * energy spread. Report NaN there rather than dividing by zero, which raises
+         * FE_DIVBYZERO (or FE_INVALID, for 0/0) under amrex.fpe_trap_zero/_invalid.
+         */
+        amrex::ParticleReal const beta_x = (emittance_xd > 0.0) ? x_msd / emittance_xd : nan;
+        amrex::ParticleReal const beta_y = (emittance_yd > 0.0) ? y_msd / emittance_yd : nan;
+        amrex::ParticleReal const beta_t = (emittance_t > 0.0) ? t_ms / emittance_t : nan;
+        amrex::ParticleReal const alpha_x = (emittance_xd > 0.0) ? - xpx_d / emittance_xd : nan;
+        amrex::ParticleReal const alpha_y = (emittance_yd > 0.0) ? - ypy_d / emittance_yd : nan;
+        amrex::ParticleReal const alpha_t = (emittance_t > 0.0) ? - tpt / emittance_t : nan;
 
         // Calculate normalized emittances
         amrex::ParticleReal emittance_xn = emittance_x * bg;
@@ -618,8 +656,6 @@ namespace
            emittance_2 = std::get<1>(emittances);
            emittance_3 = std::get<2>(emittances);
         }
-
-        auto const nan = std::numeric_limits<amrex::ParticleReal>::quiet_NaN();
 
         std::unordered_map<std::string, amrex::ParticleReal> data;
         data["mean_x"] = 0.0_prt;

--- a/src/diagnostics/ReducedBeamCharacteristics.cpp
+++ b/src/diagnostics/ReducedBeamCharacteristics.cpp
@@ -369,8 +369,7 @@ namespace
          *
          * Both are ratios to an rms emittance, and are undefined where that emittance
          * vanishes: a single particle, a cold plane, or a longitudinal plane without
-         * energy spread. Report NaN there rather than dividing by zero, which raises
-         * FE_DIVBYZERO (or FE_INVALID, for 0/0) under amrex.fpe_trap_zero/_invalid.
+         * energy spread.
          */
         amrex::ParticleReal const beta_x = (emittance_xd > 0.0) ? x_msd / emittance_xd : nan;
         amrex::ParticleReal const beta_y = (emittance_yd > 0.0) ? y_msd / emittance_yd : nan;
@@ -588,8 +587,7 @@ namespace
          *
          * Both are ratios to an rms emittance, and are undefined where that emittance
          * vanishes: a single particle, a cold plane, or a longitudinal plane without
-         * energy spread. Report NaN there rather than dividing by zero, which raises
-         * FE_DIVBYZERO (or FE_INVALID, for 0/0) under amrex.fpe_trap_zero/_invalid.
+         * energy spread.
          */
         amrex::ParticleReal const beta_x = (emittance_xd > 0.0) ? x_msd / emittance_xd : nan;
         amrex::ParticleReal const beta_y = (emittance_yd > 0.0) ? y_msd / emittance_yd : nan;

--- a/tests/python/test_beam_moments_degenerate.py
+++ b/tests/python/test_beam_moments_degenerate.py
@@ -9,8 +9,7 @@
 
 import math
 
-import impactx
-from impactx import ImpactX, distribution
+from impactx import ImpactX, create_envelope, distribution
 
 
 def waterbag(lambda_pt=2.0e-3):
@@ -102,7 +101,7 @@ def test_envelope_beam_moments_without_energy_spread():
     ref = sim.beam.ref
     ref.set_species("electron").set_kin_energy_MeV(2.0e3)
 
-    envelope = impactx.create_envelope(waterbag(lambda_pt=0.0), 1.0e-9)
+    envelope = create_envelope(waterbag(lambda_pt=0.0), 1.0e-9)
     moments = envelope.beam_moments(ref)
 
     assert moments["emittance_t"] == 0.0

--- a/tests/python/test_beam_moments_degenerate.py
+++ b/tests/python/test_beam_moments_degenerate.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+import math
+
+import impactx
+from impactx import ImpactX, distribution
+
+
+def waterbag(lambda_pt=2.0e-3):
+    """A 2 GeV electron beam, optionally without any energy spread."""
+    return distribution.Waterbag(
+        lambdaX=3.9984884770e-5,
+        lambdaY=3.9984884770e-5,
+        lambdaT=1.0e-3,
+        lambdaPx=2.6623538760e-5,
+        lambdaPy=2.6623538760e-5,
+        lambdaPt=lambda_pt,
+        muxpx=-0.846574929020762,
+        muypy=0.846574929020762,
+        mutpt=0.0,
+    )
+
+
+def test_beam_moments_single_particle():
+    """
+    A single particle has vanishing rms emittances, for which the Courant-Snyder
+    (Twiss) functions are undefined.
+    """
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.slice_step_diagnostics = False
+    sim.init_grids()
+
+    sim.beam.ref.set_species("electron").set_kin_energy_MeV(2.0e3)
+    sim.add_particles(1.0e-9, waterbag(), 1)
+
+    moments = sim.beam.beam_moments()
+
+    # the beam is a point in phase space: no extent, no emittance
+    for key in ("sigma_x", "sigma_y", "sigma_t", "emittance_x", "emittance_y"):
+        assert moments[key] == 0.0
+
+    # ... so its Twiss functions do not exist, in any plane
+    for key in ("alpha_x", "alpha_y", "alpha_t", "beta_x", "beta_y", "beta_t"):
+        assert math.isnan(moments[key])
+
+    # its position is still perfectly well defined
+    assert math.isfinite(moments["mean_x"])
+    assert moments["mean_x"] == moments["min_x"] == moments["max_x"]
+
+    sim.finalize()
+
+
+def test_beam_moments_without_energy_spread():
+    """
+    A beam without energy spread has no longitudinal emittance, and hence no
+    longitudinal Twiss functions. The transverse planes stay unaffected.
+    """
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.slice_step_diagnostics = False
+    sim.init_grids()
+
+    sim.beam.ref.set_species("electron").set_kin_energy_MeV(2.0e3)
+    sim.add_particles(1.0e-9, waterbag(lambda_pt=0.0), 1000)
+
+    moments = sim.beam.beam_moments()
+
+    assert moments["sigma_pt"] == 0.0
+    assert moments["emittance_t"] == 0.0
+    assert math.isnan(moments["beta_t"])
+    assert math.isnan(moments["alpha_t"])
+
+    assert moments["sigma_t"] > 0.0
+    assert moments["emittance_x"] > 0.0
+    assert math.isfinite(moments["beta_x"])
+    assert math.isfinite(moments["alpha_x"])
+
+    sim.finalize()
+
+
+def test_envelope_beam_moments_without_energy_spread():
+    """
+    The covariance-matrix (envelope) moments treat a vanishing emittance the same
+    way as the particle moments do.
+    """
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.slice_step_diagnostics = False
+    sim.init_grids()
+
+    ref = sim.beam.ref
+    ref.set_species("electron").set_kin_energy_MeV(2.0e3)
+
+    envelope = impactx.create_envelope(waterbag(lambda_pt=0.0), 1.0e-9)
+    moments = envelope.beam_moments(ref)
+
+    assert moments["emittance_t"] == 0.0
+    assert math.isnan(moments["beta_t"])
+    assert math.isnan(moments["alpha_t"])
+
+    assert moments["emittance_x"] > 0.0
+    assert math.isfinite(moments["beta_x"])
+    assert math.isfinite(moments["alpha_x"])
+
+    sim.finalize()

--- a/tests/python/test_beam_moments_degenerate.py
+++ b/tests/python/test_beam_moments_degenerate.py
@@ -2,7 +2,7 @@
 #
 # Copyright 2022-2026 The ImpactX Community
 #
-# Authors: Axel Huebl
+# Authors: Axel Huebl, Chad Mitchell
 # License: BSD-3-Clause-LBNL
 #
 # -*- coding: utf-8 -*-


### PR DESCRIPTION
Explicitly handle edge cases like flat and cold beams in our beam moments calculation.

Before this PR, these cases caused invalid floating point operations, which showed up in diagnostics and complicate debugging (other) bugs.

<details>

Several reduced beam characteristics were computed without checking that they exist. With `amrex.fpe_trap_invalid` enabled, a beam that is degenerate but otherwise perfectly healthy aborted the run inside its own diagnostics.

### Square roots

`emittance_xd` and `emittance_yd` took the square root of a dispersion-corrected discriminant without the guard their undispersed counterparts `emittance_x`/`_y`/`_t` already had, and the standard deviations took the square root of a variance straight from the moment sums. Both quantities are non-negative mathematically, but finite precision can put them marginally below zero, where `std::sqrt` raises `FE_INVALID`.

A new `sqrt_clamped` clamps that rounding-level case to zero. It passes a NaN through rather than clamping it, so a beam poisoned by a non-finite coordinate stays visible in the output instead of being reported as a zero width.

### Twiss functions

`alpha` and `beta` are ratios to an rms emittance and were divided by it unconditionally. A single particle, a cold plane, or a plane without energy spread has no emittance there — and `emittance_t` is in fact *forced* to zero by the guard immediately above — so the division was a plain `0/0` for any such beam. They now report NaN, which is what an undefined Twiss function is.

Both `reduced_beam_characteristics` overloads (particle container and covariance matrix) are fixed.

### Note on where a NaN detonates

A quiet NaN is silent through arithmetic and `std::sqrt`; it raises `FE_INVALID` only at an *ordered* comparison, which GCC emits as a signaling `comisd`. On GPU builds the device never traps at all. That is why a NaN born anywhere in tracking surfaces as a SIGFPE inside `reduced_beam_characteristics`, on every rank at once, after the all-reduce. `sqrt_clamped` deliberately does not swallow that.

### Tests

`tests/python/test_beam_moments_degenerate.py`: a single particle, a beam without energy spread, and the envelope counterpart of the latter. Verified to fail on `development` before the fix.

Follow-up #1617 stacks on this branch and handles beams with no particles at all.

</details>