### PR TITLE
[WIP] Exact maps (CUDA/FP32): reject out-of-domain particles at the source

### DIFF
--- a/src/elements/ExactDrift.H
+++ b/src/elements/ExactDrift.H
@@ -123,7 +123,7 @@ namespace impactx::elements
             T_Real const & AMREX_RESTRICT px,
             T_Real const & AMREX_RESTRICT py,
             T_Real const & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
+            T_IdCpu & AMREX_RESTRICT idcpu,
             [[maybe_unused]] RefPart const & AMREX_RESTRICT refpart
         ) const
         {
@@ -141,13 +141,21 @@ namespace impactx::elements
             // T_Real const pyout = py;
             // T_Real const ptout = pt;
 
-            // compute the radical in the denominator (= pz):
-            T_Real const inv_pzden = 1_prt / sqrt(
+            // Longitudinal momentum squared, pz^2 = (pt - 1/beta)^2 - 1/(beta*gamma)^2 - px^2 - py^2.
+            // A particle whose transverse momentum exceeds its total momentum has no real
+            // longitudinal momentum (pz^2 <= 0): it lies outside the domain of the exact drift
+            // map. Flag it invalid at the source so it is dropped at the next redistribute,
+            // mirroring the exact bend (ExactSbend), instead of the otherwise unguarded
+            // sqrt(<0) = NaN poisoning the whole-beam moments. The mask is a comparison, so it
+            // survives -ffast-math; it is never set in double precision, leaving that path
+            // numerically unchanged.
+            T_Real const pzden2 =
                 powi<2>(pt - m_ibeta) -
                 m_ibetagam2 -
                 powi<2>(px) -
-                powi<2>(py)
-            );
+                powi<2>(py);
+            amrex::ParticleIDWrapper<T_IdCpu>{idcpu}.make_invalid(pzden2 <= 0_prt);
+            T_Real const inv_pzden = 1_prt / sqrt(pzden2);
 
             // advance position and momentum (exact drift)
             x = xout + m_slice_ds * px * inv_pzden;
@@ -226,7 +234,7 @@ namespace impactx::elements
             [[maybe_unused]] T_Real const & AMREX_RESTRICT sx,
             [[maybe_unused]] T_Real const & AMREX_RESTRICT sy,
             [[maybe_unused]] T_Real const & AMREX_RESTRICT sz,
-            T_IdCpu const & AMREX_RESTRICT idcpu,
+            T_IdCpu & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -139,6 +139,58 @@ namespace impactx::elements
             m_omega = std::sqrt(std::abs(m_g));
         }
 
+        /** Wrapper that carries the particle global index through the (id-agnostic)
+         *  symplectic integrator, so that the exact-drift substep (map2) can invalidate a
+         *  particle that leaves the map domain at the source. It forwards map1 unchanged and
+         *  adds the domain guard around map2; the integrator drives it exactly like the
+         *  element itself.
+         */
+        template<typename T_IdCpu>
+        struct MapWithDomainGuard
+        {
+            ExactQuad const & AMREX_RESTRICT m_elem;
+            T_IdCpu & AMREX_RESTRICT m_idcpu;
+
+            template<typename T_Real>
+            AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+            void map1 (amrex::ParticleReal const tau,
+                       amrex::SmallVector<T_Real, 6, 1> & particle,
+                       amrex::ParticleReal & zeval,
+                       RefPart const & AMREX_RESTRICT refpart) const
+            {
+                m_elem.map1(tau, particle, zeval, refpart);
+            }
+
+            template<typename T_Real>
+            AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+            void map2 (amrex::ParticleReal const tau,
+                       amrex::SmallVector<T_Real, 6, 1> & particle,
+                       amrex::ParticleReal & zeval,
+                       RefPart const & AMREX_RESTRICT refpart) const
+            {
+                using namespace amrex::literals; // for _prt
+                using amrex::Math::powi;
+
+                // Source domain guard for the exact-drift substep. The longitudinal momentum
+                // squared is pz^2 = (pt - 1/beta)^2 - 1/(beta*gamma)^2 - px^2 - py^2. A deep-tail
+                // particle amplified by a strong quadrupole can reach a transverse momentum that
+                // exceeds its total momentum (pz^2 <= 0) -- a genuinely lost particle, outside
+                // the domain of the map. Flag it invalid BEFORE the sqrt so it is dropped at the
+                // next redistribute, mirroring the exact bend (ExactSbend), instead of the
+                // otherwise unguarded sqrt(<0) = NaN poisoning the whole-beam moments. The check
+                // is a comparison, so it survives -ffast-math (a post-hoc NaN test would not);
+                // it is never set in double precision, leaving that path numerically unchanged.
+                T_Real const px = particle(2);
+                T_Real const py = particle(4);
+                T_Real const pt = particle(6);
+                T_Real const pzden2 = powi<2>(pt - m_elem.m_ibeta) - m_elem.m_ibetgam2
+                                      - powi<2>(px) - powi<2>(py);
+                amrex::ParticleIDWrapper<T_IdCpu>{m_idcpu}.make_invalid(pzden2 <= 0_prt);
+
+                m_elem.map2(tau, particle, zeval, refpart);
+            }
+        };
+
         /** This is a quad functor, so that a variable of this type can be used like a quad function.
          *
          * The @see compute_constants method must be called before pushing particles through this operator.
@@ -161,7 +213,7 @@ namespace impactx::elements
             T_Real & AMREX_RESTRICT px,
             T_Real & AMREX_RESTRICT py,
             T_Real & AMREX_RESTRICT pt,
-            [[maybe_unused]] T_IdCpu const & AMREX_RESTRICT idcpu,
+            T_IdCpu & AMREX_RESTRICT idcpu,
             RefPart const & AMREX_RESTRICT refpart
         ) const
         {
@@ -177,15 +229,19 @@ namespace impactx::elements
                 x, px, y, py, t, pt
             };
 
+            // Drive the symplectic integrator through a wrapper that carries the particle id,
+            // so the exact-drift substep (map2) can reject a particle that leaves the map domain.
+            MapWithDomainGuard<T_IdCpu> const guarded{*this, idcpu};
+
             // call integrator to advance through slice (int_order = 2 or 4, otherwise default 2)
             if (m_int_order == 2) {
-                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,refpart,*this);
+                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,refpart,guarded);
             } else if (m_int_order == 4) {
-                integrators::symp4_integrate_particle(particle,zin,zout,nsteps,refpart,*this);
+                integrators::symp4_integrate_particle(particle,zin,zout,nsteps,refpart,guarded);
             } else if (m_int_order == 6) {
-                integrators::symp6_integrate_particle(particle,zin,zout,nsteps,refpart,*this);
+                integrators::symp6_integrate_particle(particle,zin,zout,nsteps,refpart,guarded);
             } else {
-                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,refpart,*this);
+                integrators::symp2_integrate_particle(particle,zin,zout,nsteps,refpart,guarded);
             }
 
             // assign updated values


### PR DESCRIPTION
## What & why

The exact drift map (`ExactDrift`) and the exact-drift substep (`map2`) of the exact
quadrupole's symplectic integrator (`ExactQuad`) both evaluate the longitudinal momentum

```
pz = sqrt( (pt - 1/beta)^2 - 1/(beta*gamma)^2 - px^2 - py^2 )
```

which is real only while a particle's transverse momentum stays below its total momentum.
A deep-tail particle amplified by a strong quadrupole can cross that boundary
(`pz^2 <= 0`) — a genuinely lost particle, **outside the domain** of the exact map. The
radicand was unguarded, so `sqrt(<0) = NaN`, and a single such particle poisons the whole
beam's RMS moments (`sigma_x`/`sigma_y = NaN`) through the reduction in
`ReducedBeamCharacteristics`.

This is **single-precision + large-N specific**: in double precision the same beam stays
inside the domain, so the guard never triggers and the DP result is bit-for-bit unchanged.

Found via cross-code benchmarking ([BLAST-ImpactX/impactx-benchmarks](https://github.com/BLAST-ImpactX/impactx-benchmarks)):
the `fodo_exact` scenario (a hot, quad-dominated FODO of `ExactQuad` + `ExactDrift`,
`sigma_x' = 100 mrad`) at 16e6 particles on an FP32 CUDA build returns `sigma_x = NaN`,
while DP is finite and correct. It passes at 4e6 and fails at 8e6/16e6 — the boundary is
the deeper Gaussian tail sampled at larger N.

## Fix

Flag out-of-domain particles **invalid at the source** (before the `sqrt`), so they are
dropped at the next redistribute — exactly the pattern the exact bend (`ExactSbend`)
already uses for its own map domain. The test is a **comparison** (`pz^2 <= 0`), so it is
robust under `-ffast-math`/`--use_fast_math`, unlike a post-hoc NaN test (which
finite-math-only would elide). It is a no-op in double precision.

- `ExactDrift.H`: guard the radicand directly in `operator()` (it already has the particle id).
- `ExactQuad.H`: the domain violation occurs inside `map2`, which the id-agnostic symplectic
  integrator drives without the particle id. A small `MapWithDomainGuard` wrapper carries the
  id through the integrator so `map2` can reject the particle in place — keeping the change
  local to `ExactQuad.H` (the shared `Integrators.H` and the sibling exact elements are
  untouched).

Diff is limited to `ExactQuad.H` + `ExactDrift.H`.

## Verification (local A2000, sm_86, CUDA 13.2; `fodo_exact` at 16e6 particles)

| build | before | after |
|---|---|---|
| FP32 CUDA, IEEE | `sigma_x = NaN` | `sigma_x = 0.1273003` (1 particle dropped) |
| FP32 CUDA, `--use_fast_math` | `sigma_x = NaN` | `sigma_x = 0.1273002` (1 particle dropped) |
| FP64 CUDA (control) | `0.12727359869750307` | `0.12727359869750307` (bit-identical, 0 dropped) |

DP reference at 16e6 is `sigma_x = 0.1272736`; the single-precision results match it to the
sampling floor. The fast-math build is why the guard must be comparison-based rather than a
NaN test.

## Notes

Complementary to #1627: that PR guards the **samplers** against `amrex::Random()` returning
the closed-interval endpoints in single precision (Box-Muller `log(0)`, and the spin
`SpinvMF` sampler); this PR guards the **exact maps** against a genuine phase-space domain
violation. Together they make `fodo_exact` (and `htu_spin`) finite in FP32 at large N.

**Scope / follow-up — two sibling elements need the same guard.** `ExactMultipole` and
`ExactCFbend` evaluate the *identical* `map2` radicand through the same shared integrators, so
they carry the same latent out-of-domain bug (`pz^2 <= 0` → `sqrt(<0) = NaN`). They are simply
not exercised by the benchmark scenario that surfaced this, so this PR deliberately scopes to
`ExactQuad` + `ExactDrift`. Guarding the two siblings is a natural follow-up: it needs `idcpu`
threaded through the shared `Integrators.H` (or the same `MapWithDomainGuard` wrapper applied
there) so their `map2` can reject out-of-domain particles at the source too.

Upstream-adjacent: same class of FP32 robustness hardening as
[AMReX-Codes/amrex#5638](https://github.com/AMReX-Codes/amrex/issues/5638).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yZzHxn77vY1d2t4WQcFHS

