### PR TITLE
Guard the idcpu Write-Back on an Active Aperture

### DIFF
--- a/src/elements/mixin/beamoptic.H
+++ b/src/elements/mixin/beamoptic.H
@@ -179,6 +179,50 @@ namespace detail
         amrex::ignore_unused(val, ptr, i);
     }
 
+    /** Store the particle index back to memory, if anything can have changed it
+     *
+     * Unlike the phase space slots, idcpu is only ever modified when a particle
+     * is lost. If the push method itself does not write it, the only writer left
+     * is \see PipeAperture::apply_aperture - which is a no-op unless an aperture
+     * is actually set on this element. That is a runtime property, so guard the
+     * write-back with it: an unset aperture then costs neither the store nor,
+     * once the compiler sinks it into the branch, the load.
+     *
+     * @tparam P_Method the push method of the element, to inspect argument constness
+     * @tparam N the argument position of idcpu in the push method
+     * @tparam T_HasAperture whether the element carries the \see PipeAperture mixin
+     * @tparam T_Element This can be a \see Drift, \see Quad, \see Sbend, etc.
+     * @tparam IndexType int or SIMD index
+     * @tparam ValType the type of the value to store
+     * @param val the value to store
+     * @param ptr pointer to the SoA data
+     * @param i index or SIMD index
+     * @param element the beamline element that was pushed through
+     */
+    template <auto P_Method, int N, bool T_HasAperture,
+              typename T, typename IndexType, typename ValType, typename T_Element>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    void store_idcpu (
+        ValType const & AMREX_RESTRICT val,
+        T * const AMREX_RESTRICT ptr,
+        IndexType const i,
+        [[maybe_unused]] T_Element const & AMREX_RESTRICT element
+    )
+    {
+#ifdef AMREX_USE_SIMD
+        // the push method writes idcpu itself: always store, as before
+        if constexpr (amrex::simd::is_nth_arg_non_const(P_Method, N)) {
+            store_pdata<P_Method, N, true>(val, ptr, i);
+        } else if constexpr (T_HasAperture) {
+            // only apply_aperture can have written idcpu, and only if it is set
+            if (element.aperture_active()) {
+                store_pdata<P_Method, N, true>(val, ptr, i);
+            }
+        }
+#endif
+        amrex::ignore_unused(val, ptr, i);
+    }
+
     /** Push a single particle through an element
      *
      * Note: we usually would just write a C++ lambda below in ParallelFor. But, due to restrictions
@@ -308,19 +352,18 @@ namespace detail
                 // write sx, sy; apply_aperture writes idcpu.
                 // These wrapper-modified slots must be stored regardless of the push
                 // method's argument constness.
-                constexpr bool wb_align    = has_alignment;
-                constexpr bool wb_aperture = has_aperture;
+                constexpr bool wb_align = has_alignment;
 
-                store_pdata<P_Method, 0, wb_align>   (x,     m_part_x,     i);
-                store_pdata<P_Method, 1, wb_align>   (y,     m_part_y,     i);
-                store_pdata<P_Method, 2>             (t,     m_part_t,     i);
-                store_pdata<P_Method, 3, wb_align>   (px,    m_part_px,    i);
-                store_pdata<P_Method, 4, wb_align>   (py,    m_part_py,    i);
-                store_pdata<P_Method, 5>             (pt,    m_part_pt,    i);
-                store_pdata<P_Method, 6, wb_align>   (sx,    m_part_sx,    i);
-                store_pdata<P_Method, 7, wb_align>   (sy,    m_part_sy,    i);
-                store_pdata<P_Method, 8>             (sz,    m_part_sz,    i);
-                store_pdata<P_Method, 9, wb_aperture>(idcpu, m_part_idcpu, i);
+                store_pdata<P_Method, 0, wb_align>(x,  m_part_x,  i);
+                store_pdata<P_Method, 1, wb_align>(y,  m_part_y,  i);
+                store_pdata<P_Method, 2>          (t,  m_part_t,  i);
+                store_pdata<P_Method, 3, wb_align>(px, m_part_px, i);
+                store_pdata<P_Method, 4, wb_align>(py, m_part_py, i);
+                store_pdata<P_Method, 5>          (pt, m_part_pt, i);
+                store_pdata<P_Method, 6, wb_align>(sx, m_part_sx, i);
+                store_pdata<P_Method, 7, wb_align>(sy, m_part_sy, i);
+                store_pdata<P_Method, 8>          (sz, m_part_sz, i);
+                store_idcpu<P_Method, 9, has_aperture>(idcpu, m_part_idcpu, i, m_element);
             }
 #endif
         }
@@ -456,16 +499,15 @@ namespace detail
                 // shift_in/shift_out write x, y, px, py; apply_aperture writes idcpu.
                 // These wrapper-modified slots must be stored regardless of the push
                 // method's argument constness.
-                constexpr bool wb_align    = has_alignment;
-                constexpr bool wb_aperture = has_aperture;
+                constexpr bool wb_align = has_alignment;
 
-                store_pdata<P_Method, 0, wb_align>   (x,     m_part_x,     i);
-                store_pdata<P_Method, 1, wb_align>   (y,     m_part_y,     i);
-                store_pdata<P_Method, 2>             (t,     m_part_t,     i);
-                store_pdata<P_Method, 3, wb_align>   (px,    m_part_px,    i);
-                store_pdata<P_Method, 4, wb_align>   (py,    m_part_py,    i);
-                store_pdata<P_Method, 5>             (pt,    m_part_pt,    i);
-                store_pdata<P_Method, 6, wb_aperture>(idcpu, m_part_idcpu, i);
+                store_pdata<P_Method, 0, wb_align>(x,  m_part_x,  i);
+                store_pdata<P_Method, 1, wb_align>(y,  m_part_y,  i);
+                store_pdata<P_Method, 2>          (t,  m_part_t,  i);
+                store_pdata<P_Method, 3, wb_align>(px, m_part_px, i);
+                store_pdata<P_Method, 4, wb_align>(py, m_part_py, i);
+                store_pdata<P_Method, 5>          (pt, m_part_pt, i);
+                store_idcpu<P_Method, 6, has_aperture>(idcpu, m_part_idcpu, i, m_element);
             }
 #endif
         }

--- a/src/elements/mixin/pipeaperture.H
+++ b/src/elements/mixin/pipeaperture.H
@@ -68,7 +68,7 @@ namespace impactx::elements::mixin
             namespace stdx = amrex::simd::stdx;
 
             // skip aperture application if aperture_x <= 0 or aperture_y <= 0
-            if (m_inv_aperture_x > 0_prt && m_inv_aperture_y > 0_prt) {
+            if (aperture_active()) {
 
                 // scale horizontal and vertical coordinates
                 // performance optimization: we intentionally store the inverse of
@@ -81,6 +81,20 @@ namespace impactx::elements::mixin
                 auto const mask = u*u + v*v > 1_prt;
                 amrex::ParticleIDWrapper<T_IdCpu>{idcpu}.make_invalid(mask);
             }
+        }
+
+        /** Is the aperture restriction active?
+         *
+         * A non-positive aperture in either plane removes the restriction,
+         * @see apply_aperture.
+         *
+         * @return true if particles can be lost in this aperture
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        bool aperture_active () const
+        {
+            using namespace amrex::literals; // for _prt
+            return m_inv_aperture_x > 0_prt && m_inv_aperture_y > 0_prt;
         }
 
         /** Horizontal aperture size


### PR DESCRIPTION
In SIMD builds the idcpu write-back is gated only at compile time on `has_pipe_aperture_v`, so every element with the `PipeAperture` mixin stores idcpu per particle even when no aperture is set — the only runtime guard sits inside `apply_aperture` and merely skips the mask.
This adds `PipeAperture::aperture_active()` and a `store_idcpu()` helper: unconditional store when the push method writes idcpu through a non-const argument, otherwise conditional on an aperture actually being set (which should also let the compiler sink the load into the branch).

## Benchmarks

Median wall time per `Drift.push` (lower is better), comparing the PR head (`e783948`) with its parent (`236d384`):

| Backend | Case | Parent (ms/push) | PR (ms/push) | Latency change |
|---|---|---:|---:|---:|
| SIMD (4-wide) | no spin, inactive aperture | 9.539 | 7.953 | **-16.62%** |
| SIMD (4-wide) | spin, inactive aperture | 9.499 | 7.959 | **-16.22%** |
| SIMD (4-wide) | no spin, active aperture | 10.393 | 10.425 | +0.31% |
| SIMD (4-wide) | spin, active aperture | 10.475 | 10.469 | -0.05% |
| Non-SIMD | no spin, inactive aperture | 8.004 | 8.038 | +0.42% |
| Non-SIMD | spin, inactive aperture | 8.002 | 8.031 | +0.36% |
| Non-SIMD | no spin, active aperture | 8.323 | 8.295 | -0.34% |
| Non-SIMD | spin, active aperture | 8.314 | 8.370 | +0.67% |
| CUDA | no spin, inactive aperture | 2.1739 | 2.1729 | -0.048% |
| CUDA | spin, inactive aperture | 2.1745 | 2.1745 | -0.002% |
| CUDA | no spin, active aperture | 2.1744 | 2.1742 | -0.008% |
| CUDA | spin, active aperture | 2.1751 | 2.1751 | -0.003% |

The inactive-aperture SIMD path is 16.2–16.6% faster (19–20% higher throughput). Active-aperture SIMD, non-SIMD, and CUDA results are unchanged within measurement noise.

Test setup: 5,000,000 particles in double-precision Release builds. CPU measurements used one pinned Intel i9-12900H P-core with one OpenMP thread; CPU samples contained 20 pushes after five warm-up pushes. CUDA measurements used an NVIDIA RTX A2000 8 GB (compute capability 8.6), explicit device synchronization around every sample, 30 warm-up pushes, and 100 pushes per sample. Each result is the median of 9 CPU or 11 CUDA samples; CPU PR values average two stable runs.
