### PR TITLE
Python: Fix Rebuild of Zero-Length Thick Elements

### DIFF
--- a/src/python/impactx/extensions/KnownElementsList.py
+++ b/src/python/impactx/extensions/KnownElementsList.py
@@ -767,12 +767,43 @@ def has_kind(self, kind_pattern) -> bool:
 
 import math
 
+# Memo for _ctor_accepts_ds(), keyed by element class. Element classes whose
+# constructor signature could not be read are not cached.
+_CTOR_ACCEPTS_DS: dict = {}
+
+
+def _ctor_accepts_ds(element_class):
+    """Whether ``element_class.__init__`` takes a ``ds`` argument.
+
+    ``inspect.signature`` does not work on pybind11 methods, so read the argument list
+    off the signature line that pybind11 writes into ``__init__.__doc__``.
+
+    Args:
+        element_class: An element class from :mod:`impactx.elements`
+
+    Returns:
+        bool: True if the constructor takes ``ds``, False if it does not, or None if
+        the signature is unavailable (a build compiled without docstrings).
+    """
+    if element_class in _CTOR_ACCEPTS_DS:
+        return _CTOR_ACCEPTS_DS[element_class]
+
+    doc = element_class.__init__.__doc__ or ""
+    if "__init__(" not in doc:
+        return None
+
+    accepts = bool(re.search(r"[(,]\s*ds:", doc))
+    _CTOR_ACCEPTS_DS[element_class] = accepts
+    return accepts
+
 
 def _filter_kwargs(d: dict) -> dict:
     """Filter a to_dict() result into valid constructor kwargs.
 
-    Removes 'type' (not a constructor argument) and 'ds' when zero
-    (thin elements don't accept ds).
+    Removes 'type' (not a constructor argument) and 'ds' for element types whose
+    constructor does not take it: ``to_dict()`` reports ``ds`` for every element, but
+    thin elements such as ``Marker`` and ``Aperture`` accept no ``ds``, while thick
+    elements require it even when it is zero.
 
     Args:
         d: Dictionary from element.to_dict()
@@ -780,7 +811,16 @@ def _filter_kwargs(d: dict) -> dict:
     Returns:
         dict: Filtered dictionary suitable for element constructor
     """
-    return {k: v for k, v in d.items() if k != "type" and (k != "ds" or v != 0.0)}
+    kwargs = {k: v for k, v in d.items() if k != "type"}
+    if "ds" in kwargs:
+        element_class = getattr(elements, d["type"], None) if "type" in d else None
+        accepts_ds = None if element_class is None else _ctor_accepts_ds(element_class)
+        if accepts_ds is None:
+            # Unknown signature: a zero ``ds`` is the thin-element case in practice.
+            accepts_ds = kwargs["ds"] != 0.0
+        if not accepts_ds:
+            del kwargs["ds"]
+    return kwargs
 
 
 def _rad2deg(radians: float) -> float:

--- a/tests/python/test_element_serialization.py
+++ b/tests/python/test_element_serialization.py
@@ -759,6 +759,67 @@ def test_clone_element_covers_all_element_types(all_elements):
     assert not failures, "elements that cannot be cloned:\n  " + "\n  ".join(failures)
 
 
+def test_clone_zero_length_thick_element(all_elements):
+    """Thick elements with ``ds=0.0`` must survive the clone as well.
+
+    ``to_dict()`` reports ``ds`` for thin and thick elements alike, so its value alone
+    cannot tell whether the constructor accepts it. Dropping ``ds`` whenever it was
+    zero left every zero-length thick element unconstructible, which broke
+    ``delete()``, ``replace_each()`` and ``replace_with_drifts()`` on such a lattice.
+    """
+    from impactx.extensions.KnownElementsList import _clone_element
+
+    lattice, _ = all_elements
+
+    tested = []
+    failures = []
+    for element in lattice:
+        type_name = type(element).__name__
+        if type_name in SKIP_ELEMENTS:
+            continue
+        constructor_params = get_constructor_params(type(element))
+        if constructor_params is None or "ds" not in constructor_params:
+            continue
+
+        element.ds = 0.0
+        tested.append(type_name)
+        try:
+            clone = _clone_element(element)
+        except Exception as e:  # noqa: BLE001 - report every offender at once
+            failures.append(f"{type_name}: {type(e).__name__}: {e}")
+            continue
+        assert type(clone) is type(element), type_name
+        assert clone.ds == 0.0, type_name
+
+    assert tested, "no thick element in the fixture"
+    assert not failures, (
+        "zero-length elements that cannot be cloned:\n  " + "\n  ".join(failures)
+    )
+
+
+def test_lattice_rebuild_with_zero_length_thick_elements():
+    """A lattice rebuild keeps zero-length thick elements intact."""
+    lattice = elements.KnownElementsList(
+        [
+            elements.Marker(name="m1"),
+            elements.Drift(ds=0.0, name="d0"),
+            elements.Quad(ds=0.0, k=1.0, name="q0"),
+            elements.Drift(ds=1.0, name="d1"),
+        ]
+    )
+
+    lattice.select(kind="Marker").delete()
+
+    assert [type(e).__name__ for e in lattice] == ["Drift", "Quad", "Drift"]
+    assert [e.name for e in lattice] == ["d0", "q0", "d1"]
+    assert [e.ds for e in lattice] == [0.0, 0.0, 1.0]
+
+    # the generated source has to keep ``ds`` as well to stay executable
+    namespace = {}
+    exec(lattice.to_py(), namespace)
+    assert [e.ds for e in namespace["get_lattice"]()] == [0.0, 0.0, 1.0]
+
+
 def test_lattice_rebuild_covers_all_element_types(all_elements):
     """The same coverage through the public API that depends on cloning."""
     lattice, _ = all_elements


### PR DESCRIPTION
## Bug

`to_dict()` reports `ds` for every element, but the constructors are not symmetric: thin elements such as `Marker` and `Aperture` take no `ds`, while thick elements require it even when it is zero. `_filter_kwargs()` decided this from the *value* and dropped `ds` whenever it was `0.0`, so a thick element of zero length could not be reconstructed:

```python
from impactx import elements

lattice = elements.KnownElementsList(
    [
        elements.Marker(name="m1"),
        elements.Drift(ds=0.0, name="d0"),
    ]
)
lattice.select(kind="Marker").delete()
# TypeError: __init__(): incompatible constructor arguments.
#   1. elements.Drift(ds: ..., dx: ... = 0.0, ...)
# Invoked with: kwargs: aperture_x=0.0, ..., name='d0', nslice=1, rotation=0.0
```

Every lattice rebuild clones the elements it keeps, so this hit `delete()`, `replace_each()`, `replace_with_drifts()` and `from_dicts()` for any lattice holding such an element. `to_py()` shares the same helper and emitted source that raises when executed.

## Fix

Decide it from the constructor instead of from the value. `_ctor_accepts_ds()` reads the argument list off the signature line pybind11 writes into `__init__.__doc__` — `inspect.signature` does not work on pybind11 methods — and memoizes the answer per element class. Builds compiled without docstrings fall back to the previous heuristic.

Checked against all 38 element classes that expose `to_dict()`: the docstring-derived answer agrees with the constructor parameter set in every case.

## Tests

Two additions to `tests/python/test_element_serialization.py`, both failing before the fix and passing after:

- `test_clone_zero_length_thick_element` — sets `ds = 0.0` on every thick element of the `all_elements` fixture and clones it (23 element types).
- `test_lattice_rebuild_with_zero_length_thick_elements` — the reproducer above through the public API, plus the `to_py()` round-trip.

The rest of `tests/python` is unchanged: same failures before and after (pre-existing, path-related), with only these two flipping to green.