### PR TITLE
Docs: Robust Doxygen Tag File Downloads

### DIFF
--- a/.github/workflows/source/doxygen
+++ b/.github/workflows/source/doxygen
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2020-2023 The ImpactX Community
+# Copyright 2020-2026 The ImpactX Community
 #
 # License: BSD-3-Clause-LBNL
 # Authors: Axel Huebl
@@ -9,16 +9,55 @@ set -eu -o pipefail
 
 cd docs
 
-curl -L -o amrex-doxygen-web.tag.xml \
-  https://amrex-codes.github.io/amrex/docs_xml/doxygen/amrex-doxygen-web.tag.xml
+# Doxygen tag files that we could download, in Doxygen's TAGFILES syntax
+tagfiles=()
 
-curl -L -o warpx-doxygen-web.tag.xml \
-  https://warpx.readthedocs.io/en/latest/_static/doxyhtml/warpx-doxygen-web.tag.xml
+# Download a Doxygen tag file to cross-link into an external documentation.
+#
+# Web servers (e.g., Read the Docs behind Cloudflare) occasionally answer
+# requests from CI runners with an HTML error page instead of the file. curl
+# writes such a page to disk just as happily as the real thing and Doxygen then
+# aborts with a rather cryptic XML parser error, e.g.,
+#   warpx-doxygen-web.tag.xml:1: error: Unexpected character `h` found
+# (the `h` of `<!DOCTYPE html>`). Thus, we retry, stop on HTTP errors and check
+# that we actually received XML. Tag files that stay unavailable are skipped:
+# they only add cross-links into external docs, which is not worth a CI failure.
+download_tagfile () {
+    local filename=$1
+    local download_url=$2
+    local docs_url=$3
 
-curl -L -o openpmd-api-doxygen-web.tag.xml \
-  https://openpmd-api.readthedocs.io/en/latest/_static/doxyhtml/openpmd-api-doxygen-web.tag.xml
+    if curl --location --fail --silent --show-error \
+            --retry 5 --retry-delay 5 --retry-all-errors \
+            --user-agent "ImpactX-docs-builder" \
+            --output "${filename}" "${download_url}" \
+       && head -c 100 "${filename}" | grep -q "<?xml"
+    then
+        tagfiles+=("${filename}=${docs_url}")
+    else
+        echo "WARNING: no valid tag file at ${download_url}" >&2
+        echo "         Continuing without cross-links into ${docs_url}" >&2
+        rm -f "${filename}"
+    fi
+}
 
-# treat all warnings as errors
-echo "WARN_AS_ERROR = YES" >> Doxyfile
+download_tagfile amrex-doxygen-web.tag.xml \
+  https://amrex-codes.github.io/amrex/docs_xml/doxygen/amrex-doxygen-web.tag.xml \
+  https://amrex-codes.github.io/amrex/doxygen/
 
-doxygen
+download_tagfile warpx-doxygen-web.tag.xml \
+  https://warpx.readthedocs.io/en/latest/_static/doxyhtml/warpx-doxygen-web.tag.xml \
+  https://warpx.readthedocs.io/en/latest/_static/doxyhtml/
+
+download_tagfile openpmd-api-doxygen-web.tag.xml \
+  https://openpmd-api.readthedocs.io/en/latest/_static/doxyhtml/openpmd-api-doxygen-web.tag.xml \
+  https://openpmd-api.readthedocs.io/en/latest/_static/doxyhtml/
+
+# Run doxygen, treating all warnings as errors and cross-linking only the tag
+# files that we have. Both options overwrite the values set in the Doxyfile,
+# which we read via stdin to keep the file itself unmodified.
+{
+    cat Doxyfile
+    echo "WARN_AS_ERROR = YES"
+    echo "TAGFILES = ${tagfiles[*]:-}"
+} | doxygen -

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,14 +41,22 @@ sys.path.insert(0, _ext_path)
 
 
 def download_with_headers(url, filename):
-    """Download a file with proper User-Agent header to avoid 403 errors."""
+    """Download a Doxygen tag file, with a User-Agent header to avoid 403 errors.
+
+    Web servers sometimes answer with an HTML error page instead of the file.
+    Writing that page to disk would make Doxygen abort reading tag files with a
+    cryptic XML parser error, thus we only keep payloads that start like XML.
+    """
     try:
         req = urllib.request.Request(
             url, headers={"User-Agent": "ImpactX-docs-builder"}
         )
         with urllib.request.urlopen(req) as response:
-            with open(filename, "wb") as f:
-                f.write(response.read())
+            payload = response.read()
+        if not payload.lstrip().startswith(b"<?xml"):
+            raise RuntimeError("downloaded file is not XML")
+        with open(filename, "wb") as f:
+            f.write(payload)
     except Exception as e:
         print(f"Could not download {filename} from {url}: {e}")
         print("Continuing build without cross-reference file...")


### PR DESCRIPTION
The `source` CI job and the Read the Docs build download the Doxygen tag files of AMReX, WarpX and openPMD-api to cross-link into their documentation. `curl -L -o` writes whatever the server answers to disk, also an HTML error page, and Doxygen then aborts with a rather cryptic XML parser error on a file that looks perfectly fine on the web:

```
docs/warpx-doxygen-web.tag.xml:1: error: Unexpected character `h` found
```

(the `h` of `<!DOCTYPE html>`). This broke the `style` job in https://github.com/BLAST-ImpactX/impactx/actions/runs/34435302269 : Read the Docs, behind Cloudflare, answered the runner with a ~5 kB HTML page for both the WarpX and the openPMD-api tag file.

Downloads now retry, stop on HTTP errors (`--fail`) and are checked to actually be XML. A tag file that stays unavailable is skipped instead of failing the run: it only adds cross-links into an external documentation, which is not worth failing CI over a third-party outage.

Internal:
- `.github/workflows/source/doxygen`: retry/validate downloads, skip unavailable tag files via a `TAGFILES` override, and pass the config through stdin (`doxygen -`) so the run no longer modifies `Doxyfile`
- `docs/source/conf.py`: only write downloaded tag files that are XML


Same as https://github.com/BLAST-WarpX/warpx/pull/7257