### PR TITLE
Tests: SP Tolerances for Strang Split & MAD-X Solenoid

### DIFF
--- a/tests/python/test_madx_min_model.py
+++ b/tests/python/test_madx_min_model.py
@@ -35,7 +35,7 @@ import warnings
 import numpy as np
 import pytest
 
-from impactx import RefPart, elements
+from impactx import Config, RefPart, elements
 from impactx.element_models import MODEL_TIERS, select_model
 from impactx.madx_to_impactx import (
     MADXImpactXTranslatorWarning,
@@ -355,7 +355,8 @@ def test_solenoid_promotion_preserves_the_reference_map(ks):
 
     linear_map = np.array(sol.transfer_map(ref)).reshape(6, 6)
     paraxial_map = np.array(acc.transfer_map(ref)).reshape(6, 6)
-    assert np.allclose(linear_map, paraxial_map, rtol=0.0, atol=1.0e-14)
+    atol = 1.0e-14 if Config.precision != "SINGLE" else 1.0e-6
+    assert np.allclose(linear_map, paraxial_map, rtol=0.0, atol=atol)
 
 
 def test_solenoid_promotion_warns_about_energy_pinning():

--- a/tests/python/test_strang_split.py
+++ b/tests/python/test_strang_split.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 
 import amrex.space3d as amr
-from impactx import ImpactX, Map6x6, distribution, elements
+from impactx import Config, ImpactX, Map6x6, distribution, elements
 
 # beam and lattice parameters, shared by all runs below
 KIN_ENERGY_MEV = 250.0
@@ -342,7 +342,10 @@ def test_split_is_time_symmetric(sliceable):
     """
     residual = _roundtrip(strang_split=True, sliceable=sliceable)
 
-    assert residual < 1.0e-10, f"beam did not return: {residual:.3e}"
+    # in single precision the floor is set by the summation order of the threaded
+    # deposition: serial returns to 1.6e-7, 2 to 8 threads spread it over 6e-7 ... 1e-5
+    rtol = 1.0e-10 if Config.precision != "SINGLE" else 3.0e-5
+    assert residual < rtol, f"beam did not return: {residual:.3e}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Guard the double-precision-only bounds in `test_strang_split.py` and `test_madx_min_model.py` with `Config.precision`, following the existing pattern in e.g. `test_dipedge_ref.py`.

Both fail in every single precision job: the solenoid maps agree to one to two ulp (relaxed to `1e-6`), and the Strang-split roundtrip floor is set by the summation order of the threaded charge deposition, spanning `1.6e-7` (serial) to `1.0e-5` (relaxed to `3e-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1UuVqw6aK4RrKJGVMVAYg