### PR TITLE
[WIP] Lattice: Reference Particle in `map_trace`, and `ref_at` / `rigidity_at`

### DIFF
--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -1271,12 +1271,59 @@ This module provides elements and methods for the accelerator lattice.
                * ``M``    -- cumulative 6x6 linear transport map from the
                  start of the lattice to the exit of this element (a
                  ``Map6x6`` instance; call ``.to_numpy()`` for a standard
-                 C-ordered NumPy array).
+                 C-ordered NumPy array);
+               * ``ref``  -- the reference particle (:py:class:`impactx.RefPart`)
+                 at the exit of this element.
 
-               The first entry always has the identity map at the starting
-               ``s``; the last entry contains the same map as
-               :py:meth:`~transfer_map`.
+               The first entry always has the identity map and the incoming
+               reference particle at the starting ``s``; the last entry
+               contains the same map as :py:meth:`~transfer_map`.
       :rtype: list[dict]
+
+   .. py:method:: ref_at(ref, name, occurrence=1)
+
+      The reference particle at the exit of a named element.
+
+      The reference particle is advanced by every element's non-linear
+      reference push, so its energy -- and with it the magnetic rigidity --
+      differs on either side of an accelerating element. This is the state
+      needed to convert an element's normalized strength to or from an
+      engineering unit.
+
+      Nothing is tracked: the lattice is walked analytically, the same way
+      :py:meth:`~map_trace` walks it.
+
+      .. code-block:: python
+
+         brho = sim.lattice.ref_at(ref, "QF01").rigidity_Tm   # T*m
+         integrated_gradient = qf.k * qf.ds * brho            # T
+
+      :param ref: reference particle at the start of the lattice; not
+                  modified in place
+      :param name: element name, matched exactly and case-sensitively
+      :param occurrence: which occurrence to address when ``name`` is used
+                         more than once, 1-based in beam order. Element names
+                         are not required to be unique; without this, a
+                         repeated name is an error rather than a silent pick
+                         of the first one.
+      :return: a copy of the reference particle at that element's exit
+      :rtype: RefPart
+
+   .. py:method:: rigidity_at(ref, name, occurrence=1)
+
+      The magnetic rigidity ``Brho`` in T*m at the exit of a named element.
+
+      Shorthand for ``ref_at(...).rigidity_Tm``. This is the conversion
+      constant between an element's normalized strength and its field: a
+      quadrupole's integrated gradient in T is ``k * ds * rigidity_at(...)``.
+
+      :param ref: reference particle at the start of the lattice; not
+                  modified in place
+      :param name: element name, matched exactly and case-sensitively
+      :param occurrence: which occurrence to address when ``name`` is used
+                         more than once, 1-based in beam order
+      :return: magnetic rigidity in T*m
+      :rtype: float
 
    .. py:method:: to_dicts()
 

--- a/src/diagnostics/LinearMap.H
+++ b/src/diagnostics/LinearMap.H
@@ -56,6 +56,14 @@ namespace impactx::diagnostics
      *  normalized by the reference momentum, t arrival-time deviation relative
      *  to the reference (in meters of c*dt), and pt the momentum deviation
      *  relative to the reference (dimensionless).
+     *
+     *  @c ref is the reference particle at the *exit* of this element, i.e. the
+     *  state against which @c M_cumulative was evaluated. It is the reference
+     *  state a downstream consumer needs in order to convert an element's
+     *  normalized strength to or from an engineering unit: a quadrupole's
+     *  gradient in T/m is @c k times @c RefPart::rigidity_Tm , and the rigidity
+     *  changes across accelerating elements, so the value at the start of the
+     *  lattice is the wrong one for anything downstream of a cavity.
      */
     struct MapTraceEntry
     {
@@ -63,6 +71,7 @@ namespace impactx::diagnostics
         std::string element_name;       //!< user-supplied element name; empty if the element was not named
         std::string element_type;       //!< element type string (e.g. "Drift", "Quad", "Sbend")
         Map6x6 M_cumulative;            //!< cumulative 6x6 linear transport map from the start up to the exit of this element
+        RefPart ref;                    //!< reference particle at the exit of this element
     };
 
     /** Compose the linear transport map element-by-element along a lattice.
@@ -99,9 +108,10 @@ namespace impactx::diagnostics
      * @param[in] on_missing      policy for elements without a linear map;
      *                            default is identity + warning
      * @return                    vector of entries, size @c lattice.size() + 1 ;
-     *                            the first entry is the identity map at the
-     *                            starting s, each subsequent entry is the
-     *                            cumulative map at the exit of one element.
+     *                            the first entry is the identity map and the
+     *                            incoming reference particle at the starting s,
+     *                            each subsequent entry is the cumulative map and
+     *                            the reference particle at the exit of one element.
      */
     std::vector<MapTraceEntry>
     map_trace (

--- a/src/diagnostics/LinearMap.cpp
+++ b/src/diagnostics/LinearMap.cpp
@@ -203,14 +203,16 @@ namespace
         std::vector<MapTraceEntry> trace;
         trace.reserve(lattice.size() + 1u);
 
-        // Leading entry: identity map at the starting s. This makes the
-        // returned vector always start at the beginning of the lattice so
-        // downstream code (e.g., Twiss propagation) can treat every entry uniformly.
+        // Leading entry: identity map at the starting s, carrying the incoming
+        // reference particle. This makes the returned vector always start at the
+        // beginning of the lattice so downstream code (e.g., Twiss propagation)
+        // can treat every entry uniformly.
         trace.push_back(MapTraceEntry{
             ref_part_init.s,
             std::string{},
             std::string{"<start>"},
-            Map6x6::Identity()
+            Map6x6::Identity(),
+            ref_part_init
         });
 
         walk_lattice(
@@ -222,7 +224,8 @@ namespace
                     ref_now.s,
                     element.has_name() ? element.name() : std::string{},
                     std::string{E::type},
-                    M_now
+                    M_now,
+                    ref_now
                 });
             }
         );
@@ -241,8 +244,8 @@ namespace
 
         // End-to-end map only: rely on walk_lattice's default no-op
         // element-exit hook (NoopElementExit), so no per-element
-        // MapTraceEntry (two std::string copies plus a 6x6 matrix per
-        // element) is constructed.
+        // MapTraceEntry (two std::string copies, a 6x6 matrix and a
+        // RefPart per element) is constructed.
         return walk_lattice(lattice, ref_part_init, on_missing);
     }
 

--- a/src/python/impactx/extensions/KnownElementsList.py
+++ b/src/python/impactx/extensions/KnownElementsList.py
@@ -1058,6 +1058,77 @@ def _lattice_isclose(self, other, *, rtol=1e-12, atol=0.0, ignore_attributes=Non
     return True
 
 
+def _ref_trace_entries(self, ref):
+    """``map_trace`` entries excluding the leading ``<start>`` entry.
+
+    ``map_trace`` returns one entry per element plus a leading entry for the
+    starting position; the element entries are what a name lookup addresses.
+    """
+    return self.map_trace(ref)[1:]
+
+
+def ref_at(self, ref, name, *, occurrence=1):
+    """The reference particle at the exit of a named element.
+
+    The reference particle is advanced by every element's non-linear
+    reference push, so its energy — and with it the magnetic rigidity — differs
+    on either side of an accelerating element. This is the state needed to
+    convert an element's normalized strength to or from an engineering unit.
+
+    Nothing is tracked: the lattice is walked analytically, the same way
+    :py:meth:`map_trace` and ``sim.twiss()`` walk it.
+
+    :param ref: reference particle at the start of the lattice
+        (:py:class:`impactx.RefPart`); not modified in place
+    :param name: element name, matched exactly and case-sensitively
+    :param occurrence: which occurrence to address when ``name`` is used more
+        than once, 1-based in beam order. Element names are not required to be
+        unique; without this, a repeated name is an error rather than a silent
+        pick of the first one.
+    :return: a copy of the reference particle at that element's exit
+        (:py:class:`impactx.RefPart`)
+    :raises ValueError: if no element carries ``name``, or if ``occurrence``
+        exceeds the number of elements that do
+
+    Examples
+    --------
+    >>> brho = sim.lattice.ref_at(ref, "QF01").rigidity_Tm  # T*m
+    >>> integrated_gradient = qf.k * qf.ds * brho  # T
+    """
+    if occurrence < 1:
+        raise ValueError(f"occurrence must be >= 1, got {occurrence}.")
+
+    entries = _ref_trace_entries(self, ref)
+    matches = [e for e in entries if e["name"] == name]
+    if not matches:
+        named = sorted({e["name"] for e in entries if e["name"]})
+        detail = f" Named elements: {named}." if named else " No element is named."
+        raise ValueError(f"No element named {name!r} in the lattice.{detail}")
+    if occurrence > len(matches):
+        raise ValueError(
+            f"Element name {name!r} occurs {len(matches)} time(s) in the "
+            f"lattice, but occurrence={occurrence} was requested."
+        )
+    return matches[occurrence - 1]["ref"]
+
+
+def rigidity_at(self, ref, name, *, occurrence=1):
+    """The magnetic rigidity ``Brho`` in T*m at the exit of a named element.
+
+    Shorthand for ``ref_at(...).rigidity_Tm``. This is the conversion constant
+    between an element's normalized strength and its field: a quadrupole's
+    integrated gradient in T is ``k * ds * rigidity_at(...)``.
+
+    :param ref: reference particle at the start of the lattice
+        (:py:class:`impactx.RefPart`); not modified in place
+    :param name: element name, matched exactly and case-sensitively
+    :param occurrence: which occurrence to address when ``name`` is used more
+        than once, 1-based in beam order
+    :return: magnetic rigidity in T*m
+    """
+    return ref_at(self, ref, name, occurrence=occurrence).rigidity_Tm
+
+
 # Apply to FilteredElementsList immediately. The pybind11 KnownElementsList is
 # patched inside register_KnownElementsList_extension() below, since that is
 # the sole entry point that receives the bound class.
@@ -1084,6 +1155,10 @@ def register_KnownElementsList_extension(kel):
     kel.to_dicts = to_dicts
     kel.to_py = to_py
     kel.from_dicts = from_dicts
+
+    # Reference particle along the lattice
+    kel.ref_at = ref_at
+    kel.rigidity_at = rigidity_at
 
     # Enhanced element selection methods
     kel.select = select

--- a/src/python/lattice.cpp
+++ b/src/python/lattice.cpp
@@ -136,6 +136,7 @@ void init_lattice(py::module& me)
                     d["name"] = e.element_name;
                     d["type"] = e.element_type;
                     d["M"] = e.M_cumulative;
+                    d["ref"] = e.ref;
                     out.append(std::move(d));
                 }
                 return out;
@@ -162,9 +163,16 @@ void init_lattice(py::module& me)
             "    * ``M``    -- cumulative 6x6 linear transport map from the\n"
             "      start of the lattice to the exit of this element (a\n"
             "      ``Map6x6`` instance; call ``.to_numpy()`` for a standard\n"
-            "      C-ordered NumPy array).\n\n"
-            "    The first entry always has the identity map at the starting\n"
-            "    ``s``; the last entry contains the same map as ``transfer_map``."
+            "      C-ordered NumPy array);\n"
+            "    * ``ref``  -- the reference particle (:py:class:`impactx.RefPart`)\n"
+            "      at the exit of this element. Use ``ref.rigidity_Tm`` to convert\n"
+            "      an element's normalized strength to or from an engineering\n"
+            "      unit; the rigidity changes across accelerating elements, so\n"
+            "      the value at the start of the lattice is the wrong one for\n"
+            "      anything downstream of a cavity.\n\n"
+            "    The first entry always has the identity map and the incoming\n"
+            "    reference particle at the starting ``s``; the last entry\n"
+            "    contains the same map as ``transfer_map``."
         )
     ;
 

--- a/tests/python/test_lattice_ref_trace.py
+++ b/tests/python/test_lattice_ref_trace.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022-2026 The ImpactX Community
+#
+# Authors: Axel Huebl
+# License: BSD-3-Clause-LBNL
+#
+# -*- coding: utf-8 -*-
+
+import math
+
+import pytest
+
+from impactx import Config, ImpactX, RefPart, elements
+
+KIN_ENERGY_MEV = 250.0
+
+# The reference particle carries pt = -gamma, and a ShortRF advances it by
+# ``pt -= V * cos(phase)`` (src/elements/ShortRF.H). The gamma gain across the
+# cavity is therefore exactly V * cos(phase), independent of the incoming energy.
+V = 0.5
+PHASE_DEG = -30.0
+GAMMA_GAIN = V * math.cos(math.radians(PHASE_DEG))
+
+if Config.precision == "SINGLE":
+    RTOL = 5.0e-5
+else:
+    RTOL = 1.0e-12
+
+
+def _ref():
+    ref = RefPart()
+    ref.set_species("electron").set_kin_energy_MeV(KIN_ENERGY_MEV)
+    return ref
+
+
+def _lattice_with_short_rf():
+    """QF -- cavity -- QF, reusing one element name either side of the cavity."""
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Quad(name="QF", ds=0.3, k=1.0),
+            elements.Drift(name="d1", ds=0.5),
+            elements.ShortRF(name="cav", V=V, freq=1.3e9, phase=PHASE_DEG),
+            elements.Drift(name="d2", ds=0.5),
+            elements.Quad(name="QF", ds=0.3, k=1.0),
+        ]
+    )
+    return lattice
+
+
+def _lattice_with_rf_cavity():
+    """A thick RFCavity: ShortRF is not the only element that accelerates."""
+    lattice = elements.KnownElementsList()
+    lattice.extend(
+        [
+            elements.Drift(name="up", ds=0.1),
+            elements.RFCavity(
+                name="rf",
+                ds=1.0,
+                escale=0.04,
+                freq=7.0e8,
+                phase=45.0,
+                cos_coefficients=[2.0],
+                sin_coefficients=[0.0],
+                mapsteps=100,
+                nslice=4,
+            ),
+            elements.Drift(name="down", ds=0.1),
+        ]
+    )
+    return lattice
+
+
+def _track_reference_through(lattice):
+    """The reference particle at the lattice exit, from actual reference tracking."""
+    sim = ImpactX()
+    sim.particle_shape = 2
+    sim.space_charge = "false"
+    sim.slice_step_diagnostics = False
+    sim.diagnostics = False
+    sim.init_grids()
+
+    ref = sim.beam.ref
+    ref.set_species("electron").set_kin_energy_MeV(KIN_ENERGY_MEV)
+    sim.lattice.extend(lattice)
+
+    try:
+        sim.track_reference(ref)
+        return ref.s, ref.gamma, ref.rigidity_Tm
+    finally:
+        sim.finalize()
+
+
+def test_map_trace_carries_reference_particle():
+    """Every map_trace entry reports the reference particle at that element's exit."""
+    ref = _ref()
+    lattice = _lattice_with_short_rf()
+
+    trace = lattice.map_trace(ref)
+
+    # one entry per element, plus the leading <start> entry
+    assert len(trace) == len(lattice) + 1
+    assert all("ref" in entry for entry in trace)
+
+    # the leading entry carries the incoming reference particle unchanged
+    assert trace[0]["type"] == "<start>"
+    assert trace[0]["ref"].gamma == pytest.approx(ref.gamma, rel=RTOL)
+
+    # s on the entry and on its reference particle agree
+    for entry in trace:
+        assert entry["ref"].s == pytest.approx(entry["s"], rel=RTOL, abs=1.0e-12)
+
+    # the caller's reference particle is not modified in place
+    assert ref.gamma == pytest.approx(_ref().gamma, rel=RTOL)
+    assert ref.s == pytest.approx(0.0, abs=1.0e-12)
+
+
+def test_reference_energy_changes_across_short_rf():
+    """The gamma gain across a ShortRF matches the analytic V*cos(phase)."""
+    lattice = _lattice_with_short_rf()
+    trace = lattice.map_trace(_ref())
+    by_name = {entry["name"]: entry for entry in trace if entry["name"]}
+
+    gamma_before = by_name["d1"]["ref"].gamma
+    gamma_after = by_name["cav"]["ref"].gamma
+
+    assert gamma_after - gamma_before == pytest.approx(GAMMA_GAIN, rel=RTOL)
+
+    # a drift does not change the reference energy
+    assert by_name["d2"]["ref"].gamma == pytest.approx(gamma_after, rel=RTOL)
+
+
+@pytest.mark.parametrize(
+    "make_lattice, last_element",
+    [
+        (_lattice_with_short_rf, ("QF", 2)),
+        (_lattice_with_rf_cavity, ("down", 1)),
+    ],
+    ids=["ShortRF", "RFCavity"],
+)
+def test_ref_at_matches_track_reference(make_lattice, last_element):
+    """ref_at() at the lattice exit reproduces what tracking the reference produces.
+
+    Parametrized over a thin and a thick accelerating element on purpose: anything
+    that reconstructs the reference energy from ShortRF alone passes the first case
+    and fails the second.
+    """
+    lattice = make_lattice()
+    name, occurrence = last_element
+
+    walked = lattice.ref_at(_ref(), name, occurrence=occurrence)
+    s, gamma, rigidity_Tm = _track_reference_through(lattice)
+
+    assert walked.s == pytest.approx(s, rel=RTOL)
+    assert walked.gamma == pytest.approx(gamma, rel=RTOL)
+    assert walked.rigidity_Tm == pytest.approx(rigidity_Tm, rel=RTOL)
+
+
+def test_rigidity_at_differs_across_cavity():
+    """rigidity_at() is the strength/field conversion constant, and a cavity moves it."""
+    ref = _ref()
+    lattice = _lattice_with_short_rf()
+
+    brho_upstream = lattice.rigidity_at(ref, "QF")
+    brho_downstream = lattice.rigidity_at(ref, "QF", occurrence=2)
+
+    # Brho = m * beta * gamma * c / q carries the sign of the charge, so it is
+    # negative for an electron; the cavity raises its magnitude.
+    assert brho_upstream < 0.0
+    assert abs(brho_downstream) > abs(brho_upstream)
+
+    # Same magnet name, different rigidity: exactly the case that makes a single
+    # lattice-entry rigidity the wrong conversion constant downstream of a cavity.
+    assert brho_downstream != pytest.approx(brho_upstream, rel=1.0e-6)
+
+    # Brho = m * beta * gamma * c / q, so it follows the reference particle.
+    after = lattice.ref_at(ref, "QF", occurrence=2)
+    assert brho_downstream == pytest.approx(after.rigidity_Tm, rel=RTOL)
+
+
+def test_ref_at_name_errors():
+    """Unknown names and out-of-range occurrences are errors, not silent picks."""
+    ref = _ref()
+    lattice = _lattice_with_short_rf()
+
+    with pytest.raises(ValueError, match="No element named 'nope'"):
+        lattice.ref_at(ref, "nope")
+
+    with pytest.raises(ValueError, match="occurs 2 time"):
+        lattice.ref_at(ref, "QF", occurrence=3)
+
+    with pytest.raises(ValueError, match="occurrence must be >= 1"):
+        lattice.ref_at(ref, "QF", occurrence=0)


### PR DESCRIPTION
Converting an element's normalized strength to or from an engineering unit needs the magnetic rigidity **at that element**, and it changes across an accelerating element — the same quadrupole name either side of a cavity has two different conversion constants. Today that requires a full `track_reference` run, so downstream code reconstructs the reference energy by reimplementing element pushes in Python: correct for `ShortRF`, silently wrong for `RFCavity`, `ChrAcc` and `SoftSolenoid`.

`walk_lattice` already has the answer on the stack — it hands `RefPart const & ref_now` to its per-element exit hook and `map_trace` throws it away. This keeps it, and adds `lattice.ref_at(ref, name)` / `lattice.rigidity_at(ref, name)` on top.

WIP: opening early for API feedback (see the open questions below); the naming and the duplicate-name policy are the parts worth arguing about.

<details>
<summary>What changed</summary>

- `MapTraceEntry` gains `RefPart ref` — the reference particle at that element's **exit**, i.e. the state `M_cumulative` was evaluated against. The leading `<start>` entry carries the incoming reference particle.
- `map_trace()` exposes it as `entry["ref"]`.
- `KnownElementsList.ref_at(ref, name, occurrence=1)` and `rigidity_at(ref, name, occurrence=1)` address it by element name. Nothing is tracked — the lattice is walked analytically, exactly as `map_trace` and `twiss()` already walk it.

```python
brho = sim.lattice.rigidity_at(ref, "QF01")   # T*m
integrated_gradient = qf.k * qf.ds * brho     # T
```

`linear_map` is unaffected: it uses `walk_lattice`'s no-op exit hook and constructs no `MapTraceEntry` at all.

</details>

<details>
<summary>Duplicate element names</summary>

Element names are explicitly not required to be unique (`mixin::Named`: *"a user defined and not necessarily unique name"*). A repeated name therefore **raises** rather than silently resolving to the first match, and `occurrence=` (1-based, in beam order) disambiguates:

```python
lattice.rigidity_at(ref, "QF")                # raises if QF occurs twice
lattice.rigidity_at(ref, "QF", occurrence=2)  # the one after the cavity
```

This is deliberately conservative — picking the first match silently is exactly the bug this PR exists to prevent. If a `NAME##2`-style spelling is preferred, it slots in here.

</details>

<details>
<summary>Tests</summary>

`tests/python/test_lattice_ref_trace.py`, 6 tests:

- `ref_at` at the lattice exit is cross-checked against an actual `track_reference` run, parametrized over a thin `ShortRF` **and** a thick `RFCavity`. The second case is the point: anything reconstructing the reference energy from `ShortRF` alone passes the first and fails the second.
- The `ShortRF` gamma gain is pinned to the analytic `V*cos(phase)` (`ShortRF.H` does `pt -= V*cos(phi)` with `pt = -gamma`).
- `rigidity_at` differs either side of the cavity for the same element name. Note `Brho = m*beta*gamma*c/q` carries the sign of the charge, so it is negative for an electron and the cavity raises its *magnitude*.
- Entry/`ref` `s` agreement, `<start>` entry contents, and that the caller's reference particle is not modified in place.
- Error paths: unknown name, out-of-range `occurrence`, `occurrence < 1`.

</details>

<details>
<summary>Local test status</summary>

Built CPU/OpenMP, DP, `MPI=OFF`, `FFT=OFF`, `OPENPMD=OFF`.

- New tests: 6/6 pass.
- `test_lattice_optics.py`, `test_lattice_select.py`, `test_lattice_insert.py`, `test_element_serialization.py`: 57/57 pass — these are the `map_trace` / `twiss` consumers.
- Full non-dashboard suite: 435 passed. The 3 remaining failures (`test_charge_deposition_2D`, `test_space_charge_phi_via_hook`, `test_wake` — the last segfaults at AMReX finalize) are the standing `FFT=OFF` failures in this configuration and are untouched by this change. Not yet run in an FFT/openPMD-enabled build — CI will cover that.

</details>

<details>
<summary>Open questions</summary>

1. **Naming.** `ref_at` / `rigidity_at` vs. something closer to `twiss()`. `rigidity_at` is strictly a convenience over `ref_at(...).rigidity_Tm`; happy to drop it.
2. **Cost.** `map_trace` now copies one `RefPart` per element. `sim.twiss()` consumes `map_trace`, so it pays this — not measured on a long lattice yet. `linear_map` is unaffected.
3. **Addressing.** Name-based lookup is a stopgap; with stable element handles (`fix-lattice-shared`) these could take an element rather than a name.
4. Should `ref_at` also be exposed on `FilteredElementsList`?

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxwqYJxgaWWTxZYpZTCQEv
