### PR TITLE
[WIP] Docs & Dashboard: Variable-Based Read Access, Optional Parameters

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -408,8 +408,8 @@ If the same element name is used multiple times, then an output series is create
     :default: ``g``
 
     openPMD `iteration encoding <https://openpmd-api.readthedocs.io/en/latest/usage/concepts.html#iteration-and-series>`__: (v)ariable based, (f)ile based, (g)roup based (default).
-    Variable based is an `experimental feature with ADIOS2 <https://openpmd-api.readthedocs.io/en/0.14.0/backends/adios2.html#experimental-new-adios2-schema>`__,
-    and `currently requires linear read access <https://github.com/openPMD/openPMD-api/issues/1911>`__ (``Access.read_linear``) in downstream readers.
+    Variable based is an experimental encoding and needs the ADIOS2 backend to store more than one iteration.
+    openPMD-api 0.17 and newer read it with random access (``Access.read_only``) as well as with linear access (``Access.read_linear``); readers older than 0.17 see only a single iteration.
 
 .. pp:param:: <monitor_name>.period_sample_intervals
     :type: ``integer``

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1959,7 +1959,8 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
    By default, the first available backend in the order given above is taken.
 
    openPMD `iteration encoding <https://openpmd-api.readthedocs.io/en/latest/usage/concepts.html#iteration-and-series>`__ determines if multiple files are created for individual output steps or not.
-   Variable based is an `experimental feature with ADIOS2 <https://openpmd-api.readthedocs.io/en/0.14.0/backends/adios2.html#experimental-new-adios2-schema>`__ and currently requires linear read access (``Access.read_linear``) in downstream readers.
+   Variable based is an experimental encoding and needs the ADIOS2 backend to store more than one iteration.
+   openPMD-api 0.17 and newer read it with random access (``Access.read_only``) as well as with linear access (``Access.read_linear``); readers older than 0.17 see only a single iteration.
 
    :param name: name of the series
    :param backend: I/O backend, e.g., ``bp``, ``h5``, ``json``

--- a/src/python/impactx/dashboard/Input/lattice/ui.py
+++ b/src/python/impactx/dashboard/Input/lattice/ui.py
@@ -47,7 +47,12 @@ def add_lattice_element() -> dict:
 
     parameters = []
     for name, default_value, default_type in parameters_data:
-        value = default_value
+        # extract_parameters() reports the string "None" for a parameter whose
+        # signature default is None, and the value None for a parameter without
+        # a default. The former is optional, the latter is required.
+        is_optional = default_value == "None"
+
+        value = "" if is_optional else default_value
         if default_type == "bool":
             # real boolean for the checkbox v-model (the string "False" is truthy in JS)
             value = str(value).strip().lower() == "true"
@@ -55,7 +60,11 @@ def add_lattice_element() -> dict:
             value = BEAM_MONITOR_DEFAULT_NAME
 
         error_message = DashboardValidation.validate(
-            name, value, category="lattice", parameter_type=default_type
+            name,
+            value,
+            category="lattice",
+            parameter_type=default_type,
+            optional=is_optional,
         )
 
         parameters.append(
@@ -64,6 +73,7 @@ def add_lattice_element() -> dict:
                 "ui_input": value,
                 "sim_input": value,
                 "parameter_type": default_type,
+                "parameter_is_optional": is_optional,
                 "parameter_error_message": error_message,
             }
         )
@@ -164,15 +174,17 @@ def on_lattice_element_parameter_change(
     else:
         state.lattice_elements_using_variables.pop(key, None)
 
-    error_message = DashboardValidation.validate(
-        parameter_name, sim_input, category="lattice", parameter_type=parameter_type
-    )
-
     for param in state.selected_lattice_list[index]["parameters"]:
         if param["parameter_name"] == parameter_name:
             param["ui_input"] = ui_input
             param["sim_input"] = sim_input
-            param["parameter_error_message"] = error_message
+            param["parameter_error_message"] = DashboardValidation.validate(
+                parameter_name,
+                sim_input,
+                category="lattice",
+                parameter_type=parameter_type,
+                optional=param.get("parameter_is_optional", False),
+            )
 
     errors_tracker.update_simulation_validation_status()
     state.dirty("selected_lattice_list")

--- a/src/python/impactx/dashboard/Input/validation/inputs.py
+++ b/src/python/impactx/dashboard/Input/validation/inputs.py
@@ -52,11 +52,26 @@ class DashboardValidation:
             setattr(state, validation_name, error_message)
 
     @staticmethod
+    def is_blank(input_value) -> bool:
+        """
+        Check whether a value was left blank by the user.
+
+        The literal ``"None"`` counts as blank as well: it is the signature
+        default that :meth:`InputDefaultsHelper.extract_parameters` reports for
+        an optional parameter.
+
+        :param input_value: The value to check.
+        :return: True if the value carries no user input.
+        """
+        return input_value is None or str(input_value).strip() in ("", "None")
+
+    @staticmethod
     def validate(
         input_name: str,
         input_value: Union[float, int],
         category: str | None = None,
         parameter_type: str | None = None,
+        optional: bool = False,
     ) -> list[str]:
         """
         Validates the input value against its default type and any additional conditions.
@@ -65,8 +80,12 @@ class DashboardValidation:
         :param input_value: The value to validate.
         :param category: The category of validation (e.g., 'distribution', 'lattice').
         :param parameter_type: The explicit type to use ('int', 'float', 'str', 'bool'). If provided, overrides type lookup.
+        :param optional: If True, a blank value is accepted and the parameter is left at its default.
         :return: A list of error messages. An empty list if there are no errors.
         """
+        if optional and DashboardValidation.is_blank(input_value):
+            return []
+
         input_type = DashboardValidation._get_input_type(
             input_name, category, parameter_type
         )

--- a/src/python/impactx/dashboard/Run/simulation.py
+++ b/src/python/impactx/dashboard/Run/simulation.py
@@ -8,6 +8,7 @@ License: BSD-3-Clause-LBNL
 
 from .. import state
 from ..Input.distribution.utils import DistributionFunctions
+from ..Input.validation import DashboardValidation
 
 TRACKING_MODE_COMMANDS = {
     "Particle Tracking": """\
@@ -68,6 +69,12 @@ def build_lattice_list() -> str:
             param_name = param["parameter_name"]
             param_value = param["sim_input"]
             param_type = param["parameter_type"]
+
+            # an optional parameter left blank stays at its default: passing an
+            # empty string instead would build the wrong element
+            if param.get("parameter_is_optional", False):
+                if DashboardValidation.is_blank(param_value):
+                    continue
 
             if param_type == "str":
                 formatted_value = f'"{param_value}"'

--- a/tests/python/dashboard/test_lattice_optional_parameters.py
+++ b/tests/python/dashboard/test_lattice_optional_parameters.py
@@ -10,13 +10,23 @@ import time
 
 from .utils import TIMEOUT, DashboardTester
 
-# 'Source' parameters whose signature default is None, and are therefore optional.
-# 'load_step' and 'load_step_index' are mutually exclusive, so neither of them
-# may be forced onto the user.
-SOURCE_OPTIONAL_PARAMETERS = ("name", "load_step", "load_step_index")
+# 'Quad' parameters whose signature default is None, and are therefore optional.
+# 'name' is the optional parameter that every lattice element carries.
+QUAD_OPTIONAL_PARAMETERS = ("name",)
 
-# 'Source' parameters without a signature default, and are therefore required
-SOURCE_REQUIRED_PARAMETERS = ("distribution", "openpmd_path")
+# 'Quad' parameters without a signature default, and are therefore required
+QUAD_REQUIRED_PARAMETERS = ("ds", "k")
+
+# 'Quad' parameters carrying a signature default other than None. Having a
+# default does not make a parameter optional: these are pre-filled, not blank.
+QUAD_DEFAULTED_PARAMETERS = {
+    "dx": "0.0",
+    "dy": "0.0",
+    "rotation": "0.0",
+    "aperture_x": "0.0",
+    "aperture_y": "0.0",
+    "nslice": "1",
+}
 
 
 def add_lattice_element(dashboard: DashboardTester, element_name: str) -> None:
@@ -58,6 +68,7 @@ def assert_parameter_error(
     :param parameter_name: The parameter to check.
     :param has_error: Whether the parameter is expected to carry an error.
     """
+    error_message = None
     for _ in range(TIMEOUT):
         error_message = lattice_parameters(dashboard, index)[parameter_name][
             "parameter_error_message"
@@ -76,20 +87,30 @@ def test_optional_parameters_are_blank_and_valid(dashboard) -> None:
     """
     An optional lattice element parameter starts out blank and valid, while a
     required one is flagged until the user provides a value.
+
+    'Quad' shows all three kinds in a single element: 'ds' and 'k' are
+    required, 'name' is optional, and the remaining parameters are pre-filled
+    from their signature defaults.
     """
-    add_lattice_element(dashboard, "Source")
+    add_lattice_element(dashboard, "Quad")
     parameters = lattice_parameters(dashboard, 0)
 
-    for name in SOURCE_OPTIONAL_PARAMETERS:
+    for name in QUAD_OPTIONAL_PARAMETERS:
         parameter = parameters[name]
         assert parameter["parameter_is_optional"] is True, name
         assert parameter["ui_input"] == "", name
         assert parameter["parameter_error_message"] == [], name
 
-    for name in SOURCE_REQUIRED_PARAMETERS:
+    for name in QUAD_REQUIRED_PARAMETERS:
         parameter = parameters[name]
         assert parameter["parameter_is_optional"] is False, name
         assert parameter["parameter_error_message"] != [], name
+
+    for name, default_value in QUAD_DEFAULTED_PARAMETERS.items():
+        parameter = parameters[name]
+        assert parameter["parameter_is_optional"] is False, name
+        assert parameter["ui_input"] == default_value, name
+        assert parameter["parameter_error_message"] == [], name
 
 
 def test_optional_parameters_are_validated_once_filled(dashboard) -> None:
@@ -97,13 +118,19 @@ def test_optional_parameters_are_validated_once_filled(dashboard) -> None:
     An optional lattice element parameter is validated as soon as it carries a
     value, and clearing it makes the error go away again.
     """
-    add_lattice_element(dashboard, "Source")
+    add_lattice_element(dashboard, "Quad")
 
-    dashboard.set_input("load_step1", "not_an_integer")
-    assert_parameter_error(dashboard, 0, "load_step", has_error=True)
+    # not a valid Python identifier
+    dashboard.set_input("name1", "2bad")
+    assert_parameter_error(dashboard, 0, "name", has_error=True)
 
-    dashboard.set_input("load_step1", "")
-    assert_parameter_error(dashboard, 0, "load_step", has_error=False)
+    # blank is valid for an optional parameter
+    dashboard.set_input("name1", "")
+    assert_parameter_error(dashboard, 0, "name", has_error=False)
+
+    # and so is a valid value
+    dashboard.set_input("name1", "q1")
+    assert_parameter_error(dashboard, 0, "name", has_error=False)
 
 
 def test_beam_monitor_name_still_defaults(dashboard) -> None:

--- a/tests/python/dashboard/test_lattice_optional_parameters.py
+++ b/tests/python/dashboard/test_lattice_optional_parameters.py
@@ -1,0 +1,168 @@
+"""
+This file is part of ImpactX
+
+Copyright 2025 ImpactX contributors
+Authors: Parthib Roy, Axel Huebl
+License: BSD-3-Clause-LBNL
+"""
+
+import time
+
+from .utils import TIMEOUT, DashboardTester
+
+# 'Source' parameters whose signature default is None, and are therefore optional.
+# 'load_step' and 'load_step_index' are mutually exclusive, so neither of them
+# may be forced onto the user.
+SOURCE_OPTIONAL_PARAMETERS = ("name", "load_step", "load_step_index")
+
+# 'Source' parameters without a signature default, and are therefore required
+SOURCE_REQUIRED_PARAMETERS = ("distribution", "openpmd_path")
+
+
+def add_lattice_element(dashboard: DashboardTester, element_name: str) -> None:
+    """
+    Adds a lattice element to a freshly reset lattice configuration.
+
+    The reset of the autouse fixture propagates asynchronously, so wait for the
+    empty lattice before adding: the helper counts the elements it expects.
+
+    :param dashboard: The dashboard test helper.
+    :param element_name: Name of the lattice element to add.
+    """
+    dashboard.assert_state_list_length("selected_lattice_list", 0)
+    dashboard.add_lattice_element(element_name)
+
+
+def lattice_parameters(dashboard: DashboardTester, index: int) -> dict:
+    """
+    Returns the parameters of a lattice element, keyed by parameter name.
+
+    :param dashboard: The dashboard test helper.
+    :param index: Index of the element in the lattice configuration.
+    """
+    lattice_list = dashboard.get_state("selected_lattice_list")
+    return {
+        parameter["parameter_name"]: parameter
+        for parameter in lattice_list[index]["parameters"]
+    }
+
+
+def assert_parameter_error(
+    dashboard: DashboardTester, index: int, parameter_name: str, has_error: bool
+) -> None:
+    """
+    Asserts a lattice parameter does or does not carry an error, with retry logic.
+
+    :param dashboard: The dashboard test helper.
+    :param index: Index of the element in the lattice configuration.
+    :param parameter_name: The parameter to check.
+    :param has_error: Whether the parameter is expected to carry an error.
+    """
+    for _ in range(TIMEOUT):
+        error_message = lattice_parameters(dashboard, index)[parameter_name][
+            "parameter_error_message"
+        ]
+        if bool(error_message) == has_error:
+            return
+        time.sleep(1)
+
+    raise AssertionError(
+        f"'{parameter_name}' error message never became "
+        f"{'non-empty' if has_error else 'empty'} (got: {error_message})"
+    )
+
+
+def test_optional_parameters_are_blank_and_valid(dashboard) -> None:
+    """
+    An optional lattice element parameter starts out blank and valid, while a
+    required one is flagged until the user provides a value.
+    """
+    add_lattice_element(dashboard, "Source")
+    parameters = lattice_parameters(dashboard, 0)
+
+    for name in SOURCE_OPTIONAL_PARAMETERS:
+        parameter = parameters[name]
+        assert parameter["parameter_is_optional"] is True, name
+        assert parameter["ui_input"] == "", name
+        assert parameter["parameter_error_message"] == [], name
+
+    for name in SOURCE_REQUIRED_PARAMETERS:
+        parameter = parameters[name]
+        assert parameter["parameter_is_optional"] is False, name
+        assert parameter["parameter_error_message"] != [], name
+
+
+def test_optional_parameters_are_validated_once_filled(dashboard) -> None:
+    """
+    An optional lattice element parameter is validated as soon as it carries a
+    value, and clearing it makes the error go away again.
+    """
+    add_lattice_element(dashboard, "Source")
+
+    dashboard.set_input("load_step1", "not_an_integer")
+    assert_parameter_error(dashboard, 0, "load_step", has_error=True)
+
+    dashboard.set_input("load_step1", "")
+    assert_parameter_error(dashboard, 0, "load_step", has_error=False)
+
+
+def test_beam_monitor_name_still_defaults(dashboard) -> None:
+    """
+    'BeamMonitor' takes a required 'name', which keeps its dashboard default.
+    """
+    add_lattice_element(dashboard, "BeamMonitor")
+    parameters = lattice_parameters(dashboard, 0)
+
+    assert parameters["name"]["parameter_is_optional"] is False
+    assert parameters["name"]["ui_input"] == "DefaultName"
+    assert parameters["name"]["parameter_error_message"] == []
+
+
+def test_blank_optional_name_tracks(dashboard) -> None:
+    """
+    A lattice whose element names are all left blank does not disable the run
+    button and tracks successfully: the blank names are omitted from the
+    element constructors instead of being passed on as an empty string.
+    """
+    BEAM_PROPERTIES = {
+        "tracking_mode": "Particle Tracking",
+        "space_charge": "false",
+        "csr": False,
+        "isr": False,
+        "charge_qe": -1,
+        "mass_MeV": 0.510998950,
+        "npart": 1000,
+        "bunch_charge_C": 1e-9,
+    }
+
+    DISTRIBUTION_PARAMETERS = {
+        "distribution": "Waterbag",
+        "distribution_type": "Quadratic",
+        "lambdaX": 3.9984884770e-5,
+        "lambdaY": 3.9984884770e-5,
+        "lambdaT": 1.0e-3,
+        "lambdaPx": 2.6623538760e-5,
+        "lambdaPy": 2.6623538760e-5,
+        "lambdaPt": 2.0e-3,
+        "muxpx": -0.846574929020762,
+        "muypy": 0.846574929020762,
+        "mutpt": 0.0,
+    }
+
+    for param_id, value in {**BEAM_PROPERTIES, **DISTRIBUTION_PARAMETERS}.items():
+        dashboard.set_input(param_id, value)
+
+    add_lattice_element(dashboard, "Drift")
+    dashboard.add_lattice_element("Quad")
+    dashboard.assert_state("total_elements", 2)
+
+    # every 'name' is deliberately left blank
+    LATTICE_PARAMS = {"ds1": 0.25, "ds2": 1.0, "k2": 1.0}
+    for param_id, value in LATTICE_PARAMS.items():
+        dashboard.set_input(param_id, value)
+
+    dashboard.assert_state("disableRunSimulationButton", False)
+
+    dashboard.sb.click("#Run_route")
+    dashboard.sb.click("#run_simulation_button")
+    dashboard.assert_state("sim_progress_status", "Complete!")

--- a/tests/python/test_beam_monitor_options.py
+++ b/tests/python/test_beam_monitor_options.py
@@ -65,8 +65,7 @@ def track_and_finalize(sim):
 def check_series(name, particles, beam_moments, npart):
     """Validate the series written by a monitor with the given flags.
 
-    Reads with linear access, which supports all iteration encodings
-    (variable-based encoding does not support random access reads).
+    Reads with linear access, which supports all iteration encodings.
     """
     files = sorted(Path("diags/openPMD").glob(f"{name}.*"))
     assert files, f"no openPMD series found for monitor '{name}'"


### PR DESCRIPTION
Two follow-up fixes split out of #1623. They are independent of each other and can be reviewed (or split into two PRs) separately.

## 1. Docs: variable-based encoding read access

The `beam_monitor` docs stated that the variable-based (`"v"`) iteration encoding "currently requires linear read access (`Access.read_linear`) in downstream readers". That is no longer the state of the world:

- ImpactX requires openPMD-api **0.17.0** or newer (`cmake/dependencies/ABLASTR.cmake`) and fetches 0.17.1.
- In [openPMD/openPMD-api#1911](https://github.com/openPMD/openPMD-api/issues/1911), @franzpoeschel confirms the warning is outdated and was removed: *"With READ_RANDOM_ACCESS in openPMD-api 0.16, a variable-based Series will show only one Iteration. Fixing this is one of the major new features of 0.17."* and *"both access modes finally have full support; there is no wrong Access for opening a Series in variable-based encoding"*.
- Verified locally against openPMD-api 0.17.1: a variable-based series with three iterations written to BP4 and to BP5 lists all three under `Access.read_only`, `Access.read_random_access` and `Access.read_linear`, and per-iteration attributes and datasets load correctly in each mode. HDF5 refuses to write more than one variable-based iteration at all (`ErrorOperationUnsupportedInBackend: Variable-based encoding requires backend support for IO steps in order to store more than one iteration (only supported in ADIOS2 backend)`).

The sentence now names the reader version an analysis workflow needs, since a user's own tooling may still be older than 0.17. The `"experimental"` wording is kept — openPMD-api 0.17.1 still describes the encoding that way — but the link to the openPMD-api 0.14.0 docs is dropped, because its target section no longer exists.

The same stale claim in the `check_series` docstring of `tests/python/test_beam_monitor_options.py` is fixed as well. The writer-side comments about ADIOS2 dropping attribute-only iterations are untouched: that limitation is real and unrelated.

## 2. Dashboard: optional lattice element parameters

The dashboard derives each lattice element's parameters by parsing the pybind11 `__init__` docstring. A parameter whose signature default is `None` — i.e. an *optional* parameter — was rendered and validated as if it were required:

```
('name', 'None', 'str')  -> ['Must be a valid Python identifier']
```

Every lattice element carries an optional `name`, so every element showed a permanent error on it that disabled the Run button until the user typed a value. (`name` is in fact the only `py::none()`-defaulted `__init__` argument on `development`: 35 of them, one per element.)

`InputDefaultsHelper.extract_parameters` already distinguishes the two cases, if subtly: it yields the Python value `None` for a parameter with *no* default (genuinely required, e.g. `Quad.ds`, `Source.distribution`) and the *string* `'None'` for a parameter whose default *is* `None` (optional). The fix makes that distinction explicit:

- `add_lattice_element` records `parameter_is_optional` and starts optional parameters blank instead of at the literal `"None"`.
- `DashboardValidation.validate` takes an `optional` flag and accepts a blank value; a non-blank one is still validated as before.
- `build_lattice_list` omits a blank optional parameter from the element constructor, so it stays at its default rather than being passed as an empty string. (Previously an unedited `name` would have been exported as `name="None"`.)

The existing `BeamMonitor` + `name` special case keeps working: `BeamMonitor.name` has no signature default, so it is required and still gets `BEAM_MONITOR_DEFAULT_NAME`.

`tests/python/dashboard/test_lattice_optional_parameters.py` covers all of it, keyed on `Quad`, which shows all three kinds of parameter in one element: `ds` and `k` are required, `dx`/`dy`/`rotation`/`aperture_x`/`aperture_y`/`nslice` carry a non-`None` default, and `name` is optional. The tests check that optional parameters start blank and valid, required ones are still flagged, defaulted ones are pre-filled (a default is not the same as optional), an optional parameter is validated once filled and clears again when emptied, `BeamMonitor` keeps its default name, and a lattice whose element names are all left blank enables the Run button and tracks to completion.

## To Do

- [x] draft 🤖 generated with [Claude Code](https://claude.com/claude-code)
- [ ] self-review
- [ ] bot-review
- [ ] finalize
