### PR TITLE
[WIP] Guard single-precision amrex::Random() edges in beam & spin distributions

### DIFF
--- a/src/particles/distribution/Gaussian.H
+++ b/src/particles/distribution/Gaussian.H
@@ -15,9 +15,11 @@
 #include <ablastr/constant.H>
 
 #include <AMReX_Random.H>
+#include <AMReX_Algorithm.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
+#include <limits>
 
 
 namespace impactx::distribution
@@ -120,6 +122,7 @@ namespace impactx::distribution
             // Generate three pairs of (optionally truncated) normal random variables using Box-Muller:
 
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             if (m_cutX > 0.0_prt) {
                 amrex::ParticleReal f = m_cutX*m_cutX/2.0_prt;
@@ -134,6 +137,7 @@ namespace impactx::distribution
             px = ln1 * std::sin(2_prt*pi*u2);
 
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             if (m_cutY > 0.0_prt) {
                 amrex::ParticleReal f = m_cutY*m_cutY/2.0_prt;
@@ -148,6 +152,7 @@ namespace impactx::distribution
             py = ln1 * std::sin(2_prt*pi*u2);
 
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             if (m_cutT > 0.0_prt) {
                 amrex::ParticleReal f = m_cutT*m_cutT/2.0_prt;

--- a/src/particles/distribution/KVdist.H
+++ b/src/particles/distribution/KVdist.H
@@ -16,9 +16,11 @@
 
 #include <AMReX_Math.H>
 #include <AMReX_Random.H>
+#include <AMReX_Algorithm.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
+#include <limits>
 
 
 namespace impactx::distribution
@@ -133,6 +135,7 @@ namespace impactx::distribution
             t = amrex::Random(engine);
             t = 2.0_prt*(t-0.5_prt);
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             ln1 = std::sqrt(-2_prt*std::log(u1));
             pt = ln1 * std::cos(2_prt*pi*u2);

--- a/src/particles/distribution/Kurth4D.H
+++ b/src/particles/distribution/Kurth4D.H
@@ -16,9 +16,11 @@
 
 #include <AMReX_Math.H>
 #include <AMReX_Random.H>
+#include <AMReX_Algorithm.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
+#include <limits>
 
 
 namespace impactx::distribution
@@ -143,6 +145,7 @@ namespace impactx::distribution
             t = amrex::Random(engine);
             t = 2.0_prt*(t-0.5_prt);
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             ln1 = std::sqrt(-2_prt*std::log(u1));
             pt = ln1 * std::cos(2_prt*pi*u2);

--- a/src/particles/distribution/Semigaussian.H
+++ b/src/particles/distribution/Semigaussian.H
@@ -15,9 +15,11 @@
 #include <ablastr/constant.H>
 
 #include <AMReX_Random.H>
+#include <AMReX_Algorithm.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
+#include <limits>
 
 
 namespace impactx::distribution
@@ -133,12 +135,14 @@ namespace impactx::distribution
             // Generate three normal random variables (px,py,pt) using Box-Muller:
 
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             ln1 = std::sqrt(-2_prt*std::log(u1));
             px = ln1 * std::cos(2_prt*pi*u2);
             py = ln1 * std::sin(2_prt*pi*u2);
 
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             ln1 = std::sqrt(-2_prt*std::log(u1));
             pt = ln1 * std::cos(2_prt*pi*u2);

--- a/src/particles/distribution/SpinvMF.H
+++ b/src/particles/distribution/SpinvMF.H
@@ -12,11 +12,13 @@
 
 #include <ablastr/constant.H>
 
+#include <AMReX_Algorithm.H>
 #include <AMReX_Math.H>
 #include <AMReX_Random.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
+#include <limits>
 
 
 namespace impactx::distribution
@@ -91,6 +93,14 @@ namespace impactx::distribution
             // Sample two iid random variables:
             amrex::ParticleReal x1 = amrex::Random(engine);
             amrex::ParticleReal x2 = amrex::Random(engine);
+            // amrex::Random() is documented as [0,1) but in single precision its GPU path
+            // (1.0f - curand_uniform()) can round UP to exactly 1.0f (when curand < ~2^-25). For a
+            // strongly concentrated / fully polarized mean vector, expm1(-2*kappa) == -1 in single
+            // precision, so x2 == 1 makes log1p(x2*expm1(-2*kappa)) == log1p(-1) == -inf -> t == NaN
+            // -> u == sqrt(1 - NaN) == NaN, a NaN spin that poisons the whole-beam moments. Clamp x2
+            // back into [0,1); a no-op in double precision and for every non-pathological draw.
+            // Same amrex::Random() single-precision edge as the Box-Muller guards above (AMReX #5638).
+            x2 = amrex::min(x2, amrex::ParticleReal(1) - std::numeric_limits<amrex::ParticleReal>::epsilon());
 
             // Basic transformation of the random variables:
             amrex::ParticleReal c = std::cos(2_prt*pi*x1);

--- a/src/particles/distribution/Thermal.H
+++ b/src/particles/distribution/Thermal.H
@@ -18,9 +18,11 @@
 #include <AMReX_Math.H>
 #include <AMReX_Print.H>
 #include <AMReX_Random.H>
+#include <AMReX_Algorithm.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
+#include <limits>
 #include <cstdint>
 #include <memory>
 #include <random>
@@ -375,16 +377,19 @@ namespace distribution
 
             // Generate six standard normal random variables using Box-Muller:
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             ln1 = std::sqrt(-2_prt*std::log(u1));
             g1 = ln1 * std::cos(2_prt*pi*u2);
             g2 = ln1 * std::sin(2_prt*pi*u2);
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             ln1 = std::sqrt(-2_prt*std::log(u1));
             g3 = ln1 * std::cos(2_prt*pi*u2);
             g4 = ln1 * std::sin(2_prt*pi*u2);
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             ln1 = std::sqrt(-2_prt*std::log(u1));
             g5 = ln1 * std::cos(2_prt*pi*u2);

--- a/src/particles/distribution/Triangle.H
+++ b/src/particles/distribution/Triangle.H
@@ -15,9 +15,11 @@
 #include <ablastr/constant.H>
 
 #include <AMReX_Random.H>
+#include <AMReX_Algorithm.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
+#include <limits>
 
 
 namespace impactx::distribution
@@ -113,16 +115,19 @@ namespace impactx::distribution
 
             // Generate five standard normal random variables using Box-Muller:
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             ln1 = std::sqrt(-2_prt*std::log(u1));
             g1 = ln1 * std::cos(2_prt*pi*u2);
             g2 = ln1 * std::sin(2_prt*pi*u2);
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             ln1 = std::sqrt(-2_prt*std::log(u1));
             g3 = ln1 * std::cos(2_prt*pi*u2);
             g4 = ln1 * std::sin(2_prt*pi*u2);
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             ln1 = std::sqrt(-2_prt*std::log(u1));
             g5 = ln1 * std::cos(2_prt*pi*u2);

--- a/src/particles/distribution/Waterbag.H
+++ b/src/particles/distribution/Waterbag.H
@@ -15,9 +15,11 @@
 #include <ablastr/constant.H>
 
 #include <AMReX_Random.H>
+#include <AMReX_Algorithm.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
+#include <limits>
 
 
 namespace impactx::distribution
@@ -114,16 +116,19 @@ namespace impactx::distribution
 
             // Generate six standard normal random variables using Box-Muller:
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             ln1 = std::sqrt(-2_prt*std::log(u1));
             g1 = ln1*std::cos(2_prt*pi*u2);
             g2 = ln1*std::sin(2_prt*pi*u2);
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             ln1 = std::sqrt(-2_prt*std::log(u1));
             g3 = ln1*std::cos(2_prt*pi*u2);
             g4 = ln1*std::sin(2_prt*pi*u2);
             u1 = amrex::Random(engine);
+            u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
             u2 = amrex::Random(engine);
             ln1 = std::sqrt(-2_prt*std::log(u1));
             g5 = ln1*std::cos(2_prt*pi*u2);


### PR DESCRIPTION
## Problem

In single precision on GPU, `sim.add_particles(...)` aborts for beams of ≳10⁶ particles with:
```
Assertion `(plo + ihi*CellSize(idim)) < (plo + (ihi + 1)*CellSize(idim))' failed,
  AMReX_Geometry.cpp ... computeRoundoffDomain failed ...
  (RealBox -inf inf  ...) sizeof Real: 4
```
It fires **before any tracking**, only in single precision, and only once N is large enough — which is the tell.

## Root cause

`amrex::Random()` returns `[0, 1)` with **0 included**. On the GPU the single-precision path is `1.0f - curand_uniform()`, which is **exactly `0.0f`** whenever `curand_uniform()` returns `1.0f`. The Box-Muller sampling in the beam distributions then computes `std::log(u1) = log(0) = -inf`, giving a particle with a `±inf` coordinate. ImpactX fits the dynamically-sized space-charge mesh to the particle min/max, so a single `inf` particle makes `ProbLo/ProbHi = ∓inf`, `dx = inf`, and `plo + ihi*dx = NaN` → the `computeRoundoffDomain` assertion aborts.

The per-draw probability of `u1 == 0` is ≈ 3×10⁻⁸ in FP32, so the failure becomes near-certain around N ≳ 10⁶ (matching "100k fine, ≥1M fails"). In double precision it needs ≈ 2⁻⁵³ (effectively never), so DP is unaffected at any N — hence single-precision-only and N-dependent.

## Fix

Clamp the Box-Muller radius argument to the smallest positive normal after sampling, so `std::log(u1)` is always finite — one guard per site:
```cpp
u1 = amrex::max(u1, std::numeric_limits<amrex::ParticleReal>::min());  // guard log(0): amrex::Random() may be exactly 0 in single precision
```
- Handles **both** pathological edges (`Random() == 0` and `Random()` rounding to `1.0f`, see below), keeps the value a normal (flush-to-zero-safe under `--use_fast_math`), and is a **no-op** in double precision and for every non-pathological single-precision draw.
- Applied at **every** Box-Muller `log(u1)` site across all affected distributions — `Gaussian`, `Waterbag`, `KVdist`, `Triangle`, `Kurth4D`, `Thermal`, `Semigaussian`. Non-`log` `amrex::Random()` draws are left unchanged.
- Adds `#include <AMReX_Algorithm.H>` (for `amrex::max`) and `#include <limits>` where needed.

### Why not the WarpX `1 - amrex::Random()` one-liner?

WarpX guards this with `1._rt - amrex::Random(engine); // ensures urand > 0`. That is **not sufficient in single precision here**: `amrex::Random()` is itself `1.0f - curand_uniform()`, and when `curand_uniform()` is tiny (≲ 2⁻²⁵) that expression **rounds up to exactly `1.0f`** (the ULP just below 1.0f is 2⁻²⁴). Then `1 - amrex::Random() == 1.0f - 1.0f == 0.0f` and we are back to `log(0)`. This is not a fast-math artifact — because `amrex::Random()` is a materialized (opaque `curand`) value, the compiler cannot reassociate `1 - (1 - c)` back to `c`, so it reproduces under **both** IEEE and `--use_fast_math`. I confirmed empirically that a CUDA single-precision build using `1 - amrex::Random()` still aborts. The clamp covers this case directly.

## Verification

Verified end-to-end on an A2000 (`sm_86`), CUDA single precision:
- 3D IGF space charge, N = 10⁶, 4×10⁶, **1.6×10⁷**: **now run** (previously aborted in `computeRoundoffDomain`).
- RMS beam sizes match the CPU-single and double-precision references (σ_x = 1.9239e-3 across all N, vs the DP/CPU-SP baseline).
- Fast-math safety of the clamp is established by static analysis (the guarded value is a normal, so no flush-to-zero and no reassociation can reintroduce a zero argument).

Found via cross-code benchmarking (BLAST-ImpactX/impactx-benchmarks).

## Also: the spin (von Mises–Fisher) sampler

The same single-precision `amrex::Random()` edge appears in a spin sampler, now guarded here too. `SpinvMF` draws `x2 = amrex::Random()` and forms `t = 1 + log1p(x2·expm1(-2κ))/κ`. For a fully polarized mean vector κ→∞, so `expm1(-2κ) == -1` in single precision; when `x2` rounds up to exactly `1.0f` (same mechanism as the Box-Muller case above), `log1p(-1) == -inf → t == NaN → u == sqrt(1 - NaN) == NaN`. About one NaN spin per 1.6×10⁷ draws then poisons the whole-beam spin moments (`sigma_s* = NaN` at large N, FP32 on GPU). Fixed by clamping `x2` back into `[0,1)` (`x2 = min(x2, 1 - ε)`) — a no-op in double precision.

Verified on GPU: `htu_spin` single precision at 1.6×10⁷ goes from NaN spin sigmas to finite values matching the double-precision reference; double precision bit-unchanged.

---
**WIP:** marked WIP pending CI + review (this environment has no `pre-commit`, so formatting hasn't been auto-applied).
