### PR TITLE
CMake: keep derived AMReX options in sync on re-configure

### DIFF
--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -80,16 +80,16 @@ macro(find_ablastr)
 
         # shared libs, i.e. for Python bindings, need relocatable code
         if(ImpactX_PYTHON OR BUILD_SHARED_LIBS)
-            set(AMReX_PIC ON CACHE INTERNAL
-                "Build AMReX with position independent code")
-            set(ABLASTR_POSITION_INDEPENDENT_CODE ON CACHE INTERNAL
-                "Build ABLASTR with position independent code")
+            # Normal variables (CMP0077 NEW) apply these requirements without
+            # writing cache entries that outlive the requirement itself.
+            set(AMReX_PIC ON)
+            set(ABLASTR_POSITION_INDEPENDENT_CODE ON)
 
             # WE NEED AMReX AS SHARED LIB, OTHERWISE WE CANNOT SHARE ITS GLOBALS
             # BETWEEN MULTIPLE PYTHON MODULES
             # TODO this is likely an export/symbol hiding issue that we could
             #      alleviate later on
-            set(AMReX_BUILD_SHARED_LIBS ON CACHE BOOL "Build AMReX shared library" FORCE)
+            set(AMReX_BUILD_SHARED_LIBS ON)
         endif()
 
         if(ImpactX_ablastr_src)


### PR DESCRIPTION
`AMReX_PIC`, `ABLASTR_POSITION_INDEPENDENT_CODE` and `AMReX_BUILD_SHARED_LIBS` were written to the cache from the "on" branch of `if(ImpactX_PYTHON OR BUILD_SHARED_LIBS)`. Those entries outlive the requirement that created them, so re-configuring an existing build directory with `-DImpactX_PYTHON=OFF` silently kept the cached `ON` and left AMReX a shared library with no Python bindings asking for it.

Set them as normal variables instead. With `CMP0077 NEW` — which we already request for the ABLASTR superbuild — the downstream `option()` calls honor a normal variable and skip creating the cache entry, so the requirement applies for exactly the configure that asks for it and leaves nothing behind for the next one. Explicit `-D` values from the caller still take precedence, because they are cache entries and we no longer `FORCE` over them.

<details>
<summary>Details</summary>

There is deliberately no `else()` branch. With nothing cached there is nothing to reset, and assigning `OFF` there would override ABLASTR's own `ABLASTR_POSITION_INDEPENDENT_CODE` default of `ON` and change what a fresh non-Python configure builds today.

`AMReX_INSTALL` keeps working: ABLASTR derives it from `if(DEFINED AMReX_BUILD_SHARED_LIBS)`, and `DEFINED` is true for a normal variable, so the Python configure still gets `AMReX_INSTALL=ON` and `install(EXPORT "pyAMReXTargets" ...)` is generated.

**Testing**

Configured `ImpactX_PYTHON=ON`, re-configured the same directory with `ImpactX_PYTHON=OFF`, and compared against a fresh `ImpactX_PYTHON=OFF` configure. Probed the effective variable values plus the resulting `amrex_3d`/`ablastr_3d` target `TYPE` and `POSITION_INDEPENDENT_CODE`, since the fix intentionally keeps these values out of the cache.

|  | fresh `PYTHON=OFF` | `ON` → re-configure `OFF` |
| --- | --- | --- |
| `development` | `AMReX_PIC=ON`, amrex `STATIC` | `AMReX_PIC=ON`, amrex **`SHARED`** |
| this PR | `AMReX_PIC=ON`, amrex `STATIC` | `AMReX_PIC=ON`, amrex `STATIC` |

A re-configured build directory now matches a fresh one, and the fresh configure still matches what `development` produces. The `ImpactX_PYTHON=ON` configure is unchanged from `development` as well: amrex `SHARED` + PIC, ablastr `STATIC` + PIC, `AMReX_INSTALL=ON`.

Same class of issue as https://github.com/BLAST-WarpX/warpx/pull/7204 on the WarpX side.

</details>
