### PR TITLE
[WIP] SIMD: Vectorized Transcendentals in Element Pushes

### DIFF
--- a/.github/workflows/dependencies/gcc.sh
+++ b/.github/workflows/dependencies/gcc.sh
@@ -24,10 +24,11 @@ sudo apt-get install -y \
     wget
 
 # vir-simd
-wget https://github.com/mattkretz/vir-simd/archive/refs/tags/v0.4.4.tar.gz
-tar -xvf v0.4.4.tar.gz
-rm -rf v0.4.4.tar.gz
-cmake -S vir-simd-0.4.4 -B vir-simd-build
+# TODO: back to the release tarball once vir/simd_vecmath.h is in one. It is
+#       what makes the SIMD transcendentals call a vector math library instead
+#       of evaluating them one lane at a time.
+git clone --depth 1 --branch topic-vecmath https://github.com/ax3l/vir-simd.git vir-simd-src
+cmake -S vir-simd-src -B vir-simd-build
 sudo cmake --build vir-simd-build --target install
 
 python3 -m pip install -U pip

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,10 +40,9 @@ jobs:
         set -e
     - name: install vir-simd
       run: |
-        wget https://github.com/mattkretz/vir-simd/archive/refs/tags/v0.4.4.tar.gz
-        tar -xvf v0.4.4.tar.gz
-        rm -rf v0.4.4.tar.gz
-        cmake -S vir-simd-0.4.4 -B vir-simd-build
+        # TODO: back to the release tarball once vir/simd_vecmath.h is in one
+        git clone --depth 1 --branch topic-vecmath https://github.com/ax3l/vir-simd.git vir-simd-src
+        cmake -S vir-simd-src -B vir-simd-build
         sudo cmake --build vir-simd-build --target install
     - name: install pip dependencies
       run: |

--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -183,10 +183,13 @@ set(ImpactX_ablastr_branch "26.08"
     "Repository branch for ImpactX_ablastr_repo if(ImpactX_ablastr_internal)")
 
 # AMReX is transitively pulled through ABLASTR
-set(ImpactX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
+# TODO: back to AMReX-Codes/amrex once the SIMD transcendentals land there.
+#       https://github.com/AMReX-Codes/amrex/pull/5644 adds the amrex::Math
+#       overloads the vectorized elements call.
+set(ImpactX_amrex_repo "https://github.com/ax3l/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(ImpactX_amrex_internal)")
-set(ImpactX_amrex_branch "26.08"
+set(ImpactX_amrex_branch "topic-simd-vecmath"
     CACHE STRING
     "Repository branch for ImpactX_amrex_repo if(ImpactX_amrex_internal)")
 

--- a/src/elements/ChrPlasmaLens.H
+++ b/src/elements/ChrPlasmaLens.H
@@ -188,10 +188,10 @@ namespace impactx::elements
                 T_Real const t0 = t - term*m_slice_ds/delta1;
 
                 T_Real const w = omega*delta1;
-                T_Real const term1 = -(powi<2>(p2) - powi<2>(q2) * powi<2>(w)) * sin(2_prt*m_slice_ds*omega);
-                T_Real const term2 = -(powi<2>(p1) - powi<2>(q1) * powi<2>(w)) * sin(2_prt*m_slice_ds*omega);
-                T_Real const term3 = -2_prt * q2 * p2 * w * cos(2_prt*m_slice_ds*omega);
-                T_Real const term4 = -2_prt * q1 * p1 * w * cos(2_prt*m_slice_ds*omega);
+                T_Real const term1 = -(powi<2>(p2) - powi<2>(q2) * powi<2>(w)) * amrex::Math::sin(2_prt*m_slice_ds*omega);
+                T_Real const term2 = -(powi<2>(p1) - powi<2>(q1) * powi<2>(w)) * amrex::Math::sin(2_prt*m_slice_ds*omega);
+                T_Real const term3 = -2_prt * q2 * p2 * w * amrex::Math::cos(2_prt*m_slice_ds*omega);
+                T_Real const term4 = -2_prt * q1 * p1 * w * amrex::Math::cos(2_prt*m_slice_ds*omega);
                 T_Real const term5 = 2_prt * omega * (q1*p1*delta1 + q2*p2*delta1
                     -(powi<2>(p1) + powi<2>(p2))*m_slice_ds - (powi<2>(q1) + powi<2>(q2)) * powi<2>(w)*m_slice_ds);
                 tout = t0 + (-1_prt+m_beta*pt)
@@ -201,8 +201,8 @@ namespace impactx::elements
             }
             else if (m_g < 0_prt)
             {
-                auto const sinh_ods = sinh(omega*m_slice_ds);
-                auto const cosh_ods = cosh(omega*m_slice_ds);
+                auto const sinh_ods = amrex::Math::sinh(omega*m_slice_ds);
+                auto const cosh_ods = amrex::Math::cosh(omega*m_slice_ds);
 
                 // advance transverse position and momentum (defocusing)
                 xout = cosh_ods * x + sinh_ods / (omega * delta1) * px;
@@ -216,10 +216,10 @@ namespace impactx::elements
                 T_Real const t0 = t - term*m_slice_ds/delta1;
 
                 T_Real const w = omega*delta1;
-                T_Real const term1 = -(powi<2>(p2) + powi<2>(q2) * powi<2>(w)) * sinh(2_prt*m_slice_ds*omega);
-                T_Real const term2 = -(powi<2>(p1) + powi<2>(q1) * powi<2>(w)) * sinh(2_prt*m_slice_ds*omega);
-                T_Real const term3 = -2_prt * q2 * p2 * w * cosh(2_prt*m_slice_ds*omega);
-                T_Real const term4 = -2_prt * q1 * p1 * w * cosh(2_prt*m_slice_ds*omega);
+                T_Real const term1 = -(powi<2>(p2) + powi<2>(q2) * powi<2>(w)) * amrex::Math::sinh(2_prt*m_slice_ds*omega);
+                T_Real const term2 = -(powi<2>(p1) + powi<2>(q1) * powi<2>(w)) * amrex::Math::sinh(2_prt*m_slice_ds*omega);
+                T_Real const term3 = -2_prt * q2 * p2 * w * amrex::Math::cosh(2_prt*m_slice_ds*omega);
+                T_Real const term4 = -2_prt * q1 * p1 * w * amrex::Math::cosh(2_prt*m_slice_ds*omega);
                 T_Real const term5 = 2_prt * omega * (q1*p1*delta1 + q2*p2*delta1
                     -(powi<2>(p1) + powi<2>(p2))*m_slice_ds - (powi<2>(q1) + powi<2>(q2)) * powi<2>(w)*m_slice_ds);
                 tout = t0 + (-1_prt+m_beta*pt)
@@ -344,8 +344,8 @@ namespace impactx::elements
 
             // compute trigonometric quantities
             auto const [sin_omega_ds, cos_omega_ds] = amrex::Math::sincos(omega*m_slice_ds);
-            T_Real const sinh_omega_ds = sinh(omega*m_slice_ds);
-            T_Real const cosh_omega_ds = cosh(omega*m_slice_ds);
+            T_Real const sinh_omega_ds = amrex::Math::sinh(omega*m_slice_ds);
+            T_Real const cosh_omega_ds = amrex::Math::cosh(omega*m_slice_ds);
 
             if (m_g > 0.0_prt)
             {

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -178,19 +178,19 @@ namespace impactx::elements
                 bool const focusing = m_g > 0_prt;
                 // raw off-diagonal trig: oscillatory (sin) for the focusing plane,
                 // hyperbolic (sinh) for the defocusing plane (delta1 > 0 always).
-                T_Real const sx = focusing ? sin(omega  * m_slice_ds) : sinh(omega * m_slice_ds);
-                T_Real const sy = focusing ? sinh(omega * m_slice_ds) : sin(omega  * m_slice_ds);
+                T_Real const sx = focusing ? amrex::Math::sin(omega  * m_slice_ds) : amrex::Math::sinh(omega * m_slice_ds);
+                T_Real const sy = focusing ? amrex::Math::sinh(omega * m_slice_ds) : amrex::Math::sin(omega  * m_slice_ds);
                 // sign on the px,py kick: -1 (x focusing) / +1 (x defocusing)
                 T_Real const ax = focusing ? -1_prt : 1_prt;
 
                 // per-particle 2x2 transfer-map blocks. omega is chromatic (it depends
                 // on delta1), so unlike our linear Quad these cannot be cached in compute_constants.
                 T_Real const w = omega * delta1;
-                T_Real const R11 = focusing ? cos(omega * m_slice_ds) : cosh(omega * m_slice_ds);
+                T_Real const R11 = focusing ? amrex::Math::cos(omega * m_slice_ds) : amrex::Math::cosh(omega * m_slice_ds);
                 T_Real const R12 = sx / w;
                 T_Real const R21 = ax * w * sx;
                 T_Real const R22 = R11;
-                T_Real const R33 = focusing ? cosh(omega * m_slice_ds) : cos(omega * m_slice_ds);
+                T_Real const R33 = focusing ? amrex::Math::cosh(omega * m_slice_ds) : amrex::Math::cos(omega * m_slice_ds);
                 T_Real const R34 = sy / w;
                 T_Real const R43 = -ax * w * sy;
                 T_Real const R44 = R33;
@@ -212,10 +212,10 @@ namespace impactx::elements
                 T_Real const term = pt + delta / m_beta;
                 T_Real const t0 = tout - term * m_slice_ds / delta1;
 
-                T_Real const term1 = -(powi<2>(p2) + powi<2>(q2) * powi<2>(w)) * sinh(2_prt * m_slice_ds * omega);
-                T_Real const term2 = -(powi<2>(p1) - powi<2>(q1) * powi<2>(w)) * sin(2_prt  * m_slice_ds * omega);
-                T_Real const term3 = -2_prt * q2 * p2 * w * cosh(2_prt * m_slice_ds * omega);
-                T_Real const term4 = -2_prt * q1 * p1 * w * cos(2_prt  * m_slice_ds * omega);
+                T_Real const term1 = -(powi<2>(p2) + powi<2>(q2) * powi<2>(w)) * amrex::Math::sinh(2_prt * m_slice_ds * omega);
+                T_Real const term2 = -(powi<2>(p1) - powi<2>(q1) * powi<2>(w)) * amrex::Math::sin(2_prt  * m_slice_ds * omega);
+                T_Real const term3 = -2_prt * q2 * p2 * w * amrex::Math::cosh(2_prt * m_slice_ds * omega);
+                T_Real const term4 = -2_prt * q1 * p1 * w * amrex::Math::cos(2_prt  * m_slice_ds * omega);
                 T_Real const term5 =  2_prt * omega * (
                     q1 * p1 * delta1 + q2 * p2 * delta1
                     -(powi<2>(p1) + powi<2>(p2)) * m_slice_ds
@@ -337,8 +337,8 @@ namespace impactx::elements
 
             // compute trigonometric quantities
             auto const [sin_omega_ds, cos_omega_ds] = amrex::Math::sincos(omega_ds);
-            T_Real const sinh_omega_ds = sinh(omega_ds);
-            T_Real const cosh_omega_ds = cosh(omega_ds);
+            T_Real const sinh_omega_ds = amrex::Math::sinh(omega_ds);
+            T_Real const cosh_omega_ds = amrex::Math::cosh(omega_ds);
 
             // The focusing/defocusing/drift cases differ only by which plane is
             // oscillatory vs. hyperbolic and by an overall sign. omega is real

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -175,7 +175,7 @@ namespace impactx::elements
                 // compute focusing constant (1/m) and rotation angle (in rad)
                 T_Real const theta_ialpha = m_acc == 0_prt
                     ? m_slice_ds / pzi_tot
-                    : log(numer / denom) / m_ez;
+                    : amrex::Math::log(numer / denom) / m_ez;
                 T_Real const theta = m_alpha * theta_ialpha;
                 auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
                 T_Real const sin_theta_ialpha = m_alpha == 0_prt
@@ -355,7 +355,7 @@ namespace impactx::elements
                 // compute focusing constant (1/m) and rotation angle (in rad)
                 T_Real const theta_over_alpha = (m_ez == 0_prt) ?
                     m_slice_ds / pzi_tot :
-                    log(numer / denom) / m_ez;
+                    amrex::Math::log(numer / denom) / m_ez;
                 T_Real const theta = m_alpha * theta_over_alpha;
                 auto const [sin2Gth, cos2Gth] = amrex::Math::sincos(2_prt * refpart.gyromagnetic_anomaly * theta);
 

--- a/src/elements/ExactQuad.H
+++ b/src/elements/ExactQuad.H
@@ -231,10 +231,10 @@ namespace impactx::elements
             T_Real tout = t;
             T_Real ptout = pt;
 
-            amrex::ParticleReal const sin_omega_ds = sin(m_omega*tau);
-            amrex::ParticleReal const cos_omega_ds = cos(m_omega*tau);
-            amrex::ParticleReal const sinh_omega_ds = sinh(m_omega*tau);
-            amrex::ParticleReal const cosh_omega_ds = cosh(m_omega*tau);
+            amrex::ParticleReal const sin_omega_ds = amrex::Math::sin(m_omega*tau);
+            amrex::ParticleReal const cos_omega_ds = amrex::Math::cos(m_omega*tau);
+            amrex::ParticleReal const sinh_omega_ds = amrex::Math::sinh(m_omega*tau);
+            amrex::ParticleReal const cosh_omega_ds = amrex::Math::cosh(m_omega*tau);
             amrex::ParticleReal const slice_bg = tau / m_betgam2;
 
             if (m_g > 0.0_prt)

--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -229,7 +229,7 @@ namespace impactx::elements
                    amrex::ParticleIDWrapper<T_IdCpu>{idcpu}.make_invalid(mask2);
                    {
                        T_Real const pzf = sqrt(powi<2>(pperp)-powi<2>(pxout));
-                       T_Real const theta = m_slice_phi + asin(px/pperp) - asin(pxout/pperp);
+                       T_Real const theta = m_slice_phi + amrex::Math::asin(px/pperp) - amrex::Math::asin(pxout/pperp);
 
                        // update position coordinates
                        x = -m_rc + rho*m_cos_phi + m_rc*(pzf + px*m_sin_phi - pzi*m_cos_phi);

--- a/src/elements/ShortRF.H
+++ b/src/elements/ShortRF.H
@@ -157,7 +157,7 @@ namespace impactx::elements
             // pyout = py;
 
             // tout = t;
-            ptout = pt - m_V * cos(m_k * t + m_phi) + m_V_cos_phi;
+            ptout = pt - m_V * amrex::Math::cos(m_k * t + m_phi) + m_V_cos_phi;
 
             // assign updated values
             // x = xout;
@@ -281,7 +281,7 @@ namespace impactx::elements
             // Integrated electric field normalized by q/mc^2 (half-step):
             T_Real const Ex = 0.0_prt;
             T_Real const Ey = 0.0_prt;
-            T_Real const Ez = 0.5_prt * m_V * cos(m_k * t + m_phi);
+            T_Real const Ez = 0.5_prt * m_V * amrex::Math::cos(m_k * t + m_phi);
 
             // Quantities required to evaluate the full Thomas-BMT precession vector (before phase space kick).
             amrex::ParticleReal beta = m_bgi / gami;


### PR DESCRIPTION
## Summary

With `ImpactX_SIMD=ON`, the elements that call `sin`, `cos`, `sinh` or `cosh` per particle got very little out of it: SIMD hardware has no transcendental instructions, so `std::experimental::simd` evaluates those **one lane at a time**. A vectorized `ChrQuad` push was barely faster than the scalar one.

This calls the `amrex::Math` transcendentals instead, which hand a whole SIMD register to a vector math library (glibc's `libmvec`).

**Measured end to end** on `examples/apochromatic`, 2·10⁶ particles, 4 slices, one thread pinned to a P-core on an otherwise idle machine, alternating runs, best of seven each:

| | before | after | |
|---|---|---|---|
| `push::ChrQuad` — `sin`, `cos`, `sinh`, `cosh` per particle | 1.917 s | **0.810 s** | **2.37×** |
| `push::ChrDrift` — no transcendentals, the control | 0.066 s | 0.065 s | 1.02× |
| whole run | 2.783 s | **1.648 s** | **1.69×** |

Run-to-run spread was 3–6 % across the seven repetitions.

`ChrDrift` is the useful part of that table: it goes through the same `ParallelForSIMD` machinery and does not change, which is what says the gain comes from the transcendentals rather than from anything else moving.

## Correctness

Same example, same seed, the two builds differing only in whether the vector math library is reachable:

* the **reference particle is bit-identical**,
* the beam moments differ by at most **1.1e-10** relative over 50 steps, worst in `dispersion_y` — a quantity built from cancellation, which is where the few ULP a vector math library costs will concentrate.

`libmvec` documents a maximum error of 4 ULP where the scalar routines stay below 1, so results are no longer bit-wise reproducible against a scalar build. For a tracking code that is the usual trade; it is worth being explicit about it.

## Why the calls are qualified

`amrex::Math::sin(x)`, not `sin(x)`. An unqualified call on a SIMD argument resolves to the SIMD library's own overload through argument-dependent lookup, and **no `using` fixes it**: the library's overload either ties with the AMReX one (ambiguous) or is more specialized and wins (compiles, silently slow). Both were verified. This is a property of ADL rather than of any particular implementation.

That is the same spelling `amrex::Math::powi` and `amrex::Math::sincos` already use here, so it reads consistently with the surrounding code.

## Scope

36 call sites across six elements: `ChrQuad`, `ChrPlasmaLens`, `ChrUniformAcc`, `ExactQuad`, `ExactSbend`, `ShortRF`.

The rest needed nothing. Most elements precompute their trigonometry scalar-side in `compute_constants`, so their per-particle path is already pure arithmetic. And the SIMD kernels themselves contain no transcendentals: `beamoptic.H` only dispatches to the elements, and the beam-moments reduction behind `ParticleReduceSIMD` is sums of products. `sqrt` and `abs` are left unqualified on purpose — they map onto hardware instructions and the SIMD library already does the right thing.

## Dependencies — this is why it is WIP

The two halves of this live upstream and are not merged yet, so `ABLASTR.cmake` and the CI dependency scripts point at branches:

* AMReX: `ax3l/amrex@topic-simd-vecmath` — https://github.com/AMReX-Codes/amrex/pull/5644, adds the `amrex::Math` SIMD overloads
* vir-simd: `ax3l/vir-simd@topic-vecmath` — adds `vir/simd_vecmath.h`, which calls libmvec's entry points directly

Each is marked with a TODO to point back at the upstream release once they land. Nothing here needs compiler flags: the vector math calls go to libmvec's entry points by name, so there is no `-ffast-math`, no `-fno-math-errno`, and no dependence on the auto-vectorizer.

Where a vector math library is not available — another architecture, another libc, an older glibc, or an older vir-simd — everything still builds and simply evaluates one lane at a time, as today.

## Testing

Built with `ImpactX_SIMD=ON` against both dependency branches; the resulting binary links `libmvec.so.1` and contains 360 vector math call sites (143 `_ZGVdN4v_cos`, 137 `_ZGVdN4v_sin`, 30 each `sinh`/`cosh`, plus `log` and `asin`).

All simulation tests pass. Two caveats on that, since they matter for reading the CI result: `solenoid.restart.run` fails locally only because I configured without openPMD, and the Python `.analysis`/`.plot` tests could not run in my environment at all (ctest records an absolute `python3` at configure time and that interpreter had no numpy). The numerical check above was done directly instead, by diffing the diagnostics of two builds.

## To do

- [ ] Land the AMReX and vir-simd sides, then point the refs back at releases.
- [ ] Check whether any of the remaining elements would benefit from moving work out of `compute_constants` now that per-particle transcendentals are cheap.
- [ ] GPU builds are untouched by this and untested here: the SIMD overloads are host-only and the scalar ones are unchanged, but that deserves a CI confirmation rather than an argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


