### PR TITLE
Tracking: One Shared Lattice Traversal Helper

### DIFF
--- a/src/diagnostics/LinearMap.cpp
+++ b/src/diagnostics/LinearMap.cpp
@@ -129,8 +129,8 @@ namespace
      *  deduplication set is maintained per call.
      *
      *  Uses the same per-element advance / linear-map evaluation
-     *  convention as the envelope tracker in
-     *  @c src/tracking/envelope.cpp , so the resulting linear optics
+     *  convention as the lattice traversal in
+     *  @c src/tracking/common.H , so the resulting linear optics
      *  is consistent with the tracker for edge-sensitive elements
      *  such as @c RFCavity, @c SoftQuad, and @c SoftSol.
      *
@@ -163,10 +163,11 @@ namespace
         // warn only once per element type
         std::set<std::string> warned_types;
 
-        // The element loop mirrors src/tracking/envelope.cpp
+        // The element loop mirrors the lattice traversal in src/tracking/common.H,
+        // without its period loop and collective-effect slices
         for (auto const & element_variant : lattice)
         {
-            ref.sedge = ref.s;
+            ref.set_edge();
 
             std::visit([&](auto && element)
             {

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -233,11 +233,6 @@ namespace impactx
         RefPart const &
         GetRefParticle () const;
 
-        /** Update reference particle element edge
-         *
-         */
-        void SetRefParticleEdge ();
-
         /** Get particle shape
          */
         int

--- a/src/particles/ImpactXParticleContainer.cpp
+++ b/src/particles/ImpactXParticleContainer.cpp
@@ -427,12 +427,6 @@ namespace impactx
         return m_refpart;
     }
 
-    void
-    ImpactXParticleContainer::SetRefParticleEdge ()
-    {
-        m_refpart.sedge = m_refpart.s;
-    }
-
     std::tuple<
             amrex::ParticleReal, amrex::ParticleReal,
             amrex::ParticleReal, amrex::ParticleReal,

--- a/src/particles/ReferenceParticle.H
+++ b/src/particles/ReferenceParticle.H
@@ -75,6 +75,18 @@ namespace impactx
             if (keep_charge) { charge = old_charge; }
         }
 
+        /** Set the element edge to the current path length
+         *
+         * Call this when entering a beamline element: s-dependent (soft-edge) maps
+         * integrate their on-axis field profile relative to this edge.
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void
+        set_edge ()
+        {
+            sedge = s;
+        }
+
         /** Set reference particle species by name
          *
          * Sets charge, mass, and gyromagnetic anomaly for a known particle species.

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -127,7 +127,7 @@ namespace
                     // private copy: the caller's reference particle is not modified
                     RefPart ref_slice = ref;
                     // the element starts at the current s, as in walk_lattice
-                    ref_slice.sedge = ref_slice.s;
+                    ref_slice.set_edge();
                     el(ref_slice);
                     return el.transport_map(ref_slice);
                 } else {

--- a/src/tracking/common.H
+++ b/src/tracking/common.H
@@ -1,4 +1,4 @@
-/* Copyright 2022-2025 The Regents of the University of California, through Lawrence
+/* Copyright 2022-2026 The Regents of the University of California, through Lawrence
  *           Berkeley National Laboratory (subject to receipt of any required
  *           approvals from the U.S. Dept. of Energy). All rights reserved.
  *
@@ -7,12 +7,12 @@
  * Authors: Axel Huebl, Chad Mitchell
  * License: BSD-3-Clause-LBNL
  */
-#ifndef IMPACTX_TRACKING_PARTICLES_H
-#define IMPACTX_TRACKING_PARTICLES_H
+#ifndef IMPACTX_TRACKING_COMMON_H
+#define IMPACTX_TRACKING_COMMON_H
 
 #include "elements/All.H"
 #include "elements/mixin/accessors.H"
-#include "particles/ImpactXParticleContainer.H"
+#include "particles/ReferenceParticle.H"
 #include "tracking/TrackingDirection.H"
 #include "tracking/TrackingState.H"
 
@@ -22,12 +22,13 @@
 #include <AMReX_REAL.H>
 
 #include <list>
+#include <stdexcept>
 #include <string>
 
 
 namespace impactx
 {
-    /** Traverse the lattice for particle (beam + reference) tracking.
+    /** Traverse the lattice, for any of the tracking models.
      *
      *  This function performs the nested lattice traversal (looping over periods,
      *  then over the beamline elements in each period, then over the
@@ -35,11 +36,19 @@ namespace impactx
      *  user-defined hooks, the reference-particle edge update and the global step
      *  counter.
      *
+     *  The tracked quantity enters only through the callables below, so that particle
+     *  tracking (@see ImpactX::track_particles), envelope tracking
+     *  (@see ImpactX::track_envelope) and reference-particle tracking
+     *  (@see ImpactX::track_reference) traverse the lattice identically and compose their
+     *  collective kicks to the same order.
+     *
      *  The caller supplies the per-slice physics as three composable operations: the
      *  collective kick @p collective_kicks ``K`` (space charge, CSR, ISR, ...), the
      *  element transport @p element_push ``M`` (the external-field map of one
      *  element slice) and the @p slice_diagnostics book-keeping (boundary conditions,
-     *  lost particles, slice diagnostics), which runs once per slice.
+     *  lost particles, slice diagnostics), which runs once per slice. A model without
+     *  collective effects passes @p collective_effects false, and its @p collective_kicks
+     *  is then never called.
      *
      *  With collective effects active (@p collective_effects) and @p strang_split on, every
      *  slice is composed as a second-order, time-symmetric Strang split. Which of the two
@@ -48,10 +57,10 @@ namespace impactx
      *  for an element that can be subdivided (@see elements::can_slice): half of the slice
      *  transport, the collective kick at the slice midpoint, then the other half. The half
      *  transports are realized by temporarily doubling the element's ``nslice``, which simply
-     *  halves the ds per slice. The expensive collective solve still runs only once per slice.
+     *  halves the ds per slice. The collective kick still runs only once per slice.
      *      ``K(ds/2) M(ds) K(ds/2)``
      *  for every other element: the kick is linear in the slice length, so halving it needs no
-     *  subdivision, at the price of a second collective solve per slice.
+     *  subdivision, at the price of a second collective kick per slice.
      *  Turning the split off composes kick and transport to first order instead:
      *  ``K(ds) M(ds)`` forward and ``M(ds) K(ds)`` backward.
      *  Zero-length elements and runs without collective effects apply ``M`` alone, since a
@@ -70,7 +79,9 @@ namespace impactx
      *
      *  The number of periods (``lattice.periods``) and verbosity (``impactx.verbose``)
      *  are read from the inputs. The step counter is advanced from its current value,
-     *  so the caller is expected to reset it (to 0) before a forward run.
+     *  so the caller is expected to reset it (to 0) before a forward run. At least one
+     *  period is always traversed, so on return ``tracking_state.m_period`` holds the
+     *  last period that was tracked.
      *
      *  @tparam HookFn callable ``void (std::string const & name)`` invoking a named hook
      *  @tparam CollectiveKicks callable
@@ -82,7 +93,7 @@ namespace impactx
      *  @tparam SliceDiagnostics callable ``void (int step, int period)`` running the
      *    once-per-slice book-keeping (boundary conditions, lost particles, slice diagnostics)
      *  @param[in,out] lattice the beamline elements to traverse
-     *  @param[in,out] pc beam particle container (reference particle / edge update)
+     *  @param[in,out] ref reference particle, its element edge is set once per element
      *  @param[in,out] tracking_state tracking state shared with hooks (element, step, period);
      *                 its ``m_direction`` selects the traversal direction
      *  @param[in] collective_effects whether any collective kick is active in this run
@@ -97,9 +108,9 @@ namespace impactx
         typename HookFn, typename CollectiveKicks,
         typename ElementPush, typename SliceDiagnostics
     >
-    void track_lattice_particles (
+    void track_lattice (
         std::list<elements::KnownElements> & lattice,
-        ImpactXParticleContainer & pc,
+        RefPart & ref,
         TrackingState & tracking_state,
         bool collective_effects,
         bool strang_split,
@@ -109,11 +120,19 @@ namespace impactx
         SliceDiagnostics && slice_diagnostics
     )
     {
+        // the period loop below takes the address of the first element; only
+        // ImpactX::track_particles runs validate(), which rejects this earlier
+        if (lattice.empty())
+        {
+            throw std::runtime_error("Beamline lattice has zero elements. Not yet initialized?");
+        }
+
         bool const forward = tracking_state.forward();
 
         // periods through the lattice (turns/cycles) and verbosity
         int num_periods = 1;
         amrex::ParmParse("lattice").queryAddWithParser("periods", num_periods);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(num_periods >= 1, "lattice.periods must be >= 1");
         int verbose = 1;
         amrex::ParmParse("impactx").queryAddWithParser("verbose", verbose);
 
@@ -127,7 +146,7 @@ namespace impactx
         {
             // set the reference-particle edge to the entrance of this element: s-dependent
             // (soft-edge) maps integrate their on-axis field profile relative to it
-            pc.SetRefParticleEdge();
+            ref.set_edge();
 
             if (forward)
             {
@@ -235,10 +254,12 @@ namespace impactx
         {
             int const period = forward ? p : (num_periods - 1 - p);
 
+            // the period is the position in the lattice, tracked in both directions
+            tracking_state.m_period = period;
+
             if (forward)
             {
                 // book-keeping update
-                tracking_state.m_period = period;
                 tracking_state.m_element = &lattice.front();
 
                 // optional, user-defined function call
@@ -273,4 +294,4 @@ namespace impactx
     }
 } // namespace impactx
 
-#endif // IMPACTX_TRACKING_PARTICLES_H
+#endif // IMPACTX_TRACKING_COMMON_H

--- a/src/tracking/envelope.cpp
+++ b/src/tracking/envelope.cpp
@@ -9,12 +9,12 @@
  */
 #include "ImpactX.H"
 #include "diagnostics/DiagnosticOutput.H"
-#include "elements/mixin/accessors.H"
 #include "envelope/spacecharge/EnvelopeSpaceChargePush.H"
 #include "initialization/Algorithms.H"
 #include "initialization/InitAmrCore.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/Push.H"
+#include "tracking/common.H"
 
 #include <ablastr/warn_manager/WarnManager.H>
 
@@ -47,10 +47,7 @@ namespace impactx
         //   before we start the tracking loop, we are in "step 0" (initial state)
         int & step = m_tracking_state.m_step;
         step = 0;
-
-        // period in the lattice (e.g., turns)
-        int & period = m_tracking_state.m_period;
-        period = 0;
+        m_tracking_state.m_direction = TrackingDirection::Forward;
 
         // check typos in inputs after step 1
         bool early_params_checked = false;
@@ -155,6 +152,8 @@ namespace impactx
 
         // the collective effect kick ``K`` of one element slice
         auto collective_kicks = [&ref, &cm, &intensity, space_charge] (
+            //! (unused) the kick does not depend on the element
+            [[maybe_unused]] elements::KnownElements & element_variant,
             amrex::ParticleReal kick_ds
         )
         {
@@ -171,8 +170,13 @@ namespace impactx
 
         // the external-field transport map ``M`` of one element slice
         //   The Strang split around collective effects applies this twice per slice, once
-        //   per half-map, so it carries no book-keeping.
-        auto element_push = [&ref, &cm] (elements::KnownElements & element_variant)
+        //   per half-map, so it carries no book-keeping: that lives in @see
+        //   slice_diagnostics below.
+        auto element_push = [&ref, &cm] (
+            elements::KnownElements & element_variant,
+            [[maybe_unused]] int step_,   //! (unused) the envelope has no per-step element output
+            [[maybe_unused]] int period_  //! (unused) the envelope has no per-period element output
+        )
         {
             std::visit([&ref, &cm](auto&& element)
             {
@@ -188,123 +192,51 @@ namespace impactx
             }, element_variant);
         };
 
-        // periods through the lattice
-        int num_periods = 1;
-        amrex::ParmParse("lattice").queryAddWithParser("periods", num_periods);
-
-        for (period=0; period < num_periods; ++period)
+        // book-keeping and diagnostics, applied once at the end of each slice
+        auto slice_diagnostics = [
+            this, &ref, &cm, verbose, &pp_diag, diag_enable, &early_params_checked
+        ] (
+            int step_,
+            int period_
+        )
         {
-            // optional, user-defined function call
-            m_tracking_state.m_element = &m_lattice.front();
-            call_hook("before_period");
-
-            // loop over all beamline elements
-            for (auto &element_variant: m_lattice)
+            // just prints an empty newline at the end of the slice_step
+            if (verbose > 0)
             {
-                // update element edge of the reference particle
-                ref.sedge = ref.s;
+                amrex::Print() << "\n";
+            }
 
-                // optional, user-defined function call
-                m_tracking_state.m_element = &element_variant;
-                call_hook("before_element");
+            // slice-step diagnostics
+            bool slice_step_diagnostics = false;
+            pp_diag.queryAdd("slice_step_diagnostics", slice_step_diagnostics);
 
-                // number of slices used for the application of space charge
-                int const nslice = elements::nslice(element_variant);
-                amrex::ParticleReal const slice_ds = elements::slice_ds(element_variant); // in meters
+            if (diag_enable && slice_step_diagnostics)
+            {
+                // print slice step reference particle to file
+                diagnostics::DiagnosticOutput(ref, "ref_particle", step_, true);
 
-                // zero-length elements receive no kick: it would leave the momenta unchanged
-                bool const kick = collective_effects && slice_ds != amrex::ParticleReal(0);
+                // print slice step reduced beam characteristics to file
+                diagnostics::DiagnosticOutput(
+                    cm, ref, "reduced_beam_characteristics", step_, period_, true);
+            }
 
-                // second-order, time-symmetric Strang split of the kick ``K`` and transport ``M``
-                bool const strang = kick && strang_split;
+            // inputs: unused parameters (e.g. typos) check after step 1 has finished
+            if (!early_params_checked) { early_params_checked = early_param_check(); }
+        };
 
-                // which of the two is halved: an element that can be subdivided puts the
-                // transport outside (MKM), any other one halves the kick instead (KMK)
-                bool const split_transport = strang && elements::can_slice(element_variant);
-                bool const split_kick = strang && !split_transport;
-
-                // sub-steps for space charge within the element
-                for (int slice_step = 0; slice_step < nslice; ++slice_step)
-                {
-                    BL_PROFILE("ImpactX::track_envelope::slice_step");
-                    step++;
-                    if (verbose > 0)
-                    {
-                        amrex::Print() << "\n++++ Starting step=" << step
-                                       << " slice_step=" << slice_step;
-                    }
-
-                    // optional, user-defined function call
-                    call_hook("before_slice");
-
-                    if (split_transport)
-                    {
-                        // M(ds/2) K(ds) M(ds/2): the doubled slice count halves each transport
-                        elements::ScopedNslice const half_slices(element_variant, 2 * nslice);
-                        element_push(element_variant);
-                        collective_kicks(slice_ds);
-                        element_push(element_variant);
-                    }
-                    else if (split_kick)
-                    {
-                        // K(ds/2) M(ds) K(ds/2): the kick is linear in the slice length, so
-                        // halving it needs no subdivision of the element
-                        amrex::ParticleReal const half_ds = amrex::ParticleReal(0.5) * slice_ds;
-                        collective_kicks(half_ds);
-                        element_push(element_variant);
-                        collective_kicks(half_ds);
-                    }
-                    else if (kick)
-                    {
-                        // the split is turned off: first-order composition
-                        collective_kicks(slice_ds);
-                        element_push(element_variant);
-                    }
-                    else
-                    {
-                        // zero-length slice or no collective effects: transport only
-                        element_push(element_variant);
-                    }
-
-                    // just prints an empty newline at the end of the slice_step
-                    if (verbose > 0)
-                    {
-                        amrex::Print() << "\n";
-                    }
-
-                    // slice-step diagnostics
-                    bool slice_step_diagnostics = false;
-                    pp_diag.queryAdd("slice_step_diagnostics", slice_step_diagnostics);
-
-
-                    if (diag_enable && slice_step_diagnostics)
-                    {
-                        // print slice step reference particle to file
-                        diagnostics::DiagnosticOutput(ref, "ref_particle", step, true);
-
-                        // print slice step reduced beam characteristics to file
-                        diagnostics::DiagnosticOutput(
-                            cm, ref, "reduced_beam_characteristics", step, period, true);
-
-                    }
-
-                    // inputs: unused parameters (e.g. typos) check after step 1 has finished
-                    if (!early_params_checked) { early_params_checked = early_param_check(); }
-
-                } // end in-element space-charge slice-step loop
-
-                // optional, user-defined function call
-                call_hook("after_element");
-
-            } // end beamline element loop
-
-            // optional, user-defined function call
-            call_hook("after_period");
-
-        } // end periods though the lattice loop
-
-        // avoid dangling references if users manipulate the lattice
-        m_tracking_state.set_no_element();
+        // traverse the lattice, applying the collective kick and the
+        // element transport per element slice (\see track_lattice)
+        track_lattice(
+            m_lattice,
+            ref,
+            m_tracking_state,
+            collective_effects,
+            strang_split,
+            [this](std::string const & name) { call_hook(name); },
+            collective_kicks,
+            element_push,
+            slice_diagnostics
+        );
 
         if (diag_enable)
         {
@@ -313,7 +245,7 @@ namespace impactx
 
             // print the final values of the reduced beam characteristics
             diagnostics::DiagnosticOutput(
-                cm, ref, "reduced_beam_characteristics_final", step, period);
+                cm, ref, "reduced_beam_characteristics_final", step, m_tracking_state.m_period);
         }
     }
 } // namespace impactx

--- a/src/tracking/particles.cpp
+++ b/src/tracking/particles.cpp
@@ -18,7 +18,7 @@
 #include "particles/spacecharge/HandleSpacecharge.H"
 #include "particles/wakefields/HandleISR.H"
 #include "particles/wakefields/HandleWakefield.H"
-#include "tracking/particles.H"
+#include "tracking/common.H"
 
 #include <AMReX.H>
 #include <AMReX_AmrParGDB.H>
@@ -202,10 +202,10 @@ namespace impactx
         };
 
         // traverse the lattice, applying the collective kick and the
-        // element transport per element slice (\see track_lattice_particles)
-        track_lattice_particles(
+        // element transport per element slice (\see track_lattice)
+        track_lattice(
             m_lattice,
-            *pc,
+            pc->GetRefParticle(),
             m_tracking_state,
             collective_effects,
             strang_split,

--- a/src/tracking/reference.cpp
+++ b/src/tracking/reference.cpp
@@ -9,11 +9,11 @@
  */
 #include "ImpactX.H"
 #include "diagnostics/DiagnosticOutput.H"
-#include "elements/mixin/accessors.H"
 #include "initialization/Algorithms.H"
 #include "initialization/InitAmrCore.H"
 #include "particles/ImpactXParticleContainer.H"
 #include "particles/Push.H"
+#include "tracking/common.H"
 
 #include <AMReX.H>
 #include <AMReX_AmrParGDB.H>
@@ -41,10 +41,7 @@ namespace impactx
         //   before we start the tracking loop, we are in "step 0" (initial state)
         int & step = m_tracking_state.m_step;
         step = 0;
-
-        // period in the lattice (e.g., turns)
-        int & period = m_tracking_state.m_period;
-        period = 0;
+        m_tracking_state.m_direction = TrackingDirection::Forward;
 
         // check typos in inputs after step 1
         bool early_params_checked = false;
@@ -86,78 +83,62 @@ namespace impactx
             );
         }
 
-        // periods through the lattice
-        int num_periods = 1;
-        amrex::ParmParse("lattice").queryAddWithParser("periods", num_periods);
-
-        for (period=0; period < num_periods; ++period)
+        // the external-field transport map ``M`` of one element slice
+        auto element_push = [&ref] (
+            elements::KnownElements & element_variant,
+            //! (unused) the reference particle has no per-step or per-period element output
+            [[maybe_unused]] int step_,
+            [[maybe_unused]] int period_
+        )
         {
-            // optional, user-defined function call
-            m_tracking_state.m_element = &m_lattice.front();
-            call_hook("before_period");
+            // push the reference particle with external maps
+            push(ref, element_variant);
+        };
 
-            // loop over all beamline elements
-            for (auto &element_variant: m_lattice) {
-                // update element edge of the reference particle
-                ref.sedge = ref.s;
+        // book-keeping and diagnostics, applied once at the end of each slice
+        auto slice_diagnostics = [
+            this, &ref, verbose, &pp_diag, diag_enable, &early_params_checked
+        ] (
+            int step_,
+            //! (unused) the reference particle output carries no period
+            [[maybe_unused]] int period_
+        )
+        {
+            // just prints an empty newline at the end of the slice_step
+            if (verbose > 0)
+            {
+                amrex::Print() << "\n";
+            }
 
-                // optional, user-defined function call
-                m_tracking_state.m_element = &element_variant;
-                call_hook("before_element");
+            // slice-step diagnostics
+            bool slice_step_diagnostics = false;
+            pp_diag.queryAdd("slice_step_diagnostics", slice_step_diagnostics);
 
-                // number of slices through the element
-                int const nslice = elements::nslice(element_variant);
+            if (diag_enable && slice_step_diagnostics)
+            {
+                // print slice step reference particle to file
+                diagnostics::DiagnosticOutput(ref, "ref_particle", step_, true);
+            }
 
-                // sub-steps within the element
-                for (int slice_step = 0; slice_step < nslice; ++slice_step)
-                {
-                    BL_PROFILE("ImpactX::track_reference::slice_step");
-                    step++;
-                    if (verbose > 0) {
-                        amrex::Print() << "\n++++ Starting step=" << step
-                                       << " slice_step=" << slice_step;
-                    }
+            // inputs: unused parameters (e.g. typos) check after step 1 has finished
+            if (!early_params_checked) { early_params_checked = early_param_check(); }
+        };
 
-                    // optional, user-defined function call
-                    call_hook("before_slice");
-
-                    // push the reference particle with external maps
-                    push(ref, element_variant);
-
-                    // just prints an empty newline at the end of the slice_step
-                    if (verbose > 0)
-                    {
-                        amrex::Print() << "\n";
-                    }
-
-                    // slice-step diagnostics
-                    bool slice_step_diagnostics = false;
-                    pp_diag.queryAdd("slice_step_diagnostics", slice_step_diagnostics);
-
-
-                    if (diag_enable && slice_step_diagnostics)
-                    {
-                        // print slice step reference particle to file
-                        diagnostics::DiagnosticOutput(ref, "ref_particle", step, true);
-                    }
-
-                    // inputs: unused parameters (e.g. typos) check after step 1 has finished
-                    if (!early_params_checked) { early_params_checked = early_param_check(); }
-
-                } // end in-element slice-step loop
-
-                // optional, user-defined function call
-                call_hook("after_element");
-
-            } // end beamline element loop
-
-            // optional, user-defined function call
-            call_hook("after_period");
-
-        } // end periods though the lattice loop
-
-        // avoid dangling references if users manipulate the lattice
-        m_tracking_state.set_no_element();
+        // traverse the lattice, applying the element transport per element slice
+        //   Reference-particle tracking rejects space charge and CSR above and models no
+        //   other collective effect, so it applies ``M`` alone and never calls the kick
+        //   (\see track_lattice).
+        track_lattice(
+            m_lattice,
+            ref,
+            m_tracking_state,
+            false, // no collective effects
+            false, // nothing to Strang-split
+            [this](std::string const & name) { call_hook(name); },
+            [](elements::KnownElements &, amrex::ParticleReal) {}, // never called
+            element_push,
+            slice_diagnostics
+        );
 
         if (diag_enable)
         {

--- a/tests/python/test_tracking_traversal.py
+++ b/tests/python/test_tracking_traversal.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl, Chad Mitchell
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from impactx import ImpactX, distribution, elements
+
+# beam and lattice parameters, shared by all runs below
+KIN_ENERGY_MEV = 250.0
+BUNCH_CHARGE_C = 1.0e-9
+NPART = 1000
+DS = 2.0  # drift length in m
+NSLICE = 3
+PERIODS = 4
+
+# the tracking state every model has to agree on: the last period that was tracked, and
+# one step per slice of every element in every period
+LAST_PERIOD = PERIODS - 1
+TOTAL_STEPS = PERIODS * NSLICE
+
+
+def _distribution():
+    return distribution.Kurth6D(
+        lambdaX=4.472135955e-4,
+        lambdaY=4.472135955e-4,
+        lambdaT=9.12241869e-7,
+        lambdaPx=1.0e-4,
+        lambdaPy=1.0e-4,
+        lambdaPt=0.0,
+    )
+
+
+def _sim():
+    """A single drift, tracked for several periods, without any collective effects."""
+    sim = ImpactX()
+
+    sim.particle_shape = 2
+    sim.space_charge = "false"
+    sim.slice_step_diagnostics = False
+    sim.diagnostics = False
+    sim.periods = PERIODS
+
+    sim.init_grids()
+
+    ref = sim.beam.ref
+    ref.set_species("electron").set_kin_energy_MeV(KIN_ENERGY_MEV)
+
+    sim.lattice.extend([elements.Drift(name="d1", ds=DS, nslice=NSLICE)])
+
+    return sim
+
+
+def _track(model):
+    """Run one tracking model and return its tracking state afterwards."""
+    sim = _sim()
+
+    try:
+        if model == "particles":
+            sim.add_particles(BUNCH_CHARGE_C, _distribution(), NPART)
+            sim.track_particles()
+        elif model == "envelope":
+            sim.init_envelope(sim.beam.ref, _distribution(), BUNCH_CHARGE_C)
+            sim.track_envelope()
+        else:
+            sim.track_reference(sim.beam.ref)
+
+        return sim.tracking_period, sim.tracking_step
+    finally:
+        sim.finalize()
+
+
+@pytest.mark.parametrize("model", ["particles", "envelope", "reference"])
+def test_tracking_state_after_a_multi_period_run(model):
+    """Every tracking model traverses the lattice the same way.
+
+    The period is the last one that was tracked, not one past it, and the step counter
+    has advanced once per slice of every element in every period. These are the values
+    a hook and ``reduced_beam_characteristics_final`` report, so the three models have to
+    agree on them.
+    """
+    period, step = _track(model)
+
+    assert period == LAST_PERIOD, (
+        f"{model}: tracked period {period}, expected {LAST_PERIOD}"
+    )
+    assert step == TOTAL_STEPS, f"{model}: {step} steps, expected {TOTAL_STEPS}"


### PR DESCRIPTION
This is just a clean-up, deduplicating the lattice-traversal logic for particle, envelope and ref-particle tracking modes.

Particle, envelope and reference tracking each carried their own copy of the nested lattice traversal, which is why the Strang split had to be written twice: once for particles in #1530, then again for the envelope in #1639.

<details>

This moves `src/tracking/particles.H` to `src/tracking/common.H` and generalizes its `track_lattice_particles` into a `track_lattice` shared by all three modes, a net -70 lines in `src/tracking/`.

One observable change falls out: envelope and reference tracking left `m_period` one past the last period tracked while particle tracking already reported the last one, so `ImpactX.tracking_period` and the `period` column of the envelope's `reduced_beam_characteristics_final` now agree with particles; the new `tests/python/test_tracking_traversal.py` pins that invariant across all three modes and fails on two of them without this change.

Two smaller behavior changes come with the shared traversal:

- The per-slice profiler region is now the same for all three modes, the existing `ImpactX::evolve::slice_step`. Envelope and reference slice steps previously reported under `ImpactX::track_envelope::slice_step` and `ImpactX::track_reference::slice_step`. Each mode still has its own top-level region, so only the slice-step breakdown pools when one process runs two of them, as the `expanding_beam` examples do.
- An empty lattice used to reach `&lattice.front()` in the envelope and reference loops, which is undefined behavior: only `track_particles` runs `validate()`, which rejects it earlier. `track_lattice` now raises `validate()`'s error itself, so all three modes fail the same way.

</details>