### PR TITLE
Source Element: Choose Which Step to Load

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -2072,21 +2072,31 @@ When ImpactX needs to sort particles spatially, it will redistribute them over M
 
 .. pp:param:: <source_name>.load_step
     :type: ``integer``
-    :default: ``-1``
+    :default: the last step in the file
 
-    Which step to load from the openPMD series.
+    Which step (iteration) to load from the openPMD series, selected by step number.
 
-    A value :math:`\geq 0` is the ImpactX step at which the ``beam_monitor`` wrote the beam, which is
-    stored as the openPMD iteration in the file.
+    This is the ImpactX step at which the ``beam_monitor`` wrote the beam, which is stored as the
+    openPMD iteration in the file.
     These step numbers are usually not consecutive, because the global step counter also advances in
-    the elements between two monitors: list them with, e.g., ``openpmd-ls`` before selecting one.
-    A step that is not in the file is an error, which lists the available steps.
+    the elements between two monitors: list them with, e.g., `openpmd-ls <https://openpmd-api.readthedocs.io/en/0.17.1/utilities/cli.html>`__ before selecting one.
+    A step that is not in the file is an error, which lists the steps that are in it.
 
-    ``-1`` reads the last step in the file and more negative values count back from it, e.g. ``-2``
-    reads the second to last step.
+    Set at most one of ``load_step`` and ``load_step_index``.
 
-    Selecting a step reads the series in random access, which the ``v`` (variable based) iteration
-    encoding of the ``beam_monitor`` does not support.
+.. pp:param:: <source_name>.load_step_index
+    :type: ``integer``
+    :default: the last step in the file
+
+    Which step (iteration) to load from the openPMD series, selected by position in the file.
+
+    ``0`` is the first step in the file and ``-1`` is the last, counting back from it as in Python,
+    e.g. ``-2`` is the second to last step.
+    Use this when the step numbers in the file are not known, e.g. to continue from the last turn
+    that a ring wrote.
+    An index that reaches past either end of the file is an error, which lists the steps in it.
+
+    Set at most one of ``load_step`` and ``load_step_index``.
 
 
 ``spin_map``

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -2072,7 +2072,7 @@ When ImpactX needs to sort particles spatially, it will redistribute them over M
 
 .. pp:param:: <source_name>.load_step
     :type: ``integer``
-    :default: the last step in the file
+    :default: unset (if neither option is set, the last step in the file is loaded)
 
     Which step (iteration) to load from the openPMD series, selected by step number.
 
@@ -2081,19 +2081,21 @@ When ImpactX needs to sort particles spatially, it will redistribute them over M
     These step numbers are usually not consecutive, because the global step counter also advances in
     the elements between two monitors: list them with, e.g., `openpmd-ls <https://openpmd-api.readthedocs.io/en/0.17.1/utilities/cli.html>`__ before selecting one.
     A step that is not in the file is an error, which lists the steps that are in it.
+    A negative value is an error, too: the step numbers in a file are not negative, use
+    ``load_step_index`` to count back from the last step.
 
     Set at most one of ``load_step`` and ``load_step_index``.
 
 .. pp:param:: <source_name>.load_step_index
     :type: ``integer``
-    :default: the last step in the file
+    :default: unset (if neither option is set, the last step in the file is loaded)
 
     Which step (iteration) to load from the openPMD series, selected by position in the file.
 
     ``0`` is the first step in the file and ``-1`` is the last, counting back from it as in Python,
     e.g. ``-2`` is the second to last step.
-    Use this when the step numbers in the file are not known, e.g. to continue from the last turn
-    that a ring wrote.
+    Use this when the step numbers in the file are not known, e.g. ``-2`` to continue from the turn
+    before the last one that a ring wrote.
     An index that reaches past either end of the file is an error, which lists the steps in it.
 
     Set at most one of ``load_step`` and ``load_step_index``.

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -2070,6 +2070,24 @@ When ImpactX needs to sort particles spatially, it will redistribute them over M
     The existing reference particle in that case needs to be manually configured before the tracking loop.
     This option acts during particle tracking, it has no effect in envelope or reference-particle-only tracking.
 
+.. pp:param:: <source_name>.load_step
+    :type: ``integer``
+    :default: ``-1``
+
+    Which step to load from the openPMD series.
+
+    A value :math:`\geq 0` is the ImpactX step at which the ``beam_monitor`` wrote the beam, which is
+    stored as the openPMD iteration in the file.
+    These step numbers are usually not consecutive, because the global step counter also advances in
+    the elements between two monitors: list them with, e.g., ``openpmd-ls`` before selecting one.
+    A step that is not in the file is an error, which lists the available steps.
+
+    ``-1`` reads the last step in the file and more negative values count back from it, e.g. ``-2``
+    reads the second to last step.
+
+    Selecting a step reads the series in random access, which the ``v`` (variable based) iteration
+    encoding of the ``beam_monitor`` does not support.
+
 
 ``spin_map``
 ^^^^^^^^^^^^

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -2024,12 +2024,14 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
       These step numbers are usually not consecutive, because the global step counter also advances in
       the elements between two monitors: list them with, e.g., `openpmd-ls <https://openpmd-api.readthedocs.io/en/0.17.1/utilities/cli.html>`__ before selecting one.
       A step that is not in the file is an error, which lists the steps that are in it.
+      A negative value is an error, too: the step numbers in a file are not negative, use
+      ``load_step_index`` to count back from the last step.
 
       ``load_step_index`` selects the step by position in the file instead: ``0`` is the first step
       and ``-1`` is the last, counting back from it as in Python, e.g. ``load_step_index=-2`` is the
       second to last step.
-      Use this when the step numbers in the file are not known, e.g. to continue from the last turn
-      that a ring wrote.
+      Use this when the step numbers in the file are not known, e.g. ``load_step_index=-2`` to
+      continue from the turn before the last one that a ring wrote.
       An index that reaches past either end of the file is an error, which lists the steps in it.
 
       Set at most one of ``load_step`` and ``load_step_index``.

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -2004,7 +2004,7 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
 
       Scale factor (in meters^(1/2)) of the IOTA nonlinear magnetic insert element used for computing H and I.
 
-.. py:class:: impactx.elements.Source(distribution, openpmd_path, active_once=True, load_ref_particle=True, name=None)
+.. py:class:: impactx.elements.Source(distribution, openpmd_path, active_once=True, load_ref_particle=True, load_step=-1, name=None)
 
    A particle source.
    Currently, this only supports openPMD files from our :py:class:`impactx.elements.BeamMonitor`
@@ -2013,7 +2013,22 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
    :param openpmd_path: path to the openPMD series
    :param active_once: Inject particles only for the first lattice period. Default: ``True``
    :param load_ref_particle: Restore the reference particle from the species metadata of the openPMD file. Default: ``True``
+   :param load_step: Which step to load from the openPMD series. Default: ``-1``
    :param name: an optional name for the element
+
+   .. note::
+
+      A ``load_step`` :math:`\geq 0` is the ImpactX step at which the :py:class:`impactx.elements.BeamMonitor`
+      wrote the beam, which is stored as the openPMD iteration in the file.
+      These step numbers are usually not consecutive, because the global step counter also advances in
+      the elements between two monitors: list them with, e.g., ``openpmd-ls`` before selecting one.
+      A step that is not in the file is an error, which lists the available steps.
+
+      ``load_step=-1`` reads the last step in the file and more negative values count back from it,
+      e.g. ``load_step=-2`` reads the second to last step.
+
+      Selecting a step reads the series in random access, which the ``"v"`` (variable based)
+      iteration encoding of the :py:class:`impactx.elements.BeamMonitor` does not support.
 
    .. note::
 

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -2004,7 +2004,7 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
 
       Scale factor (in meters^(1/2)) of the IOTA nonlinear magnetic insert element used for computing H and I.
 
-.. py:class:: impactx.elements.Source(distribution, openpmd_path, active_once=True, load_ref_particle=True, load_step=-1, name=None)
+.. py:class:: impactx.elements.Source(distribution, openpmd_path, active_once=True, load_ref_particle=True, load_step=None, load_step_index=None, name=None)
 
    A particle source.
    Currently, this only supports openPMD files from our :py:class:`impactx.elements.BeamMonitor`
@@ -2013,22 +2013,27 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
    :param openpmd_path: path to the openPMD series
    :param active_once: Inject particles only for the first lattice period. Default: ``True``
    :param load_ref_particle: Restore the reference particle from the species metadata of the openPMD file. Default: ``True``
-   :param load_step: Which step to load from the openPMD series. Default: ``-1``
+   :param load_step: Which step (iteration) to load from the openPMD series, selected by step number. Default: ``None``
+   :param load_step_index: Which step (iteration) to load from the openPMD series, selected by position in the file. Default: ``None``
    :param name: an optional name for the element
 
    .. note::
 
-      A ``load_step`` :math:`\geq 0` is the ImpactX step at which the :py:class:`impactx.elements.BeamMonitor`
+      ``load_step`` is the ImpactX step at which the :py:class:`impactx.elements.BeamMonitor`
       wrote the beam, which is stored as the openPMD iteration in the file.
       These step numbers are usually not consecutive, because the global step counter also advances in
-      the elements between two monitors: list them with, e.g., ``openpmd-ls`` before selecting one.
-      A step that is not in the file is an error, which lists the available steps.
+      the elements between two monitors: list them with, e.g., `openpmd-ls <https://openpmd-api.readthedocs.io/en/0.17.1/utilities/cli.html>`__ before selecting one.
+      A step that is not in the file is an error, which lists the steps that are in it.
 
-      ``load_step=-1`` reads the last step in the file and more negative values count back from it,
-      e.g. ``load_step=-2`` reads the second to last step.
+      ``load_step_index`` selects the step by position in the file instead: ``0`` is the first step
+      and ``-1`` is the last, counting back from it as in Python, e.g. ``load_step_index=-2`` is the
+      second to last step.
+      Use this when the step numbers in the file are not known, e.g. to continue from the last turn
+      that a ring wrote.
+      An index that reaches past either end of the file is an error, which lists the steps in it.
 
-      Selecting a step reads the series in random access, which the ``"v"`` (variable based)
-      iteration encoding of the :py:class:`impactx.elements.BeamMonitor` does not support.
+      Set at most one of ``load_step`` and ``load_step_index``.
+      If neither is set, the last step in the file is loaded.
 
    .. note::
 

--- a/examples/solenoid_restart/input_solenoid.in
+++ b/examples/solenoid_restart/input_solenoid.in
@@ -16,7 +16,7 @@ source.openpmd_path = "../solenoid/diags/openPMD/m1.h5"
 # the reference particle is restored from the file, too (default):
 #   source.load_ref_particle = true
 # the step to load, by step number in the file or by position in it;
-# set at most one of both (default: the last step in the file):
+# set at most one of the two (default: the last step in the file):
 #   source.load_step = 3
 #   source.load_step_index = -1
 

--- a/examples/solenoid_restart/input_solenoid.in
+++ b/examples/solenoid_restart/input_solenoid.in
@@ -15,6 +15,10 @@ source.distribution = openPMD
 source.openpmd_path = "../solenoid/diags/openPMD/m1.h5"
 # the reference particle is restored from the file, too (default):
 #   source.load_ref_particle = true
+# the step to load, by step number in the file or by position in it
+# (default: the last step in the file):
+#   source.load_step = 3
+#   source.load_step_index = -1
 
 m1.type = beam_monitor
 m1.backend = h5

--- a/examples/solenoid_restart/input_solenoid.in
+++ b/examples/solenoid_restart/input_solenoid.in
@@ -15,8 +15,8 @@ source.distribution = openPMD
 source.openpmd_path = "../solenoid/diags/openPMD/m1.h5"
 # the reference particle is restored from the file, too (default):
 #   source.load_ref_particle = true
-# the step to load, by step number in the file or by position in it
-# (default: the last step in the file):
+# the step to load, by step number in the file or by position in it;
+# set at most one of both (default: the last step in the file):
 #   source.load_step = 3
 #   source.load_step_index = -1
 

--- a/src/elements/Source.H
+++ b/src/elements/Source.H
@@ -32,6 +32,7 @@ namespace impactx::elements
 
         static constexpr bool DEFAULT_active_once = true;
         static constexpr bool DEFAULT_load_ref_particle = true;
+        static constexpr int DEFAULT_load_step = -1;
 
         /** A particle source
          *
@@ -40,6 +41,10 @@ namespace impactx::elements
          * @param active_once inject particles only for the first lattice period
          * @param load_ref_particle restore the reference particle from the species metadata
          *        of the openPMD file (particle tracking only)
+         * @param load_step which step to load from the openPMD series: a value >= 0 is the
+         *        ImpactX step at which the beam monitor wrote the beam (the openPMD iteration
+         *        stored in the file), -1 is the last step in the file and more negative values
+         *        count back from it (-2 is the second to last step)
          * @param name a user defined and not necessarily unique name of the element
          */
         Source (
@@ -47,13 +52,15 @@ namespace impactx::elements
             std::string openpmd_path,
             bool active_once = DEFAULT_active_once,
             bool load_ref_particle = DEFAULT_load_ref_particle,
+            int load_step = DEFAULT_load_step,
             std::optional<std::string> name = DEFAULT_name
         )
         : Named(std::move(name)),
           m_distribution(distribution),
           m_series_name(std::move(openpmd_path)),
           m_active_once(active_once),
-          m_load_ref_particle(load_ref_particle)
+          m_load_ref_particle(load_ref_particle),
+          m_load_step(load_step)
         {
             if (distribution != "openPMD") {
                 throw std::invalid_argument("Only 'openPMD' distribution is supported if openpmd_path is provided!");
@@ -69,11 +76,12 @@ namespace impactx::elements
         /** Initialize/Load particles.
          *
          * Particles are relative to the reference particle.
+         * The step that is read from the file is selected with load_step.
          * If load_ref_particle is set, the reference particle is restored from
          * the species metadata of the file before the particles are added.
          *
          * @param[in,out] pc particle container to push
-         * @param[in] step global step for diagnostics (unused)
+         * @param[in] step current global step of the tracking loop (unused)
          * @param[in] period for periodic lattices, this is the current period (turn or cycle)
          */
         void operator() (
@@ -105,6 +113,7 @@ namespace impactx::elements
         std::string m_series_name; //! openPMD filename
         bool m_active_once = true; //! Inject particles only for the first lattice period
         bool m_load_ref_particle = true; //! Restore the reference particle from the file's species metadata
+        int m_load_step = DEFAULT_load_step; //! ImpactX step (openPMD iteration) to load; negative values count back from the last step
     };
 
 } // namespace impactx

--- a/src/elements/Source.H
+++ b/src/elements/Source.H
@@ -51,6 +51,8 @@ namespace impactx::elements
          * @param load_step_index the position of the step in the file: 0 is the first step and
          *        -1 the last step, counting back from it as in Python (-2 is the second to last)
          * @param name a user defined and not necessarily unique name of the element
+         * @throws std::invalid_argument if distribution is not "openPMD", if both load_step and
+         *         load_step_index are set or if load_step is negative
          */
         Source (
             std::string distribution,
@@ -102,6 +104,10 @@ namespace impactx::elements
          * @param[in,out] pc particle container to push
          * @param[in] step current global step of the tracking loop (unused)
          * @param[in] period for periodic lattices, this is the current period (turn or cycle)
+         * @throws std::invalid_argument if both load_step and load_step_index are set or if
+         *         load_step is negative
+         * @throws std::runtime_error if the series holds no step or if the selected step or
+         *         index is not in the file
          */
         void operator() (
             ImpactXParticleContainer & pc,

--- a/src/elements/Source.H
+++ b/src/elements/Source.H
@@ -16,6 +16,7 @@
 #include "mixin/nofinalize.H"
 #include "mixin/thin.H"
 
+#include <optional>
 #include <stdexcept>
 #include <string>
 
@@ -32,19 +33,23 @@ namespace impactx::elements
 
         static constexpr bool DEFAULT_active_once = true;
         static constexpr bool DEFAULT_load_ref_particle = true;
-        static constexpr int DEFAULT_load_step = -1;
+        static constexpr std::optional<int> DEFAULT_load_step = std::nullopt;
+        static constexpr std::optional<int> DEFAULT_load_step_index = std::nullopt;
 
         /** A particle source
+         *
+         * At most one of load_step and load_step_index selects the step to read.
+         * If neither is set, the last step in the file is read.
          *
          * @param distribution Must read "openPMD" for this constructor
          * @param openpmd_path path to openPMD series as accepted by openPMD::Series
          * @param active_once inject particles only for the first lattice period
          * @param load_ref_particle restore the reference particle from the species metadata
          *        of the openPMD file (particle tracking only)
-         * @param load_step which step to load from the openPMD series: a value >= 0 is the
-         *        ImpactX step at which the beam monitor wrote the beam (the openPMD iteration
-         *        stored in the file), -1 is the last step in the file and more negative values
-         *        count back from it (-2 is the second to last step)
+         * @param load_step the ImpactX step at which the beam monitor wrote the beam, which is
+         *        stored as the openPMD iteration in the file; it must be a step in the file
+         * @param load_step_index the position of the step in the file: 0 is the first step and
+         *        -1 the last step, counting back from it as in Python (-2 is the second to last)
          * @param name a user defined and not necessarily unique name of the element
          */
         Source (
@@ -52,7 +57,8 @@ namespace impactx::elements
             std::string openpmd_path,
             bool active_once = DEFAULT_active_once,
             bool load_ref_particle = DEFAULT_load_ref_particle,
-            int load_step = DEFAULT_load_step,
+            std::optional<int> load_step = DEFAULT_load_step,
+            std::optional<int> load_step_index = DEFAULT_load_step_index,
             std::optional<std::string> name = DEFAULT_name
         )
         : Named(std::move(name)),
@@ -60,12 +66,25 @@ namespace impactx::elements
           m_series_name(std::move(openpmd_path)),
           m_active_once(active_once),
           m_load_ref_particle(load_ref_particle),
-          m_load_step(load_step)
+          m_load_step(load_step),
+          m_load_step_index(load_step_index)
         {
             if (distribution != "openPMD") {
                 throw std::invalid_argument("Only 'openPMD' distribution is supported if openpmd_path is provided!");
             }
+
+            check_step_selection();
         }
+
+        /** Check that the step to read from the file is selected unambiguously.
+         *
+         * This is checked on construction and again when particles are loaded,
+         * because both options can also be set after the element was created.
+         *
+         * @throws std::invalid_argument if both load_step and load_step_index are
+         *         set or if load_step is negative
+         */
+        void check_step_selection () const;
 
         /** Reverse the element (not supported for Source) */
         void reverse ()
@@ -76,7 +95,7 @@ namespace impactx::elements
         /** Initialize/Load particles.
          *
          * Particles are relative to the reference particle.
-         * The step that is read from the file is selected with load_step.
+         * The step that is read from the file is selected with load_step or load_step_index.
          * If load_ref_particle is set, the reference particle is restored from
          * the species metadata of the file before the particles are added.
          *
@@ -113,7 +132,8 @@ namespace impactx::elements
         std::string m_series_name; //! openPMD filename
         bool m_active_once = true; //! Inject particles only for the first lattice period
         bool m_load_ref_particle = true; //! Restore the reference particle from the file's species metadata
-        int m_load_step = DEFAULT_load_step; //! ImpactX step (openPMD iteration) to load; negative values count back from the last step
+        std::optional<int> m_load_step = DEFAULT_load_step; //! ImpactX step (openPMD iteration) to load
+        std::optional<int> m_load_step_index = DEFAULT_load_step_index; //! position of the step in the file, -1 is the last step
     };
 
 } // namespace impactx

--- a/src/elements/Source.cpp
+++ b/src/elements/Source.cpp
@@ -17,6 +17,7 @@
 namespace io = openPMD;
 #endif
 
+#include <cstddef>
 #include <iterator>
 #include <stdexcept>
 #include <string>
@@ -24,6 +25,23 @@ namespace io = openPMD;
 
 namespace impactx::elements
 {
+    void
+    Source::check_step_selection () const
+    {
+        if (m_load_step.has_value() && m_load_step_index.has_value()) {
+            throw std::invalid_argument(
+                "Source: set either load_step or load_step_index, not both."
+            );
+        }
+        if (m_load_step.has_value() && *m_load_step < 0) {
+            throw std::invalid_argument(
+                "Source: load_step " + std::to_string(*m_load_step) + " is negative, but it is "
+                "the ImpactX step stored in the file; use load_step_index to count back from "
+                "the last step in the file."
+            );
+        }
+    }
+
     void
     Source::operator() (
         ImpactXParticleContainer & pc,
@@ -35,6 +53,8 @@ namespace impactx::elements
         if (m_active_once && period > 0) {
             return;
         }
+
+        check_step_selection();
 
 #ifdef ImpactX_USE_OPENPMD
         auto series = io::Series(m_series_name, io::Access::READ_ONLY
@@ -50,39 +70,59 @@ namespace impactx::elements
         }
 
         // the steps stored in the file, for error messages
+        // a long list, e.g. one step per turn in a ring, is elided in the middle
         auto const available_steps = [&iterations] () {
-            std::string steps;
-            for (auto const & iteration_entry : iterations) {
-                if (!steps.empty()) { steps += ", "; }
-                steps += std::to_string(iteration_entry.first);
+            constexpr std::size_t max_listed = 100; //! list at most this many steps
+            std::size_t const num_steps = iterations.size();
+            bool const elide = num_steps > max_listed;
+            std::size_t const num_head = elide ? max_listed / 2 : num_steps;
+            std::size_t const num_tail = elide ? max_listed - max_listed / 2 : 0;
+
+            std::string list;
+            auto append_step = [&list] (auto const & iteration_entry) {
+                if (!list.empty()) { list += ", "; }
+                list += std::to_string(iteration_entry->first);
+            };
+
+            auto it = iterations.begin();
+            for (std::size_t i = 0; i < num_head; ++i, ++it) { append_step(it); }
+            if (elide) {
+                list += ", ...";
+                std::advance(it, static_cast<long>(num_steps - num_head - num_tail));
+                for (std::size_t i = 0; i < num_tail; ++i, ++it) { append_step(it); }
             }
-            return steps;
+
+            return std::to_string(num_steps) +
+                   (num_steps == 1 ? " available step: " : " available steps: ") + list;
         };
 
         io::Iteration::IterationIndex_t read_iteration = 0;
-        if (m_load_step >= 0)
+        if (m_load_step.has_value())
         {
             // an ImpactX step, which the beam monitor wrote as the openPMD iteration
-            auto const requested = static_cast<io::Iteration::IterationIndex_t>(m_load_step);
+            auto const requested = static_cast<io::Iteration::IterationIndex_t>(*m_load_step);
             if (!iterations.contains(requested)) {
                 throw std::runtime_error(
-                    "Source: load_step " + std::to_string(m_load_step) + " not found in " +
-                    m_series_name + " (available steps: " + available_steps() + ")"
+                    "Source: load_step " + std::to_string(*m_load_step) + " not found in " +
+                    m_series_name + " (" + available_steps() + ")"
                 );
             }
             read_iteration = requested;
         }
         else
         {
-            // negative: count back from the last step in the file (-1 is the last step)
+            // a position in the file: 0 is the first step, -1 the last, as in Python
+            constexpr int last_step_index = -1; //! read the last step in the file by default
+            int const step_index = m_load_step_index.value_or(last_step_index);
+
             auto const num_steps = static_cast<long>(iterations.size());
-            long const index = num_steps + static_cast<long>(m_load_step);
-            if (index < 0) {
+            long const index = step_index < 0
+                ? num_steps + static_cast<long>(step_index)
+                : static_cast<long>(step_index);
+            if (index < 0 || index >= num_steps) {
                 throw std::runtime_error(
-                    "Source: load_step " + std::to_string(m_load_step) +
-                    " reaches before the first of the " + std::to_string(num_steps) +
-                    " steps in " + m_series_name +
-                    " (available steps: " + available_steps() + ")"
+                    "Source: load_step_index " + std::to_string(step_index) +
+                    " is out of range in " + m_series_name + " (" + available_steps() + ")"
                 );
             }
             read_iteration = std::next(iterations.begin(), index)->first;

--- a/src/elements/Source.cpp
+++ b/src/elements/Source.cpp
@@ -15,9 +15,11 @@
 #   include "elements/diagnostics/openPMD.H"
 #   include <openPMD/openPMD.hpp>
 namespace io = openPMD;
-#else
-#  include <stdexcept>
 #endif
+
+#include <iterator>
+#include <stdexcept>
+#include <string>
 
 
 namespace impactx::elements
@@ -41,9 +43,51 @@ namespace impactx::elements
 #   endif
         );
 
-        // read the last iteration (highest openPMD iteration)
-        // TODO: later we can make this an option
-        int const read_iteration = std::prev(series.iterations.end())->first;
+        // select the step (openPMD iteration) to read
+        auto const & iterations = series.iterations;
+        if (iterations.empty()) {
+            throw std::runtime_error("Source: no step found in " + m_series_name);
+        }
+
+        // the steps stored in the file, for error messages
+        auto const available_steps = [&iterations] () {
+            std::string steps;
+            for (auto const & iteration_entry : iterations) {
+                if (!steps.empty()) { steps += ", "; }
+                steps += std::to_string(iteration_entry.first);
+            }
+            return steps;
+        };
+
+        io::Iteration::IterationIndex_t read_iteration = 0;
+        if (m_load_step >= 0)
+        {
+            // an ImpactX step, which the beam monitor wrote as the openPMD iteration
+            auto const requested = static_cast<io::Iteration::IterationIndex_t>(m_load_step);
+            if (!iterations.contains(requested)) {
+                throw std::runtime_error(
+                    "Source: load_step " + std::to_string(m_load_step) + " not found in " +
+                    m_series_name + " (available steps: " + available_steps() + ")"
+                );
+            }
+            read_iteration = requested;
+        }
+        else
+        {
+            // negative: count back from the last step in the file (-1 is the last step)
+            auto const num_steps = static_cast<long>(iterations.size());
+            long const index = num_steps + static_cast<long>(m_load_step);
+            if (index < 0) {
+                throw std::runtime_error(
+                    "Source: load_step " + std::to_string(m_load_step) +
+                    " reaches before the first of the " + std::to_string(num_steps) +
+                    " steps in " + m_series_name +
+                    " (available steps: " + available_steps() + ")"
+                );
+            }
+            read_iteration = std::next(iterations.begin(), index)->first;
+        }
+
         io::Iteration iteration = series.iterations[read_iteration];
 
         // TODO: later we can make the particle species name an option

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -616,7 +616,10 @@ element_name) );
             bool load_ref_particle = Source::DEFAULT_load_ref_particle;
             pp_element.queryAdd("load_ref_particle", load_ref_particle);
 
-            m_lattice.emplace_back( Source(distribution, openpmd_path, active_once, load_ref_particle, element_name) );
+            int load_step = Source::DEFAULT_load_step;
+            pp_element.queryAddWithParser("load_step", load_step);
+
+            m_lattice.emplace_back( Source(distribution, openpmd_path, active_once, load_ref_particle, load_step, element_name) );
         } else if (element_type == "line")
         {
             // Parse the lattice elements for the sub-lattice in the line

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <map>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -616,10 +617,20 @@ element_name) );
             bool load_ref_particle = Source::DEFAULT_load_ref_particle;
             pp_element.queryAdd("load_ref_particle", load_ref_particle);
 
-            int load_step = Source::DEFAULT_load_step;
-            pp_element.queryAddWithParser("load_step", load_step);
+            // at most one of both is set, the default reads the last step in the file
+            std::optional<int> load_step = Source::DEFAULT_load_step;
+            int load_step_value = 0;
+            if (pp_element.queryWithParser("load_step", load_step_value)) {
+                load_step = load_step_value;
+            }
 
-            m_lattice.emplace_back( Source(distribution, openpmd_path, active_once, load_ref_particle, load_step, element_name) );
+            std::optional<int> load_step_index = Source::DEFAULT_load_step_index;
+            int load_step_index_value = 0;
+            if (pp_element.queryWithParser("load_step_index", load_step_index_value)) {
+                load_step_index = load_step_index_value;
+            }
+
+            m_lattice.emplace_back( Source(distribution, openpmd_path, active_once, load_ref_particle, load_step, load_step_index, element_name) );
         } else if (element_type == "line")
         {
             // Parse the lattice elements for the sub-lattice in the line

--- a/src/initialization/InitElement.cpp
+++ b/src/initialization/InitElement.cpp
@@ -617,7 +617,7 @@ element_name) );
             bool load_ref_particle = Source::DEFAULT_load_ref_particle;
             pp_element.queryAdd("load_ref_particle", load_ref_particle);
 
-            // at most one of both is set, the default reads the last step in the file
+            // at most one of the two is set, the default reads the last step in the file
             std::optional<int> load_step = Source::DEFAULT_load_step;
             int load_step_value = 0;
             if (pp_element.queryWithParser("load_step", load_step_value)) {

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -2473,7 +2473,8 @@ void init_elements(py::module& m)
                      std::make_pair("distribution", src.m_distribution),
                      std::make_pair("openpmd_path", src.m_series_name),
                      std::make_pair("active_once", src.m_active_once),
-                     std::make_pair("load_ref_particle", src.m_load_ref_particle)
+                     std::make_pair("load_ref_particle", src.m_load_ref_particle),
+                     std::make_pair("load_step", src.m_load_step)
                  );
              }
         )
@@ -2484,7 +2485,8 @@ void init_elements(py::module& m)
                     std::make_pair("distribution", src.m_distribution),
                     std::make_pair("openpmd_path", src.m_series_name),
                     std::make_pair("active_once", src.m_active_once),
-                    std::make_pair("load_ref_particle", src.m_load_ref_particle)
+                    std::make_pair("load_ref_particle", src.m_load_ref_particle),
+                    std::make_pair("load_step", src.m_load_step)
                 );
             }
         )
@@ -2493,12 +2495,14 @@ void init_elements(py::module& m)
              std::string,
              bool,
              bool,
+             int,
              std::optional<std::string>
          >(),
              py::arg("distribution"),
              py::arg("openpmd_path"),
              py::arg("active_once") = Source::DEFAULT_active_once,
              py::arg("load_ref_particle") = Source::DEFAULT_load_ref_particle,
+             py::arg("load_step") = Source::DEFAULT_load_step,
              py::arg("name") = py::none(),
              "A particle source."
         )
@@ -2521,6 +2525,14 @@ void init_elements(py::module& m)
             [](Source & src) { return src.m_load_ref_particle; },
             [](Source & src, bool load_ref_particle) { src.m_load_ref_particle = load_ref_particle; },
             "Restore the reference particle from the species metadata of the openPMD file (particle tracking only)."
+        )
+        .def_property("load_step",
+            [](Source & src) { return src.m_load_step; },
+            [](Source & src, int load_step) { src.m_load_step = load_step; },
+            "Which step to load from the openPMD series: a value >= 0 is the ImpactX step at "
+            "which the beam monitor wrote the beam (the openPMD iteration stored in the file), "
+            "-1 is the last step in the file and more negative values count back from it "
+            "(-2 is the second to last step)."
         )
     ;
     register_push(py_Source);

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -183,7 +183,8 @@ namespace
 
     /** Helper to format {key, value} pairs
      *
-     * Expected outcome is ", key=value" with key as a string and appropriate formatting for value.
+     * Expected outcome is ", key=value" with key as a string and appropriate formatting for value;
+     * an unset std::optional value is formatted as "None".
      *
      * @tparam T value type
      * @param arg a key-value pair

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -174,6 +174,13 @@ namespace
         );
     }
 
+    /** Trait for std::optional values, which are formatted as "None" if unset */
+    template<typename T>
+    struct is_optional : std::false_type {};
+
+    template<typename T>
+    struct is_optional<std::optional<T>> : std::true_type {};
+
     /** Helper to format {key, value} pairs
      *
      * Expected outcome is ", key=value" with key as a string and appropriate formatting for value.
@@ -186,7 +193,17 @@ namespace
     std::string
     format_extra (std::pair<char const *, T> const & arg)
     {
-        if constexpr (std::is_floating_point_v<T>)
+        if constexpr (is_optional<T>::value)
+        {
+            // optional: unset is None, otherwise the value it holds
+            if (!arg.second.has_value()) {
+                return std::string(", ")
+                    .append(arg.first)
+                    .append("=None");
+            }
+            return format_extra(std::make_pair(arg.first, arg.second.value()));
+        }
+        else if constexpr (std::is_floating_point_v<T>)
         {
             // float
             // TODO: format as scientific number
@@ -2474,19 +2491,27 @@ void init_elements(py::module& m)
                      std::make_pair("openpmd_path", src.m_series_name),
                      std::make_pair("active_once", src.m_active_once),
                      std::make_pair("load_ref_particle", src.m_load_ref_particle),
-                     std::make_pair("load_step", src.m_load_step)
+                     std::make_pair("load_step", src.m_load_step),
+                     std::make_pair("load_step_index", src.m_load_step_index)
                  );
              }
         )
         .def("to_dict",
             [](Source const & src) {
+                // an unset option is None, so that the dict can be passed to the constructor
+                ElementPropertyTypes load_step = py::none();
+                if (src.m_load_step.has_value()) { load_step = src.m_load_step.value(); }
+                ElementPropertyTypes load_step_index = py::none();
+                if (src.m_load_step_index.has_value()) { load_step_index = src.m_load_step_index.value(); }
+
                 return element_dict(
                     src,
                     std::make_pair("distribution", src.m_distribution),
                     std::make_pair("openpmd_path", src.m_series_name),
                     std::make_pair("active_once", src.m_active_once),
                     std::make_pair("load_ref_particle", src.m_load_ref_particle),
-                    std::make_pair("load_step", src.m_load_step)
+                    std::make_pair("load_step", load_step),
+                    std::make_pair("load_step_index", load_step_index)
                 );
             }
         )
@@ -2495,7 +2520,8 @@ void init_elements(py::module& m)
              std::string,
              bool,
              bool,
-             int,
+             std::optional<int>,
+             std::optional<int>,
              std::optional<std::string>
          >(),
              py::arg("distribution"),
@@ -2503,6 +2529,7 @@ void init_elements(py::module& m)
              py::arg("active_once") = Source::DEFAULT_active_once,
              py::arg("load_ref_particle") = Source::DEFAULT_load_ref_particle,
              py::arg("load_step") = Source::DEFAULT_load_step,
+             py::arg("load_step_index") = Source::DEFAULT_load_step_index,
              py::arg("name") = py::none(),
              "A particle source."
         )
@@ -2528,11 +2555,19 @@ void init_elements(py::module& m)
         )
         .def_property("load_step",
             [](Source & src) { return src.m_load_step; },
-            [](Source & src, int load_step) { src.m_load_step = load_step; },
-            "Which step to load from the openPMD series: a value >= 0 is the ImpactX step at "
-            "which the beam monitor wrote the beam (the openPMD iteration stored in the file), "
-            "-1 is the last step in the file and more negative values count back from it "
-            "(-2 is the second to last step)."
+            [](Source & src, std::optional<int> load_step) { src.m_load_step = load_step; },
+            "Which step (iteration) to load from the openPMD series: the ImpactX step at which "
+            "the beam monitor wrote the beam, which is stored as the openPMD iteration in the "
+            "file. Set at most one of load_step and load_step_index; if neither is set, the "
+            "last step in the file is loaded."
+        )
+        .def_property("load_step_index",
+            [](Source & src) { return src.m_load_step_index; },
+            [](Source & src, std::optional<int> load_step_index) { src.m_load_step_index = load_step_index; },
+            "Which step (iteration) to load from the openPMD series, by position in the file: "
+            "0 is the first step and -1 the last, counting back from it as in Python "
+            "(-2 is the second to last step). Set at most one of load_step and load_step_index; "
+            "if neither is set, the last step in the file is loaded."
         )
     ;
     register_push(py_Source);

--- a/tests/python/test_source_load_step.py
+++ b/tests/python/test_source_load_step.py
@@ -11,6 +11,7 @@
 Test that the Source element can load a selected step (openPMD iteration).
 """
 
+import re
 from pathlib import Path
 
 import pytest
@@ -32,16 +33,17 @@ BACKEND = "h5" if Config.openpmd_backends.get("hdf5", False) else "default"
 RTOL = 1.0e-12 if Config.precision == "DOUBLE" else 1.0e-5
 
 
-def write_series(name, npart):
+def write_series(name, npart, periods=1):
     """Track a beam through two monitors and return the written series' path.
 
-    The lattice writes two steps: one at s=0 and one at s=DRIFT_DS.
+    The lattice writes two steps per period: one at s=0 and one at s=DRIFT_DS.
     """
     sim = ImpactX()
 
     sim.particle_shape = 2
     sim.space_charge = False
     sim.slice_step_diagnostics = False
+    sim.periods = periods
     sim.init_grids()
 
     ref = sim.beam.ref
@@ -85,7 +87,7 @@ def stored_steps(series_path):
 def test_source_load_step():
     """
     This tests that the Source element loads the step (openPMD iteration)
-    selected with load_step, absolute as well as counted back from the last.
+    selected by step number with load_step and by position with load_step_index.
     """
     npart = 512
     series_path = write_series("mon_load_step", npart)
@@ -105,48 +107,127 @@ def test_source_load_step():
     try:
         # the reference particle is restored per push, so we can read
         # several steps into the same particle container
-        for load_step, s_expected in [
-            (steps[0], 0.0),  # first step: absolute
-            (steps[-1], DRIFT_DS),  # last step: absolute
-            (-1, DRIFT_DS),  # last step: counted back
-            (-2, 0.0),  # first step: counted back
+        for selection, s_expected in [
+            ({"load_step": steps[0]}, 0.0),  # first step: by step number
+            ({"load_step": steps[-1]}, DRIFT_DS),  # last step: by step number
+            ({"load_step_index": 0}, 0.0),  # first step: by position
+            ({"load_step_index": 1}, DRIFT_DS),  # last step: by position
+            ({"load_step_index": -1}, DRIFT_DS),  # last step: counted back
+            ({"load_step_index": -2}, 0.0),  # first step: counted back
+            ({}, DRIFT_DS),  # the default is the last step in the file
         ]:
-            source = elements.Source(
-                "openPMD", series_path, load_step=load_step, name="source"
-            )
+            source = elements.Source("openPMD", series_path, name="source", **selection)
             push(beam, source)
             assert beam.ref.s == pytest.approx(s_expected, rel=RTOL, abs=1.0e-12)
             assert beam.ref.kin_energy_MeV == pytest.approx(250.0, rel=RTOL)
 
-        # the default is the last step in the file
-        push(beam, elements.Source("openPMD", series_path))
-        assert beam.ref.s == pytest.approx(DRIFT_DS, rel=RTOL)
-
-        # a step that is not in the file lists the available steps
+        # a step that is not in the file lists the steps that are in it
         missing = steps[-1] + 1
-        with pytest.raises(RuntimeError, match="available steps"):
+        with pytest.raises(RuntimeError, match="available steps") as error:
+            push(beam, elements.Source("openPMD", series_path, load_step=missing))
+        assert f"{len(steps)} available steps" in str(error.value)
+
+        # an index that reaches past either end of the file
+        for load_step_index in [-3, 2]:
+            with pytest.raises(RuntimeError, match="out of range") as error:
+                push(
+                    beam,
+                    elements.Source(
+                        "openPMD", series_path, load_step_index=load_step_index
+                    ),
+                )
+            assert f"{len(steps)} available steps" in str(error.value)
+
+        # both options set after construction is caught when the step is read
+        source = elements.Source("openPMD", series_path, load_step=steps[0])
+        source.load_step_index = -1
+        with pytest.raises(ValueError, match="not both"):
+            push(beam, source)
+    finally:
+        sim.finalize()
+
+
+def test_source_load_step_selection():
+    """
+    This tests that at most one of load_step and load_step_index selects the
+    step and that load_step is a step number, not a position in the file.
+    """
+    with pytest.raises(ValueError, match="not both"):
+        elements.Source("openPMD", "beam.h5", load_step=3, load_step_index=-1)
+
+    # counting back from the last step is load_step_index, not a negative load_step
+    with pytest.raises(ValueError, match="load_step_index"):
+        elements.Source("openPMD", "beam.h5", load_step=-2)
+
+
+@pytest.mark.manages_amrex
+def test_source_load_step_many_steps():
+    """
+    This tests that the available steps in the error message are elided in the
+    middle for a series with many steps, e.g. one per turn in a ring.
+    """
+    series_path = write_series("mon_load_step_many", npart=32, periods=51)
+
+    steps = stored_steps(series_path)
+    assert len(steps) > 100
+
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    # keep init_grids from moving the diags directory we just wrote out of the way
+    sim.diagnostics = False
+    sim.init_grids()
+    beam = sim.beam
+
+    try:
+        missing = steps[-1] + 1
+        with pytest.raises(RuntimeError, match="available steps") as error:
             push(beam, elements.Source("openPMD", series_path, load_step=missing))
 
-        # counting back further than the first step in the file
-        with pytest.raises(RuntimeError, match="available steps"):
-            push(beam, elements.Source("openPMD", series_path, load_step=-3))
+        message = str(error.value)
+        assert "..." in message
+        assert f"{len(steps)} available steps" in message
+
+        # the first and last steps are listed, the middle ones are elided
+        listed = re.findall(r"\d+", message.split("available steps: ")[1])
+        assert str(steps[0]) in listed
+        assert str(steps[-1]) in listed
+        assert str(steps[len(steps) // 2]) not in listed
+        assert len(listed) == 100
     finally:
         sim.finalize()
 
 
 def test_source_load_step_serialization():
     """
-    This tests that load_step is part of the element's repr and to_dict().
+    This tests that load_step and load_step_index are part of the element's
+    repr and to_dict(), and that an unset option is None.
     """
     source = elements.Source("openPMD", "beam.h5", load_step=3)
     assert source.load_step == 3
+    assert source.load_step_index is None
     assert "load_step=3" in repr(source)
+    assert "load_step_index=None" in repr(source)
 
     d = source.to_dict()
     assert d["load_step"] == 3
+    assert d["load_step_index"] is None
 
-    # default: the last step in the file
-    assert elements.Source("openPMD", "beam.h5").load_step == -1
+    # the dict round-trips through the constructor
+    kwargs = {k: v for k, v in d.items() if k not in ("type", "ds")}
+    assert elements.Source(**kwargs).load_step == 3
 
-    source.load_step = -2
-    assert source.load_step == -2
+    source = elements.Source("openPMD", "beam.h5", load_step_index=-2)
+    assert source.load_step is None
+    assert source.load_step_index == -2
+    assert source.to_dict()["load_step_index"] == -2
+
+    # neither is set by default: the last step in the file is loaded
+    default = elements.Source("openPMD", "beam.h5")
+    assert default.load_step is None
+    assert default.load_step_index is None
+    assert "load_step=None" in repr(default)
+
+    # an option can be unset again
+    source.load_step_index = None
+    assert source.load_step_index is None

--- a/tests/python/test_source_load_step.py
+++ b/tests/python/test_source_load_step.py
@@ -23,8 +23,9 @@ io = pytest.importorskip("openpmd_api")
 if not Config.have_openpmd:
     pytest.skip("ImpactX was compiled without openPMD support", allow_module_level=True)
 
-# the drift between the two beam monitors
-DRIFT_DS = 0.25
+# the drift between the two beam monitors: long enough that the beam widens
+# well beyond the sampling noise of the moments of a finite number of particles
+DRIFT_DS = 2.0
 
 # HDF5 as in the solenoid_restart example, else whatever this build provides
 BACKEND = "h5" if Config.openpmd_backends.get("hdf5", False) else "default"
@@ -136,7 +137,7 @@ def test_source_load_step():
             assert values == pytest.approx([values[0]] * len(values), rel=RTOL)
 
         # ... and the beam widens along the drift between the two steps
-        assert sig_x[0.0][0] < sig_x[DRIFT_DS][0]
+        assert sig_x[DRIFT_DS][0] > 1.1 * sig_x[0.0][0]
 
         # a step that is not in the file lists the steps that are in it
         missing = steps[-1] + 1

--- a/tests/python/test_source_load_step.py
+++ b/tests/python/test_source_load_step.py
@@ -105,8 +105,10 @@ def test_source_load_step():
     beam = sim.beam
 
     try:
-        # the reference particle is restored per push, so we can read
-        # several steps into the same particle container
+        # sig_x of the loaded particles, per step: the reference particle alone
+        # would not show whether the particles come from the selected step
+        sig_x = {}
+
         for selection, s_expected in [
             ({"load_step": steps[0]}, 0.0),  # first step: by step number
             ({"load_step": steps[-1]}, DRIFT_DS),  # last step: by step number
@@ -116,10 +118,25 @@ def test_source_load_step():
             ({"load_step_index": -2}, 0.0),  # first step: counted back
             ({}, DRIFT_DS),  # the default is the last step in the file
         ]:
+            # the source adds to the container, so read each step into an empty one
+            beam.clear_particles()
+
             source = elements.Source("openPMD", series_path, name="source", **selection)
             push(beam, source)
             assert beam.ref.s == pytest.approx(s_expected, rel=RTOL, abs=1.0e-12)
             assert beam.ref.kin_energy_MeV == pytest.approx(250.0, rel=RTOL)
+
+            moments = beam.beam_moments()
+            # the whole beam was read into the emptied container
+            assert moments["charge_C"] == pytest.approx(1.0e-9, rel=RTOL)
+            sig_x.setdefault(s_expected, []).append(moments["sig_x"])
+
+        # the same step selected by number or by position holds the same particles
+        for values in sig_x.values():
+            assert values == pytest.approx([values[0]] * len(values), rel=RTOL)
+
+        # ... and the beam widens along the drift between the two steps
+        assert sig_x[0.0][0] < sig_x[DRIFT_DS][0]
 
         # a step that is not in the file lists the steps that are in it
         missing = steps[-1] + 1

--- a/tests/python/test_source_load_step.py
+++ b/tests/python/test_source_load_step.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+"""
+Test that the Source element can load a selected step (openPMD iteration).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from impactx import Config, ImpactX, distribution, elements, push
+
+io = pytest.importorskip("openpmd_api")
+
+if not Config.have_openpmd:
+    pytest.skip("ImpactX was compiled without openPMD support", allow_module_level=True)
+
+# the drift between the two beam monitors
+DRIFT_DS = 0.25
+
+# HDF5 as in the solenoid_restart example, else whatever this build provides
+BACKEND = "h5" if Config.openpmd_backends.get("hdf5", False) else "default"
+
+# exact for a single drift, but single precision accumulates a few epsilon
+RTOL = 1.0e-12 if Config.precision == "DOUBLE" else 1.0e-5
+
+
+def write_series(name, npart):
+    """Track a beam through two monitors and return the written series' path.
+
+    The lattice writes two steps: one at s=0 and one at s=DRIFT_DS.
+    """
+    sim = ImpactX()
+
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.slice_step_diagnostics = False
+    sim.init_grids()
+
+    ref = sim.beam.ref
+    ref.set_species("proton").set_kin_energy_MeV(250.0)
+
+    distr = distribution.Waterbag(
+        lambdaX=1.559531175539e-3,
+        lambdaY=2.205510139392e-3,
+        lambdaT=1.0e-3,
+        lambdaPx=6.41218345413e-4,
+        lambdaPy=9.06819680526e-4,
+        lambdaPt=1.0e-3,
+    )
+    sim.add_particles(1.0e-9, distr, npart)
+
+    monitor = elements.BeamMonitor(name, backend=BACKEND)
+    sim.lattice.extend([monitor, elements.Drift(name="d1", ds=DRIFT_DS), monitor])
+
+    try:
+        sim.track_particles()
+    finally:
+        # this closes the openPMD series, so that we can read it back below
+        sim.finalize()
+
+    files = sorted(Path("diags/openPMD").glob(f"{name}.*"))
+    assert files, f"no openPMD series found for monitor '{name}'"
+
+    return str(files[0])
+
+
+def stored_steps(series_path):
+    """The steps (openPMD iterations) stored in a series."""
+    series = io.Series(series_path, io.Access.read_only)
+    steps = sorted(series.iterations)
+    series.close()
+
+    return steps
+
+
+@pytest.mark.manages_amrex
+def test_source_load_step():
+    """
+    This tests that the Source element loads the step (openPMD iteration)
+    selected with load_step, absolute as well as counted back from the last.
+    """
+    npart = 512
+    series_path = write_series("mon_load_step", npart)
+
+    steps = stored_steps(series_path)
+    assert len(steps) == 2
+
+    # read back into a fresh simulation
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    # keep init_grids from moving the diags directory we just wrote out of the way
+    sim.diagnostics = False
+    sim.init_grids()
+    beam = sim.beam
+
+    try:
+        # the reference particle is restored per push, so we can read
+        # several steps into the same particle container
+        for load_step, s_expected in [
+            (steps[0], 0.0),  # first step: absolute
+            (steps[-1], DRIFT_DS),  # last step: absolute
+            (-1, DRIFT_DS),  # last step: counted back
+            (-2, 0.0),  # first step: counted back
+        ]:
+            source = elements.Source(
+                "openPMD", series_path, load_step=load_step, name="source"
+            )
+            push(beam, source)
+            assert beam.ref.s == pytest.approx(s_expected, rel=RTOL, abs=1.0e-12)
+            assert beam.ref.kin_energy_MeV == pytest.approx(250.0, rel=RTOL)
+
+        # the default is the last step in the file
+        push(beam, elements.Source("openPMD", series_path))
+        assert beam.ref.s == pytest.approx(DRIFT_DS, rel=RTOL)
+
+        # a step that is not in the file lists the available steps
+        missing = steps[-1] + 1
+        with pytest.raises(RuntimeError, match="available steps"):
+            push(beam, elements.Source("openPMD", series_path, load_step=missing))
+
+        # counting back further than the first step in the file
+        with pytest.raises(RuntimeError, match="available steps"):
+            push(beam, elements.Source("openPMD", series_path, load_step=-3))
+    finally:
+        sim.finalize()
+
+
+def test_source_load_step_serialization():
+    """
+    This tests that load_step is part of the element's repr and to_dict().
+    """
+    source = elements.Source("openPMD", "beam.h5", load_step=3)
+    assert source.load_step == 3
+    assert "load_step=3" in repr(source)
+
+    d = source.to_dict()
+    assert d["load_step"] == 3
+
+    # default: the last step in the file
+    assert elements.Source("openPMD", "beam.h5").load_step == -1
+
+    source.load_step = -2
+    assert source.load_step == -2


### PR DESCRIPTION
The `source` element read the last openPMD iteration of a series.
In a ring, a beam monitor might write one step out per turn, so restarting from a specific turn was not possible.

This adds two options that select which step to load, of which at most one is set:

- `load_step`: the ImpactX step at which the beam monitor wrote the beam, which is stored as the openPMD iteration in the file
- `load_step_index`: the position of the step in the file, `0` is the first step and `-1` the last, counting back from it as in Python

If neither is set, the last step in the file is loaded, as before.

```python
# an ImpactX step stored in the file
push(beam, elements.Source("openPMD", "diags/openPMD/m1.h5", load_step=3))

# the second to last step in the file
push(beam, elements.Source("openPMD", "diags/openPMD/m1.h5", load_step_index=-2))
```

```ini
source.type = source
source.distribution = openPMD
source.openpmd_path = "../ring/diags/openPMD/m1.h5"
source.load_step = 3
# or, by position in the file:
#   source.load_step_index = -2
```

The step numbers stored in a series are usually not consecutive, because the global step counter also advances in the elements between two monitors.
Use `load_step_index` when they are not known, e.g. to continue from the last turn that a ring wrote.

A step that is not in the file aborts with the steps that are in it, e.g.

```
Source: load_step 7 not found in ../solenoid/diags/openPMD/m1.h5 (2 available steps: 1, 3)
```

The same list is printed for an index that reaches past either end of the file.
It is elided in the middle above 100 steps, so that a ring that wrote one step per turn does not print thousands of numbers:

```
Source: load_step 99999 not found in diags/openPMD/m1.h5 (102 available steps: 1, 3, 4, 6, ..., 151, 153)
```

Setting both options, or a negative `load_step` (which is `load_step_index` instead), is an error as well.
This is checked on construction and again when the step is read, because both options can also be set on an existing element.

Both options are keyword arguments in front of `name`, so `name` moves in the positional order of the constructor and needs to be passed as a keyword argument, as everywhere else in ImpactX.

An empty series is now caught as well, instead of dereferencing the end of an empty container.

Selecting a step works for every iteration encoding that the `beam_monitor` writes.
ImpactX requires openPMD-api 0.17.0 or newer, and as of 0.17 a `v` (variable based) series reads back in random access from BP4 and BP5 files, which is what the `source` element uses.
The `beam_monitor` documentation still carries a note from before that, which is fixed in a separate PR.

Tested in the new `tests/python/test_source_load_step.py`: a monitor series with two steps is read back by step number, by position from both ends, and by the default; the error paths, the elided step list of a series with more than 100 steps, and the `repr`/`to_dict` round-trip of both options are checked as well.

Closes #1284

## To Do

- [x] draft 🤖 generated with [Claude Code](https://claude.com/claude-code)
- [x] self-review
- [x] bot-review
- [x] finalize
