### PR TITLE
Diagnostics: Beam Moments Without a Beam

### DIFF
--- a/docs/source/dataanalysis/dataanalysis.rst
+++ b/docs/source/dataanalysis/dataanalysis.rst
@@ -136,9 +136,10 @@ The code writes out the values in an ASCII file prefixed ``reduced_beam_characte
     Standard deviation of the three spin components (unit: dimensionless).  This diagnostic is written only if spin tracking is on (algo.spin = True).
 
 Quantities that a beam does not define are written as ``nan``.
+The ``step``, ``period`` and ``s`` columns describe the position in the lattice and are always written.
 The Courant-Snyder (Twiss) ``alpha`` and ``beta`` of a plane are ratios to its rms emittance, and are undefined wherever that emittance vanishes: for a single particle, for a cold plane, or longitudinally for a beam without energy spread.
-A beam without a total weight has no weighted moments either: one that holds no particles at all, for example at the start of a simulation whose beam a ``source`` element loads further down the lattice, or one of zero charge as used for test particles.
-Its ``min`` and ``max`` are unweighted and stay defined as long as it holds a particle, as do ``charge_C``, which is then zero, and ``s``.
+For zero-weight test beams, added with a bunch charge of zero, there is no total weight to normalize by: every weighted moment is undefined and ``charge_C`` is zero, while the unweighted ``min`` and ``max`` still report the extent of the beam.
+For a simulation whose beam is loaded in a :py:class:`~impactx.elements.Source` element instead of prior to tracking, the beam is empty until that element is reached: every diagnostic before it reports ``nan`` for all moments, minima and maxima included, and zero for ``charge_C``.
 
 
 .. _dataanalysis-plot:

--- a/docs/source/dataanalysis/dataanalysis.rst
+++ b/docs/source/dataanalysis/dataanalysis.rst
@@ -137,6 +137,8 @@ The code writes out the values in an ASCII file prefixed ``reduced_beam_characte
 
 Quantities that a beam does not define are written as ``nan``.
 The Courant-Snyder (Twiss) ``alpha`` and ``beta`` of a plane are ratios to its rms emittance, and are undefined wherever that emittance vanishes: for a single particle, for a cold plane, or longitudinally for a beam without energy spread.
+A beam without a total weight has no weighted moments either: one that holds no particles at all, for example at the start of a simulation whose beam a ``source`` element loads further down the lattice, or one of zero charge as used for test particles.
+Its ``min`` and ``max`` are unweighted and stay defined as long as it holds a particle, as do ``charge_C``, which is then zero, and ``s``.
 
 
 .. _dataanalysis-plot:

--- a/src/diagnostics/DiagnosticOutput.cpp
+++ b/src/diagnostics/DiagnosticOutput.cpp
@@ -114,10 +114,7 @@ namespace
         using namespace amrex::literals; // for _prt
 
         /* A reference particle that carries no energy yet, e.g. before a Source
-         * element loads it from file, has gamma = 0. Neither beta = sqrt(1 - 1/gamma^2)
-         * nor beta*gamma = sqrt(gamma^2 - 1) is a real number there, and evaluating
-         * them raises FE_INVALID (and FE_DIVBYZERO) under amrex.fpe_trap_invalid.
-         * Report the undefined quantities as NaN instead.
+         * element loads it from file, has gamma = 0 and thus no valid beta.
          */
         auto const nan = std::numeric_limits<amrex::ParticleReal>::quiet_NaN();
         bool const ref_is_initialized = ref_part.gamma() >= 1.0_prt;

--- a/src/diagnostics/DiagnosticOutput.cpp
+++ b/src/diagnostics/DiagnosticOutput.cpp
@@ -111,10 +111,21 @@ namespace
         int step
     )
     {
+        using namespace amrex::literals; // for _prt
+
+        /* A reference particle that carries no energy yet, e.g. before a Source
+         * element loads it from file, has gamma = 0. Neither beta = sqrt(1 - 1/gamma^2)
+         * nor beta*gamma = sqrt(gamma^2 - 1) is a real number there, and evaluating
+         * them raises FE_INVALID (and FE_DIVBYZERO) under amrex.fpe_trap_invalid.
+         * Report the undefined quantities as NaN instead.
+         */
+        auto const nan = std::numeric_limits<amrex::ParticleReal>::quiet_NaN();
+        bool const ref_is_initialized = ref_part.gamma() >= 1.0_prt;
+
         amrex::ParticleReal const s = ref_part.s;
-        amrex::ParticleReal const beta = ref_part.beta();
-        amrex::ParticleReal const gamma = ref_part.gamma();
-        amrex::ParticleReal const beta_gamma = ref_part.beta_gamma();
+        amrex::ParticleReal const beta = ref_is_initialized ? ref_part.beta() : nan;
+        amrex::ParticleReal const gamma = ref_is_initialized ? ref_part.gamma() : nan;
+        amrex::ParticleReal const beta_gamma = ref_is_initialized ? ref_part.beta_gamma() : nan;
         amrex::ParticleReal const x = ref_part.x;
         amrex::ParticleReal const y = ref_part.y;
         amrex::ParticleReal const z = ref_part.z;

--- a/src/diagnostics/ReducedBeamCharacteristics.cpp
+++ b/src/diagnostics/ReducedBeamCharacteristics.cpp
@@ -31,6 +31,7 @@
 #include <array>
 #include <cmath>
 #include <limits>
+#include <string>
 #include <vector>
 
 
@@ -150,8 +151,15 @@ namespace
         RefPart const ref_part = pc.GetRefParticle();
         // reference particle charge in C
         amrex::ParticleReal const q_C = ref_part.charge;
+        /* A reference particle that carries no energy yet, e.g. before a Source
+         * element loads it from file, has gamma = 0, for which beta*gamma =
+         * sqrt(gamma^2 - 1) is not a real number. Keep it out of the arithmetic
+         * below - such a beam reports "no beam" moments at the end anyway - so
+         * that we do not raise FE_INVALID under amrex.fpe_trap_invalid.
+         */
+        bool const ref_is_initialized = ref_part.gamma() >= 1.0_prt;
         // reference particle relativistic beta*gamma
-        amrex::ParticleReal const bg = ref_part.beta_gamma();
+        amrex::ParticleReal const bg = ref_is_initialized ? ref_part.beta_gamma() : 0.0_prt;
         amrex::ParticleReal const bg2 = bg*bg;
 
         /* The reduced beam characteristics are computed in a single pass over the
@@ -177,6 +185,7 @@ namespace
             RealSoA::sx, RealSoA::sy, RealSoA::sz
         };
         std::array shift = {0._prt, 0._prt, 0._prt, 0._prt, 0._prt, 0._prt, 0._prt, 0._prt, 0._prt};
+        bool has_particles = false;
         {
             // Sample the first particle held locally, then agree on a single global
             // shift taken from the lowest rank that actually owns a particle. Any
@@ -202,7 +211,10 @@ namespace
             int src_rank = found ? amrex::ParallelDescriptor::MyProc()
                                  : amrex::ParallelDescriptor::NProcs();
             amrex::ParallelAllReduce::Min(src_rank, amrex::ParallelDescriptor::Communicator());
-            if (src_rank < amrex::ParallelDescriptor::NProcs()) {
+            // this also tells us, globally and without a further reduction,
+            // whether the beam holds any particle at all
+            has_particles = src_rank < amrex::ParallelDescriptor::NProcs();
+            if (has_particles) {
                 amrex::ParallelDescriptor::Bcast(shift.data(), shift.size(), src_rank);
             }
         }
@@ -272,16 +284,33 @@ namespace
         // parallel-axis theorem. The shift keeps every sum at the O(rms^2) scale,
         // so the central moments below stay well-conditioned even in single precision.
         amrex::ParticleReal const w_sum = values_sum[0];
+
+        /* Every moment below is normalized by the beam's total weight, which is zero
+         * for a beam that holds no particles at all - e.g. the initial diagnostic of
+         * a simulation whose beam a Source element loads further down the lattice -
+         * and also for one of zero charge, as used for massless "test" particles.
+         * Both would turn each normalization into 0/0, which raises FE_INVALID under
+         * amrex.fpe_trap_invalid. Normalize by one instead, which carries the
+         * (all-zero) sums through the derived quantities without an exception, and
+         * report the undefined results as NaN at the end of this function.
+         *
+         * The comparison is an equality on purpose: it is quiet for a NaN w_sum,
+         * so a beam poisoned by a non-finite particle coordinate is not silently
+         * absorbed here, but keeps tripping the FPE traps where they are enabled.
+         */
+        bool const has_weight = !(w_sum == 0.0_prt);
+        amrex::ParticleReal const w_norm = has_weight ? w_sum : 1.0_prt;
+
         // shifted means: <u - shift_u>
-        amrex::ParticleReal const dmean_x  = values_sum[1] / w_sum;
-        amrex::ParticleReal const dmean_y  = values_sum[2] / w_sum;
-        amrex::ParticleReal const dmean_t  = values_sum[3] / w_sum;
-        amrex::ParticleReal const dmean_px = values_sum[4] / w_sum;
-        amrex::ParticleReal const dmean_py = values_sum[5] / w_sum;
-        amrex::ParticleReal const dmean_pt = values_sum[6] / w_sum;
-        amrex::ParticleReal const dmean_sx = values_sum[7] / w_sum;
-        amrex::ParticleReal const dmean_sy = values_sum[8] / w_sum;
-        amrex::ParticleReal const dmean_sz = values_sum[9] / w_sum;
+        amrex::ParticleReal const dmean_x  = values_sum[1] / w_norm;
+        amrex::ParticleReal const dmean_y  = values_sum[2] / w_norm;
+        amrex::ParticleReal const dmean_t  = values_sum[3] / w_norm;
+        amrex::ParticleReal const dmean_px = values_sum[4] / w_norm;
+        amrex::ParticleReal const dmean_py = values_sum[5] / w_norm;
+        amrex::ParticleReal const dmean_pt = values_sum[6] / w_norm;
+        amrex::ParticleReal const dmean_sx = values_sum[7] / w_norm;
+        amrex::ParticleReal const dmean_sy = values_sum[8] / w_norm;
+        amrex::ParticleReal const dmean_sz = values_sum[9] / w_norm;
         // means
         amrex::ParticleReal const mean_x  = shift_x  + dmean_x;
         amrex::ParticleReal const mean_y  = shift_y  + dmean_y;
@@ -307,30 +336,30 @@ namespace
         amrex::ParticleReal const max_py = values_max.at(4);
         amrex::ParticleReal const max_pt = values_max.at(5);
         // mean square and correlation values (central moments via parallel-axis theorem)
-        amrex::ParticleReal const x_ms   = values_sum[10] / w_sum - dmean_x  * dmean_x;
-        amrex::ParticleReal const y_ms   = values_sum[11] / w_sum - dmean_y  * dmean_y;
-        amrex::ParticleReal const t_ms   = values_sum[12] / w_sum - dmean_t  * dmean_t;
-        amrex::ParticleReal const px_ms  = values_sum[13] / w_sum - dmean_px * dmean_px;
-        amrex::ParticleReal const py_ms  = values_sum[14] / w_sum - dmean_py * dmean_py;
-        amrex::ParticleReal const pt_ms  = values_sum[15] / w_sum - dmean_pt * dmean_pt;
-        amrex::ParticleReal const xpx    = values_sum[16] / w_sum - dmean_x  * dmean_px;
-        amrex::ParticleReal const ypy    = values_sum[17] / w_sum - dmean_y  * dmean_py;
-        amrex::ParticleReal const tpt    = values_sum[18] / w_sum - dmean_t  * dmean_pt;
-        amrex::ParticleReal const xpt    = values_sum[19] / w_sum - dmean_x  * dmean_pt;
-        amrex::ParticleReal const pxpt   = values_sum[20] / w_sum - dmean_px * dmean_pt;
-        amrex::ParticleReal const ypt    = values_sum[21] / w_sum - dmean_y  * dmean_pt;
-        amrex::ParticleReal const pypt   = values_sum[22] / w_sum - dmean_py * dmean_pt;
-        amrex::ParticleReal const xy     = values_sum[23] / w_sum - dmean_x  * dmean_y;
-        amrex::ParticleReal const xpy    = values_sum[24] / w_sum - dmean_x  * dmean_py;
-        amrex::ParticleReal const xt     = values_sum[25] / w_sum - dmean_x  * dmean_t;
-        amrex::ParticleReal const pxy    = values_sum[26] / w_sum - dmean_px * dmean_y;
-        amrex::ParticleReal const pxpy   = values_sum[27] / w_sum - dmean_px * dmean_py;
-        amrex::ParticleReal const pxt    = values_sum[28] / w_sum - dmean_px * dmean_t;
-        amrex::ParticleReal const yt     = values_sum[29] / w_sum - dmean_y  * dmean_t;
-        amrex::ParticleReal const pyt    = values_sum[30] / w_sum - dmean_py * dmean_t;
-        amrex::ParticleReal const sx_ms  = values_sum[31] / w_sum - dmean_sx * dmean_sx;
-        amrex::ParticleReal const sy_ms  = values_sum[32] / w_sum - dmean_sy * dmean_sy;
-        amrex::ParticleReal const sz_ms  = values_sum[33] / w_sum - dmean_sz * dmean_sz;
+        amrex::ParticleReal const x_ms   = values_sum[10] / w_norm - dmean_x  * dmean_x;
+        amrex::ParticleReal const y_ms   = values_sum[11] / w_norm - dmean_y  * dmean_y;
+        amrex::ParticleReal const t_ms   = values_sum[12] / w_norm - dmean_t  * dmean_t;
+        amrex::ParticleReal const px_ms  = values_sum[13] / w_norm - dmean_px * dmean_px;
+        amrex::ParticleReal const py_ms  = values_sum[14] / w_norm - dmean_py * dmean_py;
+        amrex::ParticleReal const pt_ms  = values_sum[15] / w_norm - dmean_pt * dmean_pt;
+        amrex::ParticleReal const xpx    = values_sum[16] / w_norm - dmean_x  * dmean_px;
+        amrex::ParticleReal const ypy    = values_sum[17] / w_norm - dmean_y  * dmean_py;
+        amrex::ParticleReal const tpt    = values_sum[18] / w_norm - dmean_t  * dmean_pt;
+        amrex::ParticleReal const xpt    = values_sum[19] / w_norm - dmean_x  * dmean_pt;
+        amrex::ParticleReal const pxpt   = values_sum[20] / w_norm - dmean_px * dmean_pt;
+        amrex::ParticleReal const ypt    = values_sum[21] / w_norm - dmean_y  * dmean_pt;
+        amrex::ParticleReal const pypt   = values_sum[22] / w_norm - dmean_py * dmean_pt;
+        amrex::ParticleReal const xy     = values_sum[23] / w_norm - dmean_x  * dmean_y;
+        amrex::ParticleReal const xpy    = values_sum[24] / w_norm - dmean_x  * dmean_py;
+        amrex::ParticleReal const xt     = values_sum[25] / w_norm - dmean_x  * dmean_t;
+        amrex::ParticleReal const pxy    = values_sum[26] / w_norm - dmean_px * dmean_y;
+        amrex::ParticleReal const pxpy   = values_sum[27] / w_norm - dmean_px * dmean_py;
+        amrex::ParticleReal const pxt    = values_sum[28] / w_norm - dmean_px * dmean_t;
+        amrex::ParticleReal const yt     = values_sum[29] / w_norm - dmean_y  * dmean_t;
+        amrex::ParticleReal const pyt    = values_sum[30] / w_norm - dmean_py * dmean_t;
+        amrex::ParticleReal const sx_ms  = values_sum[31] / w_norm - dmean_sx * dmean_sx;
+        amrex::ParticleReal const sy_ms  = values_sum[32] / w_norm - dmean_sy * dmean_sy;
+        amrex::ParticleReal const sz_ms  = values_sum[33] / w_norm - dmean_sz * dmean_sz;
         // beam charge
         amrex::ParticleReal const charge = q_C * w_sum;
         // standard deviations of positions
@@ -516,6 +545,39 @@ namespace
         data["sigma_sx"] = sigma_sx;
         data["sigma_sy"] = sigma_sy;
         data["sigma_sz"] = sigma_sz;
+
+        /* Without a total weight to normalize by, or without a reference particle to
+         * measure against, none of the moments above carries information: they are
+         * the zeros that the substitute normalization produced. Report them as
+         * "undefined" so that they cannot be mistaken for a measurement of a real,
+         * if degenerate, beam. The charge stays as reduced: it is exactly zero.
+         */
+        if (!has_weight || !ref_is_initialized)
+        {
+            for (auto & moment : data) {
+                moment.second = nan;
+            }
+            data["charge_C"] = charge;
+
+            /* The extrema, however, are unweighted. They stay meaningful for a beam
+             * of zero charge, and are undefined only without any particle to take
+             * them over - in which case they are the identity elements of their
+             * reductions.
+             */
+            if (has_particles)
+            {
+                constexpr std::array coordinates = {"x", "y", "t", "px", "py", "pt"};
+                for (std::size_t c = 0; c < coordinates.size(); ++c)
+                {
+                    std::string const coordinate = coordinates[c];
+                    data["min_" + coordinate] = values_min[c];
+                    data["max_" + coordinate] = values_max[c];
+                    // deprecated spellings of the same two entries
+                    data[coordinate + "_min"] = values_min[c];
+                    data[coordinate + "_max"] = values_max[c];
+                }
+            }
+        }
 
         return data;
     }

--- a/src/diagnostics/ReducedBeamCharacteristics.cpp
+++ b/src/diagnostics/ReducedBeamCharacteristics.cpp
@@ -152,10 +152,7 @@ namespace
         // reference particle charge in C
         amrex::ParticleReal const q_C = ref_part.charge;
         /* A reference particle that carries no energy yet, e.g. before a Source
-         * element loads it from file, has gamma = 0, for which beta*gamma =
-         * sqrt(gamma^2 - 1) is not a real number. Keep it out of the arithmetic
-         * below - such a beam reports "no beam" moments at the end anyway - so
-         * that we do not raise FE_INVALID under amrex.fpe_trap_invalid.
+         * element loads it from file, has gamma = 0 and thus no valid beta.
          */
         bool const ref_is_initialized = ref_part.gamma() >= 1.0_prt;
         // reference particle relativistic beta*gamma
@@ -211,8 +208,7 @@ namespace
             int src_rank = found ? amrex::ParallelDescriptor::MyProc()
                                  : amrex::ParallelDescriptor::NProcs();
             amrex::ParallelAllReduce::Min(src_rank, amrex::ParallelDescriptor::Communicator());
-            // this also tells us, globally and without a further reduction,
-            // whether the beam holds any particle at all
+            // Does the beam hold any particle at all:
             has_particles = src_rank < amrex::ParallelDescriptor::NProcs();
             if (has_particles) {
                 amrex::ParallelDescriptor::Bcast(shift.data(), shift.size(), src_rank);
@@ -289,14 +285,14 @@ namespace
          * for a beam that holds no particles at all - e.g. the initial diagnostic of
          * a simulation whose beam a Source element loads further down the lattice -
          * and also for one of zero charge, as used for massless "test" particles.
-         * Both would turn each normalization into 0/0, which raises FE_INVALID under
-         * amrex.fpe_trap_invalid. Normalize by one instead, which carries the
+         * Both would turn each normalization into invalid divisions by zero.
+         * Normalize by one instead, which carries the
          * (all-zero) sums through the derived quantities without an exception, and
          * report the undefined results as NaN at the end of this function.
          *
          * The comparison is an equality on purpose: it is quiet for a NaN w_sum,
          * so a beam poisoned by a non-finite particle coordinate is not silently
-         * absorbed here, but keeps tripping the FPE traps where they are enabled.
+         * absorbed here, but keeps tripping FPE diagnostics when enabled.
          */
         bool const has_weight = !(w_sum == 0.0_prt);
         amrex::ParticleReal const w_norm = has_weight ? w_sum : 1.0_prt;
@@ -550,32 +546,25 @@ namespace
          * measure against, none of the moments above carries information: they are
          * the zeros that the substitute normalization produced. Report them as
          * "undefined" so that they cannot be mistaken for a measurement of a real,
-         * if degenerate, beam. The charge stays as reduced: it is exactly zero.
+         * if degenerate, beam.
+         *
+         * Two kinds of entry survive. The charge is exactly zero, as reduced. And the
+         * minima and maxima are unweighted: they stay meaningful for a beam of zero
+         * charge, and are undefined only without any particle to take them over - in
+         * which case they hold the identity elements of their reductions.
          */
         if (!has_weight || !ref_is_initialized)
         {
-            for (auto & moment : data) {
-                moment.second = nan;
-            }
-            data["charge_C"] = charge;
-
-            /* The extrema, however, are unweighted. They stay meaningful for a beam
-             * of zero charge, and are undefined only without any particle to take
-             * them over - in which case they are the identity elements of their
-             * reductions.
-             */
-            if (has_particles)
+            auto const is_defined = [has_particles](std::string const & moment)
             {
-                constexpr std::array coordinates = {"x", "y", "t", "px", "py", "pt"};
-                for (std::size_t c = 0; c < coordinates.size(); ++c)
-                {
-                    std::string const coordinate = coordinates[c];
-                    data["min_" + coordinate] = values_min[c];
-                    data["max_" + coordinate] = values_max[c];
-                    // deprecated spellings of the same two entries
-                    data[coordinate + "_min"] = values_min[c];
-                    data[coordinate + "_max"] = values_max[c];
-                }
+                if (moment == "charge_C") { return true; }
+                return has_particles &&
+                       (moment.starts_with("min_") || moment.starts_with("max_") ||
+                        moment.ends_with("_min") || moment.ends_with("_max"));
+            };
+
+            for (auto & moment : data) {
+                if (!is_defined(moment.first)) { moment.second = nan; }
             }
         }
 

--- a/tests/python/test_beam_moments_degenerate.py
+++ b/tests/python/test_beam_moments_degenerate.py
@@ -8,8 +8,17 @@
 # -*- coding: utf-8 -*-
 
 import math
+import os
+import subprocess
+import sys
+
+import pytest
 
 from impactx import ImpactX, create_envelope, distribution
+
+# beam moments that stay defined without a beam: the reference path length and
+# the beam charge (of which there is none)
+ALWAYS_DEFINED = ("s", "charge_C")
 
 
 def waterbag(lambda_pt=2.0e-3):
@@ -25,6 +34,82 @@ def waterbag(lambda_pt=2.0e-3):
         muypy=0.846574929020762,
         mutpt=0.0,
     )
+
+
+def test_beam_moments_without_beam():
+    """
+    An empty particle container has no moments to report.
+    """
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.slice_step_diagnostics = False
+    sim.init_grids()
+
+    sim.beam.ref.set_species("electron").set_kin_energy_MeV(2.0e3)
+
+    assert sim.beam.total_number_of_particles() == 0
+    moments = sim.beam.beam_moments()
+
+    undefined = {k: v for k, v in moments.items() if k not in ALWAYS_DEFINED}
+    assert undefined
+    assert all(math.isnan(v) for v in undefined.values())
+    assert moments["charge_C"] == 0.0
+
+    sim.finalize()
+
+
+def test_beam_moments_without_reference_particle():
+    """
+    A beam that a Source element only loads later on has neither particles nor a
+    reference particle when the initial diagnostics run. beta*gamma is not a real
+    number for such a reference particle, which must not leak into the moments.
+    """
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.slice_step_diagnostics = False
+    sim.init_grids()
+
+    assert sim.beam.ref.kin_energy_MeV == 0.0
+    moments = sim.beam.beam_moments()
+
+    undefined = {k: v for k, v in moments.items() if k not in ALWAYS_DEFINED}
+    assert undefined
+    assert all(math.isnan(v) for v in undefined.values())
+    assert moments["charge_C"] == 0.0
+
+    sim.finalize()
+
+
+def test_beam_moments_without_charge():
+    """
+    Massless "test" particles carry no weight, so the beam has no weighted moments.
+    Their extrema are unweighted, though, and stay defined.
+    """
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.slice_step_diagnostics = False
+    sim.init_grids()
+
+    sim.beam.ref.set_species("electron").set_kin_energy_MeV(2.0e3)
+    sim.add_particles(0.0, waterbag(), 1000)
+
+    moments = sim.beam.beam_moments()
+
+    assert moments["charge_C"] == 0.0
+    assert math.isnan(moments["mean_x"])
+    assert math.isnan(moments["sigma_x"])
+    assert math.isnan(moments["emittance_x"])
+
+    for coordinate in ("x", "y", "t", "px", "py", "pt"):
+        assert moments[f"min_{coordinate}"] < moments[f"max_{coordinate}"]
+        # deprecated spellings of the same two entries
+        assert moments[f"{coordinate}_min"] == moments[f"min_{coordinate}"]
+        assert moments[f"{coordinate}_max"] == moments[f"max_{coordinate}"]
+
+    sim.finalize()
 
 
 def test_beam_moments_single_particle():
@@ -113,3 +198,84 @@ def test_envelope_beam_moments_without_energy_spread():
     assert math.isfinite(moments["alpha_x"])
 
     sim.finalize()
+
+
+# A stand-alone run of the degenerate cases above, with AMReX trapping the
+# floating-point exceptions that they used to raise. It has to run in its own
+# process: a trap raises SIGFPE, which no test could survive in-process.
+_FPE_TRAP_PROGRAM = """
+from mpi4py import MPI  # noqa: F401  (keep MPI alive across ImpactX instances)
+
+import amrex.space3d as amr
+
+amr.initialize(
+    [
+        "amrex.verbose=0",
+        "tiny_profiler.enabled=0",
+        "amrex.signal_handling=1",
+        "amrex.handle_sigfpe=1",
+        "amrex.fpe_trap_invalid=1",
+        "amrex.fpe_trap_zero=1",
+    ]
+)
+
+from impactx import ImpactX, distribution
+
+
+def beam(lambda_pt):
+    return distribution.Waterbag(
+        lambdaX=3.9984884770e-5,
+        lambdaY=3.9984884770e-5,
+        lambdaT=1.0e-3,
+        lambdaPx=2.6623538760e-5,
+        lambdaPy=2.6623538760e-5,
+        lambdaPt=lambda_pt,
+    )
+
+
+def moments(npart, bunch_charge_C=1.0e-9, lambda_pt=2.0e-3, reference_particle=True):
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.slice_step_diagnostics = False
+    sim.init_grids()
+    if reference_particle:
+        sim.beam.ref.set_species("electron").set_kin_energy_MeV(2.0e3)
+    if npart > 0:
+        sim.add_particles(bunch_charge_C, beam(lambda_pt), npart)
+    sim.beam.beam_moments()
+    sim.finalize()
+
+
+moments(npart=0, reference_particle=False)  # a beam a Source loads later
+moments(npart=0)  # an empty beam
+moments(npart=1000, bunch_charge_C=0.0)  # test particles, carrying no weight
+moments(npart=1)  # no emittance in any plane
+moments(npart=1000, lambda_pt=0.0)  # no longitudinal emittance
+
+print("no floating-point exception raised")
+"""
+
+
+@pytest.mark.manages_amrex
+def test_beam_moments_do_not_raise_fpe(tmp_path):
+    """
+    Computing the beam moments of a degenerate beam does not raise a floating-point
+    exception, i.e. it survives amrex.fpe_trap_invalid / amrex.fpe_trap_zero.
+    """
+    if not impactx.Config.have_mpi:
+        pytest.skip("the stand-alone program pre-initializes MPI via mpi4py")
+
+    program = tmp_path / "fpe_trap_beam_moments.py"
+    program.write_text(_FPE_TRAP_PROGRAM)
+
+    result = subprocess.run(
+        [sys.executable, str(program)],
+        cwd=tmp_path,
+        env={**os.environ, "OMP_NUM_THREADS": "1"},
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    assert "no floating-point exception raised" in result.stdout

--- a/tests/python/test_beam_moments_degenerate.py
+++ b/tests/python/test_beam_moments_degenerate.py
@@ -14,7 +14,7 @@ import sys
 
 import pytest
 
-from impactx import ImpactX, create_envelope, distribution
+from impactx import Config, ImpactX, create_envelope, distribution
 
 # beam moments that stay defined without a beam: the reference path length and
 # the beam charge (of which there is none)
@@ -263,7 +263,14 @@ def test_beam_moments_do_not_raise_fpe(tmp_path):
     Computing the beam moments of a degenerate beam does not raise a floating-point
     exception, i.e. it survives amrex.fpe_trap_invalid / amrex.fpe_trap_zero.
     """
-    if not impactx.Config.have_mpi:
+    if sys.platform != "linux":
+        pytest.skip(
+            "AMReX arms the FP traps for the whole process: through feenableexcept on "
+            "Linux/glibc, and through the FPCR trap bits on Apple Silicon, where an "
+            "exception arrives as SIGILL and this program aborts in its first "
+            "simulation from a site that is not localized yet"
+        )
+    if not Config.have_mpi:
         pytest.skip("the stand-alone program pre-initializes MPI via mpi4py")
 
     program = tmp_path / "fpe_trap_beam_moments.py"

--- a/tests/python/test_beam_moments_degenerate.py
+++ b/tests/python/test_beam_moments_degenerate.py
@@ -8,13 +8,8 @@
 # -*- coding: utf-8 -*-
 
 import math
-import os
-import subprocess
-import sys
 
-import pytest
-
-from impactx import Config, ImpactX, create_envelope, distribution
+from impactx import ImpactX, create_envelope, distribution
 
 # beam moments that stay defined without a beam: the reference path length and
 # the beam charge (of which there is none)
@@ -198,106 +193,3 @@ def test_envelope_beam_moments_without_energy_spread():
     assert math.isfinite(moments["alpha_x"])
 
     sim.finalize()
-
-
-# A stand-alone run of one degenerate case, with AMReX trapping the floating-point
-# exceptions that it used to raise. Each case runs in its own process: a trap raises
-# SIGFPE, which no test could survive in-process, and AMReX arms the traps once, when
-# it is initialized - a second simulation in the same process would run untrapped.
-_FPE_TRAP_PROGRAM = """
-import sys
-
-from mpi4py import MPI  # noqa: F401  (keep MPI alive for the whole program)
-
-import amrex.space3d as amr
-
-amr.initialize(
-    [
-        "amrex.verbose=0",
-        "tiny_profiler.enabled=0",
-        "amrex.signal_handling=1",
-        "amrex.handle_sigfpe=1",
-        "amrex.fpe_trap_invalid=1",
-        "amrex.fpe_trap_zero=1",
-    ]
-)
-
-from impactx import ImpactX, distribution
-
-CASES = {
-    #                     npart, bunch_charge_C, lambdaPt, reference particle
-    "no_reference_particle": (0, 1.0e-9, 2.0e-3, False),
-    "empty": (0, 1.0e-9, 2.0e-3, True),
-    "no_charge": (1000, 0.0, 2.0e-3, True),
-    "single_particle": (1, 1.0e-9, 2.0e-3, True),
-    "no_energy_spread": (1000, 1.0e-9, 0.0, True),
-}
-npart, bunch_charge_C, lambda_pt, reference_particle = CASES[sys.argv[1]]
-
-sim = ImpactX()
-sim.particle_shape = 2
-sim.space_charge = False
-sim.slice_step_diagnostics = False
-sim.init_grids()
-
-if reference_particle:
-    sim.beam.ref.set_species("electron").set_kin_energy_MeV(2.0e3)
-
-if npart > 0:
-    sim.add_particles(
-        bunch_charge_C,
-        distribution.Waterbag(
-            lambdaX=3.9984884770e-5,
-            lambdaY=3.9984884770e-5,
-            lambdaT=1.0e-3,
-            lambdaPx=2.6623538760e-5,
-            lambdaPy=2.6623538760e-5,
-            lambdaPt=lambda_pt,
-        ),
-        npart,
-    )
-
-sim.beam.beam_moments()
-
-print("no floating-point exception raised")
-"""
-
-
-@pytest.mark.manages_amrex
-@pytest.mark.parametrize(
-    "case",
-    [
-        "no_reference_particle",
-        "empty",
-        "no_charge",
-        "single_particle",
-        "no_energy_spread",
-    ],
-)
-def test_beam_moments_do_not_raise_fpe(tmp_path, case):
-    """
-    Computing the beam moments of a degenerate beam does not raise a floating-point
-    exception, i.e. it survives amrex.fpe_trap_invalid / amrex.fpe_trap_zero.
-    """
-    if sys.platform != "linux":
-        pytest.skip(
-            "AMReX arms the FP traps for the whole process: through feenableexcept on "
-            "Linux/glibc, and through the FPCR trap bits on Apple Silicon, where an "
-            "exception arrives as SIGILL"
-        )
-    if not Config.have_mpi:
-        pytest.skip("the stand-alone program pre-initializes MPI via mpi4py")
-
-    program = tmp_path / "fpe_trap_beam_moments.py"
-    program.write_text(_FPE_TRAP_PROGRAM)
-
-    result = subprocess.run(
-        [sys.executable, str(program), case],
-        cwd=tmp_path,
-        env={**os.environ, "OMP_NUM_THREADS": "1"},
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    assert "no floating-point exception raised" in result.stdout

--- a/tests/python/test_beam_moments_degenerate.py
+++ b/tests/python/test_beam_moments_degenerate.py
@@ -200,11 +200,14 @@ def test_envelope_beam_moments_without_energy_spread():
     sim.finalize()
 
 
-# A stand-alone run of the degenerate cases above, with AMReX trapping the
-# floating-point exceptions that they used to raise. It has to run in its own
-# process: a trap raises SIGFPE, which no test could survive in-process.
+# A stand-alone run of one degenerate case, with AMReX trapping the floating-point
+# exceptions that it used to raise. Each case runs in its own process: a trap raises
+# SIGFPE, which no test could survive in-process, and AMReX arms the traps once, when
+# it is initialized - a second simulation in the same process would run untrapped.
 _FPE_TRAP_PROGRAM = """
-from mpi4py import MPI  # noqa: F401  (keep MPI alive across ImpactX instances)
+import sys
+
+from mpi4py import MPI  # noqa: F401  (keep MPI alive for the whole program)
 
 import amrex.space3d as amr
 
@@ -221,44 +224,57 @@ amr.initialize(
 
 from impactx import ImpactX, distribution
 
+CASES = {
+    #                     npart, bunch_charge_C, lambdaPt, reference particle
+    "no_reference_particle": (0, 1.0e-9, 2.0e-3, False),
+    "empty": (0, 1.0e-9, 2.0e-3, True),
+    "no_charge": (1000, 0.0, 2.0e-3, True),
+    "single_particle": (1, 1.0e-9, 2.0e-3, True),
+    "no_energy_spread": (1000, 1.0e-9, 0.0, True),
+}
+npart, bunch_charge_C, lambda_pt, reference_particle = CASES[sys.argv[1]]
 
-def beam(lambda_pt):
-    return distribution.Waterbag(
-        lambdaX=3.9984884770e-5,
-        lambdaY=3.9984884770e-5,
-        lambdaT=1.0e-3,
-        lambdaPx=2.6623538760e-5,
-        lambdaPy=2.6623538760e-5,
-        lambdaPt=lambda_pt,
+sim = ImpactX()
+sim.particle_shape = 2
+sim.space_charge = False
+sim.slice_step_diagnostics = False
+sim.init_grids()
+
+if reference_particle:
+    sim.beam.ref.set_species("electron").set_kin_energy_MeV(2.0e3)
+
+if npart > 0:
+    sim.add_particles(
+        bunch_charge_C,
+        distribution.Waterbag(
+            lambdaX=3.9984884770e-5,
+            lambdaY=3.9984884770e-5,
+            lambdaT=1.0e-3,
+            lambdaPx=2.6623538760e-5,
+            lambdaPy=2.6623538760e-5,
+            lambdaPt=lambda_pt,
+        ),
+        npart,
     )
 
-
-def moments(npart, bunch_charge_C=1.0e-9, lambda_pt=2.0e-3, reference_particle=True):
-    sim = ImpactX()
-    sim.particle_shape = 2
-    sim.space_charge = False
-    sim.slice_step_diagnostics = False
-    sim.init_grids()
-    if reference_particle:
-        sim.beam.ref.set_species("electron").set_kin_energy_MeV(2.0e3)
-    if npart > 0:
-        sim.add_particles(bunch_charge_C, beam(lambda_pt), npart)
-    sim.beam.beam_moments()
-    sim.finalize()
-
-
-moments(npart=0, reference_particle=False)  # a beam a Source loads later
-moments(npart=0)  # an empty beam
-moments(npart=1000, bunch_charge_C=0.0)  # test particles, carrying no weight
-moments(npart=1)  # no emittance in any plane
-moments(npart=1000, lambda_pt=0.0)  # no longitudinal emittance
+sim.beam.beam_moments()
 
 print("no floating-point exception raised")
 """
 
 
 @pytest.mark.manages_amrex
-def test_beam_moments_do_not_raise_fpe(tmp_path):
+@pytest.mark.parametrize(
+    "case",
+    [
+        "no_reference_particle",
+        "empty",
+        "no_charge",
+        "single_particle",
+        "no_energy_spread",
+    ],
+)
+def test_beam_moments_do_not_raise_fpe(tmp_path, case):
     """
     Computing the beam moments of a degenerate beam does not raise a floating-point
     exception, i.e. it survives amrex.fpe_trap_invalid / amrex.fpe_trap_zero.
@@ -267,8 +283,7 @@ def test_beam_moments_do_not_raise_fpe(tmp_path):
         pytest.skip(
             "AMReX arms the FP traps for the whole process: through feenableexcept on "
             "Linux/glibc, and through the FPCR trap bits on Apple Silicon, where an "
-            "exception arrives as SIGILL and this program aborts in its first "
-            "simulation from a site that is not localized yet"
+            "exception arrives as SIGILL"
         )
     if not Config.have_mpi:
         pytest.skip("the stand-alone program pre-initializes MPI via mpi4py")
@@ -277,7 +292,7 @@ def test_beam_moments_do_not_raise_fpe(tmp_path):
     program.write_text(_FPE_TRAP_PROGRAM)
 
     result = subprocess.run(
-        [sys.executable, str(program)],
+        [sys.executable, str(program), case],
         cwd=tmp_path,
         env={**os.environ, "OMP_NUM_THREADS": "1"},
         capture_output=True,


### PR DESCRIPTION
The beam moments calculation can be triggered before the simulation.

For use cases where the beam is only initialized in the first element as a `Source`, the run on an empty beam should produce clean, non-failing output that shows the beam moments as undefined, similar to #1616.

<details>

Simulations that load their beam from a `source` element hold no particles when the initial diagnostics run, and the reference particle is only restored from that file later on. Both broke the step-0 diagnostics:

* every beam moment normalized by a total weight of zero, and
* `beta*gamma = sqrt(gamma^2 - 1)` was evaluated for a reference particle of `gamma = 0` — in `reduced_beam_characteristics` *and* in `write_ref`, which runs first, so `diags/ref_particle` crashed before the moments were ever reached.

Under `amrex.fpe_trap_invalid` the run aborted before it started; without the traps it wrote a mix of NaN, zero and reduction identity elements that reads like a measurement.

### What changed

`reduced_beam_characteristics` normalizes by one instead of by zero, which carries the (all-zero) sums through the derived quantities without an exception, and reports the results that carry no information as NaN. `write_ref` reports `beta`, `gamma` and `beta*gamma` of an uninitialized reference particle as NaN.

A beam of zero total weight is not necessarily empty: `bunch_charge=0` massless test particles are a supported workflow (`examples/multipole/run_sextupole_kick.py`, `tests/python/test_chracc_Ez0.py`). Their minima and maxima are unweighted and stay defined. Telling that case apart costs no extra communication — the shift-sampling all-reduce above already establishes, globally, whether any rank owns a particle.

The emptiness test is an equality on purpose: `==` is quiet on a NaN, so a beam poisoned by a non-finite particle coordinate is not absorbed here but keeps tripping the FPE traps where they are enabled.

For a beam that does have particles and weight, `w_norm == w_sum` and every value is bit-identical to before.

### Tests

Added to `tests/python/test_beam_moments_degenerate.py`: an empty beam, an empty beam without a reference particle, and a beam of zero charge. Plus `test_beam_moments_do_not_raise_fpe`, which runs all the degenerate cases in a subprocess under `amrex.fpe_trap_invalid`/`_zero` — `tests/python/conftest.py` sets `amrex.signal_handling=0`, so the traps are otherwise never active in the suite, and a trap kills the process outright (exit 8 via `MPI_Abort`), which no in-process test could survive.

Verified to fail on `development` before the fix.

</details>