### PR TITLE
Dashboard: Hold `trame` at 3.x Until the Widgets Follow

### DIFF
--- a/src/python/impactx/dashboard/requirements.txt
+++ b/src/python/impactx/dashboard/requirements.txt
@@ -1,8 +1,16 @@
 pandas>=2.2.0
 plotly>=5.23.0
-trame>=3.6.2
+# trame 4.0 pulls in trame-client 4.0, which merged trame_client.widgets.trame
+# into trame_client.widgets.client. Two of our widget packages have not followed:
+#   - trame-router (2.3.0) still imports trame_client.widgets.trame -> ImportError
+#     https://github.com/Kitware/trame-router/blob/master/trame_router/ui/router.py
+#   - trame-vuetify (3.2.5) pins trame-client<4, so pip backtracks the whole
+#     dashboard UI to the ancient trame-vuetify 2.7.2
+# Lift the cap once both support trame-client 4.
+trame>=3.6.2,<4
+trame-client<4
 trame-matplotlib>=2.0.3
 trame-plotly>=3.0.2
 trame-router>=2.2.0
-trame-vuetify>=2.6.2
+trame-vuetify>=3.0.0,<4
 trame-xterm>=0.2.1


### PR DESCRIPTION
## Problem

The `pytest.ImpactX.dashboard` test broke on `development` (`b0a413660`) in 🐧 OpenMP (both `GCC w/ MPI` and `GCC w/ SIMD`) and 🍏 macOS. Every other job — CUDA, HIP, Windows, Tooling, Source, CodeQL — is green, and nothing in our tree changed. What changed is upstream: `trame-server` 4.0.0, `trame` 4.0.0 and `trame-client` 4.0.0/4.0.1 were all published on 2026-09-09, hours before that CI run started.

The failure surfaces as a 120 s "Dashboard server did not start" timeout, which hides the real error:

```
File ".../trame_router/ui/router.py", line 4, in <module>
    from trame_client.widgets.trame import ServerTemplate
ModuleNotFoundError: No module named 'trame_client.widgets.trame'
```

CI resolved `trame-4.0.0 trame-client-4.0.1 trame-server-4.0.0 trame-vuetify-2.7.2`.

`trame-client` 4.0 dropped `trame_client/widgets/trame.py`; `ServerTemplate` now lives in `trame_client.widgets.client`. The [v3-to-v4 migration guide](https://kitware.github.io/trame/guide/versions/trame_v3-4.html) documents only the new `client_type="react"`, not this move. Two of the widget packages we depend on have not followed it:

- **`trame-router` 2.3.0** (released 2024-08, repo untouched since 2025-04) still imports the old path, and declares a bare unpinned `trame-client`, so pip installs the combination that cannot import. This is the crash.
- **`trame-vuetify` 3.2.5** pins `trame-client<4,>=3.7`, so with `trame` 4.0 in the resolution pip backtracks the whole dashboard UI to **`trame-vuetify` 2.7.2** — a 2024-11 release whose only dependency line is a bare `trame-client`. That one did not crash; it silently downgraded our widget set.

Because `trame-vuetify` itself refuses `trame-client` 4, there is no version of the dashboard's widget stack that runs on `trame` 4 today, whatever we change on our side.

## Fix

Cap `trame` and `trame-client` below 4, and raise the `trame-vuetify` floor to 3.0 so the silent backtrack to the 2.x widget set cannot recur either. The comment in the file names both blockers so the cap can be lifted deliberately rather than by accident.

## Testing

Verified locally, not just reasoned about:

- reproduced the exact `ModuleNotFoundError` in a clean venv built from the **old** requirements;
- the pinned set resolves under `pip install -U` to trame 3.13.2 / trame-client 3.13.6 / trame-vuetify 3.2.5, and every `trame` import the dashboard makes succeeds;
- launched `python -m dashboard` from this branch against an existing dev environment (trame 3.10.2) — it reaches `App running at:`.

`pytest.ImpactX.dashboard` is the regression test; it is what caught this and what should go green again here.

## Follow-ups (not in this PR)

- `wait_for_server_ready` in `tests/python/dashboard/utils.py` does not check whether the subprocess died, which is why a one-line import error cost 120 s and interleaved the traceback with 120 polling messages. Worth a `process.poll()` check.
- Upstream reports are filed; the cap here can be lifted once either is resolved:
  - Kitware/trame-router#10 — the one-line import change, verified sufficient.
  - Kitware/trame-vuetify#43 — relax `trame-client<4`; 3.2.5 appears to work against `trame-client` 4.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtgSKDGAGv2pzEjJ4maBtg
