### PR TITLE
Dependencies: AMReX CUDA CMake 3.25+

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -62,7 +62,7 @@ jobs:
           -DImpactX_COMPUTE=CUDA       \
           -DImpactX_FFT=ON             \
           -DImpactX_PYTHON=ON          \
-          -DAMReX_CUDA_ARCH=6.0        \
+          -DCMAKE_CUDA_ARCHITECTURES=60 \
           -DImpactX_PRECISION=SINGLE   \
           -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
           -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.24.0)
+cmake_minimum_required(VERSION 3.25.0)
 project(ImpactX VERSION 26.08)
 
 include(${ImpactX_SOURCE_DIR}/cmake/ImpactXFunctions.cmake)
@@ -13,21 +13,6 @@ if(CMAKE_BINARY_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
             "${CMAKE_SOURCE_DIR}/CMakeCache.txt ${CMAKE_SOURCE_DIR}/CMakeFiles/")
 endif()
 
-
-# CMake policies ##############################################################
-#
-# Setting a cmake_policy to OLD is deprecated by definition and will raise a
-# verbose warning
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-    set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
-endif()
-
-# AMReX 21.06+ supports CUDA_ARCHITECTURES with CMake 3.20+
-# CMake 3.18+: CMAKE_CUDA_ARCHITECTURES
-# https://cmake.org/cmake/help/latest/policy/CMP0104.html
-if(POLICY CMP0104)
-    cmake_policy(SET CMP0104 OLD)
-endif()
 
 
 # C++ Standard in Superbuilds #################################################

--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -178,7 +178,7 @@ set(ImpactX_openpmd_src ""
 set(ImpactX_ablastr_repo "https://github.com/BLAST-WarpX/warpx.git"
     CACHE STRING
     "Repository URI to pull and build ABLASTR from if(ImpactX_ablastr_internal)")
-set(ImpactX_ablastr_branch "26.08"
+set(ImpactX_ablastr_branch "690da5d6997cd91fcad9b5296edace0556422298"
     CACHE STRING
     "Repository branch for ImpactX_ablastr_repo if(ImpactX_ablastr_internal)")
 
@@ -186,7 +186,7 @@ set(ImpactX_ablastr_branch "26.08"
 set(ImpactX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(ImpactX_amrex_internal)")
-set(ImpactX_amrex_branch "26.08"
+set(ImpactX_amrex_branch "19e6fba747b65a37d08f3fecef3ff2935318f26b"
     CACHE STRING
     "Repository branch for ImpactX_amrex_repo if(ImpactX_amrex_internal)")
 

--- a/docs/source/install/cmake.rst
+++ b/docs/source/install/cmake.rst
@@ -307,6 +307,8 @@ For example, this builds ImpactX with Python bindings and Nvidia GPU (CUDA) supp
 
    cmake -S . -B build -DImpactX_PYTHON=ON -DImpactX_COMPUTE=CUDA
 
+On a machine without a visible GPU, e.g. an HPC login node, additionally select the GPU architecture to compile for (see :ref:`building-cmake-gpu-archs`).
+
 
 An executable ImpactX application binary will be created in ``build/bin/``.
 Additionally, a `symbolic link <https://en.wikipedia.org/wiki/Symbolic_link>`__ named ``impactx`` can be found in that directory, which points to the last built ImpactX executable.
@@ -419,6 +421,37 @@ We also support adding `additional compiler flags via environment variables <htt
    Now call ``cmake -S . -B build`` (+ further options) again to re-initialize the build configuration.
 
 
+.. _building-cmake-gpu-archs:
+
+Select GPU Architectures
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+For Nvidia GPUs, ImpactX uses the standard CMake interface to select the CUDA architectures to compile for.
+By default, we select ``native``, i.e., CMake detects the architecture of the GPU(s) visible on the machine that runs ``cmake`` and ImpactX is built exactly for those.
+
+If no GPU is visible at configuration time (a typical situation on HPC login nodes, in containers and in CI) then configuration stops with an error and you need to select the architecture explicitly, either as a CMake option:
+
+.. code-block:: bash
+
+   cmake -S . -B build -DImpactX_COMPUTE=CUDA -DCMAKE_CUDA_ARCHITECTURES=80
+
+or as an `environment variable <https://cmake.org/cmake/help/latest/envvar/CUDAARCHS.html>`__, which is what our :ref:`HPC profiles <install-hpc>` do:
+
+.. code-block:: bash
+
+   export CUDAARCHS=80
+
+Architectures are written as integers, e.g., ``80`` for A100 (compute capability 8.0) and ``90`` for H100.
+`Multiple architectures <https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html>`__ are separated by semicolons (``"80;90"``), and the special values ``native``, ``all`` and ``all-major`` are supported as well.
+
+.. note::
+
+   The older AMReX-specific spellings ``-DAMReX_CUDA_ARCH=8.0`` and ``export AMREX_CUDA_ARCH=8.0`` still work, but are deprecated and warn.
+   They are translated to the CMake variables above, including their historical value formats (``Auto``, ``Common``, ``Volta``, ``8.0``, ``7.0+PTX``, whitespace-separated lists).
+
+For AMD GPUs, select the architecture with ``-DAMReX_AMD_ARCH=gfx90a`` or ``export AMREX_AMD_ARCH=gfx90a``.
+
+
 CMake
 ^^^^^
 
@@ -427,6 +460,7 @@ CMake Option                    Default & Values                             Des
 =============================== ============================================ ===========================================================
 ``BUILD_TESTING``               **ON**/OFF                                   `Build tests <https://cmake.org/cmake/help/latest/module/CTest.html>`__
 ``CMAKE_BUILD_TYPE``            RelWithDebInfo/**Release**/Debug             `Type of build, symbols & optimizations <https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html>`__
+``CMAKE_CUDA_ARCHITECTURES``    **native**/all/all-major/``80``/...          `Nvidia GPU architectures to compile for <https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html>`__ (``ImpactX_COMPUTE=CUDA``)
 ``CMAKE_INSTALL_PREFIX``        system-dependent path                        `Install path prefix <https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html>`__
 ``CMAKE_VERBOSE_MAKEFILE``      ON/**OFF**                                   `Print all compiler commands to the terminal during build <https://cmake.org/cmake/help/latest/variable/CMAKE_VERBOSE_MAKEFILE.html>`__
 ``ImpactX_APP``                 **ON**/OFF                                   Build the ImpactX executable application
@@ -512,6 +546,7 @@ Environment variables can be used to control the build step:
 Environment Variable          Default & Values                             Description
 ============================= ============================================ ================================================================
 ``IMPACTX_COMPUTE``           NOACC/**OMP**/CUDA/SYCL/HIP                  On-node, accelerated computing backend
+``CUDAARCHS``                 **native**/all/all-major/``80``/...          Nvidia GPU architectures to compile for (see :ref:`building-cmake-gpu-archs`)
 ``IMPACTX_MPI``               ON/**OFF**                                   Multi-node support (message-passing)
 ``IMPACTX_PRECISION``         SINGLE/**DOUBLE**                            Floating point precision (single/double)
 ``IMPACTX_FFT``               ON/**OFF**                                   FFT-based solvers (IGF space charge, CSR)

--- a/docs/source/install/dependencies.rst
+++ b/docs/source/install/dependencies.rst
@@ -7,7 +7,7 @@ ImpactX depends on the following popular third party software.
 Please see installation instructions below.
 
 - a mature `C++20 <https://en.wikipedia.org/wiki/C%2B%2B20>`__ compiler, e.g., GCC 12+, Clang 14, NVCC 12.4, MSVC 19.44 or newer
-- `CMake 3.24.0+ <https://cmake.org>`__
+- `CMake 3.25.0+ <https://cmake.org>`__
 - `Git 2.18+ <https://git-scm.com>`__
 - `AMReX <https://amrex-codes.github.io>`__: we automatically download and compile a copy
 - `ABLASTR/WarpX <https://github.com/BLAST-WarpX/warpx>`__: we automatically download and compile a copy

--- a/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
+++ b/docs/source/install/hpc/perlmutter-nersc/perlmutter_gpu_impactx.profile.example
@@ -47,7 +47,7 @@ alias runNode="srun -N 1 --ntasks-per-node=4 -t 0:30:00 -q interactive -C gpu --
 export CRAY_ACCEL_TARGET=nvidia80
 
 # optimize CUDA compilation for A100
-export AMREX_CUDA_ARCH=8.0
+export CUDAARCHS=80
 
 # optimize CPU microarchitecture for AMD EPYC 3rd Gen (Milan/Zen3)
 # note: the cc/CC/ftn wrappers below add those

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "cmake>=3.24.0",
+    "cmake>=3.25.0",
     "packaging>=23",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -62,14 +62,14 @@ class CMakeBuild(build_ext):
             out = subprocess.check_output(["cmake", "--version"])
         except OSError:
             raise RuntimeError(
-                "CMake 3.24.0+ must be installed to build the following "
+                "CMake 3.25.0+ must be installed to build the following "
                 + "extensions: "
                 + ", ".join(e.name for e in self.extensions)
             )
 
         cmake_version = parse(re.search(r"version\s*([\d.]+)", out.decode()).group(1))
-        if cmake_version < parse("3.24.0"):
-            raise RuntimeError("CMake >= 3.24.0 is required")
+        if cmake_version < parse("3.25.0"):
+            raise RuntimeError("CMake >= 3.25.0 is required")
 
         for ext in self.extensions:
             self.build_extension(ext)


### PR DESCRIPTION
## Summary

Follows [AMReX-Codes/amrex#4773](https://github.com/AMReX-Codes/amrex/pull/4773) (as [BLAST-WarpX/warpx#7202](https://github.com/BLAST-WarpX/warpx/pull/7202) does for WarpX): CUDA architectures are now selected through the standard CMake interface and the CMake minimum rises to 3.25.
This moves our CI and the Perlmutter GPU profile over to the new spelling and raises ImpactX's own CMake minimum to match.

## Details

The variables we usually set in our scripts and profiles still work, but are deprecated and warn on configure.

Environment variables:

| old (deprecated, warns)            | new                        |
|------------------------------------|----------------------------|
| `export AMREX_CUDA_ARCH=8.0`       | `export CUDAARCHS=80`      |
| `export AMREX_CUDA_ARCH="7.0;7.5"` | `export CUDAARCHS="70;75"` |

CMake options:

| old (deprecated, warns)    | new                                               |
|----------------------------|---------------------------------------------------|
| `-DAMReX_CUDA_ARCH=8.0`    | `-DCMAKE_CUDA_ARCHITECTURES=80`                   |
| `-DAMReX_CUDA_ARCH=Auto`   | `-DCMAKE_CUDA_ARCHITECTURES=native` (new default) |
| `-DAMReX_CUDA_ARCH=Common` | `-DCMAKE_CUDA_ARCHITECTURES=all-major`            |

Values are integers (`80`, not `8.0`); `native`, `all`, `all-major` and the `90a` forms are supported as well.

User-facing:
- CMake 3.25.0+ is now required (was 3.24.0); documented in `docs/source/install/dependencies.rst`.
- The default is `native`, resolved from the GPUs visible to `cmake`. Configuring where no GPU is visible (HPC login node, container, CI) now requires an explicit architecture — our profile and CI set one.
- New "Select GPU Architectures" section in `docs/source/install/cmake.rst`, plus `CMAKE_CUDA_ARCHITECTURES` in the CMake option table and `CUDAARCHS` in the pip environment table, and a pointer from the CUDA build example.
- Perlmutter GPU profile now exports `CUDAARCHS=80`. Its `cmake/3.30.2` module already satisfies the new minimum, so no HPC template needs a new module.

Internal:
- Removed `cmake_policy(SET CMP0104 OLD)`, the pre-3.20 path AMReX dropped; keeping it would clear `CMAKE_CUDA_ARCHITECTURES`. The `CMAKE_WARN_DEPRECATED OFF` work-around it motivated is gone with it.
- Migrated `.github/workflows/cuda.yml` to `-DCMAKE_CUDA_ARCHITECTURES=60`.
- The `AMReX_GPU_RDC` / `AMReX_CUDA_LTO` coupling that device LTO now needs lives in ABLASTR and is handled in WarpX#7202, so nothing is needed here.
- `ImpactX_ablastr_branch` moves to the WarpX#7202 merge commit `690da5d6` and `ImpactX_amrex_branch` to the AMReX commit it pins, `19e6fba7`. Both are needed: `ImpactX_amrex_branch` force-overrides `WarpX_amrex_branch`, so the AMReX pin does not follow from the ABLASTR one.

## Testing

With the pins in this PR (no local source overrides):

- `ImpactX_COMPUTE=CUDA -DCMAKE_CUDA_ARCHITECTURES=80` configures cleanly and reports `CUDA architectures: 80`, fetching AMReX `19e6fba7` and ABLASTR `690da5d6`.
- `ImpactX_PYTHON=ON` configures and builds to completion, with `AMReX_BUILD_SHARED_LIBS=ON` / `AMReX_INSTALL=ON` as before.
- `ctest` C++ run tests: 81/85 pass. The 4 failures are all from the local build configuration, not this change - three need FFT for the IGF solver (`-DImpactX_FFT=OFF` here) and one needs PyTorch.
- Sphinx docs build with no warnings from the changed pages.
- Only remaining configure deprecation warning is the unrelated pinned `toml11` (`CMP0127`); the old AMReX one is gone now that the pin moved.
