### PR TITLE
Perlmutter CUDA 13.2 & Consistent Purge of JIT Caches

### DIFF
--- a/docs/source/install/hpc/lumi-csc/install_cpu_dependencies.sh
+++ b/docs/source/install/hpc/lumi-csc/install_cpu_dependencies.sh
@@ -31,6 +31,10 @@ python3 -m pip uninstall -qq -y pyimpactx
 python3 -m pip uninstall -qq -y impactx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # General extra dependencies ##################################################
 #
@@ -103,7 +107,6 @@ rm -rf ${build_dir}/adios2-build
 #
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
-python3 -m pip cache purge
 rm -rf ${SW_DIR}/venvs/impactx-cpu-lumi
 python3 -m venv ${SW_DIR}/venvs/impactx-cpu-lumi
 source ${SW_DIR}/venvs/impactx-cpu-lumi/bin/activate

--- a/docs/source/install/hpc/lumi-csc/install_gpu_dependencies.sh
+++ b/docs/source/install/hpc/lumi-csc/install_gpu_dependencies.sh
@@ -31,6 +31,10 @@ python3 -m pip uninstall -qq -y pyimpactx
 python3 -m pip uninstall -qq -y impactx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # General extra dependencies ##################################################
 #
@@ -103,7 +107,6 @@ rm -rf ${build_dir}/adios2-build
 #
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
-python3 -m pip cache purge
 rm -rf ${SW_DIR}/venvs/impactx-gpu-lumi
 python3 -m venv ${SW_DIR}/venvs/impactx-gpu-lumi
 source ${SW_DIR}/venvs/impactx-gpu-lumi/bin/activate

--- a/docs/source/install/hpc/perlmutter-nersc/install_cpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_cpu_dependencies.sh
@@ -39,6 +39,10 @@ mkdir -p ${SW_DIR}
 python3 -m pip uninstall -qq -y impactx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # General extra dependencies ##################################################
 #
@@ -98,7 +102,6 @@ rm -rf ${build_dir}/adios2-pm-cpu-build
 #
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
-python3 -m pip cache purge
 rm -rf ${SW_DIR}/venvs/impactx
 python3 -m venv ${SW_DIR}/venvs/impactx
 source ${SW_DIR}/venvs/impactx/bin/activate

--- a/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
@@ -39,6 +39,10 @@ mkdir -p ${SW_DIR}
 python3 -m pip uninstall -qq -y impactx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # General extra dependencies ##################################################
 #
@@ -98,7 +102,6 @@ rm -rf ${build_dir}/adios2-pm-gpu-build
 #
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
-python3 -m pip cache purge
 rm -rf ${SW_DIR}/venvs/impactx
 python3 -m venv ${SW_DIR}/venvs/impactx
 source ${SW_DIR}/venvs/impactx/bin/activate

--- a/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/docs/source/install/hpc/perlmutter-nersc/install_gpu_dependencies.sh
@@ -120,8 +120,8 @@ python3 -m pip install --upgrade matplotlib
 python3 -m pip install --upgrade yt
 # install or update impactx dependencies
 python3 -m pip install --upgrade -r $HOME/src/impactx/requirements.txt
-python3 -m pip install --upgrade cupy-cuda12x  # CUDA 12 compatible wheel
-python3 -m pip install --upgrade torch  # CUDA 12 compatible wheel
+python3 -m pip install --upgrade cupy-cuda13x  # CUDA 13 compatible wheel
+python3 -m pip install --upgrade torch --index-url https://download.pytorch.org/whl/cu132  # CUDA 13.2 compatible wheel
 
 
 # remove build temporary directory

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
@@ -8,7 +8,7 @@ if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in yo
 # these module versions are current and compatible as of Cray Programming Environment 24.07 (module cpe)
 
 # required dependencies
-module load gcc-native/13.2  # default gcc-native/14 breaks pybind11 builds with NVCC 12.9.41
+module load gcc-native/13.2  # default gcc-native/14 breaks pybind11 builds with NVCC 13.2.78
 module load cmake/3.30.2
 
 # optional: for the synmadx MAD-X lattice parser


### PR DESCRIPTION
HPC install scripts: Ensure existing PIP and JIT Python caches do not survive system upgrades and pull in stale dependencies, e.g., on old CUDA toolkits.

<details>

## X-ref

- WarpX: https://github.com/BLAST-WarpX/warpx/pull/7183 (same change, all `Tools/machines/` scripts)

## Summary

Often, after HPC system upgrades, pip caches have wheels in them that still depend on old system libs, old system modules or old CUDA runtimes that are then incompatible when combined together in Python runs/imports.

This adds a cache purge to every `install*` script in `docs/source/install/hpc/`, early in the "Remove old dependencies" section, before any dependency is installed.

## Details

User-facing:
- every HPC `install*` script now runs `python3 -m pip cache purge` and additionally wipes the GPU kernel/JIT caches `~/.cupy/kernel_cache`, `~/.nv/ComputeCache`, `~/.cache/numba` and `~/.triton`, which `pip cache purge` does not cover but which go equally stale over a CUDA/ROCm runtime upgrade

Internal:
- the purge moved up from the venv section into the "Remove old dependencies" section; the later, then redundant `pip cache purge` calls are removed, so each script purges exactly once
- the purge is guarded with `|| true` so that a disabled cache or a pip too old for the `cache` subcommand does not abort the script under `set -e`

## Testing

`bash -n` passes on all four scripts.

</details>