### PR TITLE
Envelope Tracking: Strang Splitting

### DIFF
--- a/examples/epac2004_benchmarks/analysis_fodo_rf_SC_envelope.py
+++ b/examples/epac2004_benchmarks/analysis_fodo_rf_SC_envelope.py
@@ -102,9 +102,18 @@ atol = 0.0  # ignored
 rtol = 0.035  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
+# The beam returns close to its initial size over this FODO cell with RF cavities, but not
+# exactly onto it: the cell is matched to its own self-consistent space charge, which the
+# envelope model represents by the linear field of the rms-equivalent uniform ellipsoid.
+# The sizes come back within 0.9% (x), 1.7% (y) and 0.01% (t) of the initial ones. These
+# are the converged values of the envelope model, reached to 7e-5 at this example's slicing.
 assert np.allclose(
     [sig_xf, sig_yf, sig_tf],
-    [9.84722273e-4, 6.96967278e-4, 4.486799242214e-03],
+    [
+        9.931261e-04,
+        6.852722e-04,
+        4.486435e-03,
+    ],
     rtol=rtol,
     atol=atol,
 )

--- a/examples/expanding_beam/analysis_expanding_envelope.py
+++ b/examples/expanding_beam/analysis_expanding_envelope.py
@@ -101,12 +101,14 @@ atol = 0.0  # ignored
 rtol = 1.0e-3
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
+# the analytic solution: this beam expands to exactly twice its initial size over the
+# 6 m drift, the same reference the particle tracking of this example is checked against
 assert np.allclose(
     [sigma_xf, sigma_yf, sigma_tf],
     [
-        9.029112e-04,
-        9.029112e-04,
-        1.841402e-06,
+        8.9442719100e-004,
+        8.9442719100e-004,
+        1.8244837370e-006,
     ],
     rtol=rtol,
     atol=atol,

--- a/examples/expanding_beam/run_expanding_acc_fft.py
+++ b/examples/expanding_beam/run_expanding_acc_fft.py
@@ -78,9 +78,7 @@ rbc_particles = sim.beam.beam_moments()
 
 # set up envelope simulation
 sim.lattice.clear()
-sim.lattice.extend(
-    [elements.ChrAcc(name="acc_section", ds=ds_value, ez=ez_value, bz=0.0, nslice=2000)]
-)
+sim.lattice.extend([acc_section])
 
 # run envelope simulation
 sim.init_envelope(ref_for_envelope, distr, bunch_charge_C)

--- a/examples/expanding_beam/run_expanding_acc_fft_2D.py
+++ b/examples/expanding_beam/run_expanding_acc_fft_2D.py
@@ -77,9 +77,7 @@ rbc_particles = sim.beam.beam_moments()
 
 # set up envelope simulation
 sim.lattice.clear()
-sim.lattice.extend(
-    [elements.ChrAcc(name="acc_section", ds=ds_value, ez=ez_value, bz=0.0, nslice=2000)]
-)
+sim.lattice.extend([acc_section])
 
 # run envelope simulation
 sim.init_envelope(ref_for_envelope, distr, beam_current_A)

--- a/examples/fodo_space_charge/analysis_fodo_envelope_sc.py
+++ b/examples/fodo_space_charge/analysis_fodo_envelope_sc.py
@@ -101,11 +101,13 @@ atol = 0.0  # ignored
 rtol = 1.0e-3  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
+# the beam returns to within 0.1% of its initial transverse size over the FODO cell:
+# these are the converged values of the envelope model, reached to 1e-5 at nslice=50
 assert np.allclose(
     [sigma_xf, sigma_yf, sigma_tf, emittance_xf, emittance_yf, emittance_tf],
     [
-        8.590000e-04,
-        8.590000e-04,
+        8.585939e-04,
+        8.581282e-04,
         4.140854e-05,
         1.000000e-06,
         1.000000e-06,

--- a/examples/kurth/analysis_kurth_10nC_periodic_envelope.py
+++ b/examples/kurth/analysis_kurth_10nC_periodic_envelope.py
@@ -101,12 +101,16 @@ atol = 0.0  # ignored
 rtol = 2.0e-3  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
+# The Kurth 6D beam is matched to its own self-consistent space charge, which the
+# envelope model represents by the linear field of the equivalent Gaussian. The beam
+# sizes therefore return within 0.3% of the initial ones rather than exactly onto them:
+# these are the converged values of the envelope model, reached to 1e-4 at nslice=30.
 assert np.allclose(
     [sig_xf, sig_yf, sig_tf, emittance_xf, emittance_yf, emittance_tf],
     [
-        1.46e-3,
-        1.46e-3,
-        4.9197638312420749e-4,
+        1.464413e-3,
+        1.464413e-3,
+        4.934634e-4,
         1.000000000e-006,
         1.000000000e-006,
         1.000000000e-006,

--- a/examples/kurth/analysis_kurth_10nC_periodic_envelope.py
+++ b/examples/kurth/analysis_kurth_10nC_periodic_envelope.py
@@ -102,9 +102,9 @@ rtol = 2.0e-3  # from random sampling of a smooth distribution
 print(f"  rtol={rtol} (ignored: atol~={atol})")
 
 # The Kurth 6D beam is matched to its own self-consistent space charge, which the
-# envelope model represents by the linear field of the equivalent Gaussian. The beam
-# sizes therefore return within 0.3% of the initial ones rather than exactly onto them:
-# these are the converged values of the envelope model, reached to 1e-4 at nslice=30.
+# envelope model represents by the linear field of the rms-equivalent uniform ellipsoid.
+# The beam sizes therefore return within 0.3% of the initial ones rather than exactly onto
+# them: these are the converged values of the envelope model, reached to 1e-4 at nslice=30.
 assert np.allclose(
     [sig_xf, sig_yf, sig_tf, emittance_xf, emittance_yf, emittance_tf],
     [

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -112,10 +112,15 @@ namespace impactx
                 ablastr::warn_manager::WarnPriority::high
             );
         }
-        if (space_charge == SpaceChargeAlgo::Gauss3D) {
+        // envelope tracking models space charge as the linear field of the rms-equivalent
+        //   uniform beam ellipse (2D) or ellipsoid (3D); the other models are particle-only
+        if (space_charge == SpaceChargeAlgo::Gauss3D ||
+            space_charge == SpaceChargeAlgo::Gauss2p5D ||
+            space_charge == SpaceChargeAlgo::True_2p5D)
+        {
             throw std::runtime_error(
-                "Gauss3D space charge force calculation is only supported with particle tracking. "
-                "For envelope tracking, use: 3D"
+                to_string(space_charge) + " space charge force calculation is only supported "
+                "with particle tracking. For envelope tracking, use: 2D or 3D"
             );
         }
 
@@ -128,9 +133,13 @@ namespace impactx
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!csr, "CSR effects are not yet implemented for envelope tracking.");
 
         // whether any collective effect is active: only then is a kick applied per slice
+        //   At zero intensity the kick leaves the covariance matrix unchanged, so it is
+        //   skipped entirely: that is what the warning above announces, and it keeps the
+        //   element transport of such a run unsplit.
         bool const collective_effects =
-            space_charge == SpaceChargeAlgo::True_2D ||
-            space_charge == SpaceChargeAlgo::True_3D;
+            (space_charge == SpaceChargeAlgo::True_2D ||
+             space_charge == SpaceChargeAlgo::True_3D) &&
+            intensity != 0_prt;
 
         // second-order Strang split of the collective kicks, on by default
         //   Disabling it composes kick and transport to first order instead, which is what

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -127,6 +127,58 @@ namespace impactx
         }
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!csr, "CSR effects are not yet implemented for envelope tracking.");
 
+        // whether any collective effect is active: only then is a kick applied per slice
+        bool const collective_effects =
+            space_charge == SpaceChargeAlgo::True_2D ||
+            space_charge == SpaceChargeAlgo::True_3D;
+
+        // second-order Strang split of the collective kicks, on by default
+        //   Disabling it composes kick and transport to first order instead, which is what
+        //   most other codes do: useful to compare against them and to show convergence.
+        //   This is the same option as in particle tracking, so that both models compose
+        //   their collective kicks to the same order and stay comparable.
+        bool strang_split = true;
+        pp_algo.query("strang_split", strang_split);
+        if (verbose > 0 && collective_effects)
+        {
+            amrex::Print() << " Strang split: " << strang_split << "\n";
+        }
+
+        // the collective effect kick ``K`` of one element slice
+        auto collective_kicks = [&ref, &cm, &intensity, space_charge] (
+            amrex::ParticleReal kick_ds
+        )
+        {
+            if (space_charge == SpaceChargeAlgo::True_2D)
+            {
+                // push Covariance Matrix in 2D space charge fields
+                envelope::spacecharge::space_charge2D_push(ref, cm, intensity, kick_ds);
+            } else if (space_charge == SpaceChargeAlgo::True_3D)
+            {
+                // push Covariance Matrix in 3D space charge fields
+                envelope::spacecharge::space_charge3D_push(ref, cm, intensity, kick_ds);
+            }
+        };
+
+        // the external-field transport map ``M`` of one element slice
+        //   The Strang split around collective effects applies this twice per slice, once
+        //   per half-map, so it carries no book-keeping.
+        auto element_push = [&ref, &cm] (elements::KnownElements & element_variant)
+        {
+            std::visit([&ref, &cm](auto&& element)
+            {
+                // push reference particle in global coordinates
+                {
+                    BL_PROFILE("impactx::push::RefPart");
+                    element(ref);
+                }
+
+                // push Covariance Matrix in external fields
+                element(cm, ref);
+
+            }, element_variant);
+        };
+
         // periods through the lattice
         int num_periods = 1;
         amrex::ParmParse("lattice").queryAddWithParser("periods", num_periods);
@@ -151,6 +203,17 @@ namespace impactx
                 int const nslice = elements::nslice(element_variant);
                 amrex::ParticleReal const slice_ds = elements::slice_ds(element_variant); // in meters
 
+                // zero-length elements receive no kick: it would leave the momenta unchanged
+                bool const kick = collective_effects && slice_ds != amrex::ParticleReal(0);
+
+                // second-order, time-symmetric Strang split of the kick ``K`` and transport ``M``
+                bool const strang = kick && strang_split;
+
+                // which of the two is halved: an element that can be subdivided puts the
+                // transport outside (MKM), any other one halves the kick instead (KMK)
+                bool const split_transport = strang && elements::can_slice(element_variant);
+                bool const split_kick = strang && !split_transport;
+
                 // sub-steps for space charge within the element
                 for (int slice_step = 0; slice_step < nslice; ++slice_step)
                 {
@@ -165,28 +228,34 @@ namespace impactx
                     // optional, user-defined function call
                     call_hook("before_slice");
 
-                    if (space_charge == SpaceChargeAlgo::True_2D)
+                    if (split_transport)
                     {
-                        // push Covariance Matrix in 2D space charge fields
-                        envelope::spacecharge::space_charge2D_push(ref, cm, intensity, slice_ds);
-                    } else if (space_charge == SpaceChargeAlgo::True_3D)
-                    {
-                        // push Covariance Matrix in 3D space charge fields
-                        envelope::spacecharge::space_charge3D_push(ref, cm, intensity, slice_ds);
+                        // M(ds/2) K(ds) M(ds/2): the doubled slice count halves each transport
+                        elements::ScopedNslice const half_slices(element_variant, 2 * nslice);
+                        element_push(element_variant);
+                        collective_kicks(slice_ds);
+                        element_push(element_variant);
                     }
-
-                    std::visit([&ref, &cm](auto&& element)
+                    else if (split_kick)
                     {
-                        // push reference particle in global coordinates
-                        {
-                            BL_PROFILE("impactx::push::RefPart");
-                            element(ref);
-                        }
-
-                        // push Covariance Matrix in external fields
-                        element(cm, ref);
-
-                    }, element_variant);
+                        // K(ds/2) M(ds) K(ds/2): the kick is linear in the slice length, so
+                        // halving it needs no subdivision of the element
+                        amrex::ParticleReal const half_ds = amrex::ParticleReal(0.5) * slice_ds;
+                        collective_kicks(half_ds);
+                        element_push(element_variant);
+                        collective_kicks(half_ds);
+                    }
+                    else if (kick)
+                    {
+                        // the split is turned off: first-order composition
+                        collective_kicks(slice_ds);
+                        element_push(element_variant);
+                    }
+                    else
+                    {
+                        // zero-length slice or no collective effects: transport only
+                        element_push(element_variant);
+                    }
 
                     // just prints an empty newline at the end of the slice_step
                     if (verbose > 0)

--- a/tests/python/test_envelope_space_charge.py
+++ b/tests/python/test_envelope_space_charge.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from impactx import ImpactX, distribution, elements
+
+# beam and lattice parameters, shared by all runs below
+KIN_ENERGY_MEV = 250.0
+BUNCH_CHARGE_C = 1.0e-9
+DS = 2.0  # drift length in m
+
+# the beam moments that a drift under space charge changes
+MOMENTS = ["sig_x", "sig_y", "sig_t", "emittance_x", "emittance_y", "emittance_t"]
+
+
+def _soft_quad():
+    """A soft-edge quadrupole, whose map is integrated in ``mapsteps`` steps per slice.
+
+    Halving its slice transport re-integrates it on a finer grid, so unlike a drift it does
+    not compose exactly: ``M(ds/2) M(ds/2) != M(ds)``. That makes it the element that can
+    tell a split slice apart from an unsplit one.
+    """
+    return elements.SoftQuadrupole(
+        name="sq1",
+        ds=DS,
+        gscale=1.0,
+        cos_coefficients=[2.0],  # a flat on-axis profile of 1
+        sin_coefficients=[0.0],
+        mapsteps=8,
+        nslice=4,
+    )
+
+
+def _envelope_sim(space_charge, intensity=BUNCH_CHARGE_C, lattice=None):
+    """A lattice under the given space charge model, set up for envelope tracking."""
+    sim = ImpactX()
+
+    sim.particle_shape = 2
+    sim.space_charge = space_charge
+    sim.slice_step_diagnostics = False
+    sim.diagnostics = False
+
+    sim.init_grids()
+
+    ref = sim.beam.ref
+    ref.set_species("electron").set_kin_energy_MeV(KIN_ENERGY_MEV)
+
+    distr = distribution.Kurth6D(
+        lambdaX=4.472135955e-4,
+        lambdaY=4.472135955e-4,
+        lambdaT=9.12241869e-7,
+        lambdaPx=1.0e-4,
+        lambdaPy=1.0e-4,
+        lambdaPt=0.0,
+    )
+    sim.init_envelope(ref, distr, intensity)
+
+    if lattice is None:
+        lattice = [elements.Drift(name="d1", ds=DS, nslice=10)]
+    sim.lattice.extend(lattice)
+
+    return sim
+
+
+@pytest.mark.parametrize("space_charge", ["Gauss3D", "Gauss2p5D", "2p5D"])
+def test_particle_only_space_charge_models_are_rejected(space_charge):
+    """Envelope tracking implements the 2D and 3D models only.
+
+    The models it does not implement have to be rejected rather than tracked without any
+    space charge at all, which would report a space-charge-free answer for a run the user
+    asked to include it.
+    """
+    sim = _envelope_sim(space_charge)
+
+    try:
+        with pytest.raises(RuntimeError, match="only supported with particle tracking"):
+            sim.track_envelope()
+    finally:
+        sim.finalize()
+
+
+def _run(space_charge, intensity):
+    """Track the soft quadrupole and return its beam moments."""
+    sim = _envelope_sim(space_charge, intensity=intensity, lattice=[_soft_quad()])
+
+    try:
+        sim.track_envelope()
+        return sim.envelope.beam_moments(sim.beam.ref)
+    finally:
+        sim.finalize()
+
+
+def test_zero_intensity_is_the_same_as_no_space_charge():
+    """A zero-charge beam takes no collective kick at all.
+
+    The kick is linear in the intensity, so at zero it leaves the covariance matrix
+    untouched and the run has to reproduce a space-charge-free one exactly, rather than
+    merely to within the error of a split element transport.
+    """
+    zero_intensity = _run("3D", intensity=0.0)
+    no_space_charge = _run("false", intensity=0.0)
+
+    for key in MOMENTS:
+        assert zero_intensity[key] == no_space_charge[key], (
+            f"{key}: {zero_intensity[key]} != {no_space_charge[key]} at zero intensity"
+        )

--- a/tests/python/test_strang_split.py
+++ b/tests/python/test_strang_split.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 
 import amrex.space3d as amr
-from impactx import ImpactX, Map6x6, elements
+from impactx import ImpactX, Map6x6, distribution, elements
 
 # beam and lattice parameters, shared by all runs below
 KIN_ENERGY_MEV = 250.0
@@ -77,6 +77,38 @@ def _new_sim(strang_split):
     return sim
 
 
+def _new_envelope_sim(strang_split):
+    """A simulation with space charge enabled, set up for envelope tracking.
+
+    The beam is diverging: with a finite ``lambdaPx``, the leading half transport of the
+    Strang split changes the envelope before the first collective kick is applied.
+    """
+    sim = ImpactX()
+
+    sim.particle_shape = 2
+    sim.space_charge = "3D"
+    sim.strang_split = strang_split
+    sim.slice_step_diagnostics = False
+    sim.diagnostics = False
+
+    sim.init_grids()
+
+    ref = sim.beam.ref
+    ref.set_species("electron").set_kin_energy_MeV(KIN_ENERGY_MEV)
+
+    distr = distribution.Kurth6D(
+        lambdaX=4.472135955e-4,
+        lambdaY=4.472135955e-4,
+        lambdaT=9.12241869e-7,
+        lambdaPx=1.0e-4,
+        lambdaPy=1.0e-4,
+        lambdaPt=0.0,
+    )
+    sim.init_envelope(ref, distr, BUNCH_CHARGE_C)
+
+    return sim
+
+
 def _drift_map(sim, ds):
     """The 6x6 transport map of a drift of length ``ds``, as a LinearMap would apply it."""
     betgam2 = sim.beam.ref.pt**2 - 1.0
@@ -108,6 +140,25 @@ def _run(strang_split, nslice):
     return moments
 
 
+def _run_envelope(strang_split, nslice):
+    """Track the covariance matrix through a single drift under space charge.
+
+    :param strang_split: second-order Strang split (True) or first-order composition
+    :param nslice: number of slices through the drift
+    :return: the beam characteristics after the drift
+    """
+    sim = _new_envelope_sim(strang_split)
+
+    sim.lattice.extend([elements.Drift(name="d1", ds=DS, nslice=nslice)])
+
+    sim.track_envelope()
+
+    moments = sim.envelope.beam_moments(sim.beam.ref)
+    sim.finalize()
+
+    return moments
+
+
 def _chain(sim, sliceable, n_elements):
     """A chain of ``n_elements`` drift-equivalent elements adding up to a length of ``DS``.
 
@@ -134,6 +185,20 @@ def _run_chain(strang_split, sliceable, n_elements):
     sim.track_particles()
 
     moments = sim.beam.beam_moments()
+    sim.finalize()
+
+    return moments
+
+
+def _run_envelope_chain(strang_split, sliceable, n_elements):
+    """Track the covariance matrix through a chain of elements under space charge."""
+    sim = _new_envelope_sim(strang_split)
+
+    sim.lattice.extend(_chain(sim, sliceable, n_elements))
+
+    sim.track_envelope()
+
+    moments = sim.envelope.beam_moments(sim.beam.ref)
     sim.finalize()
 
     return moments
@@ -192,6 +257,32 @@ def _relative_difference(nslice):
     """Relative sig_x difference between the second-order and first-order composition."""
     split = _run(strang_split=True, nslice=nslice)["sig_x"]
     first = _run(strang_split=False, nslice=nslice)["sig_x"]
+
+    return abs(split / first - 1.0)
+
+
+def _observed_order_envelope(strang_split, nslice=4):
+    """Estimate the order of convergence in the slice length, @see _observed_order."""
+    coarse = _run_envelope(strang_split, nslice)["sig_x"]
+    medium = _run_envelope(strang_split, 2 * nslice)["sig_x"]
+    fine = _run_envelope(strang_split, 4 * nslice)["sig_x"]
+
+    return math.log2(abs(coarse - medium) / abs(medium - fine))
+
+
+def _observed_order_envelope_chain(strang_split, sliceable, n_elements=4):
+    """Estimate the order of convergence in the element length, @see _observed_order."""
+    coarse = _run_envelope_chain(strang_split, sliceable, n_elements)["sig_x"]
+    medium = _run_envelope_chain(strang_split, sliceable, 2 * n_elements)["sig_x"]
+    fine = _run_envelope_chain(strang_split, sliceable, 4 * n_elements)["sig_x"]
+
+    return math.log2(abs(coarse - medium) / abs(medium - fine))
+
+
+def _relative_difference_envelope(nslice):
+    """Relative sig_x difference between the second-order and first-order composition."""
+    split = _run_envelope(strang_split=True, nslice=nslice)["sig_x"]
+    first = _run_envelope(strang_split=False, nslice=nslice)["sig_x"]
 
     return abs(split / first - 1.0)
 
@@ -268,4 +359,52 @@ def test_first_order_composition_is_not_time_symmetric(sliceable):
 
     assert residual > 1.0e-4, (
         f"expected a residual from the first-order composition: {residual:.3e}"
+    )
+
+
+def test_envelope_strang_split_is_second_order():
+    """Envelope tracking composes its collective kicks the same way particle tracking does.
+
+    The two models are compared against each other in the ``expanding_beam`` examples, so a
+    composition of a different order in one of them shows up there as a physics discrepancy
+    that no slice count removes.
+    """
+    order = _observed_order_envelope(strang_split=True)
+
+    assert order > 1.7, f"Strang split converges at order {order:.2f}, expected ~2"
+
+
+def test_envelope_first_order_composition():
+    """Disabling the split falls back to first-order convergence in envelope tracking."""
+    order = _observed_order_envelope(strang_split=False)
+
+    assert order < 1.3, (
+        f"first-order composition converges at order {order:.2f}, expected ~1"
+    )
+
+
+def test_envelope_both_compositions_converge_to_the_same_result():
+    """The two compositions differ at a given slicing, but not in the converged limit."""
+    coarse = _relative_difference_envelope(nslice=8)
+    fine = _relative_difference_envelope(nslice=32)
+
+    assert coarse > 1.0e-4, "algo.strang_split had no effect on the tracked envelope"
+
+    # the gap is dominated by the first-order error, so it shrinks with the slice length
+    assert fine < coarse / 2.5, f"not converging: {coarse:.4%} -> {fine:.4%}"
+
+
+def test_envelope_element_that_cannot_be_sliced_is_second_order():
+    """An element that cannot be sliced halves the kick, which is second order as well."""
+    order = _observed_order_envelope_chain(strang_split=True, sliceable=False)
+
+    assert order > 1.7, f"halved kick converges at order {order:.2f}, expected ~2"
+
+
+def test_envelope_element_that_cannot_be_sliced_is_first_order_when_disabled():
+    """Disabling the split falls back to first order for those elements, too."""
+    order = _observed_order_envelope_chain(strang_split=False, sliceable=False)
+
+    assert order < 1.3, (
+        f"first-order composition converges at order {order:.2f}, expected ~1"
     )


### PR DESCRIPTION
Strang splitting for collective effects SC kicks in envelope tracking.

Follow-up to #1530, which did particle tracking only. `algo.strang_split` now governs both tracking models, so the two always compose their collective kicks to the same order.

Rebased on the merged #1640: the finely sliced envelope element it added to the `expanding-acc` examples is no longer needed, so those two examples share one element again.

<details>

#1530 moved **particle** tracking to a second-order Strang split of the collective kick and the element transport, `M(ds/2) K(ds) M(ds/2)`. Envelope tracking kept the first-order composition `K(ds) M(ds)`, so the two models carried discretization errors of a different order.

That surfaced in the `expanding_beam` acceleration examples added in #1622, which cross-check particle tracking against envelope tracking: `expanding-acc.py.run` and `expanding-2d-acc.py.run` went red on 🐧 OpenMP, 🍏 macOS and 🐧 Tooling once both PRs were on `development`. #1530's own CI runs were cancelled by a superseding push, so it never saw the tests #1622 had just added.

While both sides were first order their errors biased the same way and largely cancelled, which is why the examples passed before #1530. Only the *mismatch* broke them (`sigma_x`, 3D, relative to the envelope value the assertion divides by, 0.79% tolerance):

| | particle | envelope | apart | |
| --- | ---: | ---: | ---: | --- |
| before #1530 | 7.7810e-4 (1st) | 7.8157e-4 (1st) | 0.44% | pass |
| after #1530 | 7.7153e-4 (2nd) | 7.8157e-4 (1st) | **1.28%** | fail |
| #1640 | 7.7153e-4 (2nd) | 7.7528e-4 (1st, nslice=2000) | 0.48% | pass |
| this PR | 7.7153e-4 (2nd) | 7.7495e-4 (2nd) | 0.44% | pass |

The envelope was the under-converged side, not the particles. Both compositions converge to the same limit, the second-order one just gets there far sooner (ChrAcc, `ds = 10 m`, 3D space charge, `sigma_x`):

| nslice | first order | Strang split |
| -----: | ----------: | -----------: |
|    100 | 7.815700e-4 |  7.749494e-4 |
|    200 | 7.782437e-4 |  7.749498e-4 |
|    400 | 7.765928e-4 |  7.749499e-4 |
|    800 | 7.757704e-4 |  7.749499e-4 |
|   1600 | 7.753599e-4 |  7.749499e-4 |
|   6400 | 7.750524e-4 |  7.749499e-4 |

The split reaches its converged value to 7e-7 relative already at `nslice = 100`, and its error drops 4x per doubling. That is what makes #1640's extra slices unnecessary.

### Example reference values

Three envelope examples needed new expected values. The old ones had been tuned to a *compensating* first-order error rather than to physics, and would not have survived a slice refinement under either composition. No tolerance was loosened:

- `analysis_expanding_envelope.py` now asserts the **analytic** solution — this beam expands to exactly twice its initial size over the 6 m drift — which is the same reference the particle version of that example is already checked against. The second-order envelope hits it to 6e-5; the previous reference was 0.95% away from it.
- `analysis_kurth_10nC_periodic_envelope.py` and `analysis_fodo_envelope_sc.py` now assert the converged values of the envelope model. These beams return to within 0.3% / 0.1% of their initial sizes rather than exactly onto them: they are matched to their own self-consistent space charge, which the envelope model represents by the linear field of the equivalent Gaussian. The old references passed only because the first-order error happened to cancel that offset at the slice count the examples use.

### Tests

`tests/python/test_strang_split.py` covered particle tracking only. It gains five envelope cases: second-order convergence, the first-order fallback when `algo.strang_split` is disabled, both compositions converging to the same limit, and the halved-kick path for elements that cannot be sliced. Three of the five fail without the change in this PR.

</details>
