### PR TITLE
CI: CodSpeed w/ AVX2

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -211,8 +211,9 @@ jobs:
         IS_CODESPEED_CPU_SIMULATION: 1
         # Force uniform glibc CPU dispatch so malloc/memcpy behave identically across Intel/AMD runner CPUs
         # Ref: https://codspeed.io/blog/why-glibc-faster-github-actions
-        # Note that we keep AVX2, which is a subset of -march=x86-64-v3, and present on all GH Ubuntu runners
-        GLIBC_TUNABLES: glibc.cpu.hwcaps=-AVX_Fast_Unaligned_Load,-ERMS,-Prefer_FSRM
+        # Note that we keep AVX2, which is a subset of -march=x86-64-v3, and present on all GH Ubuntu runners.
+        # Adding instead skip for AVX512 to guard against newer runners.
+        GLIBC_TUNABLES: glibc.cpu.hwcaps=-AVX512F,-AVX512VL,-AVX512BW,-AVX512DQ,-AVX_Fast_Unaligned_Load,-ERMS,-Prefer_FSRM
       with:
         mode: simulation
         # v5 enabled cycle estimation by default, which re-weights the simulated

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -130,6 +130,7 @@ jobs:
       run: |
         cat /proc/cpuinfo
         lscpu
+        grep -q '\bavx2\b' /proc/cpuinfo || { echo "runner lacks AVX2"; exit 1; }
 
     - name: Free More Disk Space
       uses: ax3l/free-disk-space@main
@@ -210,7 +211,8 @@ jobs:
         IS_CODESPEED_CPU_SIMULATION: 1
         # Force uniform glibc CPU dispatch so malloc/memcpy behave identically across Intel/AMD runner CPUs
         # Ref: https://codspeed.io/blog/why-glibc-faster-github-actions
-        GLIBC_TUNABLES: glibc.cpu.hwcaps=-AVX2,-AVX_Fast_Unaligned_Load,-ERMS,-Prefer_FSRM
+        # Note that we keep AVX2, which is a subset of -march=x86-64-v3, and present on all GH Ubuntu runners
+        GLIBC_TUNABLES: glibc.cpu.hwcaps=-AVX_Fast_Unaligned_Load,-ERMS,-Prefer_FSRM
       with:
         mode: simulation
         # v5 enabled cycle estimation by default, which re-weights the simulated


### PR DESCRIPTION
AVX2 is a subset of the CPU features we know exist in `-march=x86-64-v3` and are always present on GH action x86-64 cloud runners. Confuses measurements to compile for them and disable at runtime.

Seen as an issue in #1632

AVX2 has been on every Intel Xeon since Haswell (2013) and every AMD EPYC since Zen 1 (2017), which covers every CPU family Azure has ever backed these runners with.