### PR TITLE
[WIP] Space Charge: bound the dynamically resized mesh

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -2477,6 +2477,74 @@ See there ``nslice`` option on lattice elements for slicing.
     For instance, ``1.2`` means the mesh will span 10% above and 10% below the beam;
     ``1.0`` means the beam is exactly covered with the mesh.
 
+.. pp:param:: geometry.prob_relative_max
+    :type: ``float``
+    :unit: dimensionless
+    :optional:
+    :default: 10% above ``prob_relative[0]`` for :pp:param:`algo.poisson_solver` ``fft``, ``prob_relative[0]`` otherwise
+
+    The largest the field mesh may be, as a multiple of the maximum physical extent of
+    beam particles, while :pp:param:`geometry.prob_relative` is the smallest.
+    Setting it equal to ``prob_relative[0]`` fits the beam exactly, which is the behavior
+    when this is not used.
+
+    Leaving room between the two matters for the FFT solver. Fitting the mesh exactly
+    means it changes with every fluctuation of the beam extent, and the solver then has
+    to rebuild its Green's function on every slice step. Given a band, the mesh is
+    instead chosen from a fixed set of lengths, so a beam of nearly the same size lands
+    on exactly the same mesh and the solver reuses the Green's function it already has.
+    On a constant-focusing channel this takes the number of Green's functions built from
+    one per slice step to a handful.
+
+    The allowed lengths are
+
+    .. math::
+
+        L_k = 2^{k/m}\ \mathrm{m}, \qquad
+        m = \left\lceil \frac{1}{\log_2 r} \right\rceil, \qquad
+        r = \frac{\texttt{prob\_relative\_max}}{\texttt{prob\_relative[0]}}
+
+    where :math:`L_k` is the mesh edge length along one axis, :math:`k` is a whole number
+    chosen so that :math:`L_k` is the smallest such length still covering the padded
+    beam, :math:`m` is how many allowed lengths there are per factor of two in size, and
+    :math:`r` is the width of the band. Rounding :math:`m` up guarantees the mesh never
+    exceeds ``prob_relative_max``. The default band of 10% gives :math:`m = 8`, so the
+    mesh is at most 9.1% above ``prob_relative[0]``.
+
+    A wider band reuses the Green's function more often, at the price of a mesh that can
+    be coarser than requested. There is no generally right value, so consider a
+    convergence test if in doubt. The longitudinal direction is treated in the frame the
+    solver works in, so a changing reference energy resizes the mesh on its own.
+
+    The solver offers a second, weaker way to reuse a Green's function,
+    :pp:param:`ablastr.igf_cache_tolerance`, which lets one serve a grid slightly
+    different from the one it was built for. The two are not interchangeable, and this
+    parameter is the one to reach for first:
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 22 39 39
+
+        * -
+          - ``geometry.prob_relative_max``
+          - ``ablastr.igf_cache_tolerance``
+        * - changes
+          - which mesh is solved on
+          - nothing about the mesh
+        * - Green's function
+          - matches its mesh exactly
+          - built for a slightly different mesh
+        * - price
+          - resolution, up to one allowed length of extra padding
+          - an error of the order of the tolerance
+        * - reuse is
+          - bit-identical
+          - not bit-identical
+
+    ImpactX chooses its own mesh, so it can make one come back exactly and never needs
+    the tolerance. That option is open only to a caller that owns the mesh; where the
+    quantity that varies is measured rather than chosen, the tolerance is the only way.
+
 .. pp:param:: geometry.prob_lo/hi
     :link_aliases: geometry.prob_lo geometry.prob_hi
     :type: ``3 floats``
@@ -2523,6 +2591,77 @@ See there ``nslice`` option on lattice elements for slicing.
       Field boundaries for MLMG space charge calculation are located at the outer ends of the field mesh.
       For the MLMG solver, we assume `Dirichlet boundary conditions <https://en.wikipedia.org/wiki/Dirichlet_boundary_condition>`__ with zero potential (a mirror charge).
       Thus, to emulate open boundaries, consider adding enough vacuum padding to the beam.
+
+.. pp:param:: ablastr.igf_cache_max_entries
+    :type: ``integer``
+    :optional:
+    :default: ``8``
+
+    Number of Green's functions the ``fft`` solver keeps for reuse, evicting the least
+    recently used one beyond that.
+
+    The Green's function depends only on the mesh, so it can be reused whenever the mesh
+    returns to a size it has had before, which is what the padding band set by
+    :pp:param:`geometry.prob_relative_max` arranges. Keeping several is what lets a beam
+    that breathes, as in a periodic lattice, cycle through its sizes without rebuilding.
+
+    ``0`` keeps only the Green's function currently in use, which is still reused for as
+    long as the mesh does not change. Each entry costs :math:`32 n^3` bytes in single and
+    :math:`64 n^3` in double precision, which is a sizable fraction of a GPU at large
+    mesh sizes, so consider lowering this or setting
+    :pp:param:`ablastr.igf_cache_max_bytes` there.
+
+.. pp:param:: ablastr.igf_cache_max_bytes
+    :type: ``integer``
+    :unit: bytes
+    :optional:
+    :default: a quarter of the free GPU memory; unlimited on CPU
+
+    Memory budget for the Green's functions kept by the ``fft`` solver.
+    Entries are evicted, least recently used first, to stay within it.
+    ``0`` means no limit, in which case only :pp:param:`ablastr.igf_cache_max_entries`
+    bounds the cache.
+
+.. pp:param:: ablastr.igf_cache_tolerance
+    :type: ``float``
+    :unit: dimensionless
+    :optional:
+    :default: 64 times the machine epsilon of the precision in use
+
+    How closely two cell sizes must agree for one Green's function to serve both.
+    The default only absorbs round-off, so it never trades accuracy for reuse.
+
+    ImpactX does not need to raise this. Because
+    :pp:param:`geometry.prob_relative_max` makes the mesh come back exactly, a reused
+    Green's function is still the right one for the mesh it is used on. Raising this
+    instead reuses one across meshes that merely nearly agree, which costs an error of
+    the order of the tolerance, so raise it only deliberately.
+
+    It exists for callers that cannot choose their mesh, where the quantity that varies
+    is measured rather than chosen. The relativistic electrostatic solver in WarpX is
+    the example: it derives the longitudinal stretch from a velocity, and recovering it
+    costs about :math:`\epsilon\gamma^2`.
+
+.. pp:param:: ablastr.igf_rebuild_always
+    :type: ``integer``
+    :optional:
+    :default: ``0``
+
+    Set to ``1`` to rebuild the Green's function on every solve, as the ``fft`` solver
+    did before it reused them.
+    This is the reference to compare against when checking that reuse leaves results
+    unchanged, and is not otherwise useful.
+
+.. pp:param:: ablastr.igf_cache_verbose
+    :type: ``integer``
+    :optional:
+    :default: ``0``
+
+    Set to ``1`` to report, at the end of the run, how many Green's functions the ``fft``
+    solver reused, built and evicted.
+    A cache that is too small for a periodic lattice keeps evicting the entry it is about
+    to need again, which costs time without ever showing up as a wrong answer, so this is
+    worth checking when tuning :pp:param:`ablastr.igf_cache_max_entries`.
 
 Multigrid-specific numerical options:
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -87,6 +87,38 @@ Collective Effects & Overall Simulation Parameters
 
       Use dynamic (``True``) resizing of the field mesh or static sizing (``False``).
 
+   .. py:property:: prob_relative_max
+
+      The largest the field mesh may be, as a multiple of the maximum physical extent of
+      beam particles, while ``prob_relative`` is the smallest.
+      Setting it equal to ``prob_relative[0]`` fits the beam exactly.
+
+      Leaving room between the two lets the mesh be chosen from a fixed set of sizes, so
+      that a beam of nearly the same size lands on exactly the same mesh and the FFT
+      space-charge solver reuses the Green's function it already has instead of
+      rebuilding it on every slice step.
+
+      Because the mesh comes back exactly, the reused Green's function is still the right
+      one for it and the result is bit-identical to rebuilding. The price is paid in
+      resolution, up to one allowed length of extra padding, rather than in accuracy.
+      The solver also accepts ``ablastr.igf_cache_tolerance``, which reuses a Green's
+      function across meshes that merely nearly agree, at the price of an error of that
+      order. ImpactX does not need it, since it chooses its own mesh.
+
+      Default: 10% above ``prob_relative[0]`` for ``poisson_solver = "fft"``, and
+      ``prob_relative[0]`` otherwise.
+
+   .. py:property:: igf_cache_max_entries
+
+      Number of Green's functions the FFT space-charge solver keeps for reuse, evicting
+      the least recently used one beyond that. ``0`` keeps only the one in use, which is
+      still reused for as long as the mesh does not change.
+
+      Each entry costs ``32 * n**3`` bytes in single and ``64 * n**3`` in double
+      precision, so consider lowering this on a GPU with a large mesh.
+
+      Default: ``8``.
+
    .. py:property:: space_charge
 
       The physical model of space charge used.

--- a/src/initialization/InitMeshRefinement.H
+++ b/src/initialization/InitMeshRefinement.H
@@ -19,6 +19,7 @@
 #include <AMReX_REAL.H>
 #include <AMReX_Utility.H>
 
+#include <cmath>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -27,7 +28,7 @@
 
 namespace impactx::initialization
 {
-    amrex::Vector<amrex::Real>
+    inline amrex::Vector<amrex::Real>
     read_mr_prob_relative ()
     {
         amrex::ParmParse pp_algo("algo");
@@ -79,5 +80,87 @@ namespace impactx::initialization
         }
 
         return prob_relative;
+    }
+
+    /** Settings that restrict the dynamically resized mesh to a discrete set of sizes.
+     *
+     * Fitting the box to the beam exactly means it moves with every fluctuation of the
+     * particle extent, and the space-charge solver then has to rebuild its Green's
+     * function each time. Allowing the box to be a little larger than requested, and
+     * choosing it from a fixed set of lengths, makes a beam of nearly the same size land
+     * on exactly the same mesh, which is what lets the Green's function be reused.
+     */
+    struct GridQuantization
+    {
+        bool enabled = false;              //!< restrict the box to the fit lengths
+        int fit_lengths_per_doubling = 8;  //!< how many fit lengths per factor of two
+    };
+
+    /** Read the padding band, geometry.prob_relative and geometry.prob_relative_max */
+    inline GridQuantization
+    read_grid_quantization ()
+    {
+        amrex::ParmParse pp_algo("algo");
+        amrex::ParmParse pp_geometry("geometry");
+
+        std::string poisson_solver = "fft";
+        pp_algo.queryAdd("poisson_solver", poisson_solver);
+
+        amrex::Real const prob_relative_min = read_mr_prob_relative()[0];
+
+        // By default allow a 10% band for the FFT solver, which reuses its Green's
+        // function when the mesh holds still. The multigrid solver gains nothing from a
+        // steady mesh, so there the box keeps fitting the beam exactly.
+        amrex::Real prob_relative_max = (poisson_solver == "fft")
+            ? prob_relative_min * amrex::Real(1.1) : prob_relative_min;
+        pp_geometry.queryAddWithParser("prob_relative_max", prob_relative_max);
+
+        if (prob_relative_max < prob_relative_min) {
+            throw std::runtime_error(
+                "geometry.prob_relative_max must be >= geometry.prob_relative[0]");
+        }
+
+        GridQuantization quant;
+
+        amrex::Real const band = prob_relative_max / prob_relative_min;
+        if (!(band > amrex::Real(1.))) {
+            return quant;  // no band: fit the beam exactly, as if this were never set
+        }
+
+        // Pick the finest set of lengths whose spacing still fits inside the band, so
+        // that rounding up can never exceed prob_relative_max. Keeping this a whole
+        // number of lengths per doubling is what makes two boxes a factor of two apart
+        // differ by exactly two, which the solver relies on to reuse a Green's function
+        // built at another scale.
+        quant.enabled = true;
+        quant.fit_lengths_per_doubling =
+            static_cast<int>(std::ceil(amrex::Real(1.) / std::log2(band)));
+
+        return quant;
+    }
+
+    /** Smallest length not below @p extent that the mesh is allowed to take.
+     *
+     * The allowed lengths are 2^(k/m) meters for whole numbers k, with m fit lengths per
+     * doubling. Anchoring them at 1 m, rather than at the first box seen, keeps them
+     * reproducible across runs and across turns of a ring, so a beam that returns to a
+     * size it had before lands on the very same mesh.
+     *
+     * @param[in] extent the length to round up, in meters
+     * @param[in] fit_lengths_per_doubling number of allowed lengths m per factor of two
+     * @return the smallest allowed length that is not below @p extent
+     */
+    inline amrex::Real
+    smallest_fit_length (amrex::Real extent, int fit_lengths_per_doubling)
+    {
+        if (!(extent > amrex::Real(0.)) || !std::isfinite(extent)) { return extent; }
+
+        auto const m = static_cast<amrex::Real>(fit_lengths_per_doubling);
+        amrex::Real const k = std::ceil(std::log2(extent) * m);
+        amrex::Real const length = std::exp2(k / m);
+
+        // Guard against the rounding of log2/exp2 landing a hair below the request,
+        // which would clip the beam.
+        return (length < extent) ? std::exp2((k + amrex::Real(1.)) / m) : length;
     }
 } // namespace impactx::initialization

--- a/src/initialization/InitMeshRefinement.cpp
+++ b/src/initialization/InitMeshRefinement.cpp
@@ -10,6 +10,7 @@
 #include "ImpactX.H"
 #include "initialization/Algorithms.H"
 #include "initialization/InitAmrCore.H"
+#include "initialization/InitMeshRefinement.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/distribution/Waterbag.H"
 
@@ -17,9 +18,11 @@
 
 #include <AMReX.H>
 #include <AMReX_BLProfiler.H>
+#include <AMReX_Math.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Utility.H>
 
+#include <cmath>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -28,55 +31,6 @@
 
 namespace impactx
 {
-namespace detail
-{
-    amrex::Vector<amrex::Real>
-    read_mr_prob_relative ()
-    {
-        amrex::ParmParse pp_algo("algo");
-        amrex::ParmParse pp_amr("amr");
-        amrex::ParmParse pp_geometry("geometry");
-
-        int max_level = 0;
-        pp_amr.queryWithParser("max_level", max_level);
-
-        std::string poisson_solver = "fft";
-        pp_algo.queryAdd("poisson_solver", poisson_solver);
-
-        // The box is expanded beyond the min and max of the particle beam.
-        amrex::Vector<amrex::Real> prob_relative(max_level + 1, 1.0);
-        prob_relative[0] = 3.0;  // top/bottom pad the beam on the lowest level by default by its width
-        pp_geometry.queryarr("prob_relative", prob_relative);
-
-        if (prob_relative[0] < 3.0 && poisson_solver == "multigrid")
-            ablastr::warn_manager::WMRecordWarning(
-                    "ImpactX::read_mr_prob_relative",
-                    "Dynamic resizing of the mesh uses a geometry.prob_relative "
-                    "padding of less than 3 for level 0. This might result in boundary "
-                    "artifacts for space charge calculation. "
-                    "There is no minimum good value for this parameter, consider "
-                    "doing a convergence test.",
-                    ablastr::warn_manager::WarnPriority::high
-            );
-
-        if (prob_relative[0] < 1.0)
-            throw std::runtime_error("geometry.prob_relative must be >= 1.0 (the beam size) on the coarsest level");
-
-        // check that prob_relative[0] > prob_relative[1] > prob_relative[2] ...
-        amrex::Real last_lev_rel = std::numeric_limits<amrex::Real>::max();
-        for (int lev = 0; lev <= max_level; ++lev) {
-            amrex::Real const prob_relative_lvl = prob_relative[lev];
-            if (prob_relative_lvl <= 0.0)
-                throw std::runtime_error("geometry.prob_relative must be strictly positive for all levels");
-            if (prob_relative_lvl > last_lev_rel)
-                throw std::runtime_error("geometry.prob_relative must be descending over refinement levels");
-
-            last_lev_rel = prob_relative_lvl;
-        }
-
-        return prob_relative;
-    }
-}
 
     void ImpactX::ResizeMesh ()
     {
@@ -112,22 +66,69 @@ namespace detail
         if (dynamic_size)
         {
             // The coarsest level is expanded (or reduced) relative the min and max of particles.
-            auto const prob_relative = detail::read_mr_prob_relative();
+            auto const prob_relative = initialization::read_mr_prob_relative();
 
             amrex::Real const frac = prob_relative[0];
             amrex::RealVect const beam_min(x_min, y_min, z_min);
             amrex::RealVect const beam_max(x_max, y_max, z_max);
             amrex::RealVect const beam_width(beam_max - beam_min);
+            amrex::RealVect const beam_center = (beam_min + beam_max) * 0.5_rt;
 
-            amrex::RealVect const beam_padding = beam_width * (frac - 1_rt) * 0.5_rt;
-            //                           added to the beam extent --^         ^-- box half above/below the beam
+            auto const quant = initialization::read_grid_quantization();
+
+            amrex::RealVect box_lo;
+            amrex::RealVect box_hi;
+
+            if (!quant.enabled)
+            {
+                amrex::RealVect const beam_padding = beam_width * (frac - 1_rt) * 0.5_rt;
+                //                       added to the beam extent --^         ^-- box half above/below the beam
+                box_lo = beam_min - beam_padding;
+                box_hi = beam_max + beam_padding;
+            }
+            else
+            {
+                amrex::RealVect box_width = beam_width * frac;
+
+                // Round the box up to an allowed length, so that a beam of nearly the
+                // same size lands on exactly the same grid and the space-charge solver
+                // can reuse its Green's function. geometry.prob_relative stays the
+                // minimum padding and geometry.prob_relative_max bounds the result.
+                // The stretch the space-charge solver applies longitudinally. It reaches
+                // the solver as a velocity and is turned back into a stretch there, which
+                // for an ultrarelativistic beam loses about eps*gamma^2 of precision in
+                // the round trip: 1 - 1/gamma^2 cancels away the leading digits. Deriving
+                // it here the same way, rather than from gamma directly, makes that loss
+                // identical on both sides so it cancels, and the mesh the solver sees is
+                // the one we chose.
+                amrex::ParticleReal const pt_ref =
+                    amr_data->track_particles.m_particle_container->GetRefParticle().pt;
+                amrex::ParticleReal const beta_s =
+                    std::sqrt(1.0_prt - 1.0_prt / amrex::Math::powi<2>(pt_ref));
+                auto const beta_z = static_cast<amrex::Real>(beta_s);
+                amrex::Real const gamma_z = 1.0_rt / std::sqrt(1.0_rt - beta_z * beta_z);
+
+                for (int d = 0; d < AMREX_SPACEDIM; ++d)
+                {
+                    // The solver sees the longitudinal direction stretched, so that is the
+                    // length which has to be an allowed one. A change of the reference
+                    // energy then resizes the mesh by itself, with no separate tolerance.
+                    amrex::Real const boost = (d == 2) ? gamma_z : 1.0_rt;
+                    box_width[d] = initialization::smallest_fit_length(
+                        box_width[d] * boost, quant.fit_lengths_per_doubling) / boost;
+                }
+
+                amrex::RealVect const box_half = box_width * 0.5_rt;
+                box_lo = beam_center - box_half;
+                box_hi = beam_center + box_half;
+            }
 
             // In AMReX, all levels have the same problem domain, that of the
             // coarsest level, even if only partly covered.
             for (int lev = 0; lev <= amr_data->finestLevel(); ++lev)
             {
-                rb[lev].setLo(beam_min - beam_padding);
-                rb[lev].setHi(beam_max + beam_padding);
+                rb[lev].setLo(box_lo);
+                rb[lev].setHi(box_hi);
             }
         }
         else

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -9,6 +9,7 @@
 #include <diagnostics/FilePrefix.H>
 #include <initialization/Algorithms.H>
 #include <initialization/InitDistribution.H>
+#include <initialization/InitMeshRefinement.H>
 #include <particles/ChargeDeposition.H>
 #include <particles/CovarianceMatrix.H>
 #include <particles/transformation/CoordinateTransformation.H>
@@ -246,6 +247,56 @@ void init_ImpactX (py::module& m)
                   pp_geometry.add("dynamic_size", dynamic_size);
               },
               "Use dynamic (``true``) resizing of the field mesh or static sizing (``false``)."
+        )
+
+        .def_property("prob_relative_max",
+              [](ImpactX & /* ix */) {
+                  amrex::ParmParse const pp_geometry("geometry");
+                  amrex::Real prob_relative_max = 0.0;
+                  if (pp_geometry.query("prob_relative_max", prob_relative_max)) {
+                      return prob_relative_max;
+                  }
+                  // not set yet: report the default that tracking would use
+                  std::vector<amrex::Real> frac;
+                  pp_geometry.getarr("prob_relative", frac);
+                  std::string poisson_solver = "fft";
+                  amrex::ParmParse const pp_algo("algo");
+                  pp_algo.query("poisson_solver", poisson_solver);
+                  return (poisson_solver == "fft") ? frac.at(0) * amrex::Real(1.1) : frac.at(0);
+              },
+              [](ImpactX & /* ix */, amrex::Real const prob_relative_max) {
+                  amrex::ParmParse pp_geometry("geometry");
+                  pp_geometry.add("prob_relative_max", prob_relative_max);
+              },
+              "The largest the field mesh may be, as a multiple of the maximum physical extent of "
+              "beam particles, while ``prob_relative`` is the smallest. Leaving room between the "
+              "two lets the mesh be chosen from a fixed set of sizes, so that a beam of nearly the "
+              "same size lands on exactly the same mesh and the space-charge solver can reuse its "
+              "Green's function. Setting it equal to ``prob_relative[0]`` fits the beam exactly. "
+              "Defaults to 10% above ``prob_relative[0]`` for the FFT solver, and to "
+              "``prob_relative[0]`` otherwise.\n\n"
+              "Because the mesh comes back exactly, the reused Green's function is still the right "
+              "one for it and the result is bit-identical to rebuilding: the price is resolution, "
+              "up to one allowed length of extra padding, rather than accuracy. The solver also "
+              "accepts ``ablastr.igf_cache_tolerance``, which reuses a Green's function across "
+              "meshes that merely nearly agree and costs an error of that order. Reach for this "
+              "parameter first; ImpactX chooses its own mesh, so it does not need the tolerance."
+        )
+
+        .def_property("igf_cache_max_entries",
+              [](ImpactX & /* ix */) {
+                  amrex::ParmParse pp_ablastr("ablastr");
+                  int entries = 8;  // ABLASTR's default
+                  pp_ablastr.query("igf_cache_max_entries", entries);
+                  return entries;
+              },
+              [](ImpactX & /* ix */, int const entries) {
+                  amrex::ParmParse pp_ablastr("ablastr");
+                  pp_ablastr.add("igf_cache_max_entries", entries);
+              },
+              "Number of Green's functions the FFT space-charge solver keeps, evicting the least "
+              "recently used one beyond that. ``0`` keeps only the one in use, which is still "
+              "reused for as long as the mesh does not change."
         )
 
         .def_property("particle_shape",

--- a/tests/python/test_igf_greens_cache.py
+++ b/tests/python/test_igf_greens_cache.py
@@ -38,6 +38,7 @@ def _simulate(
     max_entries,
     prob_relative_max,
     lattice="constf",
+    space_charge="3D",
     n_cell=32,
     nslice=8,
 ):
@@ -52,16 +53,24 @@ def _simulate(
     pp.add("igf_cache_max_entries", max_entries)
 
     sim = ImpactX()
-    sim.n_cell = [n_cell, n_cell, n_cell]
+    # the 2.5D solver projects the charge onto one transverse plane
+    sim.n_cell = [n_cell, n_cell, n_cell if space_charge == "3D" else 1]
+    if space_charge != "3D":
+        sim.blocking_factor_z = [1]
     sim.tiny_profiler = False
     sim.particle_shape = 2
-    sim.space_charge = "3D"
+    sim.space_charge = space_charge
     sim.poisson_solver = "fft"
     sim.prob_relative = [PROB_RELATIVE]
     sim.prob_relative_max = prob_relative_max
     sim.slice_step_diagnostics = False
     sim.diagnostics = False
     sim.verbose = 0
+    if space_charge == "2p5D":
+        # the longitudinal kick gathers the potential itself, not its gradient, so this
+        # is the mode in which the additive constant of the 2D Green's function matters
+        sim.space_charge_num_longitudinal_bins = 100
+        sim.space_charge_apply_longitudinal_kick = True
     sim.init_grids()
 
     sim.beam.ref.set_species("proton").set_kin_energy_MeV(2.0e3)
@@ -99,6 +108,7 @@ def _run(
     max_entries=8,
     prob_relative_max=1.21,
     lattice="constf",
+    space_charge="3D",
 ):
     """Run one configuration in a single-threaded subprocess."""
     env = dict(os.environ)
@@ -111,6 +121,7 @@ def _run(
         str(max_entries),
         str(prob_relative_max),
         lattice,
+        space_charge,
     ]
     proc = subprocess.run(args, env=env, capture_output=True, text=True, timeout=900)
     assert proc.returncode == 0, (
@@ -186,6 +197,48 @@ def test_reuse_survives_a_changing_mesh():
     )
 
 
+@pytest.mark.parametrize("space_charge", ["3D", "2D", "2p5D"])
+def test_reuse_holds_for_every_space_charge_model(space_charge):
+    """Each solver mode must be unaffected by reuse, 2.5D above all.
+
+    The 2.5D longitudinal kick gathers the transverse potential itself rather than its
+    gradient. The 2D integrated Green's function is homogeneous only up to an additive
+    constant, and a constant in the potential, invisible to a gradient, goes straight
+    into the longitudinal momentum. Reuse must therefore not shift it.
+    """
+    reference, _ = _run(rebuild_always=True, space_charge=space_charge)
+    reused, _ = _run(rebuild_always=False, space_charge=space_charge)
+
+    assert reference == reused, (
+        f"reuse changed the {space_charge} result: {_mismatches(reference, reused)}"
+    )
+
+
+def test_two_dimensional_modes_never_reuse_across_scales():
+    """2D and 2.5D must reuse a Green's function only at the scale it was built for.
+
+    Rescaling a 3D Green's function is exact. The 2D one picks up an additive constant
+    under a change of scale, which the 2.5D longitudinal kick would feel, so the solver
+    must decline that reuse rather than correct for it. A mesh exactly twice as large is
+    the case a 3D solver would happily reuse, so it is the one to check.
+    """
+    small, cell_small = _run(space_charge="2p5D")
+    # the same beam on a mesh a factor of two larger: a 3D solve would reuse across this
+    big, cell_big = _run(space_charge="2p5D", prob_relative_max=2.0 * PROB_RELATIVE)
+
+    ratio = cell_big[0] / cell_small[0]
+    assert ratio > 1.0, (
+        f"the two runs did not end up on different meshes (ratio {ratio!r}), so this "
+        f"test cannot see whether reuse crossed scales"
+    )
+    reference, _ = _run(
+        space_charge="2p5D", rebuild_always=True, prob_relative_max=2.0 * PROB_RELATIVE
+    )
+    assert big == reference, (
+        f"reuse changed the 2.5D result on the wider mesh: {_mismatches(reference, big)}"
+    )
+
+
 @pytest.mark.parametrize("prob_relative_max", [1.32, 1.21, 1.1495])
 def test_box_lands_on_a_fit_length(prob_relative_max):
     """The transverse mesh must be one of the allowed lengths, 2**(k/m) m.
@@ -246,8 +299,13 @@ if __name__ == "__main__":
         max_entries = int(sys.argv[3])
         prob_relative_max = float(sys.argv[4])
         lattice = sys.argv[5]
+        space_charge = sys.argv[6]
         moments, cell_size = _simulate(
-            rebuild_always, max_entries, prob_relative_max, lattice=lattice
+            rebuild_always,
+            max_entries,
+            prob_relative_max,
+            lattice=lattice,
+            space_charge=space_charge,
         )
         print(json.dumps({"moments": moments, "cell_size": cell_size}))
     else:

--- a/tests/python/test_igf_greens_cache.py
+++ b/tests/python/test_igf_greens_cache.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+"""
+The FFT space-charge solver reuses its Green's function instead of rebuilding it on
+every slice step. Reuse only ever happens for a grid the Green's function was built
+for, so it must not change the answer at all: these tests compare the reusing solver
+against one forced to rebuild every time, and require the results to agree exactly.
+
+Each configuration runs in its own single-threaded subprocess. Charge deposition sums
+in a thread-dependent order, so with more than one OpenMP thread even two identical
+runs differ in the last digits and an exact comparison would be meaningless. Running
+apart also keeps ParmParse settings from leaking between configurations, since the
+parameter table outlives an individual simulation.
+"""
+
+import json
+import math
+import os
+import subprocess
+import sys
+
+import pytest
+
+BUNCH_CHARGE_C = 1.0e-8
+
+# the minimum padding used throughout; the band is set relative to it
+PROB_RELATIVE = 1.1
+
+
+def _simulate(
+    rebuild_always,
+    max_entries,
+    prob_relative_max,
+    lattice="constf",
+    n_cell=32,
+    nslice=8,
+):
+    """Run one configuration in-process and return (beam moments, cell size)."""
+    import amrex.space3d as amr
+    from impactx import ImpactX, distribution, elements
+
+    # set every control on every run: ParmParse outlives a simulation, so a value left
+    # over from a previous configuration would silently carry into this one
+    pp = amr.ParmParse("ablastr")
+    pp.add("igf_rebuild_always", 1 if rebuild_always else 0)
+    pp.add("igf_cache_max_entries", max_entries)
+
+    sim = ImpactX()
+    sim.n_cell = [n_cell, n_cell, n_cell]
+    sim.tiny_profiler = False
+    sim.particle_shape = 2
+    sim.space_charge = "3D"
+    sim.poisson_solver = "fft"
+    sim.prob_relative = [PROB_RELATIVE]
+    sim.prob_relative_max = prob_relative_max
+    sim.slice_step_diagnostics = False
+    sim.diagnostics = False
+    sim.verbose = 0
+    sim.init_grids()
+
+    sim.beam.ref.set_species("proton").set_kin_energy_MeV(2.0e3)
+    distr = distribution.Waterbag(
+        lambdaX=1.2154443728379865788e-3,
+        lambdaY=1.2154443728379865788e-3,
+        lambdaT=4.0956844276541331005e-4,
+        lambdaPx=8.2274435782286157175e-4,
+        lambdaPy=8.2274435782286157175e-4,
+        lambdaPt=2.4415943602685364584e-3,
+    )
+    sim.add_particles(BUNCH_CHARGE_C, distr, 10000)
+    if lattice == "accel":
+        # A uniform accelerating section. ez is normalized, q*Ez/(m*c^2) in 1/m, and 0.4
+        # over 2 m raises gamma by about 25%. Both the reference energy and, through
+        # adiabatic damping, the beam size then move fast enough to land on a different
+        # mesh at practically every step, so this exercises invalidation rather than reuse.
+        sim.lattice.extend(
+            [elements.ChrAcc(name="acc1", ds=2.0, ez=0.4, bz=0.0, nslice=nslice)]
+        )
+    else:
+        sim.lattice.extend(
+            [elements.ConstF(name="cf1", ds=2.0, kx=1.0, ky=1.0, kt=1.0, nslice=nslice)]
+        )
+    sim.track_particles()
+
+    moments = {k: float(v) for k, v in dict(sim.beam.beam_moments()).items()}
+    cell_size = [float(c) for c in sim.Geom(lev=0).data().CellSize()]
+    sim.finalize()
+    return moments, cell_size
+
+
+def _run(
+    rebuild_always=False,
+    max_entries=8,
+    prob_relative_max=1.21,
+    lattice="constf",
+):
+    """Run one configuration in a single-threaded subprocess."""
+    env = dict(os.environ)
+    env["OMP_NUM_THREADS"] = "1"
+    args = [
+        sys.executable,
+        os.path.abspath(__file__),
+        "--emit",
+        "1" if rebuild_always else "0",
+        str(max_entries),
+        str(prob_relative_max),
+        lattice,
+    ]
+    proc = subprocess.run(args, env=env, capture_output=True, text=True, timeout=900)
+    assert proc.returncode == 0, (
+        f"subprocess failed ({proc.returncode})\n"
+        f"--- stdout ---\n{proc.stdout[-2000:]}\n--- stderr ---\n{proc.stderr[-2000:]}"
+    )
+    # the simulation prints as it tracks; the payload is the final line
+    payload = proc.stdout.strip().splitlines()[-1]
+    result = json.loads(payload)
+    return result["moments"], result["cell_size"]
+
+
+def _mismatches(a, b):
+    return {k: (a[k], b[k]) for k in a if a[k] != b[k]}
+
+
+def test_the_reference_is_reproducible():
+    """The comparisons below are only meaningful if a run reproduces itself."""
+    first, _ = _run(rebuild_always=True)
+    second, _ = _run(rebuild_always=True)
+    assert first == second, (
+        "two identical single-threaded runs disagree, so the exact comparisons in this "
+        f"file cannot mean anything: {_mismatches(first, second)}"
+    )
+
+
+@pytest.mark.parametrize("max_entries", [0, 8])
+def test_reuse_does_not_change_the_result(max_entries):
+    """Reusing a Green's function must reproduce rebuilding it, bit for bit.
+
+    ``max_entries=0`` keeps only the Green's function currently in use, exercising the
+    reuse of an unchanged grid alone. ``max_entries=8`` additionally exercises putting
+    Green's functions aside and taking them back out as the mesh moves between allowed lengths.
+    """
+    reference, _ = _run(rebuild_always=True)
+    reused, _ = _run(rebuild_always=False, max_entries=max_entries)
+
+    assert reference == reused, (
+        f"reusing the Green's function changed the result (max_entries={max_entries}): "
+        f"{_mismatches(reference, reused)}"
+    )
+
+
+def test_exact_fit_matches_rebuild():
+    """With no band, the mesh fits the beam and every step gets its own Green's function.
+
+    This is the configuration in which nothing is ever reused, and it must also leave the
+    result untouched.
+    """
+    reference, _ = _run(rebuild_always=True, prob_relative_max=PROB_RELATIVE)
+    reused, _ = _run(rebuild_always=False, prob_relative_max=PROB_RELATIVE)
+
+    assert reference == reused, (
+        f"reuse changed the result with the mesh fitted exactly: "
+        f"{_mismatches(reference, reused)}"
+    )
+
+
+def test_reuse_survives_a_changing_mesh():
+    """A mesh that moves every step must invalidate the Green's function every step.
+
+    Under acceleration both the reference energy and the beam size change quickly, so
+    nearly every step lands on a different mesh. Reuse that failed to notice would
+    quietly apply a stale Green's function, which is a wrong answer rather than a slow
+    one, so this is the case where the guard has to be right.
+    """
+    reference, _ = _run(rebuild_always=True, lattice="accel")
+    reused, _ = _run(rebuild_always=False, lattice="accel")
+
+    assert reference == reused, (
+        f"reuse changed the result while the reference energy was changing: "
+        f"{_mismatches(reference, reused)}"
+    )
+
+
+@pytest.mark.parametrize("prob_relative_max", [1.32, 1.21, 1.1495])
+def test_box_lands_on_a_fit_length(prob_relative_max):
+    """The transverse mesh must be one of the allowed lengths, 2**(k/m) m.
+
+    This is what makes a mesh recur: two steps whose padded beam sizes fall between the
+    same pair of allowed lengths get the identical mesh, and so the identical Green's
+    function. The three bands here work out to 4, 8 and 16 lengths per doubling.
+    """
+    n_cell = 32
+    band = prob_relative_max / PROB_RELATIVE
+    fit_lengths_per_doubling = math.ceil(1.0 / math.log2(band))
+
+    _, cell_size = _run(prob_relative_max=prob_relative_max)
+
+    # the transverse mesh is rounded up directly; the longitudinal one is rounded in the
+    # frame the solver works in and so carries a gamma, which is not checked here
+    for d in (0, 1):
+        box_width = cell_size[d] * n_cell
+        k = math.log2(box_width) * fit_lengths_per_doubling
+        assert math.isclose(k, round(k), abs_tol=1e-9), (
+            f"mesh width {box_width!r} along direction {d} is not an allowed length of "
+            f"2**(k/{fit_lengths_per_doubling}) m: k = {k!r}"
+        )
+
+
+def test_exactly_fitted_box_is_not_a_fit_length():
+    """Guard against the check above passing for the wrong reason."""
+    n_cell = 32
+    _, cell_size = _run(prob_relative_max=PROB_RELATIVE)
+
+    allowed = []
+    for d in (0, 1):
+        k = math.log2(cell_size[d] * n_cell) * 8
+        allowed.append(math.isclose(k, round(k), abs_tol=1e-9))
+    assert not all(allowed), (
+        "an exactly fitted mesh happened to be an allowed length, so the check above "
+        "cannot tell a restricted mesh from a fitted one"
+    )
+
+
+def test_band_below_prob_relative_is_rejected():
+    """The mesh cannot be required to be smaller than the padding asks for."""
+    from impactx import ImpactX
+
+    sim = ImpactX()
+    sim.prob_relative = [PROB_RELATIVE]
+    sim.prob_relative_max = 0.5 * PROB_RELATIVE
+    sim.space_charge = "3D"
+    sim.poisson_solver = "fft"
+    with pytest.raises(Exception):
+        sim.init_grids()
+    sim.finalize()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--emit":
+        rebuild_always = sys.argv[2] == "1"
+        max_entries = int(sys.argv[3])
+        prob_relative_max = float(sys.argv[4])
+        lattice = sys.argv[5]
+        moments, cell_size = _simulate(
+            rebuild_always, max_entries, prob_relative_max, lattice=lattice
+        )
+        print(json.dumps({"moments": moments, "cell_size": cell_size}))
+    else:
+        test_the_reference_is_reproducible()
+        test_reuse_does_not_change_the_result(0)
+        test_reuse_does_not_change_the_result(8)
+        test_exact_fit_matches_rebuild()


### PR DESCRIPTION
`ResizeMesh` fitted the box to the exact particle extent on every slice step, so the resolution drifted continuously and the FFT solver rebuilt its Green's function each time. This gives the padding a band instead, and within it picks the mesh from a [geometric progression](https://en.wikipedia.org/wiki/Geometric_progression) (also used [in industry](https://en.wikipedia.org/wiki/Preferred_number)), so a beam of nearly the same size lands on exactly the same mesh and the Green's function can be reused. On the new `expanding-acc` test that takes builds from 100 to 10 and runtime from 0.95 s to 0.41 s, and on `cfchannel` from 50 to 4.

The allowed mesh lengths are $L_k = 2^{k/m}$ m, with $m = \lceil 1 / \log_2 r \rceil$ and $r$ the width of the band, `prob_relative_max` divided by `prob_relative[0]`. Here $L_k$ is the mesh edge length along one axis, $k$ the whole number making $L_k$ the smallest such length that still covers the padded beam, and $m$ how many allowed lengths there are per factor of two. Rounding $m$ up keeps the mesh inside the band, and keeping it a whole number per doubling makes two meshes a factor of two apart differ by *exactly* two, which the solver relies on to reuse a Green's function built at another scale.

`geometry.prob_relative` is now the smallest the mesh may be and `geometry.prob_relative_max` the largest, defaulting to 10% above it for the FFT solver, so $m = 8$. Setting them equal fits the beam exactly and is bit-identical to before. The longitudinal axis is sized in the frame the solver works in, and that stretch is derived here the same way the solver derives it, because reconstructing it from a velocity costs about $\varepsilon\gamma^2$ and would leave the mesh never quite repeating. Depends on BLAST-WarpX/warpx#7178, which is what actually reuses the Green's function.

<details>
<summary>Testing detail</summary>

Adds `tests/python/test_igf_greens_cache.py`. It compares the reusing solver against `ablastr.igf_rebuild_always=1` and requires exact equality of all beam moments, covering the store disabled and enabled, an exactly fitted mesh and a banded one, and an accelerating lattice. Each configuration runs in a single-threaded subprocess: charge deposition sums thread-dependently, so under the suite's `OMP_NUM_THREADS=2` even two identical runs differ in the last digits and the comparison would otherwise be vacuous. Running apart also keeps ParmParse from leaking between configurations. Further tests assert the mesh is one of the allowed lengths for bands giving 4, 8 and 16 lengths per doubling, with a negative control asserting an exactly fitted mesh is not, and that a band below `prob_relative[0]` is rejected.

How wide the band can get, scanned on `expanding-acc` against its own envelope comparison at `rtol` 0.79%: 1.21 gives 0.496% and 76 of 100 reused, 1.5 gives 0.554% and 90 reused, 2.0 gives 0.640% and 94 reused, 3.0 gives 1.115% and fails. So the default is conservative and roughly 2.0 is the ceiling for this test. Emittances are unchanged to 0.00% throughout. `expanding-2d-acc` passes at every band and reuses 91 of 100 at the default, though the Green's function is only about 2% of its runtime.

Space-charge regressions: 66 of 66 pass, including both new acceleration tests. The 100-slice `expanding-acc` case remains byte-identical to rebuilding every step while reusing 90 of 100, since the meshes recur exactly rather than approximately.

Also consolidates the two diverging copies of `read_mr_prob_relative`, in `impactx::initialization::` and `impactx::detail::`, which had to be kept in sync by hand for every new geometry parameter.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
