### PR TITLE
[WIP] Python: Run Multiple Simulations Per Process

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -527,6 +527,22 @@ Collective Effects & Overall Simulation Parameters
 
       Resize the mesh :py:attr:`~domain` based on the :py:attr:`~dynamic_size` and related parameters.
 
+   .. py:method:: finalize()
+
+      Deallocate all contexts and data of the simulation.
+      This is also called when the simulation object is destroyed.
+
+      Afterwards, a new :py:class:`impactx.ImpactX` simulation can be created in the same process, e.g., for parameter scans and optimization loops that run one simulation per iteration.
+      A new simulation starts with fresh inputs: set the parameters of interest again on the new simulation object.
+
+      .. note::
+
+         In :py:meth:`~init_grids`, ImpactX initializes MPI and AMReX if they are not yet initialized.
+         MPI stays initialized until the end of the process, so that any number of simulations can run in it; AMReX is finalized in ``finalize()``.
+
+         Whoever initializes MPI or AMReX also finalizes it.
+         If MPI is initialized before ImpactX, e.g., by importing ``mpi4py.MPI``, or if AMReX is initialized before ImpactX, e.g., by calling ``amrex.space3d.initialize()``, then ImpactX leaves both initialization and finalization to the caller.
+
 
 .. py:class:: impactx.Envelope
 

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -12,6 +12,7 @@
 #include "diagnostics/FilePrefix.H"
 #include "elements/mixin/accessors.H"
 #include "elements/mixin/dynamicdata.H"
+#include "initialization/InitAMReX.H"
 #include "initialization/InitAmrCore.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/Push.H"
@@ -57,8 +58,9 @@ namespace impactx {
             // this one last
             amr_data.reset();
 
-            if (amrex::Initialized())
-                amrex::Finalize();
+            // only finalize AMReX if we initialized it: another library or the
+            // user (e.g., via pyAMReX) might own AMReX in this process
+            initialization::default_finalize_AMReX();
 
             // only finalize once
             m_grids_initialized = false;

--- a/src/initialization/InitAMReX.H
+++ b/src/initialization/InitAMReX.H
@@ -18,14 +18,32 @@ namespace impactx::initialization
     /** Initialize AMReX
      *
      * Initializes AMReX if not already done.
+     *
+     * If MPI is enabled and not yet initialized, MPI is initialized here (and
+     * finalized at process exit), so that MPI outlives all
+     * amrex::Initialize/amrex::Finalize cycles of the process.
      */
     void default_init_AMReX (int argc, char* argv[]);
 
     /** Initialize AMReX
      *
      * Initializes AMReX if not already done.
+     *
+     * If MPI is enabled and not yet initialized, MPI is initialized here (and
+     * finalized at process exit), so that MPI outlives all
+     * amrex::Initialize/amrex::Finalize cycles of the process.
      */
     void default_init_AMReX ();
+
+    /** Finalize AMReX, if ImpactX initialized it
+     *
+     * This is a no-op if AMReX was initialized by another library or by the
+     * user (e.g., via pyAMReX), because then the entity that initialized AMReX
+     * also finalizes it.
+     *
+     * @return true if amrex::Finalize() was called
+     */
+    bool default_finalize_AMReX ();
 
 } // namespace impactx::initialization
 

--- a/src/initialization/InitAMReX.cpp
+++ b/src/initialization/InitAMReX.cpp
@@ -11,6 +11,8 @@
 
 #include "initialization/InitParser.H"
 
+#include <ablastr/parallelization/MPIInitHelpers.H>
+
 #include <AMReX.H>
 #include <AMReX_ParallelDescriptor.H>
 
@@ -21,28 +23,133 @@
 using amrex::mpidatatypes::MPI_COMM_WORLD;
 #endif
 
+#include <cstdlib>
+
 
 namespace impactx::initialization
 {
+namespace
+{
+    /** Did ImpactX initialize AMReX?
+     *
+     * Only then do we finalize AMReX in ImpactX::finalize(). Otherwise, e.g.,
+     * pyAMReX or another simulation code in the same process owns AMReX.
+     */
+    bool s_amrex_initialized_by_impactx = false;
+
+#if defined(AMREX_USE_MPI)
+    /** Finalize MPI at process exit
+     *
+     * This is only registered if ImpactX initialized MPI itself.
+     */
+    void
+    finalize_MPI_atexit ()
+    {
+        int is_finalized = 0;
+        MPI_Finalized(&is_finalized);
+        if (!is_finalized)
+        {
+            ablastr::parallelization::mpi_finalize();
+        }
+    }
+
+    /** Initialize MPI, if not already done
+     *
+     * We initialize MPI here instead of letting amrex::Initialize() do it,
+     * because AMReX finalizes MPI in amrex::Finalize() if and only if it
+     * initialized MPI itself. MPI cannot be re-initialized after MPI_Finalize,
+     * which would make an ImpactX simulation the last one in its process.
+     * Initializing MPI here and finalizing it at process exit keeps MPI alive
+     * over arbitrarily many amrex::Initialize/amrex::Finalize cycles, e.g., for
+     * parameter scans and optimization loops that create a new ImpactX
+     * simulation per iteration.
+     */
+    void
+    init_MPI (int argc, char* argv[])
+    {
+        int is_initialized = 0;
+        MPI_Initialized(&is_initialized);
+        if (is_initialized)
+        {
+            // MPI is owned by the user, e.g., by main() or by mpi4py
+            return;
+        }
+
+        ablastr::parallelization::mpi_init(argc, argv);
+
+        std::atexit(finalize_MPI_atexit);
+    }
+#endif
+} // namespace <anonymous>
+
     void
     default_init_AMReX (int argc, char* argv[])
     {
-        if (!amrex::Initialized())
+        if (amrex::Initialized())
         {
-            bool const build_parm_parse = true;
-            amrex::Initialize(
-                    argc,
-                    argv,
-                    build_parm_parse,
-                    MPI_COMM_WORLD,
-                    impactx::initialization::overwrite_amrex_parser_defaults
-            );
+            // AMReX is owned by the user, e.g., by pyAMReX or another
+            // simulation code in the same process
+            return;
         }
+
+        // amrex::Initialize() only initializes its runtime parameter database
+        // (ParmParse) if a command line is passed (argc >= 1). Without
+        // ParmParse::Initialize, ParmParse also never registers its
+        // ParmParse::Finalize, i.e., its parameter table is never cleared in
+        // amrex::Finalize() and the inputs of a simulation leak into the next
+        // simulation of the same process. Thus, pass a dummy program name if we
+        // have no command line.
+        // Note: with argc == 1, AMReX passes no command line arguments on to
+        //       ParmParse, it only uses argv[0] as the executable name.
+        char program_name[] = "impactx";
+        char* dummy_argv[] = {program_name, nullptr};
+        if (argc < 1)
+        {
+            argc = 1;
+            argv = dummy_argv;
+        }
+
+#if defined(AMREX_USE_MPI)
+        init_MPI(argc, argv);
+#endif
+
+        bool const build_parm_parse = true;
+        amrex::Initialize(
+                argc,
+                argv,
+                build_parm_parse,
+                MPI_COMM_WORLD,
+                impactx::initialization::overwrite_amrex_parser_defaults
+        );
+
+        s_amrex_initialized_by_impactx = true;
     }
 
     void
     default_init_AMReX ()
     {
         default_init_AMReX(0, nullptr);
+    }
+
+    bool
+    default_finalize_AMReX ()
+    {
+        if (!s_amrex_initialized_by_impactx)
+        {
+            return false;
+        }
+
+        // reset first: if AMReX was already finalized by the user, e.g., via
+        // pyAMReX, we do not own it anymore either
+        s_amrex_initialized_by_impactx = false;
+
+        if (!amrex::Initialized())
+        {
+            return false;
+        }
+
+        amrex::Finalize();
+
+        return true;
     }
 } // namespace impactx::initialization

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,19 +10,17 @@
 #include "ImpactX.H"
 #include "initialization/InitAMReX.H"
 
+#include <ablastr/parallelization/MPIInitHelpers.H>
+
 #include <AMReX.H>
 #include <AMReX_BLProfiler.H>
-
-#if defined(AMREX_USE_MPI)
-#   include <mpi.h>
-#endif
 
 
 int main(int argc, char* argv[])
 {
-#if defined(AMREX_USE_MPI)
-    AMREX_ALWAYS_ASSERT(MPI_SUCCESS == MPI_Init(&argc, &argv));
-#endif
+    // initialize MPI with the thread support level that this build was
+    // configured for, e.g., for async I/O (a no-op if built without MPI)
+    ablastr::parallelization::mpi_init(argc, argv);
 
     // although ImpactX' init_grids will call this if not done before, we call
     // it here so users can pass command line arguments
@@ -39,7 +37,5 @@ int main(int argc, char* argv[])
         impactX.finalize();
     }
 
-#if defined(AMREX_USE_MPI)
-    AMREX_ALWAYS_ASSERT(MPI_SUCCESS == MPI_Finalize());
-#endif
+    ablastr::parallelization::mpi_finalize();
 }

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -591,7 +591,11 @@ void init_ImpactX (py::module& m)
                  amrex::ParmParse pp_impactx("impactx");
                  pp_impactx.add("abort_on_warning_threshold", str_abort_on_warning_threshold);
                  // query input for warning logger variables and set up warning logger accordingly
-                 ix.init_warning_logger();
+                 //   the warning logger needs AMReX: if it is not yet initialized,
+                 //   ImpactX::init_grids sets the logger up from the same input
+                 if (amrex::Initialized()) {
+                     ix.init_warning_logger();
+                 }
              },
              "Set WarnPriority threshold to decide if ImpactX\n"
              "has to abort when a warning is recorded.\n"
@@ -617,7 +621,11 @@ void init_ImpactX (py::module& m)
                 amrex::ParmParse pp_amrex("amrex");
                 pp_amrex.add("abort_on_unused_inputs", abort_on_unused_inputs);
                 // query input for warning logger variables and set up warning logger accordingly
-                ix.init_warning_logger();
+                //   the warning logger needs AMReX: if it is not yet initialized,
+                //   ImpactX::init_grids sets the logger up from the same input
+                if (amrex::Initialized()) {
+                    ix.init_warning_logger();
+                }
             },
             "Configure simulation to abort AFTER it has run\n"
             "if there are unused parameters in the input."

--- a/tests/python/test_lifecycle.py
+++ b/tests/python/test_lifecycle.py
@@ -165,3 +165,27 @@ print("EXTERNAL_AMREX_OK")
     proc, output = run_snippet(snippet)
     assert proc.returncode == 0, output
     assert "EXTERNAL_AMREX_OK" in output, output
+
+
+@pytest.mark.manages_amrex
+def test_warning_inputs_before_init_grids():
+    """Warning logger inputs can be set before the simulation is initialized."""
+    snippet = """
+from impactx import ImpactX
+
+sim = ImpactX()
+sim.abort_on_warning_threshold = "high"
+sim.abort_on_unused_inputs = 0
+sim.always_warn_immediately = 1
+sim.particle_shape = 2
+sim.init_grids()
+
+assert sim.abort_on_warning_threshold == "high"
+assert sim.abort_on_unused_inputs == 0
+
+sim.finalize()
+print("WARNING_INPUTS_OK")
+"""
+    proc, output = run_snippet(snippet)
+    assert proc.returncode == 0, output
+    assert "WARNING_INPUTS_OK" in output, output

--- a/tests/python/test_lifecycle.py
+++ b/tests/python/test_lifecycle.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 ImpactX contributors
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+"""
+Test the lifetime of a simulation: that inputs can be set before the simulation
+is initialized, and that multiple simulations can run in the same process, e.g.,
+for parameter scans and optimization loops that create one simulation per
+iteration.
+
+Each scenario runs in a fresh subprocess that does not import mpi4py, so that
+ImpactX controls the MPI lifetime itself. In the pytest process, ``conftest.py``
+already initializes MPI (via mpi4py) and AMReX, which would hide regressions in
+the ImpactX-owned lifetime.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+# a small, quick simulation: tracked in a helper function so we can run it twice
+SIM_HELPER = """
+from impactx import ImpactX, distribution, elements
+
+distr = distribution.Waterbag(
+    lambdaX=3.9984884770e-5,
+    lambdaY=3.9984884770e-5,
+    lambdaT=1.0e-3,
+    lambdaPx=2.6623538760e-5,
+    lambdaPy=2.6623538760e-5,
+    lambdaPt=2.0e-3,
+    muxpx=-0.846574929020762,
+    muypy=0.846574929020762,
+    mutpt=0.0,
+)
+
+
+def run_sim():
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.diagnostics = False
+    sim.slice_step_diagnostics = False
+    sim.tiny_profiler = False
+    sim.init_grids()
+
+    sim.beam.ref.set_species("electron").set_kin_energy_MeV(2.0e3)
+    sim.add_particles(1.0e-9, distr, 1000)
+    sim.lattice.extend(
+        [
+            elements.Drift(name="d1", ds=0.25, nslice=1),
+            elements.Quad(name="q1", ds=1.0, k=1.0, nslice=1),
+            elements.Drift(name="d2", ds=0.5, nslice=1),
+        ]
+    )
+    sim.track_particles()
+
+    rbc = sim.beam.reduced_beam_characteristics()
+    sim.finalize()
+
+    return rbc
+"""
+
+
+def run_snippet(snippet):
+    """Run a Python snippet in a subprocess.
+
+    Returns the completed process and its combined output.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    return proc, proc.stdout + " " + proc.stderr
+
+
+@pytest.mark.manages_amrex
+def test_two_simulations_in_one_process():
+    """Two simulations, one after the other, in a single process."""
+    snippet = (
+        SIM_HELPER
+        + """
+first = run_sim()
+second = run_sim()
+
+# same input, same random seed: identical results
+assert first["sig_x"] == second["sig_x"], (first["sig_x"], second["sig_x"])
+print("TWO_RUNS_OK")
+"""
+    )
+    proc, output = run_snippet(snippet)
+    assert proc.returncode == 0, output
+    assert "TWO_RUNS_OK" in output, output
+
+
+@pytest.mark.manages_amrex
+def test_inputs_do_not_leak_between_simulations():
+    """A finalized simulation does not pass its inputs on to the next one."""
+    snippet = """
+from impactx import ImpactX
+
+sim = ImpactX()
+sim.particle_shape = 2
+sim.space_charge = True
+sim.dynamic_size = True
+sim.prob_relative = [3.0]
+sim.n_cell = [16, 16, 16]
+sim.init_grids()
+assert sim.space_charge == "3D"
+sim.finalize()
+del sim
+
+# a new simulation does not inherit the inputs of the previous one
+sim = ImpactX()
+for prop in ["space_charge", "prob_relative", "n_cell"]:
+    try:
+        value = getattr(sim, prop)
+    except RuntimeError:
+        pass  # not set: as expected for a fresh simulation
+    else:
+        raise AssertionError(f"{prop} leaked from the previous simulation: {value}")
+sim.finalize()
+print("NO_LEAK_OK")
+"""
+    proc, output = run_snippet(snippet)
+    assert proc.returncode == 0, output
+    assert "NO_LEAK_OK" in output, output
+
+
+@pytest.mark.manages_amrex
+def test_externally_initialized_amrex_is_not_finalized():
+    """ImpactX only finalizes AMReX if it initialized AMReX itself."""
+    snippet = """
+import amrex.space3d as amr
+from impactx import ImpactX
+
+amr.initialize(["amrex.verbose=0", "particles.do_tiling=1"])
+
+sim = ImpactX()
+sim.particle_shape = 2
+sim.init_grids()
+sim.finalize()
+del sim
+
+assert amr.initialized(), "AMReX was finalized by ImpactX, but not initialized by it"
+
+# a second simulation in the same AMReX context
+sim = ImpactX()
+sim.particle_shape = 2
+sim.init_grids()
+sim.finalize()
+del sim
+
+assert amr.initialized()
+amr.finalize()
+print("EXTERNAL_AMREX_OK")
+"""
+    proc, output = run_snippet(snippet)
+    assert proc.returncode == 0, output
+    assert "EXTERNAL_AMREX_OK" in output, output


### PR DESCRIPTION
Running a second ImpactX simulation in the same process (parameter scans, optimization loops, notebooks) aborted in `init_grids`:

```
Attempting to use an MPI routine (internal_Comm_dup) before initializing or after finalizing MPICH
```

unless the user initialized MPI before ImpactX, e.g., by importing `mpi4py.MPI`, as our optimization examples do.

## MPI lifetime

`amrex::Initialize` calls `MPI_Init` if MPI is not yet initialized, and then `amrex::Finalize` (called from `ImpactX::finalize`) also calls `MPI_Finalize`. MPI cannot be initialized again after that, so the first simulation was the last one of its process.

ImpactX now initializes MPI itself when nobody else did, via `ablastr::parallelization::mpi_init` (same helper as WarpX: picks the MPI thread level and carries the OLCFDEV-1655 workaround), and finalizes it at the end of the process. The two modes we support are unchanged from a user's point of view:

- **externally controlled MPI** (`main()`, mpi4py, ...): detected via `MPI_Initialized`, ImpactX does not touch its lifetime;
- **ImpactX/AMReX-owned MPI**: now spans the whole process instead of a single `amrex::Initialize`/`Finalize` cycle.

## Inputs leaked into the next simulation

`amrex::Initialize` only initializes ParmParse if a command line is passed (`argc >= 1`, `AMReX.cpp`); with ImpactX' `argc = 0`, `ParmParse::Initialize` never ran, so `ParmParse::Finalize` was never registered and the parameter table was never cleared. A second simulation silently inherited the inputs of the first one:

```
run1(space charge ON ): sim.space_charge = '3D'   sig_x = 1.19128186e-04
run2(space charge OFF): sim.space_charge = '3D'   sig_x = 1.19128186e-04   # never requested space charge
```

We now pass a program name if we have no command line. (An alternative fix would be in AMReX: treat `argc == 0` like `argc == 1` when `build_parm_parse` is set.)

## AMReX ownership

`ImpactX::finalize` called `amrex::Finalize` even when pyAMReX or another code in the same process owns AMReX. It now finalizes AMReX only if ImpactX initialized it.

## Third commit: MPI thread level of the executable

`src/main.cpp` called plain `MPI_Init`, so the standalone executable ran at `MPI_THREAD_SINGLE` even though `ImpactX_MPI_THREAD_MULTIPLE` is `ON` by default (async I/O). It now uses the same ABLASTR helpers as the Python path, and reports `MPI initialized with thread support level 3` in this build.

Not added on purpose: `ablastr::parallelization::check_mpi_thread_level()`, which WarpX calls. It records a *medium*-priority warning when the provided level is *stricter* than the requested one, and our example CTests run with `impactx.abort_on_warning_threshold=low` - that would abort them, e.g., wherever MPICH provides `MPI_THREAD_MULTIPLE` for a build that only requests `FUNNELED`.

## Second commit: warning inputs before `init_grids`

Setting `sim.abort_on_warning_threshold` or `sim.abort_on_unused_inputs` before `sim.init_grids()` segfaults (also in released versions): both setters call `init_warning_logger`, and the ABLASTR warning manager reads the MPI rank in its constructor. The setters now only touch the warning logger if AMReX is initialized; `init_grids` sets it up from the same inputs. Happy to split this into its own PR.

## Tests

`tests/python/test_lifecycle.py`: two simulations in one process, no input leak, externally initialized AMReX is not finalized, and warning inputs before `init_grids`. The scenarios run in subprocesses that do not import mpi4py, because `conftest.py` initializes MPI and AMReX for the pytest process and would mask the ImpactX-owned mode.

Verified locally, in addition: element GPU data (`RFCavity`, `PolygonAperture`), openPMD `BeamMonitor`, IGF/FFT space charge and 2 MPI ranks across cycles; scan loops that never call `finalize()`; mpi4py imported before or after ImpactX; the standalone executable (serial and `mpiexec -n 2`).

## Known limitation (follow-up, in ABLASTR)

The ABLASTR `WarnManager` is a static singleton that is never reset, so warnings recorded by one simulation are printed again by the next one in the same process, and can trip `abort_on_warning_threshold` there. Fix belongs into WarpX/ABLASTR; a test for it will follow here once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
