### PR TITLE
Examples: Converge the Envelope in expanding-acc

### DIFF
--- a/examples/expanding_beam/run_expanding_acc_fft.py
+++ b/examples/expanding_beam/run_expanding_acc_fft.py
@@ -78,7 +78,9 @@ rbc_particles = sim.beam.beam_moments()
 
 # set up envelope simulation
 sim.lattice.clear()
-sim.lattice.extend([acc_section])
+sim.lattice.extend(
+    [elements.ChrAcc(name="acc_section", ds=ds_value, ez=ez_value, bz=0.0, nslice=2000)]
+)
 
 # run envelope simulation
 sim.init_envelope(ref_for_envelope, distr, bunch_charge_C)

--- a/examples/expanding_beam/run_expanding_acc_fft_2D.py
+++ b/examples/expanding_beam/run_expanding_acc_fft_2D.py
@@ -77,7 +77,9 @@ rbc_particles = sim.beam.beam_moments()
 
 # set up envelope simulation
 sim.lattice.clear()
-sim.lattice.extend([acc_section])
+sim.lattice.extend(
+    [elements.ChrAcc(name="acc_section", ds=ds_value, ez=ez_value, bz=0.0, nslice=2000)]
+)
 
 # run envelope simulation
 sim.init_envelope(ref_for_envelope, distr, beam_current_A)


### PR DESCRIPTION
Because we merged #1530 and #1622 in parallel, we have a slight breakage of tests in `development`.

The new two `expanding_beam` examples cross-check particle tracking against envelope tracking. Since #1530 the particle side composes the collective kicks with a second-order Strang split, while the envelope side still composes them to first order — so the envelope is the under-converged side of the comparison. At `nslice = 100` its beam sizes are still ~0.9% (3D) and ~1.0% (2D) away from the converged ones, past the `2.5*npart**-0.5` = 0.79% tolerance the examples assert.

Both examples reused one `acc_section` element for both passes. The envelope pass now gets its own, finely sliced element; the particle side keeps `nslice = 100`, which the Strang split already converges.

Worst particle-vs-envelope relative deviation by envelope `nslice` (tolerance 0.0079):

| envelope nslice | 3D | 2D |
| --------------: | -------: | -------: |
|             100 | 0.0129 ❌ | 0.0133 ❌ |
|             200 | 0.0086 ❌ | 0.0081 ❌ |
|             400 |   0.0065 |   0.0055 |
|             800 |   0.0055 |   0.0042 |
|        **2000** | **0.0052** | **0.0035** |
|           12800 |   0.0045 |   0.0030 |

Both compositions converge to the same limit, first order just needs about 20x the slices to get there. The residual ~0.45% floor is the genuine difference between the PIC and the linear envelope model, not discretization. Envelope tracking costs ~1 us per slice, so `nslice = 2000` adds ~2 ms and leaves the test runtime unchanged.

#1639 removes the need for this: with the second-order envelope, sharing the original `nslice = 100` element converges to 7e-7 relative and these two hunks go away again.
