### PR TITLE
[WIP] Lost Particles: Store the Reference Particle

### DIFF
--- a/docs/source/dataanalysis/dataanalysis.rst
+++ b/docs/source/dataanalysis/dataanalysis.rst
@@ -61,6 +61,35 @@ Example to print the integrated orbit path length ``s`` at each beam monitor pos
        print(f"step {k_i:>3}: s_ref={s_ref}")
 
 
+.. _dataanalysis-lost-particles:
+
+Lost Particles
+--------------
+
+Particles that are removed from the beam, e.g., because they hit an aperture, are collected and written to ``<diag.file_prefix>/openPMD/particles_lost.*`` at the end of the simulation.
+The file contains a single iteration ``0``, with the openPMD species ``beam`` holding the same phase space variables as the beam monitor output plus:
+
+* ``s_lost`` integrated orbit path length at which the particle was lost, in meters
+
+The species carries the same reference particle attributes as a :ref:`beam monitor <dataanalysis-monitor-refparticle>`.
+``mass_ref``, ``charge_ref`` and ``gyromagnetic_anomaly_ref`` are invariants of the reference particle and describe every lost particle.
+The remaining attributes are those of the reference particle at ``s_ref``, the end of tracking, while the individual particles were lost at their respective ``s_lost``.
+In a lattice that changes the reference energy, e.g., through RF cavities, ``beta_ref``, ``gamma_ref``, ``beta_gamma_ref`` and ``pt_ref`` at the position of loss can thus differ from the values in this file.
+
+.. code-block:: python
+
+   import openpmd_api as io
+
+   series = io.Series("diags/openPMD/particles_lost.h5", io.Access.read_only)
+
+   beam = series.iterations[0].particles["beam"]
+   print(f"mass_ref={beam.get_attribute('mass_ref')} kg")
+   print(f"charge_ref={beam.get_attribute('charge_ref')} C")
+
+   lost = beam.to_df()
+   print(lost[["position_x", "position_y", "s_lost"]])
+
+
 .. _dataanalysis-python-inmemory:
 
 In-Memory Python Access

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -2828,7 +2828,7 @@ Diagnostics and output
     :default: ``default``
 
     Diagnostics for particles lost in apertures, stored as ``<diag.file_prefix>/openPMD/particles_lost.*`` at the end of the simulation.
-    See the ``beam_monitor`` element for backend values.
+    See the ``beam_monitor`` element for backend values and :ref:`Lost Particles <dataanalysis-lost-particles>` for the content of this file.
 
 .. pp:param:: diag.eigenemittances
     :type: ``boolean``

--- a/examples/aperture/analysis_aperture.py
+++ b/examples/aperture/analysis_aperture.py
@@ -40,7 +40,8 @@ initial = series.iterations[1].particles["beam"].to_df()
 final = series.iterations[last_step].particles["beam"].to_df()
 
 series_lost = io.Series("diags/openPMD/particles_lost.h5", io.Access.read_only)
-particles_lost = series_lost.iterations[0].particles["beam"].to_df()
+beam_lost = series_lost.iterations[0].particles["beam"]
+particles_lost = beam_lost.to_df()
 
 # compare number of particles
 num_particles = 10000
@@ -108,3 +109,35 @@ assert np.greater_equal(dy.max(), 0.0)
 lost_at_s = particles_lost["s_lost"]
 drift_s = np.ones_like(lost_at_s) * 0.123
 assert np.allclose(lost_at_s, drift_s)
+
+# lost particles carry the reference particle of the beam they were lost from
+beam_final = series.iterations[last_step].particles["beam"]
+print()
+for attr in [
+    "mass_ref",
+    "charge_ref",
+    "gyromagnetic_anomaly_ref",
+    "beta_ref",
+    "gamma_ref",
+    "beta_gamma_ref",
+    "s_ref",
+    "pt_ref",
+]:
+    lost_value = beam_lost.get_attribute(attr)
+    final_value = beam_final.get_attribute(attr)
+    print(f"  {attr}: lost={lost_value} final={final_value}")
+    assert np.isclose(lost_value, final_value, rtol=1.0e-12, atol=0.0)
+
+# proton at 250 MeV kinetic energy
+assert np.isclose(beam_lost.get_attribute("mass_ref"), 1.67262192369e-27, rtol=1.0e-6)
+assert np.isclose(beam_lost.get_attribute("charge_ref"), 1.602176634e-19, rtol=1.0e-6)
+assert np.isclose(beam_lost.get_attribute("gamma_ref"), 1.2664472, rtol=1.0e-5)
+
+# the reduced beam characteristics of the lost beam are scaled with the
+# reference particle charge and momentum
+charge_lost = beam_lost.get_attribute("charge_C")
+charge_total = 1.0e-9
+print(f"  charge_C={charge_lost}")
+assert np.isclose(
+    charge_lost, charge_total * len(particles_lost) / num_particles, rtol=1.0e-6
+)

--- a/src/particles/CollectLost.cpp
+++ b/src/particles/CollectLost.cpp
@@ -91,6 +91,16 @@ namespace impactx
         RefPart const ref_part = source.GetRefParticle();
         auto const s_lost = ref_part.s;
 
+        // hand the reference particle over to the lost particle container:
+        //   the lost particles are stored relative to the reference particle and
+        //   are otherwise not interpretable, e.g., in openPMD output.
+        //   Mass, charge and the gyromagnetic anomaly are invariants of the
+        //   reference particle; the remaining attributes are those at the last
+        //   time this function was called, i.e., at the end of tracking.
+        //   The path length at which each individual particle was lost is stored
+        //   per particle in "s_lost".
+        dest.SetRefParticle(ref_part);
+
         // have to resize here, not in the constructor because grids have not
         // been built when constructor was called.
         dest.reserveData();


### PR DESCRIPTION
Tracking builds the lost-particle monitor from a lost-particle container that never received a reference particle.
`particles_lost.*` was therefore written from a default-constructed `RefPart`: `mass_ref = 0`, `charge_ref = 0`, `gamma_ref = 0`, `beta_ref = 0`, ... .

The reduced beam characteristics on that species degenerate for the same reason: `reduced_beam_characteristics` scales with the reference charge and momentum and treats `gamma < 1` as an uninitialized reference particle, so the file also shipped `charge_C = 0` and vanishing normalized emittances.
The result could not be interpreted without externally supplying the reference particle that was used in the run.

## Fix

`collect_lost_particles` hands the beam's live reference particle over to the lost-particle container.
No reduction is needed: the reference particle is replicated and identical on all MPI ranks, so the openPMD attributes stay consistent across ranks.

- `mass_ref`, `charge_ref` and `gyromagnetic_anomaly_ref` are invariants of the reference particle and thus describe every lost particle exactly.
- The remaining attributes are the reference particle at the end of tracking (`s_ref`), while each particle carries the path length at which it was lost in `s_lost`.

## Known limitation

In a lattice that changes the reference energy, e.g., through RF cavities, `beta_ref`, `gamma_ref`, `beta_gamma_ref` and `pt_ref` at the position of loss differ from the values in the file.
Fully resolving that needs the reference particle state *at the time of loss*, per particle, e.g., stored alongside `s_lost`.
Documented in `docs/source/dataanalysis/dataanalysis.rst` for now; happy to follow up in a separate PR.

## Tests

`examples/aperture/analysis_aperture.py` (runs serial and MPI-parallel in CI) now checks that

- the reference particle attributes of `particles_lost` match those of the final beam monitor,
- `mass_ref`, `charge_ref` and `gamma_ref` are the values of the 250 MeV proton beam of that example,
- `charge_C` scales with the lost fraction of the bunch charge.

## Docs

New `Lost Particles` section in the data analysis docs: what `particles_lost.*` contains, `s_lost`, and which reference particle attributes are invariants vs. end-of-tracking values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4jzChqbGnZptRrjfMn3Wo
