### PR TITLE
`Aperture`: Zero `aperture_x`/`aperture_y` Disables the Boundary

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -341,6 +341,11 @@ This requires these additional parameters:
 
     Horizontal / vertical half-aperture (elliptical or rectangular).
 
+    A value of zero or less disables the boundary in that plane, so a rectangular
+    aperture with only ``aperture_y`` set acts as a horizontal slit.
+    Note that with ``action = absorb`` a disabled plane makes the absorbing domain
+    unbounded in that direction.
+
 .. pp:param:: <aperture_name>.repeat_x/y
     :link_aliases: <aperture_name>.repeat_x <aperture_name>.repeat_y
     :type: ``float``

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -2453,12 +2453,18 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
    :param rotation: rotation error in the transverse plane [degrees]
    :param name: an optional name for the element
 
-.. py:class:: impactx.elements.Aperture(aperture_x, aperture_y, repeat_x, repeat_y, shift_odd_x, shape="rectangular", dx=0, dy=0, rotation=0, name=None)
+.. py:class:: impactx.elements.Aperture(aperture_x, aperture_y, repeat_x=0, repeat_y=0, shift_odd_x=False, shape="rectangular", action="transmit", dx=0, dy=0, rotation=0, name=None)
 
    A thin collimator element, applying a transverse aperture boundary.
 
-   :param aperture_x: horizontal half-aperture (rectangular or elliptical) in m
-   :param aperture_y: vertical half-aperture (rectangular or elliptical) in m
+   A half-aperture of zero or less disables the boundary in that plane, the same
+   convention as the ``aperture_x``/``aperture_y`` of the thick elements above.
+   A rectangular aperture with only ``aperture_y`` set is thus a horizontal slit.
+   Note that with ``action="absorb"`` a disabled plane makes the absorbing domain
+   unbounded in that direction, so disabling both planes absorbs the whole beam.
+
+   :param aperture_x: horizontal half-aperture (rectangular or elliptical) in m; zero or less disables the horizontal boundary
+   :param aperture_y: vertical half-aperture (rectangular or elliptical) in m; zero or less disables the vertical boundary
    :param repeat_x: horizontal period for repeated aperture masking (inactive by default) (meter)
    :param repeat_y: vertical period for repeated aperture masking (inactive by default) (meter)
    :param shift_odd_x: for hexagonal/triangular mask patterns: horizontal shift of every 2nd (odd) vertical period by repeat_x / 2. Use alignment offsets dx,dy to move whole mask as needed.
@@ -2477,13 +2483,13 @@ For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/n
 
       aperture type (transmit, absorb)
 
-   .. py:property:: xmax
+   .. py:property:: aperture_x
 
-      maximum horizontal coordinate
+      maximum horizontal coordinate in m; zero or less removes the horizontal boundary
 
-   .. py:property:: ymax
+   .. py:property:: aperture_y
 
-      maximum vertical coordinate
+      maximum vertical coordinate in m; zero or less removes the vertical boundary
 
 .. py:class:: impactx.elements.PolygonAperture(vertices_x, vertices_y, min_radius2=0.0, repeat_x, repeat_y, shift_odd_x, action="transmit", dx=0, dy=0, rotation=0, name=None)
 

--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -62,10 +62,18 @@ namespace impactx::elements
         /** A thin collimator element that applies a transverse aperture boundary.
          *  Particles outside the boundary are considered lost.
          *
+         *  A half-aperture of zero or less disables the boundary in that plane,
+         *  the same convention as \see mixin::PipeAperture. A rectangular
+         *  aperture with only ``aperture_y`` set is thus a horizontal slit, and
+         *  an elliptical one degenerates into the same slab. Note that with
+         *  ``action = absorb`` a disabled plane makes the absorbing domain
+         *  unbounded in that direction: disabling both planes absorbs the whole
+         *  beam, while for ``action = transmit`` the element becomes a no-op.
+         *
          * @param shape aperture shape
          * @param action specify action of domain (transmit/absorb)
-         * @param aperture_x horizontal half-aperture (m)
-         * @param aperture_y vertical half-aperture (m)
+         * @param aperture_x horizontal half-aperture (m), zero or less disables the horizontal boundary
+         * @param aperture_y vertical half-aperture (m), zero or less disables the vertical boundary
          * @param repeat_x horizontal period for repeated masking, optional (m)
          * @param repeat_y vertical period for repeated masking, optional (m)
          * @param shift_odd_x for hexagonal/triangular mask patterns: horizontal shift of every 2nd (odd) vertical period by repeat_x / 2. Use alignment offsets dx,dy to move whole mask as needed.
@@ -93,17 +101,8 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
 
-            if (aperture_x > 0_prt) {
-                m_inv_aperture_x = 1_prt / aperture_x;
-            } else {
-                throw std::invalid_argument("Aperture: aperture_x must be > 0!");
-            }
-
-            if (aperture_y > 0_prt) {
-                m_inv_aperture_y = 1_prt / aperture_y;
-            } else {
-                throw std::invalid_argument("Aperture: aperture_y must be > 0!");
-            }
+            set_aperture_x(aperture_x);
+            set_aperture_y(aperture_y);
 
             if (m_repeat_y == 0_prt && m_shift_odd_x) {
                 throw std::invalid_argument("Aperture: shift_odd_x can only be used if repeat_y is set, too!");
@@ -270,13 +269,73 @@ namespace impactx::elements
             return rotate_aligned_map(Map6x6::Identity());
         }
 
+        /** Maximum horizontal coordinate
+         *
+         * @return horizontal half-aperture size [m]; zero if the horizontal
+         *         boundary is disabled
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        amrex::ParticleReal aperture_x () const
+        {
+            using namespace amrex::literals; // for _prt
+            return m_inv_aperture_x > 0_prt ? 1_prt / m_inv_aperture_x : 0_prt;
+        }
+
+        /** Maximum vertical coordinate
+         *
+         * @return vertical half-aperture size [m]; zero if the vertical
+         *         boundary is disabled
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        amrex::ParticleReal aperture_y () const
+        {
+            using namespace amrex::literals; // for _prt
+            return m_inv_aperture_y > 0_prt ? 1_prt / m_inv_aperture_y : 0_prt;
+        }
+
+        /** Set the maximum horizontal coordinate
+         *
+         * A value of zero or less removes the horizontal boundary, the same
+         * convention as \see mixin::PipeAperture::set_aperture_x.
+         *
+         * @param aperture_x horizontal half-aperture size [m]
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void set_aperture_x (amrex::ParticleReal aperture_x)
+        {
+            using namespace amrex::literals; // for _prt
+
+            // performance optimization: we intentionally store the inverse of
+            //   the aperture, @see m_inv_aperture_x
+            m_inv_aperture_x = aperture_x > 0_prt ? 1_prt / aperture_x : 0_prt;
+        }
+
+        /** Set the maximum vertical coordinate
+         *
+         * A value of zero or less removes the vertical boundary, the same
+         * convention as \see mixin::PipeAperture::set_aperture_y.
+         *
+         * @param aperture_y vertical half-aperture size [m]
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void set_aperture_y (amrex::ParticleReal aperture_y)
+        {
+            using namespace amrex::literals; // for _prt
+
+            // performance optimization: we intentionally store the inverse of
+            //   the aperture, @see m_inv_aperture_y
+            m_inv_aperture_y = aperture_y > 0_prt ? 1_prt / aperture_y : 0_prt;
+        }
+
         Shape m_shape; //! aperture type (rectangular, elliptical)
         Action m_action; //! action type (transmit, absorb)
         // performance optimization: we intentionally store the inverse of
         //   the aperture, so we can do a quick multiplication instead of a costly
-        //   division in the comparison operation per particle
-        amrex::ParticleReal m_inv_aperture_x; //! maximum horizontal coordinate
-        amrex::ParticleReal m_inv_aperture_y; //! maximum vertical coordinate
+        //   division in the comparison operation per particle.
+        //   A stored zero scales the coordinate away and thus disables the
+        //   boundary in that plane, @see set_aperture_x
+        amrex::ParticleReal m_inv_aperture_x = 0; //! inverse of the horizontal half-aperture [1/m]
+        amrex::ParticleReal m_inv_aperture_y = 0; //! inverse of the vertical half-aperture [1/m]
         amrex::ParticleReal m_repeat_x; //! horizontal period for repeated masking
         amrex::ParticleReal m_repeat_y; //! vertical period for repeated masking
         bool m_shift_odd_x; //! for hexagonal/triangular mask patterns: horizontal shift of every 2nd (odd) vertical period by m_repeat_x / 2. Use Alignment offsets to move whole mask as needed.

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -576,13 +576,12 @@ void init_elements(py::module& m)
         )
         .def("to_dict",
             [](Aperture const & ap) {
-                using namespace amrex::literals;
                 return element_dict(
                     ap,
                     std::make_pair("shape", amrex::getEnumNameString(ap.m_shape)),
                     std::make_pair("action", amrex::getEnumNameString(ap.m_action)),
-                    std::make_pair("aperture_x", 1_prt / ap.m_inv_aperture_x),
-                    std::make_pair("aperture_y", 1_prt / ap.m_inv_aperture_y),
+                    std::make_pair("aperture_x", ap.aperture_x()),
+                    std::make_pair("aperture_y", ap.aperture_y()),
                     std::make_pair("repeat_x", ap.m_repeat_x),
                     std::make_pair("repeat_y", ap.m_repeat_y),
                     std::make_pair("shift_odd_x", ap.m_shift_odd_x)
@@ -643,14 +642,14 @@ void init_elements(py::module& m)
             "action type (transmit, absorb)"
         )
         .def_property("aperture_x",
-            [](Aperture & ap) { using namespace amrex::literals; return 1_prt / ap.m_inv_aperture_x; },
-            [](Aperture & ap, amrex::ParticleReal aperture_x) { using namespace amrex::literals; ap.m_inv_aperture_x = 1_prt / aperture_x; },
-            "maximum horizontal coordinate"
+            [](Aperture & ap) { return ap.aperture_x(); },
+            [](Aperture & ap, amrex::ParticleReal aperture_x) { ap.set_aperture_x(aperture_x); },
+            "maximum horizontal coordinate in m; zero or less removes the horizontal boundary"
         )
         .def_property("aperture_y",
-            [](Aperture & ap) { using namespace amrex::literals; return 1_prt / ap.m_inv_aperture_y; },
-            [](Aperture & ap, amrex::ParticleReal aperture_y) { using namespace amrex::literals; ap.m_inv_aperture_y = 1_prt / aperture_y; },
-            "maximum vertical coordinate"
+            [](Aperture & ap) { return ap.aperture_y(); },
+            [](Aperture & ap, amrex::ParticleReal aperture_y) { ap.set_aperture_y(aperture_y); },
+            "maximum vertical coordinate in m; zero or less removes the vertical boundary"
         )
         .def_property("repeat_x",
             [](Aperture & ap) { return ap.m_repeat_x; },

--- a/tests/python/test_aperture_disabled.py
+++ b/tests/python/test_aperture_disabled.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+from impactx import ImpactX, distribution, elements
+
+NPART = 10000
+SIGMA = 1.0e-3  # transverse rms beam size in m
+HALF_APERTURE = 1.0e-3  # in m
+
+
+def _track(aperture):
+    """
+    Track a round Gaussian beam through a single aperture element.
+
+    :param aperture: the thin collimator to track through
+    :return: number of surviving particles, their max |x| and max |y| in m
+    """
+    sim = ImpactX()
+
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.diagnostics = False
+    sim.slice_step_diagnostics = False
+    sim.init_grids()
+
+    sim.beam.ref.set_species("proton").set_kin_energy_MeV(250.0)
+
+    distr = distribution.Gaussian(
+        lambdaX=SIGMA,
+        lambdaY=SIGMA,
+        lambdaT=1.0e-3,
+        lambdaPx=1.0e-4,
+        lambdaPy=1.0e-4,
+        lambdaPt=1.0e-3,
+    )
+    sim.add_particles(1.0e-9, distr, NPART)
+
+    sim.lattice.append(aperture)
+    sim.track_particles()
+
+    pc = sim.particle_container()
+    n_surviving = pc.total_number_of_particles()
+
+    max_x, max_y = 0.0, 0.0
+    if n_surviving > 0:
+        xmin, ymin, _, xmax, ymax, _ = pc.min_and_max_positions()
+        max_x = max(abs(xmin), abs(xmax))
+        max_y = max(abs(ymin), abs(ymax))
+
+    sim.finalize()
+
+    return n_surviving, max_x, max_y
+
+
+def test_aperture_disabled_transmits_everything():
+    """
+    Test that an Aperture with both half-apertures disabled is a no-op for the
+    default "transmit" action, for both the constructor and the setters.
+    """
+    n_ctor, _, _ = _track(elements.Aperture(aperture_x=0.0, aperture_y=0.0))
+    assert n_ctor == NPART
+
+    collimator = elements.Aperture(aperture_x=HALF_APERTURE, aperture_y=HALF_APERTURE)
+    collimator.aperture_x = 0.0
+    collimator.aperture_y = 0.0
+    n_setter, _, _ = _track(collimator)
+    assert n_setter == NPART
+
+
+def test_aperture_disabled_plane_is_a_slit():
+    """
+    Test that disabling a single plane keeps the boundary of the other plane:
+    a rectangular aperture with only aperture_y set is a horizontal slit.
+    """
+    n_slit, max_x, max_y = _track(
+        elements.Aperture(aperture_x=0.0, aperture_y=HALF_APERTURE)
+    )
+    n_both, max_x_both, _ = _track(
+        elements.Aperture(aperture_x=HALF_APERTURE, aperture_y=HALF_APERTURE)
+    )
+
+    # the vertical boundary is enforced in both cases; the boundary itself is
+    # transmitting, so allow for the roundoff of the inverted-aperture scaling
+    on_edge = HALF_APERTURE * (1.0 + 1.0e-9)
+    assert 0 < n_slit < NPART
+    assert max_y <= on_edge
+
+    # the disabled horizontal plane does not restrict x, so the slit keeps
+    # everything the fully bounded aperture keeps, and more
+    assert n_slit > n_both
+    assert max_x > HALF_APERTURE
+    assert max_x_both <= on_edge
+
+
+def test_aperture_disabled_plane_absorbs_unbounded():
+    """
+    Test the documented corner of the "zero disables" convention: for the
+    "absorb" action a disabled plane makes the absorbing domain unbounded, so
+    disabling both planes absorbs the whole beam.
+    """
+    n_surviving, _, _ = _track(
+        elements.Aperture(aperture_x=0.0, aperture_y=0.0, action="absorb")
+    )
+    assert n_surviving == 0

--- a/tests/python/test_element_serialization.py
+++ b/tests/python/test_element_serialization.py
@@ -698,6 +698,38 @@ def test_mixin_properties_are_settable(all_elements):
     )
 
 
+def test_aperture_disabled_by_nonpositive():
+    """
+    Test that Aperture.aperture_x/aperture_y follow the PipeAperture convention:
+    a half-aperture of zero or less disables the boundary in that plane and
+    reads back as zero, both from the constructor and from assignment.
+    """
+    aperture = elements.Aperture(aperture_x=0.01, aperture_y=0.02)
+
+    # a valid assignment is kept and is visible in to_dict()
+    aperture.aperture_x = 0.03
+    aperture.aperture_y = 0.04
+    assert aperture.aperture_x == pytest.approx(0.03)
+    assert aperture.aperture_y == pytest.approx(0.04)
+    assert aperture.to_dict()["aperture_x"] == pytest.approx(0.03)
+    assert aperture.to_dict()["aperture_y"] == pytest.approx(0.04)
+
+    # zero or less disables the boundary and reads back as an exact zero,
+    # so that a to_dict() roundtrip reproduces the disabled element
+    for disabled in [0.0, -0.01]:
+        aperture.aperture_x = disabled
+        aperture.aperture_y = disabled
+        assert aperture.aperture_x == 0.0
+        assert aperture.aperture_y == 0.0
+        assert aperture.to_dict()["aperture_x"] == 0.0
+        assert aperture.to_dict()["aperture_y"] == 0.0
+
+        # the constructor uses the same convention
+        from_ctor = elements.Aperture(aperture_x=disabled, aperture_y=disabled)
+        assert from_ctor.aperture_x == 0.0
+        assert from_ctor.aperture_y == 0.0
+
+
 def test_individual_element_roundtrip(all_elements):
     """
     Test each element type individually for roundtrip consistency.


### PR DESCRIPTION
The `Aperture` constructor rejected a half-aperture of zero or less, while the Python property setter divided unconditionally, so `ap.aperture_x = 0.0` silently stored an infinite inverse aperture and a `transmit` aperture then lost the whole beam.

The `PipeAperture` mixin already treats zero or less as "no aperture restriction in that plane". This uses and documents the same convention for the standalone `Aperture`. `set_aperture_x()`/`set_aperture_y()` carry it along with the inverted storage, the matching getters read a disabled plane back as zero, and the constructor and the bindings go through them. A rectangular aperture with only `aperture_y` set is thus a horizontal zero-width slit (an elliptical one degenerates into the same slab), for `action="absorb"` the absorbing domain is unbounded in that direction instead, which the docs call out.

Behavior change: the constructor used to raise on a half-aperture of zero or less and now disables that plane.

Adds `tests/python/test_aperture_disabled.py`, which tracks a beam through the disabled, half-disabled and absorbing cases — a get/set roundtrip alone cannot cover the setter bug, since `1/inf` reads back as zero just like a disabled plane does. Extends `test_element_serialization.py` with that property roundtrip.

Follow-up to #1644.
