### PR TITLE
[WIP] ABLASTR: MLMGOptions for computePhi

### DIFF
--- a/cmake/dependencies/ABLASTR.cmake
+++ b/cmake/dependencies/ABLASTR.cmake
@@ -175,10 +175,13 @@ set(ImpactX_openpmd_src ""
     "Local path to openPMD-api source directory (preferred if set)")
 
 # Git fetcher
-set(ImpactX_ablastr_repo "https://github.com/BLAST-WarpX/warpx.git"
+# TODO: WIP - temporarily tracking the ABLASTR MLMGOptions branch of
+#       https://github.com/BLAST-WarpX/warpx/pull/7228
+#       Reset to BLAST-WarpX/warpx and a development commit once that PR landed.
+set(ImpactX_ablastr_repo "https://github.com/roelof-groenewald/WarpX.git"
     CACHE STRING
     "Repository URI to pull and build ABLASTR from if(ImpactX_ablastr_internal)")
-set(ImpactX_ablastr_branch "690da5d6997cd91fcad9b5296edace0556422298"
+set(ImpactX_ablastr_branch "mlmg_solver_options"
     CACHE STRING
     "Repository branch for ImpactX_ablastr_repo if(ImpactX_ablastr_internal)")
 

--- a/src/particles/spacecharge/PoissonSolve.cpp
+++ b/src/particles/spacecharge/PoissonSolve.cpp
@@ -12,6 +12,7 @@
 #include "initialization/Algorithms.H"
 #include "particles/ChargeDeposition.H"
 
+#include <ablastr/fields/MLMGOptions.H>
 #include <ablastr/fields/PoissonSolver.H>
 
 #include <AMReX_BLProfiler.H>
@@ -75,21 +76,22 @@ namespace impactx::particles::spacecharge
         }
 
         // MLMG options
+        ablastr::fields::MLMGOptions mlmg_options;
         //   Single precision: achievable relative residual is limited by float32
         //   round-off (machine epsilon ~1.2e-7).
 #ifdef AMREX_USE_FLOAT
-        amrex::Real mlmg_relative_tolerance = 1.e-4_rt; // relative (single precision)
+        mlmg_options.relative_tolerance = 1.e-4_rt; // relative (single precision)
 #else
-        amrex::Real mlmg_relative_tolerance = 1.e-7_rt; // relative (double precision)
+        mlmg_options.relative_tolerance = 1.e-7_rt; // relative (double precision)
 #endif
-        amrex::Real mlmg_absolute_tolerance = 0.0;   // ignored
-        pp_algo.queryAddWithParser("mlmg_relative_tolerance", mlmg_relative_tolerance);
-        pp_algo.queryAddWithParser("mlmg_absolute_tolerance", mlmg_absolute_tolerance);
+        mlmg_options.absolute_tolerance = 0.0;   // ignored
+        mlmg_options.max_iters = 100;
+        mlmg_options.verbosity = 1;
 
-        int mlmg_max_iters = 100;
-        int mlmg_verbosity = 1;
-        pp_algo.queryAddWithParser("mlmg_max_iters", mlmg_max_iters);
-        pp_algo.queryAddWithParser("mlmg_verbosity", mlmg_verbosity);
+        pp_algo.queryAddWithParser("mlmg_relative_tolerance", mlmg_options.relative_tolerance);
+        pp_algo.queryAddWithParser("mlmg_absolute_tolerance", mlmg_options.absolute_tolerance);
+        pp_algo.queryAddWithParser("mlmg_max_iters", mlmg_options.max_iters);
+        pp_algo.queryAddWithParser("mlmg_verbosity", mlmg_options.verbosity);
 
         // flatten rho to 2D; store it in the output so it can be accessed after
         // the solve (e.g. via sim.rho), like the solved potential phi
@@ -135,10 +137,7 @@ namespace impactx::particles::spacecharge
             sorted_rho,
             sorted_phi,
             beta_xyz,
-            mlmg_relative_tolerance,
-            mlmg_absolute_tolerance,
-            mlmg_max_iters,
-            mlmg_verbosity,
+            mlmg_options,
             pc.GetParGDB()->Geom(),
             pc.GetParGDB()->DistributionMap(),
             pc.GetParGDB()->boxArray(),


### PR DESCRIPTION
Prepare ImpactX for the breaking ABLASTR change in BLAST-WarpX/warpx#7228.

That PR replaces the four loose MLMG solver arguments of
`ablastr::fields::computePhi` with a single `ablastr::fields::MLMGOptions`
struct, which additionally exposes the bottom solver and the coarse-level
(agglomeration/consolidation/coarsening) controls.

**Do not merge as-is.** This is a work-in-progress PR so we can validate the
migration early and land it quickly once upstream is in. Before merging, the
first commit has to be replaced by a regular dependency update that resets
`ImpactX_ablastr_repo`/`ImpactX_ablastr_branch` to `BLAST-WarpX/warpx` and a
`development` commit that contains #7228.

## Changes

* `cmake/dependencies/ABLASTR.cmake`: temporarily track
  `roelof-groenewald/WarpX @ mlmg_solver_options` (marked with a `TODO`).
* `src/particles/spacecharge/PoissonSolve.cpp`: fill an
  `ablastr::fields::MLMGOptions` from the existing defaults and `algo.mlmg_*`
  inputs and pass it to `computePhi`.

`computePhi` is the only ImpactX call site touched by #7228 — ImpactX does not
use `computeEffectivePotentialPhi` or `getMaxNormRho`, and the remaining
ABLASTR delta is additive.

## No user-facing change

The `algo.mlmg_relative_tolerance`, `algo.mlmg_absolute_tolerance`,
`algo.mlmg_max_iters` and `algo.mlmg_verbosity` inputs and their `sim.mlmg_*`
Python properties are unchanged. The `MLMGOptions` members that ImpactX does
not set (bottom solver, bottom verbosity/iterations/tolerances, max coarsening
level, agglomeration, consolidation, final smoothing sweeps) default to the
same AMReX defaults that ImpactX used implicitly before, so the solve is
unchanged. Existing space-charge tests provide the coverage.

## Testing

Built against the #7228 branch (OMP, MPI, FFT, double precision) with the
AMReX commit ImpactX currently pins — no bump needed, no new warnings.
The full CTest suite passes (201/201), including
`cfchannel_spacecharge_mlmg`, `cfchannel_spacecharge_fft`,
`expanding_beam_mlmg`, `expanding_beam_fft`, `kurth_10nC_periodic`,
`expanding-fft-2d` and `chicane_csr`.

## Follow-ups

* Optionally expose the new bottom solver and coarse-level controls as
  ImpactX inputs — they gave a 16% runtime win on 8 A100s upstream.
* #7228 also lands `ablastr::warn_manager::WMClear()`, which would let ImpactX
  reset the ABLASTR warning state between `ImpactX` re-creations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U98bFCQjdzryCL3idcxWgh
