### PR TITLE
`PipeAperture`: Make `aperture_x`/`aperture_y` Settable

### DIFF
--- a/src/elements/mixin/pipeaperture.H
+++ b/src/elements/mixin/pipeaperture.H
@@ -37,10 +37,8 @@ namespace impactx::elements::mixin
             amrex::ParticleReal aperture_y
         )
         {
-            using namespace amrex::literals;  // for _prt
-
-            m_inv_aperture_x = aperture_x > 0_prt ? 1_prt / aperture_x : 0_prt;
-            m_inv_aperture_y = aperture_y > 0_prt ? 1_prt / aperture_y : 0_prt;
+            set_aperture_x(aperture_x);
+            set_aperture_y(aperture_y);
         }
 
         PipeAperture () = default;
@@ -105,6 +103,38 @@ namespace impactx::elements::mixin
         {
             using namespace amrex::literals; // for _prt
             return m_inv_aperture_y > 0_prt ? 1_prt / m_inv_aperture_y : 0_prt;
+        }
+
+        /** Set the horizontal aperture size
+         *
+         * A value of zero or less removes the horizontal aperture restriction.
+         *
+         * @param aperture_x horizontal aperture size [m]
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void set_aperture_x (amrex::ParticleReal aperture_x)
+        {
+            using namespace amrex::literals; // for _prt
+
+            // performance optimization: we intentionally store the inverse of
+            //   the aperture, @see m_inv_aperture_x
+            m_inv_aperture_x = aperture_x > 0_prt ? 1_prt / aperture_x : 0_prt;
+        }
+
+        /** Set the vertical aperture size
+         *
+         * A value of zero or less removes the vertical aperture restriction.
+         *
+         * @param aperture_y vertical aperture size [m]
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void set_aperture_y (amrex::ParticleReal aperture_y)
+        {
+            using namespace amrex::literals; // for _prt
+
+            // performance optimization: we intentionally store the inverse of
+            //   the aperture, @see m_inv_aperture_y
+            m_inv_aperture_y = aperture_y > 0_prt ? 1_prt / aperture_y : 0_prt;
         }
 
         // performance optimization: we intentionally store the inverse of

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -423,13 +423,21 @@ void init_elements(py::module& m)
     ;
 
     py::class_<elements::mixin::PipeAperture>(mx, "PipeAperture")
-        .def_property_readonly("aperture_x",
-            &elements::mixin::PipeAperture::aperture_x,
-            "horizontal aperture in m"
+        .def_property("aperture_x",
+            [](elements::mixin::PipeAperture & pa) { return pa.aperture_x(); },
+            [](elements::mixin::PipeAperture & pa, amrex::ParticleReal aperture_x)
+            {
+                pa.set_aperture_x(aperture_x);
+            },
+            "horizontal aperture in m; zero or less removes the aperture restriction"
         )
-        .def_property_readonly("aperture_y",
-            &elements::mixin::PipeAperture::aperture_y,
-            "vertical aperture in m"
+        .def_property("aperture_y",
+            [](elements::mixin::PipeAperture & pa) { return pa.aperture_y(); },
+            [](elements::mixin::PipeAperture & pa, amrex::ParticleReal aperture_y)
+            {
+                pa.set_aperture_y(aperture_y);
+            },
+            "vertical aperture in m; zero or less removes the aperture restriction"
         )
     ;
 

--- a/tests/python/test_element_serialization.py
+++ b/tests/python/test_element_serialization.py
@@ -651,6 +651,53 @@ def test_element_dict_has_constructor_params(all_elements):
         assert not extra, f"{element_type}: to_dict() has extra keys: {extra}"
 
 
+def test_mixin_properties_are_settable(all_elements):
+    """
+    Test that the read/write properties inherited from the mixin classes can be
+    assigned after construction, and that to_dict() sees the new value.
+    """
+    lattice, _ = all_elements
+
+    # property name -> value to assign
+    settable = {
+        "aperture_x": 0.05,
+        "aperture_y": 0.06,
+        "dx": 0.007,
+        "dy": 0.008,
+        "rotation": 0.09,
+    }
+    # apertures are stored inverted, so a set/get pair costs two divisions
+    rtol = 1e-5 if Config.precision == "SINGLE" else 1e-12
+
+    covered = set()
+    for element in lattice:
+        element_type = type(element).__name__
+
+        if element_type in SKIP_ELEMENTS:
+            continue
+
+        for prop, value in settable.items():
+            if not hasattr(element, prop):
+                continue
+
+            setattr(element, prop, value)
+            assert getattr(element, prop) == pytest.approx(value, rel=rtol), (
+                f"{element_type}.{prop} did not keep the assigned value"
+            )
+
+            d = element.to_dict()
+            assert prop in d, f"{element_type}: to_dict() is missing {prop}"
+            assert d[prop] == pytest.approx(value, rel=rtol), (
+                f"{element_type}: to_dict()[{prop!r}] does not reflect the assignment"
+            )
+
+            covered.add(prop)
+
+    assert covered == set(settable), (
+        f"no element exercised: {sorted(set(settable) - covered)}"
+    )
+
+
 def test_individual_element_roundtrip(all_elements):
     """
     Test each element type individually for roundtrip consistency.


### PR DESCRIPTION
The `PipeAperture` mixin exposed only getters, so `aperture_x`/`aperture_y` were read-only on every element with a pipe aperture (`drift.aperture_x = 1.0` raised `AttributeError`), unlike the `Alignment` mixin, whose `dx`/`dy`/`rotation` are read/write.
Adds `set_aperture_x()`/`set_aperture_y()` encapsulating the inverted storage, keeping the constructor convention that zero or less removes the restriction, and extends `test_element_serialization.py` to check settable mixin properties across all element types.

- [x] 🤖 Generated with [Claude Code](https://claude.com/claude-code)
- [x] self-reviewed