### PR TITLE
Docs: Boost on Perlmutter (synmadx)

### DIFF
--- a/docs/source/install/hpc/perlmutter-nersc/install_cpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_cpu_dependencies.sh
@@ -51,6 +51,19 @@ curl -Lo ${build_dir}/ccache.tar.xz https://github.com/ccache/ccache/releases/do
 tar -xf ${build_dir}/ccache.tar.xz -C ${build_dir}
 mv ${build_dir}/ccache-4.10.2-linux-x86_64 ${SW_DIR}/ccache-4.10.2
 
+# Boost (header-only libraries, for the synmadx MAD-X lattice parser)
+#   unpacked in $HOME: the Boost sources are too large for the tmpfs build dir
+rm -rf $HOME/src/boost-temp
+mkdir -p $HOME/src/boost-temp
+curl -Lo $HOME/src/boost-temp/boost.tar.gz https://archives.boost.io/release/1.82.0/source/boost_1_82_0.tar.gz
+tar -xzf $HOME/src/boost-temp/boost.tar.gz -C $HOME/src/boost-temp
+(
+  cd $HOME/src/boost-temp/boost_1_82_0
+  ./bootstrap.sh --with-libraries=headers --prefix=${SW_DIR}/boost-1.82.0
+  ./b2 install -j 16
+)
+rm -rf $HOME/src/boost-temp
+
 # c-blosc (I/O compression)
 if [ -d $HOME/src/c-blosc ]
 then

--- a/docs/source/install/hpc/perlmutter-nersc/install_cpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_cpu_dependencies.sh
@@ -43,6 +43,9 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 # General extra dependencies ##################################################
 #
 
+# build parallelism
+PARALLEL=16
+
 # tmpfs build directory: avoids issues often seen with $HOME and is faster
 build_dir=$(mktemp -d)
 
@@ -52,17 +55,15 @@ tar -xf ${build_dir}/ccache.tar.xz -C ${build_dir}
 mv ${build_dir}/ccache-4.10.2-linux-x86_64 ${SW_DIR}/ccache-4.10.2
 
 # Boost (header-only libraries, for the synmadx MAD-X lattice parser)
-#   unpacked in $HOME: the Boost sources are too large for the tmpfs build dir
-rm -rf $HOME/src/boost-temp
-mkdir -p $HOME/src/boost-temp
-curl -Lo $HOME/src/boost-temp/boost.tar.gz https://archives.boost.io/release/1.82.0/source/boost_1_82_0.tar.gz
-tar -xzf $HOME/src/boost-temp/boost.tar.gz -C $HOME/src/boost-temp
+curl -Lo ${build_dir}/boost.tar.gz https://archives.boost.io/release/1.82.0/source/boost_1_82_0.tar.gz
+tar -xzf ${build_dir}/boost.tar.gz -C ${build_dir}
+rm -rf ${build_dir}/boost.tar.gz
 (
-  cd $HOME/src/boost-temp/boost_1_82_0
+  cd ${build_dir}/boost_1_82_0
   ./bootstrap.sh --with-libraries=headers --prefix=${SW_DIR}/boost-1.82.0
-  ./b2 install -j 16
+  ./b2 cxxflags="-std=c++20" install -j ${PARALLEL}
 )
-rm -rf $HOME/src/boost-temp
+rm -rf ${build_dir}/boost_1_82_0
 
 # c-blosc (I/O compression)
 if [ -d $HOME/src/c-blosc ]
@@ -75,7 +76,7 @@ else
   git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git $HOME/src/c-blosc
 fi
 cmake -S $HOME/src/c-blosc -B ${build_dir}/c-blosc-pm-cpu-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
-cmake --build ${build_dir}/c-blosc-pm-cpu-build --target install --parallel 16
+cmake --build ${build_dir}/c-blosc-pm-cpu-build --target install --parallel ${PARALLEL}
 rm -rf ${build_dir}/c-blosc-pm-cpu-build
 
 # ADIOS2
@@ -89,7 +90,7 @@ else
   git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
 fi
 cmake -S $HOME/src/adios2 -B ${build_dir}/adios2-pm-cpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_CUDA=OFF -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.10.2
-cmake --build ${build_dir}/adios2-pm-cpu-build --target install -j 16
+cmake --build ${build_dir}/adios2-pm-cpu-build --target install -j ${PARALLEL}
 rm -rf ${build_dir}/adios2-pm-cpu-build
 
 

--- a/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
@@ -51,6 +51,19 @@ curl -Lo ${build_dir}/ccache.tar.xz https://github.com/ccache/ccache/releases/do
 tar -xf ${build_dir}/ccache.tar.xz -C ${build_dir}
 mv ${build_dir}/ccache-4.10.2-linux-x86_64 ${SW_DIR}/ccache-4.10.2
 
+# Boost (header-only libraries, for the synmadx MAD-X lattice parser)
+#   unpacked in $HOME: the Boost sources are too large for the tmpfs build dir
+rm -rf $HOME/src/boost-temp
+mkdir -p $HOME/src/boost-temp
+curl -Lo $HOME/src/boost-temp/boost.tar.gz https://archives.boost.io/release/1.82.0/source/boost_1_82_0.tar.gz
+tar -xzf $HOME/src/boost-temp/boost.tar.gz -C $HOME/src/boost-temp
+(
+  cd $HOME/src/boost-temp/boost_1_82_0
+  ./bootstrap.sh --with-libraries=headers --prefix=${SW_DIR}/boost-1.82.0
+  ./b2 install -j 16
+)
+rm -rf $HOME/src/boost-temp
+
 # c-blosc (I/O compression)
 if [ -d $HOME/src/c-blosc ]
 then

--- a/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
@@ -43,6 +43,9 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 # General extra dependencies ##################################################
 #
 
+# build parallelism
+PARALLEL=16
+
 # tmpfs build directory: avoids issues often seen with $HOME and is faster
 build_dir=$(mktemp -d)
 
@@ -52,17 +55,15 @@ tar -xf ${build_dir}/ccache.tar.xz -C ${build_dir}
 mv ${build_dir}/ccache-4.10.2-linux-x86_64 ${SW_DIR}/ccache-4.10.2
 
 # Boost (header-only libraries, for the synmadx MAD-X lattice parser)
-#   unpacked in $HOME: the Boost sources are too large for the tmpfs build dir
-rm -rf $HOME/src/boost-temp
-mkdir -p $HOME/src/boost-temp
-curl -Lo $HOME/src/boost-temp/boost.tar.gz https://archives.boost.io/release/1.82.0/source/boost_1_82_0.tar.gz
-tar -xzf $HOME/src/boost-temp/boost.tar.gz -C $HOME/src/boost-temp
+curl -Lo ${build_dir}/boost.tar.gz https://archives.boost.io/release/1.82.0/source/boost_1_82_0.tar.gz
+tar -xzf ${build_dir}/boost.tar.gz -C ${build_dir}
+rm -rf ${build_dir}/boost.tar.gz
 (
-  cd $HOME/src/boost-temp/boost_1_82_0
+  cd ${build_dir}/boost_1_82_0
   ./bootstrap.sh --with-libraries=headers --prefix=${SW_DIR}/boost-1.82.0
-  ./b2 install -j 16
+  ./b2 cxxflags="-std=c++20" install -j ${PARALLEL}
 )
-rm -rf $HOME/src/boost-temp
+rm -rf ${build_dir}/boost_1_82_0
 
 # c-blosc (I/O compression)
 if [ -d $HOME/src/c-blosc ]
@@ -75,7 +76,7 @@ else
   git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git $HOME/src/c-blosc
 fi
 cmake -S $HOME/src/c-blosc -B ${build_dir}/c-blosc-pm-gpu-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
-cmake --build ${build_dir}/c-blosc-pm-gpu-build --target install --parallel 16
+cmake --build ${build_dir}/c-blosc-pm-gpu-build --target install --parallel ${PARALLEL}
 rm -rf ${build_dir}/c-blosc-pm-gpu-build
 
 # ADIOS2
@@ -89,7 +90,7 @@ else
   git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git $HOME/src/adios2
 fi
 cmake -S $HOME/src/adios2 -B ${build_dir}/adios2-pm-gpu-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.10.2
-cmake --build ${build_dir}/adios2-pm-gpu-build --target install -j 16
+cmake --build ${build_dir}/adios2-pm-gpu-build --target install -j ${PARALLEL}
 rm -rf ${build_dir}/adios2-pm-gpu-build
 
 

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_cpu_impactx.profile.example
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_cpu_impactx.profile.example
@@ -10,6 +10,10 @@ module load cpu
 module load cmake/3.30.2
 module load cray-fftw/3.3.10.6
 
+# optional: for the synmadx MAD-X lattice parser
+#   header-only Boost, thus no LD_LIBRARY_PATH entry needed
+export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/boost-1.82.0:$CMAKE_PREFIX_PATH
+
 # optional: for openPMD support
 module load cray-hdf5-parallel/1.12.2.9
 export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/cpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
@@ -11,6 +11,10 @@ if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in yo
 module load gcc-native/13.2  # default gcc-native/14 breaks pybind11 builds with NVCC 12.9.41
 module load cmake/3.30.2
 
+# optional: for the synmadx MAD-X lattice parser
+#   header-only Boost, thus no LD_LIBRARY_PATH entry needed
+export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/gpu/boost-1.82.0:$CMAKE_PREFIX_PATH
+
 # optional: for openPMD support
 module load cray-hdf5-parallel/1.12.2.9
 export CMAKE_PREFIX_PATH=${CFS}/${proj}/${USER}/sw/perlmutter/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH

--- a/docs/source/install/hpc/perlmutter.rst
+++ b/docs/source/install/hpc/perlmutter.rst
@@ -165,7 +165,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile the applicat
          cd $HOME/src/impactx
          rm -rf build_pm_gpu_py
 
-         cmake -S . -B build_pm_gpu_py -DImpactX_COMPUTE=CUDA -DImpactX_APP=OFF -DImpactX_FFT=ON -DImpactX_PYTHON=ON
+         cmake -S . -B build_pm_gpu_py -DImpactX_COMPUTE=CUDA -DImpactX_APP=OFF -DImpactX_FFT=ON -DImpactX_PYTHON=ON -DImpactX_SYNMADX=ON
          cmake --build build_pm_gpu_py -j 16 --target pip_install
 
    .. tab-item:: CPU Nodes
@@ -185,7 +185,7 @@ Use the following :ref:`cmake commands <building-cmake>` to compile the applicat
 
          rm -rf build_pm_cpu_py
 
-         cmake -S . -B build_pm_cpu_py -DImpactX_COMPUTE=OMP -DImpactX_APP=OFF -DImpactX_FFT=ON -DImpactX_PYTHON=ON
+         cmake -S . -B build_pm_cpu_py -DImpactX_COMPUTE=OMP -DImpactX_APP=OFF -DImpactX_FFT=ON -DImpactX_PYTHON=ON -DImpactX_SYNMADX=ON
          cmake --build build_pm_cpu_py -j 16 --target pip_install
 
 Now, you can :ref:`submit Perlmutter compute jobs <running-cpp-perlmutter>` for ImpactX :ref:`Python scripts <usage-python>` (:ref:`example scripts <usage-examples>`).


### PR DESCRIPTION
Now that we optionally support `synmadx`, which needs (header-only) Boost, add Boost to the Perlmutter (NERSC) dependency install scripts and profiles, following what WarpX does on the same machine.

<details>

### Changes

- `install_cpu_dependencies.sh` / `install_gpu_dependencies.sh`: install Boost 1.82.0 into `${SW_DIR}/boost-1.82.0` (same version as WarpX installs on Perlmutter)
- `perlmutter_cpu_impactx.profile.example` / `perlmutter_gpu_impactx.profile.example`: export the Boost prefix via `CMAKE_PREFIX_PATH`
- `perlmutter.rst`: add `-DImpactX_SYNMADX=ON` to the documented Python builds, which is where the parser is exposed as `impactx.synmadx`

### Notes on the two deviations from WarpX

WarpX needs compiled Boost.Math for the PICSAR QED tables; ImpactX only needs the header-only libraries (Spirit, Phoenix, Fusion, Optional, Math constants, Algorithm/String), which `find_package(Boost 1.70.0 CONFIG REQUIRED)` + `Boost::headers` consume. So:

1. We install with `--with-libraries=headers` instead of `--with-libraries=math`. This is Boost's [`libs/headers`](https://github.com/boostorg/headers) pseudo-library, whose `install` target installs the headers *and* `BoostConfig.cmake`.
2. The profiles export only `CMAKE_PREFIX_PATH`, no `LD_LIBRARY_PATH` — there is no runtime library to find.

As in WarpX, the Boost sources are unpacked in `$HOME` rather than in the tmpfs build directory, since the unpacked tree is too large for `/tmp`.

### Verification

The install recipe was run end-to-end locally (not on Perlmutter):

- `./bootstrap.sh --with-libraries=headers --prefix=… && ./b2 install` produces `include/boost/` plus `lib/cmake/Boost-1.82.0/BoostConfig.cmake` and `lib/cmake/boost_headers-1.82.0/`, and no compiled libraries
- with only that prefix on `CMAKE_PREFIX_PATH`, `find_package(Boost 1.70.0 CONFIG REQUIRED)` resolves it (`Boost_VERSION = 1.82.0`)
- a translation unit with the exact header set of `src/synmadx/synergia/lattice/mx_parse.cc`, including a live Spirit Qi grammar, compiles and links against `Boost::headers` at C++20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>