### PR TITLE
`PipeAperture`: Bound Each Plane Independently

### DIFF
--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -347,6 +347,11 @@ This requires these additional parameters:
 
     Horizontal / vertical half-aperture (elliptical or rectangular).
 
+    A value of zero or less disables the boundary in that plane, so a rectangular
+    aperture with only ``aperture_y`` set acts as a horizontal slit.
+    Note that with ``action = absorb`` a disabled plane makes the absorbing domain
+    unbounded in that direction.
+
 .. pp:param:: <aperture_name>.repeat_x/y
     :link_aliases: <aperture_name>.repeat_x <aperture_name>.repeat_y
     :type: ``float``

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -326,11 +326,14 @@ Lattice Elements
 
     Indicates the element type for this lattice element. This should be one of the following.
 
-Many elements accept a transverse beam pipe aperture via ``aperture_x`` and ``aperture_y``.
-Each plane is bounded independently: a half-aperture of zero or less (the default) removes the
-constraint in that plane only, while the other plane still cuts.
-Setting only ``aperture_y``, for instance, loses a particle when ``|y| > aperture_y`` at any ``x``.
-The aperture is disabled entirely only if both planes are zero or less.
+Many elements take a transverse aperture via ``aperture_x`` and ``aperture_y``: the ``aperture``
+collimator, and as a beam pipe most other elements.
+They all follow the same convention. Each plane is bounded independently: a half-aperture of zero
+or less removes the constraint in that plane only, while the other plane still cuts.
+Bounding a single plane gives a jaw (slit) collimator, bounding both an iris; with only
+``aperture_y`` set, a particle is lost when ``|y| > aperture_y`` at any ``x``, and the
+``rectangular`` and ``elliptical`` shapes degenerate to the same slab.
+The aperture is disabled entirely only if both planes are zero or less, which is the default.
 
 
 ``aperture``
@@ -347,10 +350,9 @@ This requires these additional parameters:
 
     Horizontal / vertical half-aperture (elliptical or rectangular).
 
-    A value of zero or less disables the boundary in that plane, so a rectangular
-    aperture with only ``aperture_y`` set acts as a horizontal slit.
     Note that with ``action = absorb`` a disabled plane makes the absorbing domain
-    unbounded in that direction.
+    unbounded in that direction, so zeroing both planes absorbs the whole beam,
+    while for ``action = transmit`` the element becomes a no-op.
 
 .. pp:param:: <aperture_name>.repeat_x/y
     :link_aliases: <aperture_name>.repeat_x <aperture_name>.repeat_y

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -352,7 +352,7 @@ This requires these additional parameters:
 
     Note that with ``action = absorb`` a disabled plane makes the absorbing domain
     unbounded in that direction, so zeroing both planes absorbs the whole beam,
-    while for ``action = transmit`` the element becomes a no-op.
+    while for ``action = transmit`` the element has no effect on the beam.
 
 .. pp:param:: <aperture_name>.repeat_x/y
     :link_aliases: <aperture_name>.repeat_x <aperture_name>.repeat_y

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -326,6 +326,12 @@ Lattice Elements
 
     Indicates the element type for this lattice element. This should be one of the following.
 
+Many elements accept a transverse beam pipe aperture via ``aperture_x`` and ``aperture_y``.
+Each plane is bounded independently: a half-aperture of zero or less (the default) removes the
+constraint in that plane only, while the other plane still cuts.
+Setting only ``aperture_y``, for instance, loses a particle when ``|y| > aperture_y`` at any ``x``.
+The aperture is disabled entirely only if both planes are zero or less.
+
 
 ``aperture``
 ^^^^^^^^^^^^

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -2490,7 +2490,7 @@ The aperture is disabled entirely only if both planes are zero or less, which is
    convention as every other element's ``aperture_x``/``aperture_y`` above.
    Note that with ``action="absorb"`` a disabled plane makes the absorbing domain
    unbounded in that direction, so disabling both planes absorbs the whole beam,
-   while for ``action="transmit"`` the element becomes a no-op.
+   while for ``action="transmit"`` the element has no effect on the beam.
 
    :param aperture_x: horizontal half-aperture (rectangular or elliptical) in m; zero or less disables the horizontal boundary
    :param aperture_y: vertical half-aperture (rectangular or elliptical) in m; zero or less disables the vertical boundary

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1661,6 +1661,12 @@ element's analytic 6x6 linear transport map (phase-space ordering ``(x, px, y, p
 particle ``ref``, (iv) ``reverse()`` to reverse the element in place, and (v) ``to_dict()`` to serialize it.
 For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/nslice`` slice.
 
+Many elements accept a transverse beam pipe aperture via ``aperture_x`` and ``aperture_y``.
+Each plane is bounded independently: a half-aperture of zero or less (the default) removes the
+constraint in that plane only, while the other plane still cuts.
+Setting only ``aperture_y``, for instance, loses a particle when ``|y| > aperture_y`` at any ``x``.
+The aperture is disabled entirely only if both planes are zero or less.
+
 .. py:class:: impactx.elements.CFbend(ds, rc, k, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, nslice=1, name=None)
 
    A combined function bending magnet.  This is an ideal Sbend with a normal quadrupole field component.

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1661,11 +1661,14 @@ element's analytic 6x6 linear transport map (phase-space ordering ``(x, px, y, p
 particle ``ref``, (iv) ``reverse()`` to reverse the element in place, and (v) ``to_dict()`` to serialize it.
 For an element with ``nslice`` > 1, the pushes and maps refer to a single ``ds/nslice`` slice.
 
-Many elements accept a transverse beam pipe aperture via ``aperture_x`` and ``aperture_y``.
-Each plane is bounded independently: a half-aperture of zero or less (the default) removes the
-constraint in that plane only, while the other plane still cuts.
-Setting only ``aperture_y``, for instance, loses a particle when ``|y| > aperture_y`` at any ``x``.
-The aperture is disabled entirely only if both planes are zero or less.
+Many elements take a transverse aperture via ``aperture_x`` and ``aperture_y``: the ``Aperture``
+collimator, and as a beam pipe most other elements.
+They all follow the same convention. Each plane is bounded independently: a half-aperture of zero
+or less removes the constraint in that plane only, while the other plane still cuts.
+Bounding a single plane gives a jaw (slit) collimator, bounding both an iris; with only
+``aperture_y`` set, a particle is lost when ``|y| > aperture_y`` at any ``x``, and the
+``rectangular`` and ``elliptical`` shapes degenerate to the same slab.
+The aperture is disabled entirely only if both planes are zero or less, which is the default.
 
 .. py:class:: impactx.elements.CFbend(ds, rc, k, dx=0, dy=0, rotation=0, aperture_x=0, aperture_y=0, nslice=1, name=None)
 
@@ -2484,10 +2487,10 @@ The aperture is disabled entirely only if both planes are zero or less.
    A thin collimator element, applying a transverse aperture boundary.
 
    A half-aperture of zero or less disables the boundary in that plane, the same
-   convention as the ``aperture_x``/``aperture_y`` of the thick elements above.
-   A rectangular aperture with only ``aperture_y`` set is thus a horizontal slit.
+   convention as every other element's ``aperture_x``/``aperture_y`` above.
    Note that with ``action="absorb"`` a disabled plane makes the absorbing domain
-   unbounded in that direction, so disabling both planes absorbs the whole beam.
+   unbounded in that direction, so disabling both planes absorbs the whole beam,
+   while for ``action="transmit"`` the element becomes a no-op.
 
    :param aperture_x: horizontal half-aperture (rectangular or elliptical) in m; zero or less disables the horizontal boundary
    :param aperture_y: vertical half-aperture (rectangular or elliptical) in m; zero or less disables the vertical boundary

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -2479,12 +2479,18 @@ The aperture is disabled entirely only if both planes are zero or less.
    :param rotation: rotation error in the transverse plane [degrees]
    :param name: an optional name for the element
 
-.. py:class:: impactx.elements.Aperture(aperture_x, aperture_y, repeat_x, repeat_y, shift_odd_x, shape="rectangular", dx=0, dy=0, rotation=0, name=None)
+.. py:class:: impactx.elements.Aperture(aperture_x, aperture_y, repeat_x=0, repeat_y=0, shift_odd_x=False, shape="rectangular", action="transmit", dx=0, dy=0, rotation=0, name=None)
 
    A thin collimator element, applying a transverse aperture boundary.
 
-   :param aperture_x: horizontal half-aperture (rectangular or elliptical) in m
-   :param aperture_y: vertical half-aperture (rectangular or elliptical) in m
+   A half-aperture of zero or less disables the boundary in that plane, the same
+   convention as the ``aperture_x``/``aperture_y`` of the thick elements above.
+   A rectangular aperture with only ``aperture_y`` set is thus a horizontal slit.
+   Note that with ``action="absorb"`` a disabled plane makes the absorbing domain
+   unbounded in that direction, so disabling both planes absorbs the whole beam.
+
+   :param aperture_x: horizontal half-aperture (rectangular or elliptical) in m; zero or less disables the horizontal boundary
+   :param aperture_y: vertical half-aperture (rectangular or elliptical) in m; zero or less disables the vertical boundary
    :param repeat_x: horizontal period for repeated aperture masking (inactive by default) (meter)
    :param repeat_y: vertical period for repeated aperture masking (inactive by default) (meter)
    :param shift_odd_x: for hexagonal/triangular mask patterns: horizontal shift of every 2nd (odd) vertical period by repeat_x / 2. Use alignment offsets dx,dy to move whole mask as needed.
@@ -2503,13 +2509,13 @@ The aperture is disabled entirely only if both planes are zero or less.
 
       aperture type (transmit, absorb)
 
-   .. py:property:: xmax
+   .. py:property:: aperture_x
 
-      maximum horizontal coordinate
+      maximum horizontal coordinate in m; zero or less removes the horizontal boundary
 
-   .. py:property:: ymax
+   .. py:property:: aperture_y
 
-      maximum vertical coordinate
+      maximum vertical coordinate in m; zero or less removes the vertical boundary
 
 .. py:class:: impactx.elements.PolygonAperture(vertices_x, vertices_y, min_radius2=0.0, repeat_x, repeat_y, shift_odd_x, action="transmit", dx=0, dy=0, rotation=0, name=None)
 

--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -62,10 +62,18 @@ namespace impactx::elements
         /** A thin collimator element that applies a transverse aperture boundary.
          *  Particles outside the boundary are considered lost.
          *
+         *  A half-aperture of zero or less disables the boundary in that plane,
+         *  the same convention as \see mixin::PipeAperture. A rectangular
+         *  aperture with only ``aperture_y`` set is thus a horizontal slit, and
+         *  an elliptical one degenerates into the same slab. Note that with
+         *  ``action = absorb`` a disabled plane makes the absorbing domain
+         *  unbounded in that direction: disabling both planes absorbs the whole
+         *  beam, while for ``action = transmit`` the element becomes a no-op.
+         *
          * @param shape aperture shape
          * @param action specify action of domain (transmit/absorb)
-         * @param aperture_x horizontal half-aperture (m)
-         * @param aperture_y vertical half-aperture (m)
+         * @param aperture_x horizontal half-aperture (m), zero or less disables the horizontal boundary
+         * @param aperture_y vertical half-aperture (m), zero or less disables the vertical boundary
          * @param repeat_x horizontal period for repeated masking, optional (m)
          * @param repeat_y vertical period for repeated masking, optional (m)
          * @param shift_odd_x for hexagonal/triangular mask patterns: horizontal shift of every 2nd (odd) vertical period by repeat_x / 2. Use alignment offsets dx,dy to move whole mask as needed.
@@ -93,17 +101,8 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
 
-            if (aperture_x > 0_prt) {
-                m_inv_aperture_x = 1_prt / aperture_x;
-            } else {
-                throw std::invalid_argument("Aperture: aperture_x must be > 0!");
-            }
-
-            if (aperture_y > 0_prt) {
-                m_inv_aperture_y = 1_prt / aperture_y;
-            } else {
-                throw std::invalid_argument("Aperture: aperture_y must be > 0!");
-            }
+            set_aperture_x(aperture_x);
+            set_aperture_y(aperture_y);
 
             if (m_repeat_y == 0_prt && m_shift_odd_x) {
                 throw std::invalid_argument("Aperture: shift_odd_x can only be used if repeat_y is set, too!");
@@ -270,13 +269,73 @@ namespace impactx::elements
             return rotate_aligned_map(Map6x6::Identity());
         }
 
+        /** Maximum horizontal coordinate
+         *
+         * @return horizontal half-aperture size [m]; zero if the horizontal
+         *         boundary is disabled
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        amrex::ParticleReal aperture_x () const
+        {
+            using namespace amrex::literals; // for _prt
+            return m_inv_aperture_x > 0_prt ? 1_prt / m_inv_aperture_x : 0_prt;
+        }
+
+        /** Maximum vertical coordinate
+         *
+         * @return vertical half-aperture size [m]; zero if the vertical
+         *         boundary is disabled
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        amrex::ParticleReal aperture_y () const
+        {
+            using namespace amrex::literals; // for _prt
+            return m_inv_aperture_y > 0_prt ? 1_prt / m_inv_aperture_y : 0_prt;
+        }
+
+        /** Set the maximum horizontal coordinate
+         *
+         * A value of zero or less removes the horizontal boundary, the same
+         * convention as \see mixin::PipeAperture::set_aperture_x.
+         *
+         * @param aperture_x horizontal half-aperture size [m]
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void set_aperture_x (amrex::ParticleReal aperture_x)
+        {
+            using namespace amrex::literals; // for _prt
+
+            // performance optimization: we intentionally store the inverse of
+            //   the aperture, @see m_inv_aperture_x
+            m_inv_aperture_x = aperture_x > 0_prt ? 1_prt / aperture_x : 0_prt;
+        }
+
+        /** Set the maximum vertical coordinate
+         *
+         * A value of zero or less removes the vertical boundary, the same
+         * convention as \see mixin::PipeAperture::set_aperture_y.
+         *
+         * @param aperture_y vertical half-aperture size [m]
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void set_aperture_y (amrex::ParticleReal aperture_y)
+        {
+            using namespace amrex::literals; // for _prt
+
+            // performance optimization: we intentionally store the inverse of
+            //   the aperture, @see m_inv_aperture_y
+            m_inv_aperture_y = aperture_y > 0_prt ? 1_prt / aperture_y : 0_prt;
+        }
+
         Shape m_shape; //! aperture type (rectangular, elliptical)
         Action m_action; //! action type (transmit, absorb)
         // performance optimization: we intentionally store the inverse of
         //   the aperture, so we can do a quick multiplication instead of a costly
-        //   division in the comparison operation per particle
-        amrex::ParticleReal m_inv_aperture_x; //! maximum horizontal coordinate
-        amrex::ParticleReal m_inv_aperture_y; //! maximum vertical coordinate
+        //   division in the comparison operation per particle.
+        //   A stored zero scales the coordinate away and thus disables the
+        //   boundary in that plane, @see set_aperture_x
+        amrex::ParticleReal m_inv_aperture_x = 0; //! inverse of the horizontal half-aperture [1/m]
+        amrex::ParticleReal m_inv_aperture_y = 0; //! inverse of the vertical half-aperture [1/m]
         amrex::ParticleReal m_repeat_x; //! horizontal period for repeated masking
         amrex::ParticleReal m_repeat_y; //! vertical period for repeated masking
         bool m_shift_odd_x; //! for hexagonal/triangular mask patterns: horizontal shift of every 2nd (odd) vertical period by m_repeat_x / 2. Use Alignment offsets to move whole mask as needed.

--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -70,7 +70,7 @@ namespace impactx::elements
          *  elliptical shapes degenerate to the same slab. Note that with
          *  ``action = absorb`` a disabled plane makes the absorbing domain
          *  unbounded in that direction: disabling both planes absorbs the whole
-         *  beam, while for ``action = transmit`` the element becomes a no-op.
+         *  beam, while for ``action = transmit`` the element has no effect on the beam.
          *
          * @param shape aperture shape
          * @param action specify action of domain (transmit/absorb)

--- a/src/elements/Aperture.H
+++ b/src/elements/Aperture.H
@@ -63,9 +63,11 @@ namespace impactx::elements
          *  Particles outside the boundary are considered lost.
          *
          *  A half-aperture of zero or less disables the boundary in that plane,
-         *  the same convention as \see mixin::PipeAperture. A rectangular
-         *  aperture with only ``aperture_y`` set is thus a horizontal slit, and
-         *  an elliptical one degenerates into the same slab. Note that with
+         *  the same convention as \see mixin::PipeAperture: each plane is bounded
+         *  independently, so bounding a single plane gives a jaw (slit) collimator
+         *  and bounding both an iris. With only ``aperture_y`` set, a particle is
+         *  lost when ``|y| > aperture_y`` at any ``x``, and the rectangular and
+         *  elliptical shapes degenerate to the same slab. Note that with
          *  ``action = absorb`` a disabled plane makes the absorbing domain
          *  unbounded in that direction: disabling both planes absorbs the whole
          *  beam, while for ``action = transmit`` the element becomes a no-op.

--- a/src/elements/mixin/pipeaperture.H
+++ b/src/elements/mixin/pipeaperture.H
@@ -29,6 +29,8 @@ namespace impactx::elements::mixin
 
         /** An element with a constant elliptical aperture.
          *
+         * A half-aperture of zero or less removes the boundary in that plane.
+         *
          * @param aperture_x horizontal half-aperture size [m]
          * @param aperture_y vertical half-aperture size [m]
          */
@@ -51,6 +53,12 @@ namespace impactx::elements::mixin
 
         /** Apply the transverse aperture
          *
+         * Each plane is bounded independently: a half-aperture of zero or less
+         * removes the constraint in that plane only, while the other plane still
+         * cuts. This falls out of storing the inverse half-aperture: a stored zero
+         * scales its coordinate away, so that plane never contributes to the
+         * boundary comparison and the ellipse degenerates into a slab.
+         *
          * @param[inout] x horizontal position relative to reference particle
          * @param[inout] y vertical position relative to reference particle
          * @param idcpu particle global index
@@ -67,13 +75,15 @@ namespace impactx::elements::mixin
             using amrex::Math::powi;
             namespace stdx = amrex::simd::stdx;
 
-            // skip aperture application if aperture_x <= 0 or aperture_y <= 0
+            // skip aperture application if neither plane is bounded
             if (aperture_active()) {
 
                 // scale horizontal and vertical coordinates
                 // performance optimization: we intentionally store the inverse of
                 //   the aperture, so we can do a quick multiplication (instead of a
                 //   costly division) here.
+                // a stored zero disables that plane: the coordinate is scaled away
+                //   and never contributes to the comparison below
                 T_Real const u = x * m_inv_aperture_x;
                 T_Real const v = y * m_inv_aperture_y;
 
@@ -85,8 +95,8 @@ namespace impactx::elements::mixin
 
         /** Is the aperture restriction active?
          *
-         * A non-positive aperture in either plane removes the restriction,
-         * @see apply_aperture.
+         * The restriction is removed only if both planes are non-positive: a
+         * single bounded plane still cuts, @see apply_aperture.
          *
          * @return true if particles can be lost in this aperture
          */
@@ -94,7 +104,7 @@ namespace impactx::elements::mixin
         bool aperture_active () const
         {
             using namespace amrex::literals; // for _prt
-            return m_inv_aperture_x > 0_prt && m_inv_aperture_y > 0_prt;
+            return m_inv_aperture_x > 0_prt || m_inv_aperture_y > 0_prt;
         }
 
         /** Horizontal aperture size

--- a/src/elements/mixin/pipeaperture.H
+++ b/src/elements/mixin/pipeaperture.H
@@ -98,13 +98,19 @@ namespace impactx::elements::mixin
          * The restriction is removed only if both planes are non-positive: a
          * single bounded plane still cuts, @see apply_aperture.
          *
+         * Both stored inverses are non-negative, @see set_aperture_x, so the sum
+         * is positive exactly if at least one plane is bounded. Written as a sum
+         * rather than the equivalent `||` on purpose: the single comparison keeps
+         * GCC hoisting this loop-invariant test out of the vectorized particle
+         * loop, so an element without an aperture pays nothing per particle.
+         *
          * @return true if particles can be lost in this aperture
          */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         bool aperture_active () const
         {
             using namespace amrex::literals; // for _prt
-            return m_inv_aperture_x > 0_prt || m_inv_aperture_y > 0_prt;
+            return m_inv_aperture_x + m_inv_aperture_y > 0_prt;
         }
 
         /** Horizontal aperture size

--- a/src/python/elements.cpp
+++ b/src/python/elements.cpp
@@ -576,13 +576,12 @@ void init_elements(py::module& m)
         )
         .def("to_dict",
             [](Aperture const & ap) {
-                using namespace amrex::literals;
                 return element_dict(
                     ap,
                     std::make_pair("shape", amrex::getEnumNameString(ap.m_shape)),
                     std::make_pair("action", amrex::getEnumNameString(ap.m_action)),
-                    std::make_pair("aperture_x", 1_prt / ap.m_inv_aperture_x),
-                    std::make_pair("aperture_y", 1_prt / ap.m_inv_aperture_y),
+                    std::make_pair("aperture_x", ap.aperture_x()),
+                    std::make_pair("aperture_y", ap.aperture_y()),
                     std::make_pair("repeat_x", ap.m_repeat_x),
                     std::make_pair("repeat_y", ap.m_repeat_y),
                     std::make_pair("shift_odd_x", ap.m_shift_odd_x)
@@ -643,14 +642,14 @@ void init_elements(py::module& m)
             "action type (transmit, absorb)"
         )
         .def_property("aperture_x",
-            [](Aperture & ap) { using namespace amrex::literals; return 1_prt / ap.m_inv_aperture_x; },
-            [](Aperture & ap, amrex::ParticleReal aperture_x) { using namespace amrex::literals; ap.m_inv_aperture_x = 1_prt / aperture_x; },
-            "maximum horizontal coordinate"
+            [](Aperture & ap) { return ap.aperture_x(); },
+            [](Aperture & ap, amrex::ParticleReal aperture_x) { ap.set_aperture_x(aperture_x); },
+            "maximum horizontal coordinate in m; zero or less removes the horizontal boundary"
         )
         .def_property("aperture_y",
-            [](Aperture & ap) { using namespace amrex::literals; return 1_prt / ap.m_inv_aperture_y; },
-            [](Aperture & ap, amrex::ParticleReal aperture_y) { using namespace amrex::literals; ap.m_inv_aperture_y = 1_prt / aperture_y; },
-            "maximum vertical coordinate"
+            [](Aperture & ap) { return ap.aperture_y(); },
+            [](Aperture & ap, amrex::ParticleReal aperture_y) { ap.set_aperture_y(aperture_y); },
+            "maximum vertical coordinate in m; zero or less removes the vertical boundary"
         )
         .def_property("repeat_x",
             [](Aperture & ap) { return ap.m_repeat_x; },

--- a/tests/python/test_aperture_disabled.py
+++ b/tests/python/test_aperture_disabled.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+from impactx import ImpactX, distribution, elements
+
+NPART = 10000
+SIGMA = 1.0e-3  # transverse rms beam size in m
+HALF_APERTURE = 1.0e-3  # in m
+
+
+def _track(aperture):
+    """
+    Track a round Gaussian beam through a single aperture element.
+
+    :param aperture: the thin collimator to track through
+    :return: number of surviving particles, their max |x| and max |y| in m
+    """
+    sim = ImpactX()
+
+    sim.particle_shape = 2
+    sim.space_charge = False
+    sim.diagnostics = False
+    sim.slice_step_diagnostics = False
+    sim.init_grids()
+
+    sim.beam.ref.set_species("proton").set_kin_energy_MeV(250.0)
+
+    distr = distribution.Gaussian(
+        lambdaX=SIGMA,
+        lambdaY=SIGMA,
+        lambdaT=1.0e-3,
+        lambdaPx=1.0e-4,
+        lambdaPy=1.0e-4,
+        lambdaPt=1.0e-3,
+    )
+    sim.add_particles(1.0e-9, distr, NPART)
+
+    sim.lattice.append(aperture)
+    sim.track_particles()
+
+    pc = sim.particle_container()
+    n_surviving = pc.total_number_of_particles()
+
+    max_x, max_y = 0.0, 0.0
+    if n_surviving > 0:
+        xmin, ymin, _, xmax, ymax, _ = pc.min_and_max_positions()
+        max_x = max(abs(xmin), abs(xmax))
+        max_y = max(abs(ymin), abs(ymax))
+
+    sim.finalize()
+
+    return n_surviving, max_x, max_y
+
+
+def test_aperture_disabled_transmits_everything():
+    """
+    Test that an Aperture with both half-apertures disabled is a no-op for the
+    default "transmit" action, for both the constructor and the setters.
+    """
+    n_ctor, _, _ = _track(elements.Aperture(aperture_x=0.0, aperture_y=0.0))
+    assert n_ctor == NPART
+
+    collimator = elements.Aperture(aperture_x=HALF_APERTURE, aperture_y=HALF_APERTURE)
+    collimator.aperture_x = 0.0
+    collimator.aperture_y = 0.0
+    n_setter, _, _ = _track(collimator)
+    assert n_setter == NPART
+
+
+def test_aperture_disabled_plane_is_a_slit():
+    """
+    Test that disabling a single plane keeps the boundary of the other plane:
+    a rectangular aperture with only aperture_y set is a horizontal slit.
+    """
+    n_slit, max_x, max_y = _track(
+        elements.Aperture(aperture_x=0.0, aperture_y=HALF_APERTURE)
+    )
+    n_both, max_x_both, _ = _track(
+        elements.Aperture(aperture_x=HALF_APERTURE, aperture_y=HALF_APERTURE)
+    )
+
+    # the vertical boundary is enforced in both cases; the boundary itself is
+    # transmitting, so allow for the roundoff of the inverted-aperture scaling
+    on_edge = HALF_APERTURE * (1.0 + 1.0e-9)
+    assert 0 < n_slit < NPART
+    assert max_y <= on_edge
+
+    # the disabled horizontal plane does not restrict x, so the slit keeps
+    # everything the fully bounded aperture keeps, and more
+    assert n_slit > n_both
+    assert max_x > HALF_APERTURE
+    assert max_x_both <= on_edge
+
+
+def test_aperture_disabled_plane_absorbs_unbounded():
+    """
+    Test the documented corner of the "zero disables" convention: for the
+    "absorb" action a disabled plane makes the absorbing domain unbounded, so
+    disabling both planes absorbs the whole beam.
+    """
+    n_surviving, _, _ = _track(
+        elements.Aperture(aperture_x=0.0, aperture_y=0.0, action="absorb")
+    )
+    assert n_surviving == 0

--- a/tests/python/test_element_serialization.py
+++ b/tests/python/test_element_serialization.py
@@ -734,6 +734,38 @@ def test_mixin_properties_are_settable(all_elements):
     )
 
 
+def test_aperture_disabled_by_nonpositive():
+    """
+    Test that Aperture.aperture_x/aperture_y follow the PipeAperture convention:
+    a half-aperture of zero or less disables the boundary in that plane and
+    reads back as zero, both from the constructor and from assignment.
+    """
+    aperture = elements.Aperture(aperture_x=0.01, aperture_y=0.02)
+
+    # a valid assignment is kept and is visible in to_dict()
+    aperture.aperture_x = 0.03
+    aperture.aperture_y = 0.04
+    assert aperture.aperture_x == pytest.approx(0.03)
+    assert aperture.aperture_y == pytest.approx(0.04)
+    assert aperture.to_dict()["aperture_x"] == pytest.approx(0.03)
+    assert aperture.to_dict()["aperture_y"] == pytest.approx(0.04)
+
+    # zero or less disables the boundary and reads back as an exact zero,
+    # so that a to_dict() roundtrip reproduces the disabled element
+    for disabled in [0.0, -0.01]:
+        aperture.aperture_x = disabled
+        aperture.aperture_y = disabled
+        assert aperture.aperture_x == 0.0
+        assert aperture.aperture_y == 0.0
+        assert aperture.to_dict()["aperture_x"] == 0.0
+        assert aperture.to_dict()["aperture_y"] == 0.0
+
+        # the constructor uses the same convention
+        from_ctor = elements.Aperture(aperture_x=disabled, aperture_y=disabled)
+        assert from_ctor.aperture_x == 0.0
+        assert from_ctor.aperture_y == 0.0
+
+
 def test_individual_element_roundtrip(all_elements):
     """
     Test each element type individually for roundtrip consistency.

--- a/tests/python/test_thin_element_aperture.py
+++ b/tests/python/test_thin_element_aperture.py
@@ -135,3 +135,45 @@ def test_thin_element_aperture_off_by_default(element_name):
     )
 
     sim.finalize()
+
+
+@pytest.mark.parametrize(
+    "make_element",
+    [
+        pytest.param(lambda: elements.ShortRF(V=0.0, freq=1.0e6), id="thin"),
+        pytest.param(lambda: elements.Drift(ds=0.1), id="thick"),
+    ],
+)
+@pytest.mark.parametrize("plane", ["x", "y"])
+def test_single_plane_aperture_still_cuts(make_element, plane):
+    """A half-aperture set in one plane only bounds that plane, not both.
+
+    The other plane is left unbounded, so the aperture degenerates into a slab
+    rather than being switched off entirely.
+    """
+    element = make_element()
+    half_aperture = APERTURE_X if plane == "x" else APERTURE_Y
+    setattr(element, f"aperture_{plane}", half_aperture)
+    assert getattr(element, f"aperture_{'y' if plane == 'x' else 'x'}") == 0.0
+
+    sim, pc = _track(element)
+
+    n_final = pc.total_number_of_particles()
+    assert n_final < NPART, (
+        f"aperture_{plane} alone did not scrape: the bounded plane was ignored"
+    )
+
+    df = pc.to_df()
+    # the bounded plane cuts ...
+    bounded = df[f"position_{plane}"].abs()
+    assert np.all(bounded <= half_aperture * (1.0 + 1.0e-5)), (
+        f"a particle beyond aperture_{plane} survived"
+    )
+    # ... while the other plane keeps particles well outside its own beam size
+    other = "y" if plane == "x" else "x"
+    other_sigma = LAMBDA_Y if other == "y" else LAMBDA_X
+    assert df[f"position_{other}"].abs().max() > 2.0 * other_sigma, (
+        f"position_{other} looks bounded, but no aperture_{other} was set"
+    )
+
+    sim.finalize()


### PR DESCRIPTION
For our mixin class per element `PipeAperture`, setting only one of `aperture_x`/`aperture_y` disabled the beam pipe entirely.
This silently discarded the half-aperture that was actually set, e.g.
```py
Drift(ds=0.1, aperture_x=1e-4, aperture_y=0)
```
lost no particles at all.

With this change, each plane is bounded independently, so both collimator types are expressible:

* a **jaw** (slit) collimator bounds a single plane - the example above is now infinitely open in y and bounded at ±`1e-4` in x,
* an **iris** (the usual beam pipe) bounds both planes, as before.

For a single bounded plane the `rectangular` and `elliptical` shapes degenerate to the same slab. `PolygonAperture` is unaffected, as it is defined by vertices rather than half-apertures.

This is a behavior change for elements setting exactly one plane, from "no aperture" to "the plane you set cuts". Nothing in the examples or tests sets a single plane, and the old convention was documented nowhere.

## Also folds in #1645

This supersedes #1645, so that the `Aperture` collimator and the `PipeAperture` beam pipe land on the same convention in one go and the docs can state it once:

* `Aperture` no longer throws on a non-positive half-aperture, it disables that plane, matching `PipeAperture`.
* Small Python fix: the `aperture_x`/`aperture_y` properties and `to_dict()` went through a raw `1 / m_inv_aperture_*`, which divides by zero once a plane is disabled. They now use the `aperture_x()`/`aperture_y()` accessors and report `0` for a disabled plane, so `to_dict()`/`from_dicts()` round-trips again.

Verified that the two now agree exactly: a beam pipe, a `rectangular` collimator and an `elliptical` collimator with `aperture_x=1e-4, aperture_y=0` all transmit the same 805 of 10000 particles (the expected Gaussian slab fraction of ~8%).

## Docs

The convention is stated once for the inputs file and once for the Python API, covering the collimator and the beam pipe together. Only what is specific to the collimator stays in its own block: how a disabled plane interacts with `action = absorb`.

## Tests

* `test_single_plane_aperture_still_cuts` in `tests/python/test_thin_element_aperture.py`, parametrized over plane x {thin, thick}: the bounded plane cuts while the other stays unbounded.
* `tests/python/test_aperture_disabled.py` and the serialization coverage from #1645.
